### PR TITLE
feat(core): MusicXML壊さない編集のMVP Core実装とVitest基盤を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+coverage/

--- a/README.md
+++ b/README.md
@@ -26,6 +26,14 @@ mikuscore は、MVPとして機能を最小限に絞る代わりに、以下を�
 - 自動 rest 挿入 / tie 追加 / divisions 変更
 - backup/forward の自動再計算
 
+## 他ツールとの位置づけ（MuseScoreとの違い）
+
+- MuseScore: 高機能な「作譜・編集」の統合環境
+- mikuscore: 既存 MusicXML に安全に手を入れるための外科ツール
+
+mikuscore は、高機能化よりも「壊さない保証」を優先します。  
+MVPが尖って見えるのは、機能を削ってでも round-trip の信頼性と最小変更を先に成立させる設計だからです。
+
 ## 主要な仕様ハイライト（MVP）
 
 - `dirty === false` の保存は入力 XML 文字列をそのまま返す（`original_noop`）

--- a/core/ScoreCore.ts
+++ b/core/ScoreCore.ts
@@ -1,0 +1,217 @@
+import { getCommandNodeId, isUiOnlyCommand } from "./commands";
+import type {
+  CoreCommand,
+  DispatchResult,
+  Diagnostic,
+  NodeId,
+  SaveResult,
+  ScoreCoreOptions,
+  Warning,
+} from "./interfaces";
+import { getMeasureTimingForVoice } from "./timeIndex";
+import {
+  createNoteElement,
+  getDurationValue,
+  parseXml,
+  reindexNodeIds,
+  serializeXml,
+  setDurationValue,
+  setPitch,
+} from "./xmlUtils";
+import {
+  validateBackupForwardBoundaryForStructuralEdit,
+  validateProjectedMeasureTiming,
+  validateSupportedNoteKind,
+  validateVoice,
+} from "./validators";
+
+const DEFAULT_EDITABLE_VOICE = "1";
+
+export class ScoreCore {
+  private readonly editableVoice: string;
+  private originalXml = "";
+  private doc: XMLDocument | null = null;
+  private dirty = false;
+
+  // Node identity is kept outside XML with WeakMap as required by spec.
+  private nodeToId = new WeakMap<Node, NodeId>();
+  private idToNode = new Map<NodeId, Element>();
+  private nodeCounter = 0;
+
+  public constructor(options: ScoreCoreOptions = {}) {
+    this.editableVoice = options.editableVoice ?? DEFAULT_EDITABLE_VOICE;
+  }
+
+  public load(xml: string): void {
+    this.originalXml = xml;
+    this.doc = parseXml(xml);
+    this.dirty = false;
+    this.reindex();
+  }
+
+  public dispatch(command: CoreCommand): DispatchResult {
+    if (!this.doc) {
+      return this.fail("MVP_INVALID_TARGET", "Score is not loaded.");
+    }
+    if (isUiOnlyCommand(command)) {
+      return { ok: true, dirtyChanged: false, diagnostics: [], warnings: [] };
+    }
+
+    const voiceDiagnostic = validateVoice(command, this.editableVoice);
+    if (voiceDiagnostic) return this.failWith(voiceDiagnostic);
+
+    const targetId = getCommandNodeId(command);
+    if (!targetId) return this.fail("MVP_INVALID_TARGET", "Command target is missing.");
+    const target = this.idToNode.get(targetId);
+    if (!target) return this.fail("MVP_INVALID_TARGET", `Unknown nodeId: ${targetId}`);
+
+    const noteKindDiagnostic = validateSupportedNoteKind(target);
+    if (noteKindDiagnostic) return this.failWith(noteKindDiagnostic);
+
+    const bfDiagnostic = validateBackupForwardBoundaryForStructuralEdit(command, target);
+    if (bfDiagnostic) return this.failWith(bfDiagnostic);
+
+    const snapshot = serializeXml(this.doc);
+    const warnings: Warning[] = [];
+
+    try {
+      if (command.type === "change_pitch") {
+        setPitch(target, command.pitch);
+      } else if (command.type === "change_duration") {
+        const oldDuration = getDurationValue(target) ?? 0;
+        const timing = getMeasureTimingForVoice(target, command.voice);
+        if (timing) {
+          const projected = timing.occupied - oldDuration + command.duration;
+          const result = validateProjectedMeasureTiming(target, command.voice, projected);
+          if (result.diagnostic) return this.failWith(result.diagnostic);
+          if (result.warning) warnings.push(result.warning);
+        }
+        setDurationValue(target, command.duration);
+      } else if (command.type === "insert_note_after") {
+        const timing = getMeasureTimingForVoice(target, command.voice);
+        if (timing) {
+          const projected = timing.occupied + command.note.duration;
+          const result = validateProjectedMeasureTiming(target, command.voice, projected);
+          if (result.diagnostic) return this.failWith(result.diagnostic);
+          if (result.warning) warnings.push(result.warning);
+        }
+        const note = createNoteElement(
+          this.doc,
+          command.voice,
+          command.note.duration,
+          command.note.pitch
+        );
+        target.after(note);
+      } else if (command.type === "delete_note") {
+        const duration = getDurationValue(target) ?? 0;
+        const timing = getMeasureTimingForVoice(target, command.voice);
+        if (timing) {
+          const projected = timing.occupied - duration;
+          const result = validateProjectedMeasureTiming(target, command.voice, projected);
+          if (result.diagnostic) return this.failWith(result.diagnostic);
+          if (result.warning) warnings.push(result.warning);
+        }
+        target.remove();
+      }
+    } catch {
+      this.restoreFrom(snapshot);
+      return this.fail("MVP_INVALID_TARGET", "Command failed unexpectedly.");
+    }
+
+    this.reindex();
+    const dirtyBefore = this.dirty;
+    this.dirty = true;
+    return {
+      ok: true,
+      dirtyChanged: !dirtyBefore,
+      diagnostics: [],
+      warnings,
+    };
+  }
+
+  public save(): SaveResult {
+    if (!this.doc) {
+      return {
+        ok: false,
+        mode: "original_noop",
+        xml: "",
+        diagnostics: [{ code: "MVP_INVALID_TARGET", message: "Score is not loaded." }],
+      };
+    }
+
+    if (!this.dirty) {
+      return {
+        ok: true,
+        mode: "original_noop",
+        xml: this.originalXml,
+        diagnostics: [],
+      };
+    }
+
+    const overfull = this.findOverfullDiagnostic();
+    if (overfull) {
+      return { ok: false, mode: "serialized_dirty", xml: "", diagnostics: [overfull] };
+    }
+
+    return {
+      ok: true,
+      mode: "serialized_dirty",
+      xml: serializeXml(this.doc),
+      diagnostics: [],
+    };
+  }
+
+  public isDirty(): boolean {
+    return this.dirty;
+  }
+
+  public listNoteNodeIds(): NodeId[] {
+    return Array.from(this.idToNode.keys());
+  }
+
+  private nextNodeId(): NodeId {
+    this.nodeCounter += 1;
+    return `n${this.nodeCounter}`;
+  }
+
+  private reindex(): void {
+    if (!this.doc) return;
+    reindexNodeIds(this.doc, this.nodeToId, this.idToNode, () => this.nextNodeId());
+  }
+
+  private restoreFrom(xmlSnapshot: string): void {
+    this.doc = parseXml(xmlSnapshot);
+    this.reindex();
+  }
+
+  private findOverfullDiagnostic(): Diagnostic | null {
+    if (!this.doc) return null;
+    const measures = this.doc.querySelectorAll("measure");
+    for (const measure of measures) {
+      const note = measure.querySelector("note");
+      if (!note) continue;
+      const timing = getMeasureTimingForVoice(note, this.editableVoice);
+      if (!timing) continue;
+      if (timing.occupied > timing.capacity) {
+        return {
+          code: "MEASURE_OVERFULL",
+          message: `Occupied time ${timing.occupied} exceeds capacity ${timing.capacity}.`,
+        };
+      }
+    }
+    return null;
+  }
+
+  private fail(code: Diagnostic["code"], message: string): DispatchResult {
+    return this.failWith({ code, message });
+  }
+
+  private failWith(diagnostic: Diagnostic): DispatchResult {
+    return {
+      ok: false,
+      dirtyChanged: false,
+      diagnostics: [diagnostic],
+      warnings: [],
+    };
+  }
+}

