### PR TITLE
docs: README追加とコマンド境界・ビルド方針仕様を整備

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,59 @@
+# mikuscore
+
+ブラウザ上で完結する MusicXML スコアエディタのプロジェクトです。  
+このアプリの主眼は「多機能化」ではなく、**既存 MusicXML を壊さずに編集する信頼性**です。  
+MVP段階で機能を絞っているのは意図的で、まず「壊さない編集」を確実に成立させることを最優先にしています。
+
+## このアプリの特徴
+
+- 既存 MusicXML の保全を最優先
+- 最小パッチ編集（必要なノードだけ変更）
+- ラウンドトリップ安全性（`load -> edit -> save` の意味的同一性）
+- unknown / unsupported 要素の保持
+- `<backup>` / `<forward>` / 既存 `<beam>` の保持
+- 失敗時は原子的にロールバック（DOM 不変）
+- 将来 UI を差し替え可能な Core / UI 分離設計
+
+## なぜ新規で作るのか
+
+既存ツールでは、保存時の再整形や自動補正によって、意図しない差分が入りやすい課題があります。  
+mikuscore は、MVPとして機能を最小限に絞る代わりに、以下を明示的に禁止・制約し、差分と破壊的変更を抑えます。  
+つまり本プロジェクトの売りは、機能数ではなく「既存 MusicXML を壊さずに編集できること」です。
+
+- 不要な正規化
+- 無関係ノードの再生成
+- 自動 rest 挿入 / tie 追加 / divisions 変更
+- backup/forward の自動再計算
+
+## 主要な仕様ハイライト（MVP）
+
+- `dirty === false` の保存は入力 XML 文字列をそのまま返す（`original_noop`）
+- 小節 overfull は `MEASURE_OVERFULL` で拒否
+- 非編集対象 voice は `MVP_UNSUPPORTED_NON_EDITABLE_VOICE` で拒否
+- underfull は許容可能（警告を出す場合あり）
+- pretty-print なしでシリアライズ
+
+詳細は `SPEC.md` と `docs/spec/` を参照してください。
+
+## 配布と開発方針
+
+- 配布形態: **Single-file Web App**（単一 HTML）
+- 実行条件: オフライン動作、外部依存なし
+- 開発形態: 分割 TypeScript ソース
+- ビルド方針: `app-src.html` + `src/` から `app.html` を生成
+
+## ドキュメント
+
+- `SPEC.md`: MVP コア仕様
+- `docs/spec/TERMS.md`: 用語とスコープ
+- `docs/spec/COMMANDS.md`: dispatch/save 契約
+- `docs/spec/COMMAND_CATALOG.md`: コマンド境界（payload/失敗条件）
+- `docs/spec/DIAGNOSTICS.md`: 診断コード定義
+- `docs/spec/TEST_MATRIX.md`: 必須テスト観点
+- `docs/spec/BUILD_PROCESS.md`: 単一 HTML 配布向けビルド方針
+- `TODO.md`: 仕様・実装・テストのタスク管理
+
+## 現在のステータス
+
+現時点は仕様策定フェーズです。  
+次の段階で Core 実装（TypeScript）とユニットテストを追加します。

--- a/TODO.md
+++ b/TODO.md
@@ -6,6 +6,7 @@
 - [ ] Add explicit save rejection contract when current state is overfull.
 - [ ] Define message text policy (i18n vs fixed English) for diagnostics.
 - [ ] Add one canonical fixture MusicXML for each required test ID.
+- [ ] Align file naming conventions for single-file build (`app-src.html` / `app.html` or alternatives).
 
 ## Core Implementation
 
@@ -28,3 +29,4 @@
 
 - [ ] Keep `SPEC.md` and `docs/spec/*` synchronized when rules change.
 - [ ] Update prompt template if file layout changes.
+- [ ] Keep `docs/spec/BUILD_PROCESS.md` and package scripts consistent.

