### PR TITLE
docs: MusicXML Editor MVP仕様と生成ワークフロー文書を追加

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1,0 +1,256 @@
+# Browser-based MusicXML Score Editor
+## Core Specification (MVP)
+
+---
+
+# 1. Design Principles
+
+## 1.1 Primary Goal
+
+The system MUST prioritize:
+
+- Preservation of existing MusicXML
+- Minimal structural modification
+- Safe round-trip behavior
+
+The architecture SHALL separate:
+
+- Core (behavior / guarantees)
+- UI (interaction / rendering)
+
+---
+
+# 2. Round-trip Guarantees
+
+## 2.1 Semantic Identity (MUST)
+
+After:
+
+```
+load(xml) → edit → save()
+```
+
+The resulting MusicXML MUST preserve:
+
+- Musical meaning
+- Playback semantics
+- Notational intent
+
+---
+
+## 2.2 Structural Identity (MUST)
+
+The following MUST be preserved:
+
+- part / measure / voice structure
+- ordering of elements where possible
+- unknown / unsupported elements
+- existing `<backup>` and `<forward>`
+- existing `<beam>`
+
+Unknown elements MUST NOT be deleted.
+
+---
+
+## 2.3 Textual Identity (NON-GUARANTEED)
+
+The system DOES NOT guarantee:
+
+- identical whitespace
+- identical attribute order
+- identical indentation
+- identical XML declaration formatting
+
+Textual diff-zero is NOT required.
+
+---
+
+# 3. No-op Save Optimization
+
+## 3.1 Definition
+
+If no editing command has modified musical content:
+
+```
+dirty === false
+```
+
+Then:
+
+- The original XML text MUST be returned unchanged.
+- Output mode MUST be `"original_noop"`.
+
+This guarantees diff-zero when no edit occurs.
+
+---
+
+# 4. Architecture Separation
+
+## 4.1 Core Responsibilities
+
+- DOM preservation
+- Original XML retention
+- Minimal patch updates
+- Dirty tracking
+- Command dispatch
+- Measure integrity validation
+- Beam policy enforcement
+- Backup/forward preservation
+- Serialization
+
+## 4.2 UI Responsibilities
+
+- Selection state
+- Cursor management
+- Input interpretation
+- Rendering
+- Displaying warnings/errors
+
+UI MUST NOT modify DOM directly.
+
+---
+
+# 5. DOM Preservation Strategy
+
+## 5.1 Node Identity
+
+- Internal `nodeId` MUST be assigned.
+- XML MUST NOT be modified to store nodeId.
+- Mapping SHALL use WeakMap<Node, NodeId>.
+
+## 5.2 Minimal Patch Rule
+
+Edits MUST:
+
+- Modify only required nodes.
+- Not regenerate entire measures.
+- Not reorder siblings.
+- Not normalize unrelated elements.
+
+---
+
+# 6. Measure Time Integrity (MVP)
+
+Definitions:
+
+- measureCapacity = beats × divisions
+- occupiedTime = sum of durations in editable voice
+
+## 6.1 Overfull (MUST Reject)
+
+If occupiedTime > measureCapacity:
+
+- dispatch MUST return `ok=false`
+- DOM MUST remain unchanged
+- Diagnostic code: `MEASURE_OVERFULL`
+
+Saving MUST be rejected.
+
+## 6.2 Underfull (MAY Allow)
+
+If occupiedTime < measureCapacity:
+
+- Operation MAY succeed
+- Warning MAY be issued
+- No rest auto-fill allowed
+
+Saving is allowed.
+
+## 6.3 Automatic Corrections (FORBIDDEN)
+
+The system MUST NOT automatically:
+
+- Insert rests
+- Split notes
+- Add ties
+- Modify `<divisions>`
+- Recalculate `<backup>` / `<forward>`
+
+---
+
+# 7. Beam Policy
+
+## 7.1 Preservation
+
+- MUST NOT auto-normalize existing `<beam>` elements.
+
+## 7.2 New Notes
+
+- MAY assign `<beam>` to newly created notes.
+
+## 7.3 Local Recalculation (Conditional)
+
+Beam recalculation MAY occur ONLY within a "continuous region":
+
+A continuous region is defined as:
+
+- Same part
+- Same measure
+- Same voice
+- Beam-eligible notes (flagged durations)
+- Time-index continuous (no rest, no backup/forward boundary)
+
+Beam recalculation MUST NOT:
+
+- Cross measure boundaries
+- Affect other voices
+- Modify unrelated beams
+
+---
+
+# 8. Backup / Forward Policy (MVP)
+
+## 8.1 Preservation
+
+- `<backup>` and `<forward>` MUST be preserved.
+- MUST NOT be auto-generated or removed.
+- MUST NOT be normalized on save.
+
+## 8.2 Editing Constraints
+
+MVP supports editing only editable voices (default: voice=1).
+
+- Editing non-editable voices MUST fail.
+- Editing that requires restructuring backup/forward MUST fail.
+- Diagnostic code: `MVP_UNSUPPORTED_NON_EDITABLE_VOICE`
+
+---
+
+# 9. Dirty State Definition
+
+`dirty = true` ONLY when:
+
+- A content-changing command succeeds.
+
+UI-only actions MUST NOT set dirty.
+
+---
+
+# 10. Save Behavior
+
+```
+if dirty === false:
+  return original XML text
+else:
+  return XMLSerializer output
+```
+
+Pretty-printing MUST NOT be applied.
+
+---
+
+# 11. Testing Requirements
+
+The following MUST be covered by automated tests:
+
+- RT-0: No-op save returns original text
+- RT-1: Pitch change produces serialized output
+- TI-1: Overfull is rejected
+- TI-2: Underfull allowed with warning
+- PT-1: Unknown elements preserved
+- BM-1: Existing beam unchanged
+- BF-1: Non-editable voice rejected
+
+---
+
+# End of MVP Core Specification

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,30 @@
+# TODO
+
+## Spec Work
+
+- [ ] Confirm command catalog for MVP (exact command names and payloads).
+- [ ] Add explicit save rejection contract when current state is overfull.
+- [ ] Define message text policy (i18n vs fixed English) for diagnostics.
+- [ ] Add one canonical fixture MusicXML for each required test ID.
+
+## Core Implementation
+
+- [ ] Create `core/interfaces.ts`.
+- [ ] Create `core/commands.ts`.
+- [ ] Create `core/xmlUtils.ts` (parse/serialize, unknown node-safe helpers).
+- [ ] Create `core/timeIndex.ts` (measure capacity / occupied time helpers).
+- [ ] Create `core/validators.ts` (overfull, voice edit constraints).
+- [ ] Create `core/ScoreCore.ts` (load/dispatch/save + dirty tracking).
+- [ ] Create `core/index.ts` exports.
+
+## Tests
+
+- [ ] Add `tests/unit/core.spec.ts`.
+- [ ] Implement RT-0, RT-1, TI-1, TI-2, PT-1, BM-1, BF-1.
+- [ ] Add fixtures for unknown elements and backup/forward boundaries.
+- [ ] Confirm no-op save returns exact original XML string.
+
+## Docs
+
+- [ ] Keep `SPEC.md` and `docs/spec/*` synchronized when rules change.
+- [ ] Update prompt template if file layout changes.