--- a/core/commands.ts
+++ b/core/commands.ts
@@ -1,0 +1,17 @@
+import type { CoreCommand, NodeId } from "./interfaces";
+
+export const isUiOnlyCommand = (command: CoreCommand): boolean =>
+  command.type === "ui_noop";
+
+export const getCommandNodeId = (command: CoreCommand): NodeId | null => {
+  switch (command.type) {
+    case "change_pitch":
+    case "change_duration":
+    case "delete_note":
+      return command.targetNodeId;
+    case "insert_note_after":
+      return command.anchorNodeId;
+    case "ui_noop":
+      return null;
+  }
+};

--- a/core/index.ts
+++ b/core/index.ts
@@ -1,0 +1,6 @@
+export * from "./interfaces";
+export * from "./commands";
+export * from "./timeIndex";
+export * from "./validators";
+export * from "./xmlUtils";
+export * from "./ScoreCore";

--- a/core/interfaces.ts
+++ b/core/interfaces.ts
@@ -1,0 +1,88 @@
+export type NodeId = string;
+export type VoiceId = string;
+
+export type DiagnosticCode =
+  | "MEASURE_OVERFULL"
+  | "MVP_UNSUPPORTED_NON_EDITABLE_VOICE"
+  | "MVP_UNSUPPORTED_NOTE_KIND"
+  | "MVP_INVALID_TARGET";
+
+export type WarningCode = "MEASURE_UNDERFULL";
+
+export type Diagnostic = {
+  code: DiagnosticCode;
+  message: string;
+};
+
+export type Warning = {
+  code: WarningCode;
+  message: string;
+};
+
+export type DispatchResult = {
+  ok: boolean;
+  dirtyChanged: boolean;
+  diagnostics: Diagnostic[];
+  warnings: Warning[];
+};
+
+export type SaveMode = "original_noop" | "serialized_dirty";
+
+export type SaveResult = {
+  ok: boolean;
+  mode: SaveMode;
+  xml: string;
+  diagnostics: Diagnostic[];
+};
+
+export type Pitch = {
+  step: "A" | "B" | "C" | "D" | "E" | "F" | "G";
+  alter?: -2 | -1 | 0 | 1 | 2;
+  octave: number;
+};
+
+export type ChangePitchCommand = {
+  type: "change_pitch";
+  targetNodeId: NodeId;
+  voice: VoiceId;
+  pitch: Pitch;
+};
+
+export type ChangeDurationCommand = {
+  type: "change_duration";
+  targetNodeId: NodeId;
+  voice: VoiceId;
+  duration: number;
+};
+
+export type InsertNoteAfterCommand = {
+  type: "insert_note_after";
+  anchorNodeId: NodeId;
+  voice: VoiceId;
+  note: {
+    duration: number;
+    pitch: Pitch;
+  };
+};
+
+export type DeleteNoteCommand = {
+  type: "delete_note";
+  targetNodeId: NodeId;
+  voice: VoiceId;
+};
+
+export type UiNoopCommand = {
+  type: "ui_noop";
+  reason: "selection_change" | "cursor_move" | "viewport_change";
+};
+
+export type CoreCommand =
+  | ChangePitchCommand
+  | ChangeDurationCommand
+  | InsertNoteAfterCommand
+  | DeleteNoteCommand
+  | UiNoopCommand;
+
+export type ScoreCoreOptions = {
+  editableVoice?: VoiceId;
+};