--- a/docs/spec/BUILD_PROCESS.md
+++ b/docs/spec/BUILD_PROCESS.md
@@ -1,0 +1,67 @@
+# Build Process (Single-file Runtime / Split TS Dev)
+
+## Purpose
+
+This project adopts:
+
+- development with split TypeScript source files
+- distribution as a single self-contained HTML file
+
+The build process is designed to preserve offline and zero-runtime-dependency behavior.
+
+## Target Artifact
+
+- Development template: `app-src.html` (editable source template)
+- Distribution artifact: `app.html` (generated file, do not edit directly)
+
+## Suggested Project Layout (MVP)
+
+- `app-src.html`
+- `app.html` (generated)
+- `src/css/app.css`
+- `src/ts/main.ts`
+- `src/ts/**/*.ts` (core/ui split modules)
+- `src/js/main.js` (generated from TS)
+- `src/js/**/*.js` (generated)
+- `src/vendor/**/*.js` (optional vendored libraries, local only)
+
+## Build Command
+
+```bash
+npm run build
+```
+
+`build` SHOULD perform the following steps:
+
+1. Compile `src/ts/**/*.ts` to `src/js/**/*.js`
+2. Validate `app-src.html` tag order (CSS and JS include order)
+3. Inline local CSS and JS into HTML
+4. Output `app.html` as single-file artifact
+
+## Optional Commands
+
+```bash
+npm run typecheck
+npm run clean
+```
+
+- `typecheck`: strict TS check for development quality
+- `clean`: remove generated JS and distribution HTML
+
+## Runtime Constraints (MUST)
+
+- `app.html` MUST run offline (no network required)
+- `app.html` MUST NOT fetch external CDN/resources at runtime
+- all required scripts/styles MUST be embedded or locally bundled
+- behavior of generated `app.html` MUST match development source behavior
+
+## Editing Rules
+
+- `app.html` is generated; do not edit directly
+- edit only `app-src.html` and files under `src/`
+- PRs SHOULD include regenerated `app.html` when behavior changes
+
+## Notes
+
+- If TypeScript compiler is unavailable, build MAY fail fast (recommended), or use an explicit fallback policy if defined in package scripts.
+- This document defines process and constraints; concrete script implementation is tracked separately.