--- a/docs/generation/CODEX_PROMPT_TEMPLATE.md
+++ b/docs/generation/CODEX_PROMPT_TEMPLATE.md
@@ -1,0 +1,72 @@
+# Codex Prompt Template (Spec -> Generate)
+
+Use this template when asking Codex to generate or update core code from project specs.
+
+## Prompt
+
+```md
+You are Codex, an expert coding assistant.
+I am building a browser-based MusicXML Score Editor.
+Generate implementation code according to the formal specifications below.
+
+## Specifications
+- SPEC.md
+- docs/spec/TERMS.md
+- docs/spec/COMMANDS.md
+- docs/spec/DIAGNOSTICS.md
+- docs/spec/TEST_MATRIX.md
+
+## Output Requirements
+Produce the following outputs only:
+
+1. Core implementation files in TypeScript:
+   - core/interfaces.ts
+   - core/ScoreCore.ts
+   - core/commands.ts
+   - core/index.ts
+   - core/timeIndex.ts
+   - core/validators.ts
+   - core/xmlUtils.ts
+   - tests/unit/core.spec.ts
+
+2. Include:
+   - function signatures
+   - inline documentation comments
+   - logic flow reflecting spec guarantees
+   - minimal stubs where details are not finalized
+   - no full UI implementation
+
+3. Ensure:
+   - strict adherence to core specs
+   - tests for RT-0, RT-1, TI-1, TI-2, PT-1, BM-1, BF-1
+   - modular, testable code
+
+4. Add clear comments for:
+   - DOM vs WeakMap node identity
+   - dirty tracking rules
+   - measure capacity / occupied time logic
+   - backup/forward preservation boundaries
+
+## Constraints
+- no pretty printing for XML serialization
+- do not mutate unsupported XML nodes
+- do not auto-normalize beams
+- edits must be minimal patches
+- core API must stay UI-composable
+
+## Output Format
+Respond with a single JSON object:
+{
+  "files": [
+    { "path": "...", "content": "..." }
+  ],
+  "instructions": "How to use generated code"
+}
+
+If anything in specs is unclear or contradictory, ask one focused clarification question first.
+```
+
+## Notes
+
+- Paste actual spec contents (or file references, depending on your environment).
+- Keep the requested file list explicit to reduce scope drift.

