### PR TITLE
docs: MVP仕様を実装前提で確定（Architecture追加・コマンド境界/診断/テスト更新）

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ブラウザ上で完結する MusicXML スコアエディタのプロジェクトです。  
 このアプリの主眼は「多機能化」ではなく、**既存 MusicXML を壊さずに編集する信頼性**です。  
 MVP段階で機能を絞っているのは意図的で、まず「壊さない編集」を確実に成立させることを最優先にしています。
+ただし実運用で最低限必要な編集体験を満たすため、MVPでも `insert` / `delete` は対象に含めます。
 
 ## このアプリの特徴
 
@@ -30,17 +31,25 @@ mikuscore は、MVPとして機能を最小限に絞る代わりに、以下を�
 - `dirty === false` の保存は入力 XML 文字列をそのまま返す（`original_noop`）
 - 小節 overfull は `MEASURE_OVERFULL` で拒否
 - 非編集対象 voice は `MVP_UNSUPPORTED_NON_EDITABLE_VOICE` で拒否
+- 実用最低限として `change_pitch` / `change_duration` / `insert_note_after` / `delete_note` をMVPに含める
+- `grace` / `cue` / `chord` / `rest` はMVPでは編集対象外（`MVP_UNSUPPORTED_NOTE_KIND`）
 - underfull は許容可能（警告を出す場合あり）
 - pretty-print なしでシリアライズ
 
 詳細は `SPEC.md` と `docs/spec/` を参照してください。
+
+## 対応する MusicXML バージョン
+
+- 対象: **MusicXML 4.0**
+- 位置づけ: 2026-02-14 時点の最新安定版（Final Community Group Report は 2021-06-01 公開）
+- 方針: MVP実装とテストは 4.0 前提で設計する
 
 ## 配布と開発方針
 
 - 配布形態: **Single-file Web App**（単一 HTML）
 - 実行条件: オフライン動作、外部依存なし
 - 開発形態: 分割 TypeScript ソース
-- ビルド方針: `app-src.html` + `src/` から `app.html` を生成
+- ビルド方針: `mikuscore-src.html` + `src/` から `mikuscore.html` を生成
 
 ## ドキュメント
 
@@ -51,6 +60,7 @@ mikuscore は、MVPとして機能を最小限に絞る代わりに、以下を�
 - `docs/spec/DIAGNOSTICS.md`: 診断コード定義
 - `docs/spec/TEST_MATRIX.md`: 必須テスト観点
 - `docs/spec/BUILD_PROCESS.md`: 単一 HTML 配布向けビルド方針
+- `docs/spec/ARCHITECTURE.md`: Core/UI分離とバージョン前提を含むアーキテクチャ方針
 - `TODO.md`: 仕様・実装・テストのタスク管理
 
 ## 現在のステータス

--- a/SPEC.md
+++ b/SPEC.md
@@ -117,6 +117,8 @@ UI MUST NOT modify DOM directly.
 - Internal `nodeId` MUST be assigned.
 - XML MUST NOT be modified to store nodeId.
 - Mapping SHALL use WeakMap<Node, NodeId>.
+- `nodeId` stability is required only within a loaded session.
+- Cross-reload `nodeId` identity is NOT guaranteed in MVP.
 
 ## 5.2 Minimal Patch Rule
 
@@ -213,6 +215,8 @@ MVP supports editing only editable voices (default: voice=1).
 - Editing non-editable voices MUST fail.
 - Editing that requires restructuring backup/forward MUST fail.
 - Diagnostic code: `MVP_UNSUPPORTED_NON_EDITABLE_VOICE`
+- Editing `grace`, `cue`, `chord`, and `rest` notes MUST fail in MVP.
+- Diagnostic code: `MVP_UNSUPPORTED_NOTE_KIND`
 
 ---
 
@@ -250,6 +254,7 @@ The following MUST be covered by automated tests:
 - PT-1: Unknown elements preserved
 - BM-1: Existing beam unchanged
 - BF-1: Non-editable voice rejected
+- NK-1: Unsupported note kind (`grace/cue/chord/rest`) rejected
 
 ---
 