--- a/docs/spec/COMMAND_CATALOG.md
+++ b/docs/spec/COMMAND_CATALOG.md
@@ -1,0 +1,160 @@
+# Command Catalog (MVP)
+
+## Purpose
+
+This document fixes the API boundary for `dispatch(command)` in MVP.
+It complements:
+
+- `docs/spec/COMMANDS.md` (result contract / save contract)
+- `docs/spec/DIAGNOSTICS.md` (error and warning codes)
+- `docs/spec/TEST_MATRIX.md` (required test coverage)
+
+## Command Envelope
+
+```ts
+type NodeId = string;
+type VoiceId = string;
+
+type CoreCommand =
+  | ChangePitchCommand
+  | ChangeDurationCommand
+  | InsertNoteAfterCommand
+  | DeleteNoteCommand
+  | UiNoopCommand;
+```
+
+## Command Definitions
+
+### 1. `change_pitch`
+
+```ts
+type ChangePitchCommand = {
+  type: "change_pitch";
+  targetNodeId: NodeId; // note node
+  voice: VoiceId; // must match editable voice in MVP
+  pitch: {
+    step: "A" | "B" | "C" | "D" | "E" | "F" | "G";
+    alter?: -2 | -1 | 0 | 1 | 2;
+    octave: number;
+  };
+};
+```
+
+Rules:
+
+- MUST only patch pitch-related children of the target note.
+- MUST NOT rewrite sibling notes or measure structure.
+- MUST reject when `voice` is non-editable (`MVP_UNSUPPORTED_NON_EDITABLE_VOICE`).
+- On success: `dirty=true`.
+
+### 2. `change_duration`
+
+```ts
+type ChangeDurationCommand = {
+  type: "change_duration";
+  targetNodeId: NodeId; // note node
+  voice: VoiceId;
+  duration: number; // MusicXML duration units
+};
+```
+
+Rules:
+
+- MUST modify only the target `<duration>` (minimal patch).
+- MUST validate measure integrity after tentative change:
+  - if overfull: reject with `MEASURE_OVERFULL`, no mutation
+  - if underfull: MAY succeed, MAY emit `MEASURE_UNDERFULL`
+- MUST reject non-editable voice with `MVP_UNSUPPORTED_NON_EDITABLE_VOICE`.
+- On success: `dirty=true`.
+
+### 3. `insert_note_after`
+
+```ts
+type InsertNoteAfterCommand = {
+  type: "insert_note_after";
+  anchorNodeId: NodeId; // insert after this note in same voice lane
+  voice: VoiceId;
+  note: {
+    duration: number;
+    pitch?: {
+      step: "A" | "B" | "C" | "D" | "E" | "F" | "G";
+      alter?: -2 | -1 | 0 | 1 | 2;
+      octave: number;
+    };
+    isRest?: boolean;
+  };
+};
+```
+
+Rules:
+
+- MUST insert only one note/rest node near anchor (no full-measure regeneration).
+- Existing `<backup>/<forward>` MUST remain untouched.
+- Existing unrelated `<beam>` MUST remain untouched.
+- If insertion implies unsupported backup/forward restructuring: reject with `MVP_UNSUPPORTED_NON_EDITABLE_VOICE`.
+- If result is overfull: reject with `MEASURE_OVERFULL`, no mutation.
+- If result is underfull: MAY succeed with warning.
+- On success: `dirty=true`.
+
+### 4. `delete_note`
+
+```ts
+type DeleteNoteCommand = {
+  type: "delete_note";
+  targetNodeId: NodeId;
+  voice: VoiceId;
+};
+```
+
+Rules:
+
+- MUST delete only the target note node.
+- MUST NOT auto-fill rests, split notes, add ties, or modify divisions.
+- MUST reject non-editable voice with `MVP_UNSUPPORTED_NON_EDITABLE_VOICE`.
+- Underfull after deletion is allowed (warning optional).
+- On success: `dirty=true`.
+
+### 5. `ui_noop`
+
+```ts
+type UiNoopCommand = {
+  type: "ui_noop";
+  reason: "selection_change" | "cursor_move" | "viewport_change";
+};
+```
+
+Rules:
+
+- MUST produce `ok=true` without content mutation.
+- MUST NOT set `dirty=true`.
+- Useful for integration tests that verify dirty boundaries.
+
+## Common Precondition Checks
+
+For content-changing commands, core MUST evaluate in this order:
+
+1. Resolve `targetNodeId` / `anchorNodeId` to an existing note node.
+2. Verify target command voice equals editable voice (`voice=1` by default).
+3. Verify operation does not require backup/forward restructuring.
+4. Apply operation on a tentative basis and validate measure integrity.
+5. Commit patch atomically only if constraints pass.
+
+## Atomicity Contract
+
+If command fails:
+
+- return `ok=false`
+- include diagnostic code(s)
+- DOM MUST be unchanged
+- dirty MUST be unchanged
+
+This applies to all rejection paths, including overfull and non-editable voice.
+
+## Save Boundary
+
+Catalog commands do not change save behavior:
+
+- `dirty===false` -> save mode `original_noop`, return original XML text
+- `dirty===true` -> save mode `serialized_dirty`, return serializer output
+
+No pretty-printing is allowed.


### PR DESCRIPTION
## 概要
MVP仕様の実装準備として、プロジェクトの価値提案を明文化したREADMEを追加し、
あわせてコマンドAPI境界とSingle-file配布向けビルド方針を仕様として追加しました。

## 変更内容

- `README.md` を新規追加
  - アプリの主眼（既存MusicXMLを壊さずに編集する信頼性）
  - MVPで機能を絞る意図
  - 主要仕様ハイライトと参照ドキュメント一覧
- `docs/spec/COMMAND_CATALOG.md` を新規追加
  - `dispatch(command)` のコマンド境界を固定
  - 各コマンドのpayload、成功/失敗条件、dirtyルール、原子性を定義
- `docs/spec/BUILD_PROCESS.md` を新規追加
  - 分割TS開発 + 単一HTML配布のビルド方針を定義
  - オフライン/非依存（外部CDNなし）制約を明記
- `TODO.md` を更新
  - ビルド命名規約とビルド仕様同期のタスクを追加

## 目的
- 実装前にAPI境界を固定し、仕様解釈の揺れを減らす
- 「壊さない編集」をプロジェクトの中核価値として明示する
- 将来の実装・テスト・配布フローを仕様先行で安定化する

## 影響範囲
- ドキュメントのみ（実装コード変更なし）

## テスト
- ドキュメント変更のみのため、コードテストは未実施