--- a/docs/generation/WORKFLOW.md
+++ b/docs/generation/WORKFLOW.md
@@ -1,0 +1,39 @@
+# Spec-to-Code Workflow
+
+## Goal
+
+Generate consistent core code from the project specs without violating preservation rules.
+
+## Steps
+
+1. Confirm specs are up to date:
+- `SPEC.md`
+- `docs/spec/TERMS.md`
+- `docs/spec/COMMANDS.md`
+- `docs/spec/DIAGNOSTICS.md`
+- `docs/spec/TEST_MATRIX.md`
+
+2. Start from `docs/generation/CODEX_PROMPT_TEMPLATE.md`.
+
+3. Keep output scope fixed:
+- only requested files
+- no UI implementation
+- no extra architecture outside MVP unless explicitly requested
+
+4. Verify generated code against constraints:
+- no-op save returns original XML unchanged
+- dirty state changes only on successful content edits
+- overfull rejects atomically with `MEASURE_OVERFULL`
+- non-editable voice rejects with `MVP_UNSUPPORTED_NON_EDITABLE_VOICE`
+- unknown elements remain preserved
+- existing beam/backup/forward remain preserved
+
+5. Run and extend tests based on `docs/spec/TEST_MATRIX.md`.
+
+## Review Checklist
+
+- Is save mode correctly split into `original_noop` and serialized mode?
+- Are failed commands mutation-free?
+- Is node identity managed outside XML (WeakMap)?
+- Are unsupported nodes untouched?
+- Is there any implicit pretty-printing or normalization?