--- a/core/timeIndex.ts
+++ b/core/timeIndex.ts
@@ -1,0 +1,60 @@
+import { findAncestorMeasure, getDurationValue, getVoiceText } from "./xmlUtils";
+
+export type MeasureTiming = {
+  capacity: number;
+  occupied: number;
+};
+
+export const getMeasureTimingForVoice = (
+  noteInMeasure: Element,
+  voice: string
+): MeasureTiming | null => {
+  const measure = findAncestorMeasure(noteInMeasure);
+  if (!measure) return null;
+
+  const capacity = getMeasureCapacity(measure);
+  if (capacity === null) return null;
+  const occupied = getOccupiedTime(measure, voice);
+
+  return { capacity, occupied };
+};
+
+export const getMeasureCapacity = (measure: Element): number | null => {
+  // Simplified MVP rule: local measure attributes are used when present.
+  const beatsText = measure.querySelector("attributes > time > beats")?.textContent;
+  const beatTypeText = measure.querySelector(
+    "attributes > time > beat-type"
+  )?.textContent;
+  const divisionsText = measure.querySelector("attributes > divisions")?.textContent;
+
+  if (!beatsText || !beatTypeText || !divisionsText) return null;
+
+  const beats = Number(beatsText.trim());
+  const beatType = Number(beatTypeText.trim());
+  const divisions = Number(divisionsText.trim());
+
+  if (
+    !Number.isFinite(beats) ||
+    !Number.isFinite(beatType) ||
+    !Number.isFinite(divisions) ||
+    beatType <= 0
+  ) {
+    return null;
+  }
+
+  const beatUnit = (4 / beatType) * divisions;
+  return Math.round(beats * beatUnit);
+};
+
+export const getOccupiedTime = (measure: Element, voice: string): number => {
+  const directChildren = Array.from(measure.children);
+  let total = 0;
+  for (const child of directChildren) {
+    if (child.tagName !== "note") continue;
+    const noteVoice = getVoiceText(child);
+    if (noteVoice !== voice) continue;
+    const duration = getDurationValue(child);
+    if (duration !== null) total += duration;
+  }
+  return total;
+};