--- a/TODO.md
+++ b/TODO.md
@@ -2,11 +2,13 @@
 
 ## Spec Work
 
-- [ ] Confirm command catalog for MVP (exact command names and payloads).
+- [x] Confirm command catalog for MVP (exact command names and payloads, including insert/delete).
 - [ ] Add explicit save rejection contract when current state is overfull.
+- [x] Decide nodeId stability policy (session-local only in MVP).
+- [x] Decide unsupported note kinds in MVP (`grace` / `cue` / `chord` / `rest` -> reject).
 - [ ] Define message text policy (i18n vs fixed English) for diagnostics.
 - [ ] Add one canonical fixture MusicXML for each required test ID.
-- [ ] Align file naming conventions for single-file build (`app-src.html` / `app.html` or alternatives).
+- [x] Align file naming conventions for single-file build (`mikuscore-src.html` / `mikuscore.html`).
 
 ## Core Implementation
 
@@ -20,6 +22,7 @@
 
 ## Tests
 
+- [ ] Set up Vitest (`test:unit`) as the unit test runner baseline.
 - [ ] Add `tests/unit/core.spec.ts`.
 - [ ] Implement RT-0, RT-1, TI-1, TI-2, PT-1, BM-1, BF-1.
 - [ ] Add fixtures for unknown elements and backup/forward boundaries.

--- a/docs/spec/ARCHITECTURE.md
+++ b/docs/spec/ARCHITECTURE.md
@@ -1,0 +1,57 @@
+# Architecture (MVP)
+
+## Purpose
+
+This document defines high-level architecture boundaries for mikuscore MVP.
+
+## MusicXML Version Baseline
+
+- Baseline format: **MusicXML 4.0**
+- Stability note: as of 2026-02-14, MusicXML 4.0 is treated as the latest stable baseline for this project
+- Rule: core interfaces, validators, and fixtures MUST be authored against 4.0 semantics
+
+## Architectural Separation
+
+- `Core`:
+  - load / dispatch / save
+  - DOM preservation and minimal patch edits
+  - dirty tracking
+  - measure integrity checks
+  - diagnostics
+- `UI`:
+  - selection state
+  - cursor and input handling
+  - rendering
+  - warning/error display
+
+UI MUST NOT mutate XML DOM directly.
+
+## Runtime and Build Model
+
+- Runtime distribution: single self-contained HTML (`mikuscore.html`)
+- Development model: split TypeScript source files
+- Build model: compile TS and inline local CSS/JS into one HTML
+- Runtime dependency rule: no external CDN/API required
+
+## Language and Runtime Baseline
+
+- TypeScript baseline: `5.9.x` (verified with `5.9.3`)
+- Emitted JavaScript baseline: `ES2018`
+- Browser baseline: latest Chrome / Edge / Safari, with ES2018 output policy for better compatibility headroom on older Android environments
+
+## Core Invariants
+
+- unknown / unsupported elements MUST be preserved
+- existing `<backup>`, `<forward>`, and unrelated `<beam>` MUST be preserved
+- failed command MUST be atomic (DOM unchanged, dirty unchanged)
+- no-op save (`dirty=false`) MUST return original XML text unchanged
+
+## References
+
+- `SPEC.md`
+- `docs/spec/TERMS.md`
+- `docs/spec/COMMANDS.md`
+- `docs/spec/COMMAND_CATALOG.md`
+- `docs/spec/DIAGNOSTICS.md`
+- `docs/spec/TEST_MATRIX.md`
+- `docs/spec/BUILD_PROCESS.md`

--- a/docs/spec/BUILD_PROCESS.md
+++ b/docs/spec/BUILD_PROCESS.md
@@ -11,13 +11,13 @@ The build process is designed to preserve offline and zero-runtime-dependency be
 
 ## Target Artifact
 
-- Development template: `app-src.html` (editable source template)
-- Distribution artifact: `app.html` (generated file, do not edit directly)
+- Development template: `mikuscore-src.html` (editable source template)
+- Distribution artifact: `mikuscore.html` (generated file, do not edit directly)
 
 ## Suggested Project Layout (MVP)
 