--- a/docs/spec/COMMANDS.md
+++ b/docs/spec/COMMANDS.md
@@ -1,0 +1,62 @@
+# Command and Save Contract (MVP)
+
+## Purpose
+
+This document defines the minimum command interface contract for core implementation.
+
+## Suggested Core API (MVP)
+
+```ts
+type DiagnosticCode =
+  | "MEASURE_OVERFULL"
+  | "MVP_UNSUPPORTED_NON_EDITABLE_VOICE";
+
+type WarningCode =
+  | "MEASURE_UNDERFULL";
+
+type DispatchResult = {
+  ok: boolean;
+  dirtyChanged: boolean;
+  diagnostics: Array<{ code: DiagnosticCode; message: string }>;
+  warnings: Array<{ code: WarningCode; message: string }>;
+};
+
+type SaveMode = "original_noop" | "serialized_dirty";
+
+type SaveResult = {
+  ok: boolean;
+  mode: SaveMode;
+  xml: string;
+  diagnostics: Array<{ code: DiagnosticCode; message: string }>;
+};
+```
+
+## Required Behavior
+
+1. `dispatch(command)`:
+- MUST reject commands targeting non-editable voice with `MVP_UNSUPPORTED_NON_EDITABLE_VOICE`.
+- MUST reject overfull measure with `MEASURE_OVERFULL`.
+- MUST leave DOM unchanged on reject.
+- MUST set `dirty=true` only when a content-changing command succeeds.
+- UI-only commands MUST NOT set dirty.
+
+2. `save()`:
+- If `dirty === false`, MUST return original input XML text with `mode="original_noop"`.
+- If `dirty === true`, MUST return `XMLSerializer` output with `mode="serialized_dirty"`.
+- Pretty-printing MUST NOT be applied.
+
+3. Serialization:
+- MUST preserve unknown/unsupported elements in DOM.
+- MUST NOT normalize `<backup>`, `<forward>`, existing `<beam>`.
+
+## Command Categories (MVP)
+
+- `Content-changing`: pitch edit, duration edit, note insertion/deletion (only if policy constraints pass).
+- `UI-only`: selection move, cursor move, viewport changes (tracked outside core or no-op in core).
+
+## Rejection Rule
+
+- On any constraint violation, command MUST fail atomically:
+  - no partial mutation
+  - no dirty transition
+  - diagnostic(s) attached

--- a/docs/spec/DIAGNOSTICS.md
+++ b/docs/spec/DIAGNOSTICS.md
@@ -1,0 +1,39 @@
+# Diagnostics Catalog (MVP)
+
+## Purpose
+
+Single source of truth for diagnostics emitted by core.
+
+## Error Diagnostics
+
+1. `MEASURE_OVERFULL`
+- Severity: error
+- Trigger: command would cause `occupiedTime > measureCapacity` in editable voice.
+- Required behavior:
+  - command result `ok=false`
+  - DOM unchanged
+  - dirty unchanged
+  - save rejection when current state is overfull
+
+2. `MVP_UNSUPPORTED_NON_EDITABLE_VOICE`
+- Severity: error
+- Trigger: command targets non-editable voice, or would require backup/forward restructuring to realize edit.
+- Required behavior:
+  - command result `ok=false`
+  - DOM unchanged
+  - dirty unchanged
+
+## Warning Diagnostics
+
+1. `MEASURE_UNDERFULL`
+- Severity: warning
+- Trigger: command leaves `occupiedTime < measureCapacity`.
+- Required behavior:
+  - command MAY succeed
+  - no automatic rest insertion
+  - warning emitted
+
+## Message Policy
+
+- Human-readable `message` SHOULD be attached for UI display.
+- `code` is normative and MUST be stable.

--- a/docs/spec/TERMS.md
+++ b/docs/spec/TERMS.md
@@ -1,0 +1,38 @@
+# Terms and Scope (MVP)
+
+## Purpose
+
+This document defines normative terms and MVP scope boundaries used by `SPEC.md`.
+
+## Normative Keywords
+
+- `MUST`: required for conformance
+- `MUST NOT`: prohibited
+- `SHALL`: equivalent to MUST in this project
+- `MAY`: optional behavior
+
+## Core Terms
+
+- `Core`: the non-UI engine responsible for MusicXML load/edit/save guarantees.
+- `UI`: selection/cursor/input/render layer. It MUST NOT mutate XML DOM directly.
+- `Editable voice`: the voice ID allowed to be edited in MVP (default: `1`).
+- `Non-editable voice`: any voice other than editable voice in MVP.
+- `Dirty`: internal state indicating successful content-changing edit has occurred.
+- `No-op save`: save when `dirty === false`; returns original XML text unchanged.
+- `Continuous region` (beam): same part/measure/voice, beam-eligible notes only, continuous in time with no rest and no backup/forward boundary.
+
+## MVP In Scope
+
+- Load MusicXML text into DOM while preserving unknown elements.
+- Edit operations limited to supported commands on editable voice.
+- Save behavior with no-op optimization and serializer fallback.
+- Measure time integrity validation (overfull reject / underfull allow).
+- Preservation policy for existing `<beam>`, `<backup>`, `<forward>`.
+
+## MVP Out of Scope
+
+- Full automatic notation repair (rest fill, note split, tie insertion).
+- Cross-voice structural reflow.
+- Rewriting backup/forward structure.
+- Global beam normalization.
+- Guarantee of textual equivalence after content-changing edits.