--- a/core/validators.ts
+++ b/core/validators.ts
@@ -1,0 +1,75 @@
+import type { CoreCommand, Diagnostic, VoiceId, Warning } from "./interfaces";
+import { getMeasureTimingForVoice } from "./timeIndex";
+import {
+  findAncestorMeasure,
+  isUnsupportedNoteKind,
+  measureHasBackupOrForward,
+} from "./xmlUtils";
+
+export const validateVoice = (
+  command: CoreCommand,
+  editableVoice: VoiceId
+): Diagnostic | null => {
+  if (command.type === "ui_noop") return null;
+  if (command.voice === editableVoice) return null;
+  return {
+    code: "MVP_UNSUPPORTED_NON_EDITABLE_VOICE",
+    message: `Voice ${command.voice} is not editable in MVP.`,
+  };
+};
+
+export const validateSupportedNoteKind = (note: Element): Diagnostic | null => {
+  if (!isUnsupportedNoteKind(note)) return null;
+  return {
+    code: "MVP_UNSUPPORTED_NOTE_KIND",
+    message: "Editing grace/cue/chord/rest notes is not supported in MVP.",
+  };
+};
+
+export const validateBackupForwardBoundaryForStructuralEdit = (
+  command: CoreCommand,
+  anchorOrTarget: Element
+): Diagnostic | null => {
+  if (command.type !== "insert_note_after" && command.type !== "delete_note") {
+    return null;
+  }
+  const measure = findAncestorMeasure(anchorOrTarget);
+  if (!measure) return null;
+  if (!measureHasBackupOrForward(measure)) return null;
+
+  return {
+    code: "MVP_UNSUPPORTED_NON_EDITABLE_VOICE",
+    message: "Operation requires backup/forward restructuring in MVP.",
+  };
+};
+
+export const validateProjectedMeasureTiming = (
+  noteInMeasure: Element,
+  voice: string,
+  projectedOccupiedTime: number
+): { diagnostic: Diagnostic | null; warning: Warning | null } => {
+  const timing = getMeasureTimingForVoice(noteInMeasure, voice);
+  if (!timing) return { diagnostic: null, warning: null };
+
+  if (projectedOccupiedTime > timing.capacity) {
+    return {
+      diagnostic: {
+        code: "MEASURE_OVERFULL",
+        message: `Projected occupied time ${projectedOccupiedTime} exceeds capacity ${timing.capacity}.`,
+      },
+      warning: null,
+    };
+  }
+
+  if (projectedOccupiedTime < timing.capacity) {
+    return {
+      diagnostic: null,
+      warning: {
+        code: "MEASURE_UNDERFULL",
+        message: `Projected occupied time ${projectedOccupiedTime} is below capacity ${timing.capacity}.`,
+      },
+    };
+  }
+
+  return { diagnostic: null, warning: null };
+};