-- `app-src.html`
-- `app.html` (generated)
+- `mikuscore-src.html`
+- `mikuscore.html` (generated)
 - `src/css/app.css`
 - `src/ts/main.ts`
 - `src/ts/**/*.ts` (core/ui split modules)
@@ -34,32 +34,46 @@ npm run build
 `build` SHOULD perform the following steps:
 
 1. Compile `src/ts/**/*.ts` to `src/js/**/*.js`
-2. Validate `app-src.html` tag order (CSS and JS include order)
+2. Validate `mikuscore-src.html` tag order (CSS and JS include order)
 3. Inline local CSS and JS into HTML
-4. Output `app.html` as single-file artifact
+4. Output `mikuscore.html` as single-file artifact
 
 ## Optional Commands
 
 ```bash
 npm run typecheck
+npm run test:unit
 npm run clean
 ```
 
 - `typecheck`: strict TS check for development quality
+- `test:unit`: run unit tests with Vitest
 - `clean`: remove generated JS and distribution HTML
+
+## Toolchain Baseline
+
+- TypeScript: `5.9.x` baseline (current verified: `5.9.3`)
+- JavaScript output target: `ES2018`
+- Recommendation: pin exact TypeScript patch version in lockfile for reproducible builds
+
+## Browser Support Baseline
+
+- Primary targets: latest Chrome, latest Edge, latest Safari
+- Compatibility strategy: keep emitted JS at `ES2018` to improve tolerance for older Android Chrome/WebView environments
+- Note: very old Android devices may still require additional runtime compatibility checks
 
 ## Runtime Constraints (MUST)
 
-- `app.html` MUST run offline (no network required)
-- `app.html` MUST NOT fetch external CDN/resources at runtime
+- `mikuscore.html` MUST run offline (no network required)
+- `mikuscore.html` MUST NOT fetch external CDN/resources at runtime
 - all required scripts/styles MUST be embedded or locally bundled
-- behavior of generated `app.html` MUST match development source behavior
+- behavior of generated `mikuscore.html` MUST match development source behavior
 
 ## Editing Rules
 
-- `app.html` is generated; do not edit directly
-- edit only `app-src.html` and files under `src/`
-- PRs SHOULD include regenerated `app.html` when behavior changes
+- `mikuscore.html` is generated; do not edit directly
+- edit only `mikuscore-src.html` and files under `src/`
+- PRs SHOULD include regenerated `mikuscore.html` when behavior changes
 
 ## Notes
 