--- a/docs/spec/TEST_MATRIX.md
+++ b/docs/spec/TEST_MATRIX.md
@@ -1,0 +1,65 @@
+# MVP Test Matrix
+
+## Purpose
+
+Executable test planning mapped from `SPEC.md` requirements.
+
+## Required Automated Tests
+
+1. `RT-0 No-op save returns original text`
+- Given: loaded XML, no content-changing command
+- When: `save()`
+- Then:
+  - `mode === "original_noop"`
+  - output XML bytes/text equals original input text
+
+2. `RT-1 Pitch change produces serialized output`
+- Given: loaded XML
+- When: successful pitch-changing command on editable voice
+- Then:
+  - `dirty === true`
+  - `save().mode === "serialized_dirty"`
+  - musical change reflected in output
+
+3. `TI-1 Overfull is rejected`
+- Given: measure at capacity
+- When: command increases occupied time beyond capacity
+- Then:
+  - result `ok=false`
+  - diagnostic `MEASURE_OVERFULL`
+  - DOM unchanged
+  - dirty unchanged
+
+4. `TI-2 Underfull allowed with warning`
+- Given: command reduces occupied time below capacity
+- When: command applied on editable voice
+- Then:
+  - result may be `ok=true`
+  - warning may include `MEASURE_UNDERFULL`
+  - no rest auto-fill
+
+5. `PT-1 Unknown elements preserved`
+- Given: XML containing unsupported/unknown elements
+- When: load -> supported edit -> save
+- Then:
+  - unknown elements still exist in output DOM/serialized output
+
+6. `BM-1 Existing beam unchanged`
+- Given: measure with existing `<beam>`
+- When: edit outside beam-local recalculation scope
+- Then:
+  - existing unrelated beam markup remains unchanged
+
+7. `BF-1 Non-editable voice rejected`
+- Given: command targeting non-editable voice
+- When: `dispatch`
+- Then:
+  - result `ok=false`
+  - diagnostic `MVP_UNSUPPORTED_NON_EDITABLE_VOICE`
+  - DOM unchanged
+
+## Additional Recommended Tests
+
+1. `DR-1 Dirty not set by UI-only action`
+2. `SV-1 No pretty-print artifacts in save output`
+3. `AT-1 Atomic failure leaves DOM byte-equivalent after serialize`


### PR DESCRIPTION
## 概要
MusicXML Score Editor のMVP開発を進めるため、仕様の正本と、仕様から実装を生成するための運用ドキュメントを追加しました。 本PRはドキュメント追加のみで、実装コード変更は含みません。

## 変更内容
以下のファイルを新規追加しました。

- `SPEC.md`
  - Browser-based MusicXML Score Editor のMVPコア仕様
- `docs/spec/TERMS.md`
  - 用語定義とMVPスコープ
- `docs/spec/COMMANDS.md`
  - `dispatch/save` の契約、戻り値、失敗時の原子性
- `docs/spec/DIAGNOSTICS.md`
  - 診断コード定義（`MEASURE_OVERFULL` など）
- `docs/spec/TEST_MATRIX.md`
  - 必須テスト観点（RT-0, RT-1, TI-1, TI-2, PT-1, BM-1, BF-1）
- `docs/generation/CODEX_PROMPT_TEMPLATE.md`
  - 仕様→コード生成用のCodexプロンプトテンプレート
- `docs/generation/WORKFLOW.md`
  - 仕様確認〜生成〜検証の実行フロー
- `TODO.md`
  - 仕様詰め・実装・テストのタスク一覧

## 目的
- 仕様の解釈ブレを減らす
- 生成コードの逸脱を抑える
- 実装前に検証観点を固定する

## 影響範囲
- ドキュメントのみ
- 実行挙動・ビルド・テスト結果への直接影響なし

## テスト
- ドキュメント追加のみのため、コードテストは未実施