--- a/core/xmlUtils.ts
+++ b/core/xmlUtils.ts
@@ -1,0 +1,144 @@
+import type { NodeId, Pitch } from "./interfaces";
+
+const SCORE_PARTWISE = "score-partwise";
+
+export const parseXml = (xmlText: string): XMLDocument => {
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(xmlText, "application/xml");
+  const parserError = doc.querySelector("parsererror");
+  if (parserError) {
+    throw new Error("Invalid XML input.");
+  }
+  const root = doc.documentElement;
+  if (!root || root.tagName !== SCORE_PARTWISE) {
+    throw new Error("MusicXML root must be <score-partwise>.");
+  }
+  return doc;
+};
+
+export const serializeXml = (doc: XMLDocument): string =>
+  new XMLSerializer().serializeToString(doc);
+
+/**
+ * Assigns stable-in-session node IDs without mutating XML.
+ */
+export const reindexNodeIds = (
+  doc: XMLDocument,
+  nodeToId: WeakMap<Node, NodeId>,
+  idToNode: Map<NodeId, Element>,
+  nextId: () => NodeId
+): void => {
+  idToNode.clear();
+  const notes = doc.querySelectorAll("note");
+  for (const note of notes) {
+    const existing = nodeToId.get(note);
+    const id = existing ?? nextId();
+    nodeToId.set(note, id);
+    idToNode.set(id, note);
+  }
+};
+
+export const getVoiceText = (note: Element): string | null => {
+  const voice = getDirectChild(note, "voice");
+  return voice?.textContent?.trim() ?? null;
+};
+
+export const getDurationValue = (note: Element): number | null => {
+  const duration = getDirectChild(note, "duration");
+  if (!duration?.textContent) return null;
+  const n = Number(duration.textContent.trim());
+  return Number.isFinite(n) ? n : null;
+};
+
+export const setDurationValue = (note: Element, duration: number): void => {
+  let durationNode = getDirectChild(note, "duration");
+  if (!durationNode) {
+    durationNode = note.ownerDocument.createElement("duration");
+    note.appendChild(durationNode);
+  }
+  durationNode.textContent = String(duration);
+};
+
+export const setPitch = (note: Element, pitch: Pitch): void => {
+  let pitchNode = getDirectChild(note, "pitch");
+  if (!pitchNode) {
+    pitchNode = note.ownerDocument.createElement("pitch");
+    // Keep patch local by adding pitch near start, but do not reorder siblings.
+    note.insertBefore(pitchNode, note.firstChild);
+  }
+
+  upsertSimpleChild(pitchNode, "step", pitch.step);
+  if (typeof pitch.alter === "number") {
+    upsertSimpleChild(pitchNode, "alter", String(pitch.alter));
+  } else {
+    const alter = getDirectChild(pitchNode, "alter");
+    if (alter) alter.remove();
+  }
+  upsertSimpleChild(pitchNode, "octave", String(pitch.octave));
+};
+
+export const isUnsupportedNoteKind = (note: Element): boolean =>
+  hasDirectChild(note, "grace") ||
+  hasDirectChild(note, "cue") ||
+  hasDirectChild(note, "chord") ||
+  hasDirectChild(note, "rest");
+
+export const createNoteElement = (
+  doc: XMLDocument,
+  voice: string,
+  duration: number,
+  pitch: Pitch
+): Element => {
+  const note = doc.createElement("note");
+
+  const pitchNode = doc.createElement("pitch");
+  upsertSimpleChild(pitchNode, "step", pitch.step);
+  if (typeof pitch.alter === "number") {
+    upsertSimpleChild(pitchNode, "alter", String(pitch.alter));
+  }
+  upsertSimpleChild(pitchNode, "octave", String(pitch.octave));
+  note.appendChild(pitchNode);
+
+  const durationNode = doc.createElement("duration");
+  durationNode.textContent = String(duration);
+  note.appendChild(durationNode);
+
+  const voiceNode = doc.createElement("voice");
+  voiceNode.textContent = voice;
+  note.appendChild(voiceNode);
+
+  return note;
+};
+
+export const findAncestorMeasure = (node: Element): Element | null => {
+  let cursor: Element | null = node;
+  while (cursor) {
+    if (cursor.tagName === "measure") return cursor;
+    cursor = cursor.parentElement;
+  }
+  return null;
+};
+
+export const measureHasBackupOrForward = (measure: Element): boolean =>
+  Array.from(measure.children).some(
+    (child) => child.tagName === "backup" || child.tagName === "forward"
+  );
+
+const upsertSimpleChild = (
+  parent: Element,
+  tagName: string,
+  value: string
+): void => {
+  let node = getDirectChild(parent, tagName);
+  if (!node) {
+    node = parent.ownerDocument.createElement(tagName);
+    parent.appendChild(node);
+  }
+  node.textContent = value;
+};
+
+const hasDirectChild = (parent: Element, tagName: string): boolean =>
+  Array.from(parent.children).some((child) => child.tagName === tagName);
+
+const getDirectChild = (parent: Element, tagName: string): Element | null =>
+  Array.from(parent.children).find((child) => child.tagName === tagName) ?? null;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "mikuscore",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test:unit": "vitest run",
+    "test:unit:watch": "vitest"
+  },
+  "devDependencies": {
+    "@types/node": "^24.3.0",
+    "typescript": "5.9.3",
+    "vitest": "^3.2.0",
+    "jsdom": "^26.1.0"
+  }
+}