--- a/docs/spec/COMMANDS.md
+++ b/docs/spec/COMMANDS.md
@@ -9,7 +9,8 @@ This document defines the minimum command interface contract for core implementa
 ```ts
 type DiagnosticCode =
   | "MEASURE_OVERFULL"
-  | "MVP_UNSUPPORTED_NON_EDITABLE_VOICE";
+  | "MVP_UNSUPPORTED_NON_EDITABLE_VOICE"
+  | "MVP_UNSUPPORTED_NOTE_KIND";
 
 type WarningCode =
   | "MEASURE_UNDERFULL";
@@ -35,6 +36,7 @@ type SaveResult = {
 
 1. `dispatch(command)`:
 - MUST reject commands targeting non-editable voice with `MVP_UNSUPPORTED_NON_EDITABLE_VOICE`.
+- MUST reject commands targeting unsupported note kinds (`grace`, `cue`, `chord`, `rest`) with `MVP_UNSUPPORTED_NOTE_KIND`.
 - MUST reject overfull measure with `MEASURE_OVERFULL`.
 - MUST leave DOM unchanged on reject.
 - MUST set `dirty=true` only when a content-changing command succeeds.
@@ -43,6 +45,7 @@ type SaveResult = {
 2. `save()`:
 - If `dirty === false`, MUST return original input XML text with `mode="original_noop"`.
 - If `dirty === true`, MUST return `XMLSerializer` output with `mode="serialized_dirty"`.
+- If current score state is overfull, save MUST be rejected with `ok=false` and diagnostic `MEASURE_OVERFULL`.
 - Pretty-printing MUST NOT be applied.
 
 3. Serialization:

--- a/docs/spec/DIAGNOSTICS.md
+++ b/docs/spec/DIAGNOSTICS.md
@@ -23,6 +23,14 @@ Single source of truth for diagnostics emitted by core.
   - DOM unchanged
   - dirty unchanged
 
+3. `MVP_UNSUPPORTED_NOTE_KIND`
+- Severity: error
+- Trigger: command targets unsupported note kinds in MVP (`grace`, `cue`, `chord`, `rest`).
+- Required behavior:
+  - command result `ok=false`
+  - DOM unchanged
+  - dirty unchanged
+
 ## Warning Diagnostics
 
 1. `MEASURE_UNDERFULL`

--- a/docs/spec/TEST_MATRIX.md
+++ b/docs/spec/TEST_MATRIX.md
@@ -4,6 +4,11 @@
 
 Executable test planning mapped from `SPEC.md` requirements.
 
+## Test Runner Baseline
+
+- Unit test runner: `Vitest`
+- Scope: core behavior and invariants in `tests/unit/*`
+
 ## Required Automated Tests
 
 1. `RT-0 No-op save returns original text`
@@ -56,6 +61,14 @@ Executable test planning mapped from `SPEC.md` requirements.
 - Then:
   - result `ok=false`
   - diagnostic `MVP_UNSUPPORTED_NON_EDITABLE_VOICE`
+  - DOM unchanged
+
+8. `NK-1 Unsupported note kind rejected`
+- Given: command targeting `grace`, `cue`, `chord`, or `rest`
+- When: `dispatch`
+- Then:
+  - result `ok=false`
+  - diagnostic `MVP_UNSUPPORTED_NOTE_KIND`
   - DOM unchanged
 
 ## Additional Recommended Tests


### PR DESCRIPTION
## 概要
MVP実装開始前の仕様確定を目的に、READMEと仕様ドキュメント群を更新しました。
本PRで「壊さない編集」を軸にしつつ、実用最低限の編集機能（insert/delete含む）を明文化しています。

## 変更内容

### 1. アーキテクチャ仕様の追加
- `docs/spec/ARCHITECTURE.md` を新規追加
  - Core/UI分離
  - MusicXML 4.0 前提
  - Single-file配布方針
  - 言語/ランタイム基準（TypeScript 5.9系, ES2018）

### 2. ビルド/配布方針の具体化
- `docs/spec/BUILD_PROCESS.md` 更新
  - 出力名を `mikuscore.html` / `mikuscore-src.html` に統一
  - Toolchain Baseline / Browser Support Baseline を追記
  - `test:unit`（Vitest）をオプションコマンドとして明記

### 3. コマンド・診断・テスト仕様の強化
- `docs/spec/COMMANDS.md` 更新
  - `MVP_UNSUPPORTED_NOTE_KIND` 追加
  - overfull状態での `save()` 拒否契約を明文化
- `docs/spec/COMMAND_CATALOG.md` 更新
  - insert/delete をMVPに含む方針を維持
  - `grace/cue/chord/rest` をMVP編集対象外として明記
- `docs/spec/DIAGNOSTICS.md` 更新
  - `MVP_UNSUPPORTED_NOTE_KIND` 追加
- `docs/spec/TEST_MATRIX.md` 更新
  - `NK-1`（unsupported note kind reject）追加

### 4. 主要ドキュメント整合
- `SPEC.md` 更新
  - `nodeId` はセッション内安定のみ（再load跨ぎ非保証）
  - unsupported note kind 制約を追加
  - テスト要件へ `NK-1` 追加
- `README.md` 更新
  - MVPの狙い（壊さない編集）と実用最低限機能（insert/delete）を明確化
  - MusicXML 4.0 前提の説明を追記
- `TODO.md` 更新
  - 仕様決定済み項目の反映と状態更新

## 目的
- 実装着手前にAPI境界と失敗契約を固定
- 「MVPは狭く、しかし実用最低限は確保」の方針を文書化
- テスト設計（Vitest前提）を仕様と同期

## 影響範囲
- ドキュメントのみ（コード実装変更なし）

## テスト
- ドキュメント更新のみのため、コードテストは未実施