--- a/tests/unit/core.spec.ts
+++ b/tests/unit/core.spec.ts
@@ -1,0 +1,128 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from "vitest";
+import { ScoreCore } from "../../core/ScoreCore";
+
+const BASE_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list>
+    <score-part id="P1"><part-name>Music</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+      </attributes>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>1</duration><voice>1</voice></note>
+      <note><pitch><step>D</step><octave>4</octave></pitch><duration>1</duration><voice>1</voice></note>
+      <note><pitch><step>E</step><octave>4</octave></pitch><duration>1</duration><voice>1</voice></note>
+      <note><pitch><step>F</step><octave>4</octave></pitch><duration>1</duration><voice>1</voice></note>
+    </measure>
+  </part>
+</score-partwise>`;
+
+describe("ScoreCore MVP", () => {
+  it("RT-0: no-op save returns original text", () => {
+    const core = new ScoreCore();
+    core.load(BASE_XML);
+
+    const saved = core.save();
+    expect(saved.ok).toBe(true);
+    expect(saved.mode).toBe("original_noop");
+    expect(saved.xml).toBe(BASE_XML);
+  });
+
+  it("RT-1: pitch change returns serialized output", () => {
+    const core = new ScoreCore();
+    core.load(BASE_XML);
+    const [first] = core.listNoteNodeIds();
+
+    const result = core.dispatch({
+      type: "change_pitch",
+      targetNodeId: first,
+      voice: "1",
+      pitch: { step: "G", octave: 5 },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(core.isDirty()).toBe(true);
+
+    const saved = core.save();
+    expect(saved.ok).toBe(true);
+    expect(saved.mode).toBe("serialized_dirty");
+    expect(saved.xml).toContain("<step>G</step>");
+    expect(saved.xml).toContain("<octave>5</octave>");
+  });
+
+  it("TI-1: overfull is rejected", () => {
+    const core = new ScoreCore();
+    core.load(BASE_XML);
+    const [first] = core.listNoteNodeIds();
+
+    const result = core.dispatch({
+      type: "change_duration",
+      targetNodeId: first,
+      voice: "1",
+      duration: 2,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.diagnostics[0]?.code).toBe("MEASURE_OVERFULL");
+    expect(core.isDirty()).toBe(false);
+  });
+
+  it("BF-1: non-editable voice is rejected", () => {
+    const core = new ScoreCore();
+    core.load(BASE_XML);
+    const [first] = core.listNoteNodeIds();
+
+    const result = core.dispatch({
+      type: "change_pitch",
+      targetNodeId: first,
+      voice: "2",
+      pitch: { step: "A", octave: 4 },
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.diagnostics[0]?.code).toBe("MVP_UNSUPPORTED_NON_EDITABLE_VOICE");
+  });
+
+  it("NK-1: unsupported note kind is rejected", () => {
+    const xmlWithRest = BASE_XML.replace(
+      "<note><pitch><step>C</step><octave>4</octave></pitch><duration>1</duration><voice>1</voice></note>",
+      "<note><rest/><duration>1</duration><voice>1</voice></note>"
+    );
+    const core = new ScoreCore();
+    core.load(xmlWithRest);
+    const [first] = core.listNoteNodeIds();
+
+    const result = core.dispatch({
+      type: "delete_note",
+      targetNodeId: first,
+      voice: "1",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.diagnostics[0]?.code).toBe("MVP_UNSUPPORTED_NOTE_KIND");
+  });
+
+  it("PT-1: unknown elements are preserved", () => {
+    const xmlWithUnknown = BASE_XML.replace(
+      "</measure>",
+      "<unknown-tag foo=\"bar\">x</unknown-tag></measure>"
+    );
+    const core = new ScoreCore();
+    core.load(xmlWithUnknown);
+    const [first] = core.listNoteNodeIds();
+    core.dispatch({
+      type: "change_pitch",
+      targetNodeId: first,
+      voice: "1",
+      pitch: { step: "B", octave: 4 },
+    });
+
+    const saved = core.save();
+    expect(saved.ok).toBe(true);
+    expect(saved.xml).toContain("<unknown-tag foo=\"bar\">x</unknown-tag>");
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2018",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "noEmit": true,
+    "lib": ["DOM", "DOM.Iterable", "ES2018"]
+  },
+  "include": ["core/**/*.ts"]
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "jsdom",
+    include: ["tests/unit/**/*.spec.ts"],
+  },
+});


### PR DESCRIPTION
## 概要
「既存MusicXMLを壊さず編集する」MVP方針に沿って、Core実装の初版とユニットテスト基盤を追加しました。 本PRで `load / dispatch / save` の最小一式と、主要仕様の挙動テストを導入しています。

## 変更内容

### Core実装を新規追加
- `core/interfaces.ts`
  - コマンド/診断/保存結果の型定義
- `core/ScoreCore.ts`
  - `load`, `dispatch`, `save`, `dirty` 管理
  - `original_noop` / `serialized_dirty` の保存モード
  - overfull時の拒否、非編集voice拒否、unsupported note kind拒否
- `core/commands.ts`
  - コマンド判定ユーティリティ
- `core/xmlUtils.ts`
  - parse/serialize、最小パッチ編集ヘルパ、nodeId再索引
- `core/timeIndex.ts`
  - measure capacity / occupied time 計算
- `core/validators.ts`
  - voice制約、note kind制約、backup/forward境界、時間整合チェック
- `core/index.ts`
  - エクスポート集約

### テスト追加（Vitest）
- `tests/unit/core.spec.ts`
  - RT-0: no-op save
  - RT-1: pitch change save
  - TI-1: overfull reject
  - BF-1: non-editable voice reject
  - NK-1: unsupported note kind reject
  - PT-1: unknown elements preserve

### 開発基盤追加
- `package.json`
  - `typecheck`, `test:unit`, `test:unit:watch`
- `tsconfig.json`
- `vitest.config.ts`
- `.gitignore` (`node_modules/`, `coverage/`)
- `README.md` に実装方針追記

## 目的
- MVP仕様をコード化して、実装/検証ループを開始可能にする
- 「壊さない編集」をテストで担保する土台を作る

## 影響範囲
- 新規Coreコード追加
- テスト基盤追加
- ドキュメント軽微更新

## テスト結果
- `npm run typecheck` : ✅
- `npm run test:unit` : ✅ (6 tests passed)

## 補足
- 現段階はMVP初版のため、対応範囲は仕様で定義した最小セットに限定
- UI実装は本PRスコープ外