### PR TITLE
MVP UI/ビルド基盤を追加し、デバッグ再生とchord時間計算の整合性を修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,15 @@ MVPが尖って見えるのは、機能を削ってでも round-trip の信頼�
 - 開発形態: 分割 TypeScript ソース
 - ビルド方針: `mikuscore-src.html` + `src/` から `mikuscore.html` を生成
 
+## 開発コマンド
+
+- `npm run build`: `mikuscore-src.html` と `src/` から `mikuscore.html`（配布物）を生成
+- `npm run clean`: 生成物（`mikuscore.html`, `src/js/main.js`）を削除
+- `npm run typecheck`: 型チェック
+- `npm run test:unit`: ユニットテスト
+- `npm run test:property`: propertyテスト
+- `npm run test:all`: 全テスト
+
 ## ドキュメント
 
 - `SPEC.md`: MVP コア仕様

--- a/core/ScoreCore.ts
+++ b/core/ScoreCore.ts
@@ -205,6 +205,15 @@ export class ScoreCore {
     return Array.from(this.idToNode.keys());
   }
 
+  /**
+   * Debug-only helper for UI diagnostics.
+   * Returns current in-memory XML regardless of dirty/validation state.
+   */
+  public debugSerializeCurrentXml(): string | null {
+    if (!this.doc) return null;
+    return serializeXml(this.doc);
+  }
+
   private nextNodeId(): NodeId {
     this.nodeCounter += 1;
     return `n${this.nodeCounter}`;

--- a/core/timeIndex.ts
+++ b/core/timeIndex.ts
@@ -42,6 +42,8 @@ export const getOccupiedTime = (measure: Element, voice: string): number => {
   let total = 0;
   for (const child of directChildren) {
     if (child.tagName !== "note") continue;
+    // Chord notes share onset with the previous note and must not advance time.
+    if (Array.from(child.children).some((c) => c.tagName === "chord")) continue;
     const noteVoice = getVoiceText(child);
     if (noteVoice !== voice) continue;
     const duration = getDurationValue(child);

--- a/docs/spec/UI_SPEC.md
+++ b/docs/spec/UI_SPEC.md
@@ -1,0 +1,149 @@
+# UI Specification (MVP)
+
+## Purpose
+
+This document defines MVP UI behavior for `mikuscore` while preserving core guarantees.
+
+UI is an interaction layer only. Core remains the single source of truth for score mutation.
+
+## Non-Negotiable Rule
+
+- UI MUST NOT mutate XML DOM directly.
+- UI MUST call core APIs only: `load(xml)`, `dispatch(command)`, `save()`.
+
+## Screen Layout (MVP)
+
+1. Input Panel
+- Paste/import MusicXML text
+- `Load` button
+
+2. Editor Panel
+- Note list (by `nodeId`, voice, pitch, duration)
+- Selection state (`selectedNodeId`)
+- Command controls:
+  - change pitch
+  - change duration
+  - insert note after selected
+  - delete selected note
+
+3. Diagnostics Panel
+- Last dispatch diagnostics/warnings
+- Last save diagnostics
+
+4. Output Panel
+- Save mode display (`original_noop` / `serialized_dirty`)
+- Output XML textarea (read-only in MVP)
+- Download button
+
+## Input Panel Pattern (Recommended)
+
+Use the same interaction pattern as existing music tools:
+
+- Input mode radio:
+  - `file` (default)
+  - `source`
+- Two mutually exclusive blocks:
+  - `sourceInputBlock`: textarea for MusicXML paste/edit
+  - `fileInputBlock`: file selection UI + hidden file input
+
+Recommended element IDs:
+
+- `inputModeFile`
+- `inputModeSource`
+- `sourceInputBlock`
+- `fileInputBlock`
+- `xmlInput`
+- `fileSelectBtn`
+- `fileInput`
+- `fileNameText`
+- `loadBtn`
+
+Recommended behavior:
+
+1. On mode change, UI MUST toggle visibility between source/file blocks.
+2. File mode:
+- clicking `fileSelectBtn` opens hidden `fileInput`
+- selected file name is shown in `fileNameText`
+- file text is read as UTF-8 and copied to `xmlInput`
+3. Source mode:
+- `xmlInput` is the authoritative source text
+4. `loadBtn` always calls `core.load(xmlInput.value)` after source text is prepared.
+
+## UI State Model (MVP)
+
+```ts
+type UiState = {
+  loaded: boolean;
+  dirty: boolean;
+  selectedNodeId: string | null;
+  noteNodeIds: string[];
+  lastDispatchResult: DispatchResult | null;
+  lastSaveResult: SaveResult | null;
+  sourceXmlText: string;
+  outputXmlText: string;
+};
+```
+
+## Core Integration Contract
+
+1. `Load` action
+- Input: raw XML text
+- Effect:
+  - call `core.load(xml)`
+  - refresh `noteNodeIds = core.listNoteNodeIds()`
+  - reset selection, dispatch/save results
+  - set `dirty = core.isDirty()`
+
+2. `Dispatch` action
+- Preconditions:
+  - score loaded
+  - command payload built from current UI controls
+- Effect:
+  - call `core.dispatch(command)`
+  - store `lastDispatchResult`
+  - refresh `noteNodeIds`
+  - set `dirty = core.isDirty()`
+  - if selected node deleted, clear selection
+
+3. `Save` action
+- Effect:
+  - call `core.save()`
+  - store `lastSaveResult`
+  - if `ok=true`, set `outputXmlText = result.xml`
+
+## Selection and Command Rules
+
+- Selection key is `nodeId` only.
+- If `selectedNodeId` is missing from refreshed `noteNodeIds`, UI MUST clear selection.
+- UI MAY pre-validate obvious required fields, but core validation is authoritative.
+
+## Diagnostics Display Policy
+
+- Display diagnostics/warnings in arrival order.
+- Always show `code` and `message`.
+- Error color and warning color MUST be visually distinct.
+- UI MUST NOT hide core diagnostics.
+
+## Dirty Display Policy
+
+- Dirty indicator is derived from `core.isDirty()`.
+- `ui_noop` operations MUST NOT change dirty indicator.
+
+## Save/Download Policy
+
+- Download uses the latest successful `save()` output only.
+- If `save().ok=false`, download MUST be disabled until next successful save.
+
+## Accessibility (MVP)
+
+- Keyboard focus order across panels MUST be predictable.
+- Buttons MUST have clear labels.
+- Diagnostics area SHOULD be screen-reader friendly (live region recommended).
+
+## Out of Scope (MVP UI)
+
+- Notation rendering
+- Advanced keyboard editing model
+- Undo/redo history
+- Multi-voice editing workflow
+- Pretty-print or XML text formatting features

--- a/mikuscore-src.html
+++ b/mikuscore-src.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>mikuscore</title>
+  <link rel="stylesheet" href="src/css/app.css" />
+</head>
+<body>
+  <main class="ms-shell">
+    <section class="ms-card">
+      <h1 class="ms-title">mikuscore (MVP)</h1>
+      <p class="ms-intro">
+        既存MusicXMLを壊さずに、安全に最小編集するためのMVPエディタです。
+      </p>
+      <ol class="ms-steps">
+        <li>「サンプルを読む」または MusicXML を読み込み</li>
+        <li>ノート(nodeId)を選択してコマンド実行</li>
+        <li>Save して Output XML / Download で結果確認</li>
+      </ol>
+      <div class="ms-actions">
+        <button id="loadSampleBtn" type="button">サンプルを読む（ソース入力）</button>
+      </div>
+
+      <section class="ms-section">
+        <h2>MusicXML入力</h2>
+        <div class="ms-radio-group" role="radiogroup" aria-label="入力方式">
+          <label><input id="inputModeFile" type="radio" name="inputMode" value="file" checked /> ファイル読込</label>
+          <label><input id="inputModeSource" type="radio" name="inputMode" value="source" /> ソース入力</label>
+        </div>
+
+        <div id="fileInputBlock" class="ms-block">
+          <button id="fileSelectBtn" type="button">ファイルを選択</button>
+          <span id="fileNameText">未選択</span>
+          <input id="fileInput" type="file" accept=".musicxml,.xml,text/xml,application/xml" hidden />
+        </div>
+
+        <div id="sourceInputBlock" class="ms-block ms-hidden">
+          <label for="xmlInput" class="ms-label">MusicXML</label>
+          <textarea id="xmlInput" rows="12" spellcheck="false"></textarea>
+        </div>
+
+        <div class="ms-actions">
+          <button id="loadBtn" type="button">Load</button>
+        </div>
+      </section>
+
+      <section class="ms-section">
+        <h2>Editor</h2>
+        <p id="statusText">未ロード</p>
+        <label for="noteSelect" class="ms-label">ノート選択 (nodeId)</label>
+        <select id="noteSelect"></select>
+
+        <div class="ms-grid">
+          <label>step
+            <select id="pitchStep">
+              <option value="C">C</option>
+              <option value="D">D</option>
+              <option value="E">E</option>
+              <option value="F">F</option>
+              <option value="G">G</option>
+              <option value="A">A</option>
+              <option value="B">B</option>
+            </select>
+          </label>
+          <label>alter
+            <select id="pitchAlter">
+              <option value="">none</option>
+              <option value="-2">-2</option>
+              <option value="-1">-1</option>
+              <option value="0">0</option>
+              <option value="1">1</option>
+              <option value="2">2</option>
+            </select>
+          </label>
+          <label>octave
+            <input id="pitchOctave" type="number" min="0" max="9" step="1" value="4" />
+          </label>
+          <label>duration
+            <input id="durationInput" type="number" min="1" step="1" value="1" />
+          </label>
+        </div>
+
+        <div class="ms-actions">
+          <button id="changePitchBtn" type="button">change_pitch</button>
+          <button id="changeDurationBtn" type="button">change_duration</button>
+          <button id="insertAfterBtn" type="button">insert_note_after</button>
+          <button id="deleteBtn" type="button">delete_note</button>
+        </div>
+      </section>
+
+      <section class="ms-section">
+        <h2>Save / Output</h2>
+        <div class="ms-actions">
+          <button id="saveBtn" type="button">Save</button>
+          <button id="playBtn" type="button">デバッグ再生</button>
+          <button id="stopBtn" type="button" disabled>停止</button>
+          <button id="downloadBtn" type="button" disabled>Download XML</button>
+        </div>
+        <p id="playbackText">playback: idle</p>
+        <p>save mode: <span id="saveModeText">-</span></p>
+        <label for="outputXml" class="ms-label">Output XML</label>
+        <textarea id="outputXml" rows="12" readonly></textarea>
+      </section>
+
+      <section class="ms-section">
+        <h2>Diagnostics</h2>
+        <div id="diagArea" aria-live="polite"></div>
+      </section>
+    </section>
+  </main>
+
+  <script src="src/js/main.js"></script>
+</body>
+</html>

--- a/mikuscore.html
+++ b/mikuscore.html
@@ -1,0 +1,1742 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>mikuscore</title>
+  <style>
+:root {
+  --bg: #f5f7fb;
+  --card: #ffffff;
+  --text: #17212b;
+  --muted: #4b5d73;
+  --border: #d8e1ed;
+  --primary: #1456d8;
+  --danger: #c02626;
+  --warn: #9a6700;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "BIZ UDPGothic", "Hiragino Sans", "Yu Gothic", sans-serif;
+  color: var(--text);
+  background: radial-gradient(circle at top left, #e6edff 0%, var(--bg) 60%);
+}
+
+.ms-shell {
+  max-width: 980px;
+  margin: 0 auto;
+  padding: 24px;
+}
+
+.ms-card {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 18px;
+}
+
+.ms-title {
+  margin: 0 0 8px;
+}
+
+.ms-intro {
+  margin: 0 0 8px;
+  color: var(--muted);
+}
+
+.ms-steps {
+  margin: 0 0 10px;
+  padding-left: 1.2rem;
+  color: var(--muted);
+}
+
+.ms-section {
+  border-top: 1px solid var(--border);
+  padding-top: 12px;
+  margin-top: 14px;
+}
+
+.ms-section h2 {
+  margin: 0 0 10px;
+  font-size: 1rem;
+}
+
+.ms-block {
+  margin-bottom: 10px;
+}
+
+.ms-hidden {
+  display: none;
+}
+
+.ms-label {
+  display: block;
+  margin-bottom: 4px;
+  color: var(--muted);
+}
+
+.ms-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.ms-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 8px;
+}
+
+textarea,
+input,
+select,
+button {
+  width: 100%;
+  font: inherit;
+}
+
+textarea,
+input,
+select {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 8px;
+}
+
+button {
+  border: 1px solid var(--primary);
+  border-radius: 8px;
+  padding: 8px 10px;
+  background: #eff4ff;
+  color: #0f397e;
+  cursor: pointer;
+}
+
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.ms-radio-group {
+  display: flex;
+  gap: 16px;
+  margin-bottom: 8px;
+}
+
+.ms-radio-group label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.ms-radio-group input {
+  width: auto;
+}
+
+#diagArea .diag-error {
+  color: var(--danger);
+}
+
+#diagArea .diag-warning {
+  color: var(--warn);
+}
+
+#statusText {
+  margin: 0 0 8px;
+  color: var(--muted);
+}
+
+#playbackText {
+  margin: 8px 0 0;
+  color: var(--muted);
+}
+
+@media (max-width: 768px) {
+  .ms-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+</style>
+</head>
+<body>
+  <main class="ms-shell">
+    <section class="ms-card">
+      <h1 class="ms-title">mikuscore (MVP)</h1>
+      <p class="ms-intro">
+        既存MusicXMLを壊さずに、安全に最小編集するためのMVPエディタです。
+      </p>
+      <ol class="ms-steps">
+        <li>「サンプルを読む」または MusicXML を読み込み</li>
+        <li>ノート(nodeId)を選択してコマンド実行</li>
+        <li>Save して Output XML / Download で結果確認</li>
+      </ol>
+      <div class="ms-actions">
+        <button id="loadSampleBtn" type="button">サンプルを読む（ソース入力）</button>
+      </div>
+
+      <section class="ms-section">
+        <h2>MusicXML入力</h2>
+        <div class="ms-radio-group" role="radiogroup" aria-label="入力方式">
+          <label><input id="inputModeFile" type="radio" name="inputMode" value="file" checked /> ファイル読込</label>
+          <label><input id="inputModeSource" type="radio" name="inputMode" value="source" /> ソース入力</label>
+        </div>
+
+        <div id="fileInputBlock" class="ms-block">
+          <button id="fileSelectBtn" type="button">ファイルを選択</button>
+          <span id="fileNameText">未選択</span>
+          <input id="fileInput" type="file" accept=".musicxml,.xml,text/xml,application/xml" hidden />
+        </div>
+
+        <div id="sourceInputBlock" class="ms-block ms-hidden">
+          <label for="xmlInput" class="ms-label">MusicXML</label>
+          <textarea id="xmlInput" rows="12" spellcheck="false"></textarea>
+        </div>
+
+        <div class="ms-actions">
+          <button id="loadBtn" type="button">Load</button>
+        </div>
+      </section>
+
+      <section class="ms-section">
+        <h2>Editor</h2>
+        <p id="statusText">未ロード</p>
+        <label for="noteSelect" class="ms-label">ノート選択 (nodeId)</label>
+        <select id="noteSelect"></select>
+
+        <div class="ms-grid">
+          <label>step
+            <select id="pitchStep">
+              <option value="C">C</option>
+              <option value="D">D</option>
+              <option value="E">E</option>
+              <option value="F">F</option>
+              <option value="G">G</option>
+              <option value="A">A</option>
+              <option value="B">B</option>
+            </select>
+          </label>
+          <label>alter
+            <select id="pitchAlter">
+              <option value="">none</option>
+              <option value="-2">-2</option>
+              <option value="-1">-1</option>
+              <option value="0">0</option>
+              <option value="1">1</option>
+              <option value="2">2</option>
+            </select>
+          </label>
+          <label>octave
+            <input id="pitchOctave" type="number" min="0" max="9" step="1" value="4" />
+          </label>
+          <label>duration
+            <input id="durationInput" type="number" min="1" step="1" value="1" />
+          </label>
+        </div>
+
+        <div class="ms-actions">
+          <button id="changePitchBtn" type="button">change_pitch</button>
+          <button id="changeDurationBtn" type="button">change_duration</button>
+          <button id="insertAfterBtn" type="button">insert_note_after</button>
+          <button id="deleteBtn" type="button">delete_note</button>
+        </div>
+      </section>
+
+      <section class="ms-section">
+        <h2>Save / Output</h2>
+        <div class="ms-actions">
+          <button id="saveBtn" type="button">Save</button>
+          <button id="playBtn" type="button">デバッグ再生</button>
+          <button id="stopBtn" type="button" disabled>停止</button>
+          <button id="downloadBtn" type="button" disabled>Download XML</button>
+        </div>
+        <p id="playbackText">playback: idle</p>
+        <p>save mode: <span id="saveModeText">-</span></p>
+        <label for="outputXml" class="ms-label">Output XML</label>
+        <textarea id="outputXml" rows="12" readonly></textarea>
+      </section>
+
+      <section class="ms-section">
+        <h2>Diagnostics</h2>
+        <div id="diagArea" aria-live="polite"></div>
+      </section>
+    </section>
+  </main>
+
+  <script>
+(function () {
+const modules = {
+  "src/ts/main.js": function (require, module, exports) {
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const ScoreCore_1 = require("../../core/ScoreCore");
+const timeIndex_1 = require("../../core/timeIndex");
+const EDITABLE_VOICE = "1";
+const sampleXml = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list>
+    <score-part id="P1"><part-name>Music</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+      </attributes>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>1</duration><voice>1</voice></note>
+      <note><pitch><step>D</step><octave>4</octave></pitch><duration>1</duration><voice>1</voice></note>
+      <note><pitch><step>E</step><octave>4</octave></pitch><duration>1</duration><voice>1</voice></note>
+      <note><pitch><step>F</step><octave>4</octave></pitch><duration>1</duration><voice>1</voice></note>
+    </measure>
+  </part>
+</score-partwise>`;
+const q = (selector) => {
+    const el = document.querySelector(selector);
+    if (!el)
+        throw new Error(`Missing element: ${selector}`);
+    return el;
+};
+const inputModeFile = q("#inputModeFile");
+const inputModeSource = q("#inputModeSource");
+const fileInputBlock = q("#fileInputBlock");
+const sourceInputBlock = q("#sourceInputBlock");
+const xmlInput = q("#xmlInput");
+const fileSelectBtn = q("#fileSelectBtn");
+const fileInput = q("#fileInput");
+const fileNameText = q("#fileNameText");
+const loadBtn = q("#loadBtn");
+const loadSampleBtn = q("#loadSampleBtn");
+const noteSelect = q("#noteSelect");
+const statusText = q("#statusText");
+const pitchStep = q("#pitchStep");
+const pitchAlter = q("#pitchAlter");
+const pitchOctave = q("#pitchOctave");
+const durationInput = q("#durationInput");
+const changePitchBtn = q("#changePitchBtn");
+const changeDurationBtn = q("#changeDurationBtn");
+const insertAfterBtn = q("#insertAfterBtn");
+const deleteBtn = q("#deleteBtn");
+const saveBtn = q("#saveBtn");
+const playBtn = q("#playBtn");
+const stopBtn = q("#stopBtn");
+const downloadBtn = q("#downloadBtn");
+const saveModeText = q("#saveModeText");
+const playbackText = q("#playbackText");
+const outputXml = q("#outputXml");
+const diagArea = q("#diagArea");
+const core = new ScoreCore_1.ScoreCore({ editableVoice: EDITABLE_VOICE });
+const state = {
+    loaded: false,
+    selectedNodeId: null,
+    noteNodeIds: [],
+    lastDispatchResult: null,
+    lastSaveResult: null,
+    lastSuccessfulSaveXml: "",
+};
+xmlInput.value = sampleXml;
+let audioContext = null;
+let activeOscillators = [];
+let activeGains = [];
+let playbackTimer = null;
+let isPlaying = false;
+const DEBUG_LOG = true;
+const logDiagnostics = (phase, diagnostics, warnings = []) => {
+    if (!DEBUG_LOG)
+        return;
+    for (const d of diagnostics) {
+        console.error(`[mikuscore][${phase}][${d.code}] ${d.message}`);
+    }
+    for (const w of warnings) {
+        console.warn(`[mikuscore][${phase}][${w.code}] ${w.message}`);
+    }
+};
+const dumpOverfullContext = (xml, voice) => {
+    var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k;
+    if (!DEBUG_LOG)
+        return;
+    const doc = new DOMParser().parseFromString(xml, "application/xml");
+    if (doc.querySelector("parsererror")) {
+        console.error("[mikuscore][debug] XML parse failed while dumping overfull context.");
+        return;
+    }
+    const measures = Array.from(doc.querySelectorAll("part > measure"));
+    let found = false;
+    for (const measure of measures) {
+        const number = (_a = measure.getAttribute("number")) !== null && _a !== void 0 ? _a : "(no-number)";
+        const divisionsText = (_d = (_c = (_b = measure.querySelector("attributes > divisions")) === null || _b === void 0 ? void 0 : _b.textContent) === null || _c === void 0 ? void 0 : _c.trim()) !== null && _d !== void 0 ? _d : "(inherit)";
+        const beatsText = (_g = (_f = (_e = measure.querySelector("attributes > time > beats")) === null || _e === void 0 ? void 0 : _e.textContent) === null || _f === void 0 ? void 0 : _f.trim()) !== null && _g !== void 0 ? _g : "(inherit)";
+        const beatTypeText = (_k = (_j = (_h = measure.querySelector("attributes > time > beat-type")) === null || _h === void 0 ? void 0 : _h.textContent) === null || _j === void 0 ? void 0 : _j.trim()) !== null && _k !== void 0 ? _k : "(inherit)";
+        const noteRows = [];
+        const occupied = (0, timeIndex_1.getOccupiedTime)(measure, voice);
+        Array.from(measure.children).forEach((child, idx) => {
+            var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p;
+            if (child.tagName !== "note")
+                return;
+            const noteVoice = (_c = (_b = (_a = child.querySelector("voice")) === null || _a === void 0 ? void 0 : _a.textContent) === null || _b === void 0 ? void 0 : _b.trim()) !== null && _c !== void 0 ? _c : "";
+            const duration = Number((_f = (_e = (_d = child.querySelector("duration")) === null || _d === void 0 ? void 0 : _d.textContent) === null || _e === void 0 ? void 0 : _e.trim()) !== null && _f !== void 0 ? _f : "");
+            const isRest = Boolean(child.querySelector("rest"));
+            const step = (_j = (_h = (_g = child.querySelector("pitch > step")) === null || _g === void 0 ? void 0 : _g.textContent) === null || _h === void 0 ? void 0 : _h.trim()) !== null && _j !== void 0 ? _j : "";
+            const alter = (_l = (_k = child.querySelector("pitch > alter")) === null || _k === void 0 ? void 0 : _k.textContent) === null || _l === void 0 ? void 0 : _l.trim();
+            const octave = (_p = (_o = (_m = child.querySelector("pitch > octave")) === null || _m === void 0 ? void 0 : _m.textContent) === null || _o === void 0 ? void 0 : _o.trim()) !== null && _p !== void 0 ? _p : "";
+            const alterText = alter ? `${alter >= "0" ? "+" : ""}${alter}` : "";
+            const pitch = isRest ? "rest" : `${step}${alterText}${octave ? octave : ""}`;
+            noteRows.push({
+                idx,
+                voice: noteVoice || "(none)",
+                duration: Number.isFinite(duration) ? duration : NaN,
+                pitch,
+                isRest,
+            });
+        });
+        const capacity = (0, timeIndex_1.getMeasureCapacity)(measure);
+        if (capacity === null)
+            continue;
+        if (occupied <= capacity)
+            continue;
+        found = true;
+        console.groupCollapsed(`[mikuscore][debug][MEASURE_OVERFULL] measure=${number} occupied=${occupied} capacity=${capacity}`);
+        console.log({
+            measure: number,
+            voice,
+            divisions: divisionsText,
+            beats: beatsText,
+            beatType: beatTypeText,
+            occupied,
+            capacity,
+        });
+        console.table(noteRows);
+        console.groupEnd();
+    }
+    if (!found) {
+        console.warn("[mikuscore][debug] no overfull measure found while dumping context.");
+    }
+};
+const renderInputMode = () => {
+    const fileMode = inputModeFile.checked;
+    fileInputBlock.classList.toggle("ms-hidden", !fileMode);
+    sourceInputBlock.classList.toggle("ms-hidden", fileMode);
+};
+const renderStatus = () => {
+    const dirty = core.isDirty();
+    statusText.textContent = state.loaded
+        ? `ロード済み / dirty=${dirty} / notes=${state.noteNodeIds.length}`
+        : "未ロード（まず Load してください）";
+};
+const renderNotes = () => {
+    noteSelect.innerHTML = "";
+    const placeholder = document.createElement("option");
+    placeholder.value = "";
+    placeholder.textContent = state.noteNodeIds.length === 0 ? "(ノートなし)" : "(選択してください)";
+    noteSelect.appendChild(placeholder);
+    for (const nodeId of state.noteNodeIds) {
+        const option = document.createElement("option");
+        option.value = nodeId;
+        option.textContent = nodeId;
+        noteSelect.appendChild(option);
+    }
+    if (state.selectedNodeId && state.noteNodeIds.includes(state.selectedNodeId)) {
+        noteSelect.value = state.selectedNodeId;
+    }
+    else {
+        state.selectedNodeId = null;
+        noteSelect.value = "";
+    }
+};
+const renderDiagnostics = () => {
+    diagArea.innerHTML = "";
+    const dispatch = state.lastDispatchResult;
+    const save = state.lastSaveResult;
+    if (!dispatch && !save) {
+        diagArea.textContent = "診断なし";
+        return;
+    }
+    if (dispatch) {
+        for (const diagnostic of dispatch.diagnostics) {
+            const line = document.createElement("div");
+            line.className = "diag-error";
+            line.textContent = `[dispatch][${diagnostic.code}] ${diagnostic.message}`;
+            diagArea.appendChild(line);
+        }
+        for (const warning of dispatch.warnings) {
+            const line = document.createElement("div");
+            line.className = "diag-warning";
+            line.textContent = `[dispatch][${warning.code}] ${warning.message}`;
+            diagArea.appendChild(line);
+        }
+    }
+    if (save) {
+        for (const diagnostic of save.diagnostics) {
+            const line = document.createElement("div");
+            line.className = "diag-error";
+            line.textContent = `[save][${diagnostic.code}] ${diagnostic.message}`;
+            diagArea.appendChild(line);
+        }
+    }
+    if (!diagArea.firstChild) {
+        diagArea.textContent = "診断なし";
+    }
+};
+const renderOutput = () => {
+    var _a, _b;
+    saveModeText.textContent = state.lastSaveResult ? state.lastSaveResult.mode : "-";
+    outputXml.value = ((_a = state.lastSaveResult) === null || _a === void 0 ? void 0 : _a.ok) ? state.lastSaveResult.xml : "";
+    downloadBtn.disabled = !((_b = state.lastSaveResult) === null || _b === void 0 ? void 0 : _b.ok);
+};
+const renderControlState = () => {
+    const hasSelection = Boolean(state.selectedNodeId);
+    noteSelect.disabled = !state.loaded;
+    changePitchBtn.disabled = !state.loaded || !hasSelection;
+    changeDurationBtn.disabled = !state.loaded || !hasSelection;
+    insertAfterBtn.disabled = !state.loaded || !hasSelection;
+    deleteBtn.disabled = !state.loaded || !hasSelection;
+    saveBtn.disabled = !state.loaded;
+    playBtn.disabled = !state.loaded || isPlaying;
+    stopBtn.disabled = !isPlaying;
+};
+const renderAll = () => {
+    renderInputMode();
+    renderNotes();
+    renderStatus();
+    renderDiagnostics();
+    renderOutput();
+    renderControlState();
+};
+const refreshNotesFromCore = () => {
+    state.noteNodeIds = core.listNoteNodeIds();
+    if (state.selectedNodeId && !state.noteNodeIds.includes(state.selectedNodeId)) {
+        state.selectedNodeId = null;
+    }
+};
+const midiToHz = (midi) => 440 * Math.pow(2, (midi - 69) / 12);
+const pitchToMidi = (step, alter, octave) => {
+    const semitoneMap = {
+        C: 0,
+        D: 2,
+        E: 4,
+        F: 5,
+        G: 7,
+        A: 9,
+        B: 11,
+    };
+    const base = semitoneMap[step];
+    if (base === undefined)
+        return null;
+    return (octave + 1) * 12 + base + alter;
+};
+const getFirstNumber = (el, selector) => {
+    var _a, _b;
+    const text = (_b = (_a = el.querySelector(selector)) === null || _a === void 0 ? void 0 : _a.textContent) === null || _b === void 0 ? void 0 : _b.trim();
+    if (!text)
+        return null;
+    const n = Number(text);
+    return Number.isFinite(n) ? n : null;
+};
+const buildPlaybackEventsFromXml = (xml) => {
+    var _a, _b, _c, _d, _e, _f, _g, _h;
+    const doc = new DOMParser().parseFromString(xml, "application/xml");
+    if (doc.querySelector("parsererror"))
+        return [];
+    const part = doc.querySelector("part");
+    if (!part)
+        return [];
+    let currentDivisions = 1;
+    const defaultTempo = 120;
+    const tempo = (_a = getFirstNumber(doc, "sound[tempo]")) !== null && _a !== void 0 ? _a : defaultTempo;
+    const secPerDivision = 60 / tempo / currentDivisions;
+    const events = [];
+    let cursorSec = 0;
+    let lastNoteStartSec = 0;
+    for (const measure of Array.from(part.querySelectorAll(":scope > measure"))) {
+        const divisions = getFirstNumber(measure, "attributes > divisions");
+        if (divisions && divisions > 0) {
+            currentDivisions = divisions;
+        }
+        const measureSecPerDivision = 60 / tempo / currentDivisions;
+        for (const child of Array.from(measure.children)) {
+            if (child.tagName !== "note")
+                continue;
+            const voice = (_d = (_c = (_b = child.querySelector("voice")) === null || _b === void 0 ? void 0 : _b.textContent) === null || _c === void 0 ? void 0 : _c.trim()) !== null && _d !== void 0 ? _d : "1";
+            if (voice !== EDITABLE_VOICE)
+                continue;
+            const durationValue = getFirstNumber(child, "duration");
+            if (!durationValue || durationValue <= 0)
+                continue;
+            const durationSec = durationValue * measureSecPerDivision;
+            const isRest = Boolean(child.querySelector("rest"));
+            const isChord = Boolean(child.querySelector("chord"));
+            if (isRest) {
+                cursorSec += durationSec;
+                continue;
+            }
+            const step = (_g = (_f = (_e = child.querySelector("pitch > step")) === null || _e === void 0 ? void 0 : _e.textContent) === null || _f === void 0 ? void 0 : _f.trim()) !== null && _g !== void 0 ? _g : "";
+            const octave = getFirstNumber(child, "pitch > octave");
+            const alter = (_h = getFirstNumber(child, "pitch > alter")) !== null && _h !== void 0 ? _h : 0;
+            if (octave === null) {
+                cursorSec += durationSec;
+                continue;
+            }
+            const midi = pitchToMidi(step, alter, octave);
+            if (midi === null) {
+                if (!isChord) {
+                    cursorSec += durationSec;
+                }
+                continue;
+            }
+            const startSec = isChord ? lastNoteStartSec : cursorSec;
+            events.push({
+                freqHz: midiToHz(midi),
+                startSec,
+                durSec: Math.max(0.05, durationSec),
+            });
+            if (!isChord) {
+                lastNoteStartSec = cursorSec;
+                cursorSec += durationSec;
+            }
+        }
+    }
+    // Touch computed variable so TypeScript keeps intent explicit and avoids accidental drift.
+    void secPerDivision;
+    return events;
+};
+const stopPlayback = () => {
+    for (const osc of activeOscillators) {
+        try {
+            osc.stop();
+        }
+        catch (_a) {
+            // ignore stale node stop calls
+        }
+        osc.disconnect();
+    }
+    for (const gain of activeGains) {
+        gain.disconnect();
+    }
+    activeOscillators = [];
+    activeGains = [];
+    if (playbackTimer !== null) {
+        window.clearTimeout(playbackTimer);
+        playbackTimer = null;
+    }
+    isPlaying = false;
+    playbackText.textContent = "playback: idle";
+    renderControlState();
+};
+const startPlayback = async () => {
+    if (!state.loaded || isPlaying)
+        return;
+    const saveResult = core.save();
+    state.lastSaveResult = saveResult;
+    if (!saveResult.ok) {
+        logDiagnostics("playback", saveResult.diagnostics);
+        if (saveResult.diagnostics.some((d) => d.code === "MEASURE_OVERFULL")) {
+            const debugXml = core.debugSerializeCurrentXml();
+            if (debugXml) {
+                dumpOverfullContext(debugXml, EDITABLE_VOICE);
+            }
+            else if (DEBUG_LOG) {
+                console.warn("[mikuscore][debug] no in-memory XML to dump.");
+            }
+        }
+        renderAll();
+        playbackText.textContent = "playback: save failed";
+        return;
+    }
+    const events = buildPlaybackEventsFromXml(saveResult.xml);
+    if (events.length === 0) {
+        playbackText.textContent = "playback: no playable notes";
+        renderControlState();
+        return;
+    }
+    if (!audioContext) {
+        audioContext = new AudioContext();
+    }
+    await audioContext.resume();
+    const now = audioContext.currentTime + 0.02;
+    let maxEnd = 0;
+    for (const event of events) {
+        const gain = audioContext.createGain();
+        gain.gain.setValueAtTime(0.0001, now + event.startSec);
+        gain.gain.exponentialRampToValueAtTime(0.12, now + event.startSec + 0.01);
+        gain.gain.exponentialRampToValueAtTime(0.0001, now + event.startSec + Math.max(0.02, event.durSec * 0.9));
+        gain.connect(audioContext.destination);
+        const osc = audioContext.createOscillator();
+        osc.type = "sine";
+        osc.frequency.setValueAtTime(event.freqHz, now + event.startSec);
+        osc.connect(gain);
+        osc.start(now + event.startSec);
+        osc.stop(now + event.startSec + event.durSec);
+        activeOscillators.push(osc);
+        activeGains.push(gain);
+        maxEnd = Math.max(maxEnd, event.startSec + event.durSec);
+    }
+    isPlaying = true;
+    playbackText.textContent = `playback: playing (${events.length} notes)`;
+    renderControlState();
+    playbackTimer = window.setTimeout(() => {
+        stopPlayback();
+    }, Math.ceil(maxEnd * 1000) + 60);
+    renderAll();
+};
+const readSelectedPitch = () => {
+    const octave = Number(pitchOctave.value);
+    if (!Number.isInteger(octave))
+        return null;
+    const alterText = pitchAlter.value.trim();
+    const base = {
+        step: pitchStep.value,
+        octave,
+    };
+    if (alterText === "")
+        return base;
+    const alter = Number(alterText);
+    if (!Number.isInteger(alter) || alter < -2 || alter > 2)
+        return null;
+    return { ...base, alter: alter };
+};
+const readDuration = () => {
+    const duration = Number(durationInput.value);
+    if (!Number.isInteger(duration) || duration <= 0)
+        return null;
+    return duration;
+};
+const runCommand = (command) => {
+    if (!state.loaded)
+        return;
+    state.lastDispatchResult = core.dispatch(command);
+    if (!state.lastDispatchResult.ok || state.lastDispatchResult.warnings.length > 0) {
+        logDiagnostics("dispatch", state.lastDispatchResult.diagnostics, state.lastDispatchResult.warnings);
+    }
+    state.lastSaveResult = null;
+    if (state.lastDispatchResult.ok) {
+        refreshNotesFromCore();
+    }
+    renderAll();
+};
+const loadFromText = (xml) => {
+    try {
+        core.load(xml);
+    }
+    catch (err) {
+        if (DEBUG_LOG) {
+            console.error("[mikuscore][load] load failed:", err);
+        }
+        state.loaded = false;
+        state.lastDispatchResult = {
+            ok: false,
+            dirtyChanged: false,
+            changedNodeIds: [],
+            affectedMeasureNumbers: [],
+            diagnostics: [
+                {
+                    code: "MVP_COMMAND_EXECUTION_FAILED",
+                    message: err instanceof Error ? err.message : "Load failed.",
+                },
+            ],
+            warnings: [],
+        };
+        state.lastSaveResult = null;
+        logDiagnostics("load", state.lastDispatchResult.diagnostics);
+        renderAll();
+        return;
+    }
+    state.loaded = true;
+    state.selectedNodeId = null;
+    state.lastDispatchResult = null;
+    state.lastSaveResult = null;
+    state.lastSuccessfulSaveXml = "";
+    refreshNotesFromCore();
+    renderAll();
+};
+const onLoadClick = async () => {
+    var _a;
+    if (inputModeFile.checked) {
+        const selected = (_a = fileInput.files) === null || _a === void 0 ? void 0 : _a[0];
+        if (!selected) {
+            state.lastDispatchResult = {
+                ok: false,
+                dirtyChanged: false,
+                changedNodeIds: [],
+                affectedMeasureNumbers: [],
+                diagnostics: [{ code: "MVP_INVALID_COMMAND_PAYLOAD", message: "ファイルを選択してください。" }],
+                warnings: [],
+            };
+            renderAll();
+            return;
+        }
+        const text = await selected.text();
+        xmlInput.value = text;
+    }
+    loadFromText(xmlInput.value);
+};
+const requireSelectedNode = () => {
+    const nodeId = state.selectedNodeId;
+    if (nodeId)
+        return nodeId;
+    state.lastDispatchResult = {
+        ok: false,
+        dirtyChanged: false,
+        changedNodeIds: [],
+        affectedMeasureNumbers: [],
+        diagnostics: [{ code: "MVP_COMMAND_TARGET_MISSING", message: "ノートを選択してください。" }],
+        warnings: [],
+    };
+    renderAll();
+    return null;
+};
+const onChangePitch = () => {
+    const targetNodeId = requireSelectedNode();
+    if (!targetNodeId)
+        return;
+    const pitch = readSelectedPitch();
+    if (!pitch) {
+        state.lastDispatchResult = {
+            ok: false,
+            dirtyChanged: false,
+            changedNodeIds: [],
+            affectedMeasureNumbers: [],
+            diagnostics: [{ code: "MVP_INVALID_COMMAND_PAYLOAD", message: "pitch 入力が不正です。" }],
+            warnings: [],
+        };
+        renderAll();
+        return;
+    }
+    const command = {
+        type: "change_pitch",
+        targetNodeId,
+        voice: EDITABLE_VOICE,
+        pitch,
+    };
+    runCommand(command);
+};
+const onChangeDuration = () => {
+    const targetNodeId = requireSelectedNode();
+    if (!targetNodeId)
+        return;
+    const duration = readDuration();
+    if (!duration) {
+        state.lastDispatchResult = {
+            ok: false,
+            dirtyChanged: false,
+            changedNodeIds: [],
+            affectedMeasureNumbers: [],
+            diagnostics: [{ code: "MVP_INVALID_COMMAND_PAYLOAD", message: "duration 入力が不正です。" }],
+            warnings: [],
+        };
+        renderAll();
+        return;
+    }
+    const command = {
+        type: "change_duration",
+        targetNodeId,
+        voice: EDITABLE_VOICE,
+        duration,
+    };
+    runCommand(command);
+};
+const onInsertAfter = () => {
+    const anchorNodeId = requireSelectedNode();
+    if (!anchorNodeId)
+        return;
+    const duration = readDuration();
+    const pitch = readSelectedPitch();
+    if (!duration || !pitch) {
+        state.lastDispatchResult = {
+            ok: false,
+            dirtyChanged: false,
+            changedNodeIds: [],
+            affectedMeasureNumbers: [],
+            diagnostics: [{ code: "MVP_INVALID_COMMAND_PAYLOAD", message: "挿入ノート入力が不正です。" }],
+            warnings: [],
+        };
+        renderAll();
+        return;
+    }
+    const command = {
+        type: "insert_note_after",
+        anchorNodeId,
+        voice: EDITABLE_VOICE,
+        note: { duration, pitch },
+    };
+    runCommand(command);
+};
+const onDelete = () => {
+    const targetNodeId = requireSelectedNode();
+    if (!targetNodeId)
+        return;
+    const command = {
+        type: "delete_note",
+        targetNodeId,
+        voice: EDITABLE_VOICE,
+    };
+    runCommand(command);
+};
+const onSave = () => {
+    if (!state.loaded)
+        return;
+    const result = core.save();
+    state.lastSaveResult = result;
+    if (!result.ok) {
+        logDiagnostics("save", result.diagnostics);
+        if (result.diagnostics.some((d) => d.code === "MEASURE_OVERFULL")) {
+            const debugXml = core.debugSerializeCurrentXml();
+            if (debugXml) {
+                dumpOverfullContext(debugXml, EDITABLE_VOICE);
+            }
+            else if (DEBUG_LOG) {
+                console.warn("[mikuscore][debug] no in-memory XML to dump.");
+            }
+        }
+    }
+    if (result.ok) {
+        state.lastSuccessfulSaveXml = result.xml;
+    }
+    renderAll();
+};
+const onDownload = () => {
+    if (!state.lastSuccessfulSaveXml)
+        return;
+    const blob = new Blob([state.lastSuccessfulSaveXml], { type: "application/xml;charset=utf-8" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "mikuscore.musicxml";
+    a.click();
+    URL.revokeObjectURL(url);
+};
+inputModeFile.addEventListener("change", renderInputMode);
+inputModeSource.addEventListener("change", renderInputMode);
+fileSelectBtn.addEventListener("click", () => fileInput.click());
+fileInput.addEventListener("change", () => {
+    var _a;
+    const f = (_a = fileInput.files) === null || _a === void 0 ? void 0 : _a[0];
+    fileNameText.textContent = f ? f.name : "未選択";
+});
+loadBtn.addEventListener("click", () => {
+    void onLoadClick();
+});
+loadSampleBtn.addEventListener("click", () => {
+    inputModeSource.checked = true;
+    inputModeFile.checked = false;
+    xmlInput.value = sampleXml;
+    fileNameText.textContent = "未選択";
+    renderInputMode();
+});
+noteSelect.addEventListener("change", () => {
+    state.selectedNodeId = noteSelect.value || null;
+    renderStatus();
+    renderControlState();
+});
+changePitchBtn.addEventListener("click", onChangePitch);
+changeDurationBtn.addEventListener("click", onChangeDuration);
+insertAfterBtn.addEventListener("click", onInsertAfter);
+deleteBtn.addEventListener("click", onDelete);
+saveBtn.addEventListener("click", onSave);
+playBtn.addEventListener("click", () => {
+    void startPlayback();
+});
+stopBtn.addEventListener("click", stopPlayback);
+downloadBtn.addEventListener("click", onDownload);
+renderAll();
+
+  },
+  "core/interfaces.js": function (require, module, exports) {
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+
+  },
+  "core/timeIndex.js": function (require, module, exports) {
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.getOccupiedTime = exports.getMeasureCapacity = exports.getMeasureTimingForVoice = void 0;
+const xmlUtils_1 = require("./xmlUtils");
+const getMeasureTimingForVoice = (noteInMeasure, voice) => {
+    const measure = (0, xmlUtils_1.findAncestorMeasure)(noteInMeasure);
+    if (!measure)
+        return null;
+    const capacity = (0, exports.getMeasureCapacity)(measure);
+    if (capacity === null)
+        return null;
+    const occupied = (0, exports.getOccupiedTime)(measure, voice);
+    return { capacity, occupied };
+};
+exports.getMeasureTimingForVoice = getMeasureTimingForVoice;
+const getMeasureCapacity = (measure) => {
+    const context = resolveTimingContext(measure);
+    if (!context)
+        return null;
+    const { beats, beatType, divisions } = context;
+    if (!Number.isFinite(beats) ||
+        !Number.isFinite(beatType) ||
+        !Number.isFinite(divisions) ||
+        beatType <= 0) {
+        return null;
+    }
+    const beatUnit = (4 / beatType) * divisions;
+    return Math.round(beats * beatUnit);
+};
+exports.getMeasureCapacity = getMeasureCapacity;
+const getOccupiedTime = (measure, voice) => {
+    const directChildren = Array.from(measure.children);
+    let total = 0;
+    for (const child of directChildren) {
+        if (child.tagName !== "note")
+            continue;
+        // Chord notes share onset with the previous note and must not advance time.
+        if (Array.from(child.children).some((c) => c.tagName === "chord"))
+            continue;
+        const noteVoice = (0, xmlUtils_1.getVoiceText)(child);
+        if (noteVoice !== voice)
+            continue;
+        const duration = (0, xmlUtils_1.getDurationValue)(child);
+        if (duration !== null)
+            total += duration;
+    }
+    return total;
+};
+exports.getOccupiedTime = getOccupiedTime;
+const resolveTimingContext = (measure) => {
+    var _a, _b, _c, _d, _e, _f;
+    const part = measure.parentElement;
+    if (!part || part.tagName !== "part")
+        return null;
+    let beats = null;
+    let beatType = null;
+    let divisions = null;
+    const measures = Array.from(part.children).filter((child) => child.tagName === "measure");
+    const measureIndex = measures.indexOf(measure);
+    if (measureIndex < 0)
+        return null;
+    for (let i = measureIndex; i >= 0; i -= 1) {
+        const candidate = measures[i];
+        const attributes = candidate.querySelector("attributes");
+        if (!attributes)
+            continue;
+        if (divisions === null) {
+            const divisionsText = (_b = (_a = attributes.querySelector("divisions")) === null || _a === void 0 ? void 0 : _a.textContent) === null || _b === void 0 ? void 0 : _b.trim();
+            if (divisionsText)
+                divisions = Number(divisionsText);
+        }
+        if (beats === null) {
+            const beatsText = (_d = (_c = attributes.querySelector("time > beats")) === null || _c === void 0 ? void 0 : _c.textContent) === null || _d === void 0 ? void 0 : _d.trim();
+            if (beatsText)
+                beats = Number(beatsText);
+        }
+        if (beatType === null) {
+            const beatTypeText = (_f = (_e = attributes
+                .querySelector("time > beat-type")) === null || _e === void 0 ? void 0 : _e.textContent) === null || _f === void 0 ? void 0 : _f.trim();
+            if (beatTypeText)
+                beatType = Number(beatTypeText);
+        }
+        if (beats !== null && beatType !== null && divisions !== null) {
+            return { beats, beatType, divisions };
+        }
+    }
+    return null;
+};
+
+  },
+  "core/xmlUtils.js": function (require, module, exports) {
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.measureHasBackupOrForward = exports.findAncestorMeasure = exports.createNoteElement = exports.isUnsupportedNoteKind = exports.setPitch = exports.setDurationValue = exports.getDurationValue = exports.getVoiceText = exports.reindexNodeIds = exports.serializeXml = exports.parseXml = void 0;
+const SCORE_PARTWISE = "score-partwise";
+const parseXml = (xmlText) => {
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(xmlText, "application/xml");
+    const parserError = doc.querySelector("parsererror");
+    if (parserError) {
+        throw new Error("Invalid XML input.");
+    }
+    const root = doc.documentElement;
+    if (!root || root.tagName !== SCORE_PARTWISE) {
+        throw new Error("MusicXML root must be <score-partwise>.");
+    }
+    return doc;
+};
+exports.parseXml = parseXml;
+const serializeXml = (doc) => new XMLSerializer().serializeToString(doc);
+exports.serializeXml = serializeXml;
+/**
+ * Assigns stable-in-session node IDs without mutating XML.
+ */
+const reindexNodeIds = (doc, nodeToId, idToNode, nextId) => {
+    idToNode.clear();
+    const notes = doc.querySelectorAll("note");
+    for (const note of notes) {
+        const existing = nodeToId.get(note);
+        const id = existing !== null && existing !== void 0 ? existing : nextId();
+        nodeToId.set(note, id);
+        idToNode.set(id, note);
+    }
+};
+exports.reindexNodeIds = reindexNodeIds;
+const getVoiceText = (note) => {
+    var _a, _b;
+    const voice = getDirectChild(note, "voice");
+    return (_b = (_a = voice === null || voice === void 0 ? void 0 : voice.textContent) === null || _a === void 0 ? void 0 : _a.trim()) !== null && _b !== void 0 ? _b : null;
+};
+exports.getVoiceText = getVoiceText;
+const getDurationValue = (note) => {
+    const duration = getDirectChild(note, "duration");
+    if (!(duration === null || duration === void 0 ? void 0 : duration.textContent))
+        return null;
+    const n = Number(duration.textContent.trim());
+    return Number.isFinite(n) ? n : null;
+};
+exports.getDurationValue = getDurationValue;
+const setDurationValue = (note, duration) => {
+    let durationNode = getDirectChild(note, "duration");
+    if (!durationNode) {
+        durationNode = note.ownerDocument.createElement("duration");
+        note.appendChild(durationNode);
+    }
+    durationNode.textContent = String(duration);
+};
+exports.setDurationValue = setDurationValue;
+const setPitch = (note, pitch) => {
+    let pitchNode = getDirectChild(note, "pitch");
+    if (!pitchNode) {
+        pitchNode = note.ownerDocument.createElement("pitch");
+        // Keep patch local by adding pitch near start, but do not reorder siblings.
+        note.insertBefore(pitchNode, note.firstChild);
+    }
+    upsertSimpleChild(pitchNode, "step", pitch.step);
+    if (typeof pitch.alter === "number") {
+        upsertSimpleChild(pitchNode, "alter", String(pitch.alter));
+    }
+    else {
+        const alter = getDirectChild(pitchNode, "alter");
+        if (alter)
+            alter.remove();
+    }
+    upsertSimpleChild(pitchNode, "octave", String(pitch.octave));
+};
+exports.setPitch = setPitch;
+const isUnsupportedNoteKind = (note) => hasDirectChild(note, "grace") ||
+    hasDirectChild(note, "cue") ||
+    hasDirectChild(note, "chord") ||
+    hasDirectChild(note, "rest");
+exports.isUnsupportedNoteKind = isUnsupportedNoteKind;
+const createNoteElement = (doc, voice, duration, pitch) => {
+    const note = doc.createElement("note");
+    const pitchNode = doc.createElement("pitch");
+    upsertSimpleChild(pitchNode, "step", pitch.step);
+    if (typeof pitch.alter === "number") {
+        upsertSimpleChild(pitchNode, "alter", String(pitch.alter));
+    }
+    upsertSimpleChild(pitchNode, "octave", String(pitch.octave));
+    note.appendChild(pitchNode);
+    const durationNode = doc.createElement("duration");
+    durationNode.textContent = String(duration);
+    note.appendChild(durationNode);
+    const voiceNode = doc.createElement("voice");
+    voiceNode.textContent = voice;
+    note.appendChild(voiceNode);
+    return note;
+};
+exports.createNoteElement = createNoteElement;
+const findAncestorMeasure = (node) => {
+    let cursor = node;
+    while (cursor) {
+        if (cursor.tagName === "measure")
+            return cursor;
+        cursor = cursor.parentElement;
+    }
+    return null;
+};
+exports.findAncestorMeasure = findAncestorMeasure;
+const measureHasBackupOrForward = (measure) => Array.from(measure.children).some((child) => child.tagName === "backup" || child.tagName === "forward");
+exports.measureHasBackupOrForward = measureHasBackupOrForward;
+const upsertSimpleChild = (parent, tagName, value) => {
+    let node = getDirectChild(parent, tagName);
+    if (!node) {
+        node = parent.ownerDocument.createElement(tagName);
+        parent.appendChild(node);
+    }
+    node.textContent = value;
+};
+const hasDirectChild = (parent, tagName) => Array.from(parent.children).some((child) => child.tagName === tagName);
+const getDirectChild = (parent, tagName) => { var _a; return (_a = Array.from(parent.children).find((child) => child.tagName === tagName)) !== null && _a !== void 0 ? _a : null; };
+
+  },
+  "core/ScoreCore.js": function (require, module, exports) {
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.ScoreCore = void 0;
+const commands_1 = require("./commands");
+const timeIndex_1 = require("./timeIndex");
+const xmlUtils_1 = require("./xmlUtils");
+const validators_1 = require("./validators");
+const DEFAULT_EDITABLE_VOICE = "1";
+class ScoreCore {
+    constructor(options = {}) {
+        var _a;
+        this.originalXml = "";
+        this.doc = null;
+        this.dirty = false;
+        // Node identity is kept outside XML with WeakMap as required by spec.
+        this.nodeToId = new WeakMap();
+        this.idToNode = new Map();
+        this.nodeCounter = 0;
+        this.editableVoice = (_a = options.editableVoice) !== null && _a !== void 0 ? _a : DEFAULT_EDITABLE_VOICE;
+    }
+    load(xml) {
+        this.originalXml = xml;
+        this.doc = (0, xmlUtils_1.parseXml)(xml);
+        this.dirty = false;
+        this.reindex();
+    }
+    dispatch(command) {
+        var _a, _b;
+        if (!this.doc) {
+            return this.fail("MVP_SCORE_NOT_LOADED", "Score is not loaded.");
+        }
+        if ((0, commands_1.isUiOnlyCommand)(command)) {
+            return {
+                ok: true,
+                dirtyChanged: false,
+                changedNodeIds: [],
+                affectedMeasureNumbers: [],
+                diagnostics: [],
+                warnings: [],
+            };
+        }
+        const voiceDiagnostic = (0, validators_1.validateVoice)(command, this.editableVoice);
+        if (voiceDiagnostic)
+            return this.failWith(voiceDiagnostic);
+        const payloadDiagnostic = (0, validators_1.validateCommandPayload)(command);
+        if (payloadDiagnostic)
+            return this.failWith(payloadDiagnostic);
+        const targetId = (0, commands_1.getCommandNodeId)(command);
+        if (!targetId) {
+            return this.fail("MVP_COMMAND_TARGET_MISSING", "Command target is missing.");
+        }
+        const target = this.idToNode.get(targetId);
+        if (!target)
+            return this.fail("MVP_TARGET_NOT_FOUND", `Unknown nodeId: ${targetId}`);
+        const noteKindDiagnostic = (0, validators_1.validateSupportedNoteKind)(target);
+        if (noteKindDiagnostic)
+            return this.failWith(noteKindDiagnostic);
+        const targetVoiceDiagnostic = (0, validators_1.validateTargetVoiceMatch)(command, target);
+        if (targetVoiceDiagnostic)
+            return this.failWith(targetVoiceDiagnostic);
+        const bfDiagnostic = (0, validators_1.validateBackupForwardBoundaryForStructuralEdit)(command, target);
+        if (bfDiagnostic)
+            return this.failWith(bfDiagnostic);
+        const laneDiagnostic = (0, validators_1.validateInsertLaneBoundary)(command, target);
+        if (laneDiagnostic)
+            return this.failWith(laneDiagnostic);
+        const snapshot = (0, xmlUtils_1.serializeXml)(this.doc);
+        const warnings = [];
+        let insertedNode = null;
+        let removedNodeId = null;
+        const affectedMeasureNumbers = this.collectAffectedMeasureNumbers(target);
+        try {
+            if (command.type === "change_pitch") {
+                (0, xmlUtils_1.setPitch)(target, command.pitch);
+            }
+            else if (command.type === "change_duration") {
+                const oldDuration = (_a = (0, xmlUtils_1.getDurationValue)(target)) !== null && _a !== void 0 ? _a : 0;
+                const timing = (0, timeIndex_1.getMeasureTimingForVoice)(target, command.voice);
+                if (timing) {
+                    const projected = timing.occupied - oldDuration + command.duration;
+                    const result = (0, validators_1.validateProjectedMeasureTiming)(target, command.voice, projected);
+                    if (result.diagnostic)
+                        return this.failWith(result.diagnostic);
+                    if (result.warning)
+                        warnings.push(result.warning);
+                }
+                (0, xmlUtils_1.setDurationValue)(target, command.duration);
+            }
+            else if (command.type === "insert_note_after") {
+                const timing = (0, timeIndex_1.getMeasureTimingForVoice)(target, command.voice);
+                if (timing) {
+                    const projected = timing.occupied + command.note.duration;
+                    const result = (0, validators_1.validateProjectedMeasureTiming)(target, command.voice, projected);
+                    if (result.diagnostic)
+                        return this.failWith(result.diagnostic);
+                    if (result.warning)
+                        warnings.push(result.warning);
+                }
+                const note = (0, xmlUtils_1.createNoteElement)(this.doc, command.voice, command.note.duration, command.note.pitch);
+                target.after(note);
+                insertedNode = note;
+            }
+            else if (command.type === "delete_note") {
+                const duration = (_b = (0, xmlUtils_1.getDurationValue)(target)) !== null && _b !== void 0 ? _b : 0;
+                const timing = (0, timeIndex_1.getMeasureTimingForVoice)(target, command.voice);
+                if (timing) {
+                    const projected = timing.occupied - duration;
+                    const result = (0, validators_1.validateProjectedMeasureTiming)(target, command.voice, projected);
+                    if (result.diagnostic)
+                        return this.failWith(result.diagnostic);
+                    if (result.warning)
+                        warnings.push(result.warning);
+                }
+                removedNodeId = targetId;
+                target.remove();
+            }
+        }
+        catch (_c) {
+            this.restoreFrom(snapshot);
+            return this.fail("MVP_COMMAND_EXECUTION_FAILED", "Command failed unexpectedly.");
+        }
+        this.reindex();
+        const dirtyBefore = this.dirty;
+        this.dirty = true;
+        const changedNodeIds = this.buildChangedNodeIds(command, targetId, insertedNode, removedNodeId);
+        return {
+            ok: true,
+            dirtyChanged: !dirtyBefore,
+            changedNodeIds,
+            affectedMeasureNumbers,
+            diagnostics: [],
+            warnings,
+        };
+    }
+    save() {
+        if (!this.doc) {
+            return {
+                ok: false,
+                mode: "original_noop",
+                xml: "",
+                diagnostics: [{ code: "MVP_SCORE_NOT_LOADED", message: "Score is not loaded." }],
+            };
+        }
+        const integrity = this.findInvalidNoteDiagnostic();
+        if (integrity) {
+            return { ok: false, mode: "serialized_dirty", xml: "", diagnostics: [integrity] };
+        }
+        const overfull = this.findOverfullDiagnostic();
+        if (overfull) {
+            return { ok: false, mode: "serialized_dirty", xml: "", diagnostics: [overfull] };
+        }
+        if (!this.dirty) {
+            return {
+                ok: true,
+                mode: "original_noop",
+                xml: this.originalXml,
+                diagnostics: [],
+            };
+        }
+        return {
+            ok: true,
+            mode: "serialized_dirty",
+            xml: (0, xmlUtils_1.serializeXml)(this.doc),
+            diagnostics: [],
+        };
+    }
+    isDirty() {
+        return this.dirty;
+    }
+    listNoteNodeIds() {
+        return Array.from(this.idToNode.keys());
+    }
+    /**
+     * Debug-only helper for UI diagnostics.
+     * Returns current in-memory XML regardless of dirty/validation state.
+     */
+    debugSerializeCurrentXml() {
+        if (!this.doc)
+            return null;
+        return (0, xmlUtils_1.serializeXml)(this.doc);
+    }
+    nextNodeId() {
+        this.nodeCounter += 1;
+        return `n${this.nodeCounter}`;
+    }
+    reindex() {
+        if (!this.doc)
+            return;
+        (0, xmlUtils_1.reindexNodeIds)(this.doc, this.nodeToId, this.idToNode, () => this.nextNodeId());
+    }
+    restoreFrom(xmlSnapshot) {
+        this.doc = (0, xmlUtils_1.parseXml)(xmlSnapshot);
+        this.reindex();
+    }
+    findOverfullDiagnostic() {
+        if (!this.doc)
+            return null;
+        const measures = this.doc.querySelectorAll("measure");
+        for (const measure of measures) {
+            const note = measure.querySelector("note");
+            if (!note)
+                continue;
+            const timing = (0, timeIndex_1.getMeasureTimingForVoice)(note, this.editableVoice);
+            if (!timing)
+                continue;
+            if (timing.occupied > timing.capacity) {
+                return {
+                    code: "MEASURE_OVERFULL",
+                    message: `Occupied time ${timing.occupied} exceeds capacity ${timing.capacity}.`,
+                };
+            }
+        }
+        return null;
+    }
+    findInvalidNoteDiagnostic() {
+        if (!this.doc)
+            return null;
+        const notes = this.doc.querySelectorAll("note");
+        for (const note of notes) {
+            const voice = (0, xmlUtils_1.getVoiceText)(note);
+            if (!voice) {
+                return {
+                    code: "MVP_INVALID_NOTE_VOICE",
+                    message: "Note is missing a valid <voice> value.",
+                };
+            }
+            const duration = (0, xmlUtils_1.getDurationValue)(note);
+            if (duration === null || duration <= 0) {
+                return {
+                    code: "MVP_INVALID_NOTE_DURATION",
+                    message: "Note is missing a valid positive <duration> value.",
+                };
+            }
+            const pitchDiagnostic = this.validateNotePitch(note);
+            if (pitchDiagnostic)
+                return pitchDiagnostic;
+        }
+        return null;
+    }
+    fail(code, message) {
+        return this.failWith({ code, message });
+    }
+    failWith(diagnostic) {
+        return {
+            ok: false,
+            dirtyChanged: false,
+            changedNodeIds: [],
+            affectedMeasureNumbers: [],
+            diagnostics: [diagnostic],
+            warnings: [],
+        };
+    }
+    collectAffectedMeasureNumbers(note) {
+        var _a;
+        const measure = (0, xmlUtils_1.findAncestorMeasure)(note);
+        if (!measure)
+            return [];
+        const number = (_a = measure.getAttribute("number")) !== null && _a !== void 0 ? _a : "";
+        return number ? [number] : [];
+    }
+    validateNotePitch(note) {
+        var _a, _b, _c, _d, _e, _f, _g, _h, _j;
+        const hasRest = Array.from(note.children).some((c) => c.tagName === "rest");
+        const hasChord = Array.from(note.children).some((c) => c.tagName === "chord");
+        const pitch = (_a = Array.from(note.children).find((c) => c.tagName === "pitch")) !== null && _a !== void 0 ? _a : null;
+        if (hasRest && hasChord) {
+            return {
+                code: "MVP_INVALID_NOTE_PITCH",
+                message: "Note must not contain both <rest> and <chord>.",
+            };
+        }
+        if (hasRest && pitch) {
+            return {
+                code: "MVP_INVALID_NOTE_PITCH",
+                message: "Rest note must not contain <pitch>.",
+            };
+        }
+        if (hasChord && !pitch) {
+            return {
+                code: "MVP_INVALID_NOTE_PITCH",
+                message: "Chord note must contain a valid <pitch>.",
+            };
+        }
+        if (!pitch) {
+            if (hasRest)
+                return null;
+            return {
+                code: "MVP_INVALID_NOTE_PITCH",
+                message: "Non-rest note is missing a valid <pitch>.",
+            };
+        }
+        const step = (_d = (_c = (_b = pitch.querySelector("step")) === null || _b === void 0 ? void 0 : _b.textContent) === null || _c === void 0 ? void 0 : _c.trim()) !== null && _d !== void 0 ? _d : "";
+        if (!["A", "B", "C", "D", "E", "F", "G"].includes(step)) {
+            return {
+                code: "MVP_INVALID_NOTE_PITCH",
+                message: "Pitch step is invalid.",
+            };
+        }
+        const octaveText = (_g = (_f = (_e = pitch.querySelector("octave")) === null || _e === void 0 ? void 0 : _e.textContent) === null || _f === void 0 ? void 0 : _f.trim()) !== null && _g !== void 0 ? _g : "";
+        const octave = Number(octaveText);
+        if (!Number.isInteger(octave)) {
+            return {
+                code: "MVP_INVALID_NOTE_PITCH",
+                message: "Pitch octave is invalid.",
+            };
+        }
+        const alterText = (_j = (_h = pitch.querySelector("alter")) === null || _h === void 0 ? void 0 : _h.textContent) === null || _j === void 0 ? void 0 : _j.trim();
+        if (alterText !== undefined) {
+            const alter = Number(alterText);
+            if (!Number.isInteger(alter) || alter < -2 || alter > 2) {
+                return {
+                    code: "MVP_INVALID_NOTE_PITCH",
+                    message: "Pitch alter is invalid.",
+                };
+            }
+        }
+        return null;
+    }
+    buildChangedNodeIds(command, targetId, insertedNode, removedNodeId) {
+        var _a;
+        if (command.type === "insert_note_after") {
+            const insertedId = insertedNode ? (_a = this.nodeToId.get(insertedNode)) !== null && _a !== void 0 ? _a : null : null;
+            return insertedId ? [targetId, insertedId] : [targetId];
+        }
+        if (command.type === "delete_note") {
+            return removedNodeId ? [removedNodeId] : [targetId];
+        }
+        return [targetId];
+    }
+}
+exports.ScoreCore = ScoreCore;
+
+  },
+  "core/validators.js": function (require, module, exports) {
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.validateProjectedMeasureTiming = exports.validateBackupForwardBoundaryForStructuralEdit = exports.validateInsertLaneBoundary = exports.validateTargetVoiceMatch = exports.validateSupportedNoteKind = exports.validateCommandPayload = exports.validateVoice = void 0;
+const timeIndex_1 = require("./timeIndex");
+const xmlUtils_1 = require("./xmlUtils");
+const validateVoice = (command, editableVoice) => {
+    if (command.type === "ui_noop")
+        return null;
+    if (command.voice === editableVoice)
+        return null;
+    return {
+        code: "MVP_UNSUPPORTED_NON_EDITABLE_VOICE",
+        message: `Voice ${command.voice} is not editable in MVP.`,
+    };
+};
+exports.validateVoice = validateVoice;
+const validateCommandPayload = (command) => {
+    if (command.type === "ui_noop")
+        return null;
+    if (command.type === "change_duration") {
+        if (!isPositiveInteger(command.duration)) {
+            return {
+                code: "MVP_INVALID_COMMAND_PAYLOAD",
+                message: "change_duration.duration must be a positive integer.",
+            };
+        }
+        return null;
+    }
+    if (command.type === "insert_note_after") {
+        if (!isPositiveInteger(command.note.duration)) {
+            return {
+                code: "MVP_INVALID_COMMAND_PAYLOAD",
+                message: "insert_note_after.note.duration must be a positive integer.",
+            };
+        }
+        if (!isValidPitch(command.note.pitch)) {
+            return {
+                code: "MVP_INVALID_COMMAND_PAYLOAD",
+                message: "insert_note_after.note.pitch is invalid.",
+            };
+        }
+        return null;
+    }
+    if (command.type === "change_pitch") {
+        if (!isValidPitch(command.pitch)) {
+            return {
+                code: "MVP_INVALID_COMMAND_PAYLOAD",
+                message: "change_pitch.pitch is invalid.",
+            };
+        }
+    }
+    return null;
+};
+exports.validateCommandPayload = validateCommandPayload;
+const validateSupportedNoteKind = (note) => {
+    if (!(0, xmlUtils_1.isUnsupportedNoteKind)(note))
+        return null;
+    return {
+        code: "MVP_UNSUPPORTED_NOTE_KIND",
+        message: "Editing grace/cue/chord/rest notes is not supported in MVP.",
+    };
+};
+exports.validateSupportedNoteKind = validateSupportedNoteKind;
+const validateTargetVoiceMatch = (command, targetNote) => {
+    if (command.type === "ui_noop")
+        return null;
+    const targetVoice = (0, xmlUtils_1.getVoiceText)(targetNote);
+    if (targetVoice === command.voice)
+        return null;
+    return {
+        code: "MVP_UNSUPPORTED_NON_EDITABLE_VOICE",
+        message: `Target note voice (${targetVoice !== null && targetVoice !== void 0 ? targetVoice : "none"}) does not match command voice (${command.voice}).`,
+    };
+};
+exports.validateTargetVoiceMatch = validateTargetVoiceMatch;
+const validateInsertLaneBoundary = (command, anchorNote) => {
+    if (command.type !== "insert_note_after")
+        return null;
+    const measure = (0, xmlUtils_1.findAncestorMeasure)(anchorNote);
+    if (!measure)
+        return null;
+    const children = Array.from(measure.children);
+    const anchorIndex = children.indexOf(anchorNote);
+    if (anchorIndex < 0)
+        return null;
+    for (let i = anchorIndex + 1; i < children.length; i += 1) {
+        const node = children[i];
+        if (node.tagName !== "note")
+            continue;
+        const nextVoice = (0, xmlUtils_1.getVoiceText)(node);
+        if (nextVoice !== command.voice) {
+            return {
+                code: "MVP_UNSUPPORTED_NON_EDITABLE_VOICE",
+                message: "Insert is restricted to a continuous local voice lane in MVP.",
+            };
+        }
+        break;
+    }
+    return null;
+};
+exports.validateInsertLaneBoundary = validateInsertLaneBoundary;
+const validateBackupForwardBoundaryForStructuralEdit = (command, anchorOrTarget) => {
+    if (command.type !== "insert_note_after" && command.type !== "delete_note") {
+        return null;
+    }
+    const prev = anchorOrTarget.previousElementSibling;
+    const next = anchorOrTarget.nextElementSibling;
+    if (command.type === "insert_note_after") {
+        if (next && isBackupOrForward(next)) {
+            return {
+                code: "MVP_UNSUPPORTED_NON_EDITABLE_VOICE",
+                message: "Insert point crosses a backup/forward boundary in MVP.",
+            };
+        }
+        return null;
+    }
+    // delete_note
+    if ((prev && isBackupOrForward(prev)) || (next && isBackupOrForward(next))) {
+        return {
+            code: "MVP_UNSUPPORTED_NON_EDITABLE_VOICE",
+            message: "Delete point crosses a backup/forward boundary in MVP.",
+        };
+    }
+    return null;
+};
+exports.validateBackupForwardBoundaryForStructuralEdit = validateBackupForwardBoundaryForStructuralEdit;
+const validateProjectedMeasureTiming = (noteInMeasure, voice, projectedOccupiedTime) => {
+    const timing = (0, timeIndex_1.getMeasureTimingForVoice)(noteInMeasure, voice);
+    if (!timing)
+        return { diagnostic: null, warning: null };
+    if (projectedOccupiedTime > timing.capacity) {
+        return {
+            diagnostic: {
+                code: "MEASURE_OVERFULL",
+                message: `Projected occupied time ${projectedOccupiedTime} exceeds capacity ${timing.capacity}.`,
+            },
+            warning: null,
+        };
+    }
+    if (projectedOccupiedTime < timing.capacity) {
+        return {
+            diagnostic: null,
+            warning: {
+                code: "MEASURE_UNDERFULL",
+                message: `Projected occupied time ${projectedOccupiedTime} is below capacity ${timing.capacity}.`,
+            },
+        };
+    }
+    return { diagnostic: null, warning: null };
+};
+exports.validateProjectedMeasureTiming = validateProjectedMeasureTiming;
+const isBackupOrForward = (node) => node.tagName === "backup" || node.tagName === "forward";
+const isPositiveInteger = (value) => Number.isFinite(value) && Number.isInteger(value) && value > 0;
+const isValidPitch = (pitch) => {
+    const stepOk = ["A", "B", "C", "D", "E", "F", "G"].includes(pitch.step);
+    if (!stepOk)
+        return false;
+    if (!Number.isFinite(pitch.octave) || !Number.isInteger(pitch.octave))
+        return false;
+    if (typeof pitch.alter === "number") {
+        if (!Number.isInteger(pitch.alter))
+            return false;
+        if (pitch.alter < -2 || pitch.alter > 2)
+            return false;
+    }
+    return true;
+};
+
+  },
+  "core/commands.js": function (require, module, exports) {
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.getCommandNodeId = exports.isUiOnlyCommand = void 0;
+const isUiOnlyCommand = (command) => command.type === "ui_noop";
+exports.isUiOnlyCommand = isUiOnlyCommand;
+const getCommandNodeId = (command) => {
+    switch (command.type) {
+        case "change_pitch":
+        case "change_duration":
+        case "delete_note":
+            return command.targetNodeId;
+        case "insert_note_after":
+            return command.anchorNodeId;
+        case "ui_noop":
+            return null;
+    }
+};
+exports.getCommandNodeId = getCommandNodeId;
+
+  }
+};
+
+const cache = {};
+
+function normalizePath(p) {
+  const parts = [];
+  for (const part of p.split('/')) {
+    if (!part || part === '.') continue;
+    if (part === '..') {
+      parts.pop();
+    } else {
+      parts.push(part);
+    }
+  }
+  return parts.join('/');
+}
+
+function resolve(fromId, specifier) {
+  if (!specifier.startsWith('.')) {
+    throw new Error('External module is not allowed in single-file build: ' + specifier);
+  }
+  const fromParts = fromId.split('/');
+  fromParts.pop();
+  const resolvedBase = normalizePath(fromParts.concat(specifier.split('/')).join('/'));
+  const candidates = [resolvedBase + '.js', resolvedBase + '/index.js'];
+  for (const c of candidates) {
+    if (Object.prototype.hasOwnProperty.call(modules, c)) return c;
+  }
+  throw new Error('Cannot resolve module at runtime: ' + specifier + ' from ' + fromId);
+}
+
+function load(id) {
+  if (cache[id]) return cache[id].exports;
+  const factory = modules[id];
+  if (!factory) throw new Error('Unknown module: ' + id);
+  const module = { exports: {} };
+  cache[id] = module;
+  const localRequire = function (specifier) {
+    return load(resolve(id, specifier));
+  };
+  factory(localRequire, module, module.exports);
+  return module.exports;
+}
+
+load("src/ts/main.js");
+})();
+
+</script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "build": "node scripts/build.mjs",
+    "clean": "rm -f mikuscore.html src/js/main.js",
     "typecheck": "tsc --noEmit",
     "test:unit": "vitest run tests/unit",
     "test:property": "vitest run tests/property",

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -1,0 +1,134 @@
+import { readFileSync, writeFileSync, mkdirSync, existsSync, rmSync } from "node:fs";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+
+const ROOT = process.cwd();
+const ENTRY_TS = "src/ts/main.ts";
+const ENTRY_JS = ENTRY_TS.replace(/\.ts$/, ".js");
+const TEMPLATE = "mikuscore-src.html";
+const DIST = "mikuscore.html";
+const CSS_PATH = "src/css/app.css";
+const JS_OUT = "src/js/main.js";
+const TMP_DIR = ".mikuscore-build";
+
+const normalize = (p) => p.split(path.sep).join("/");
+const toAbs = (relPath) => path.join(ROOT, relPath);
+const readText = (relPath) => readFileSync(toAbs(relPath), "utf8");
+
+const importRe = /(?:import|export)\s+[^"']*?from\s+["'](.+?)["']|import\s*\(\s*["'](.+?)["']\s*\)/g;
+
+const resolveTsModule = (fromId, specifier) => {
+  if (!specifier.startsWith(".")) return null;
+  const fromDir = path.dirname(fromId);
+  const candidateBase = normalize(path.join(fromDir, specifier));
+  const tsFile = `${candidateBase}.ts`;
+  const indexTs = `${candidateBase}/index.ts`;
+  if (existsSync(toAbs(tsFile))) return tsFile;
+  if (existsSync(toAbs(indexTs))) return indexTs;
+  throw new Error(`Cannot resolve module: ${specifier} (from ${fromId})`);
+};
+
+const collectGraph = () => {
+  const queue = [ENTRY_TS];
+  const seen = new Set();
+  const order = [];
+
+  while (queue.length > 0) {
+    const id = queue.pop();
+    if (!id || seen.has(id)) continue;
+    seen.add(id);
+    order.push(id);
+
+    const src = readText(id);
+    importRe.lastIndex = 0;
+    for (;;) {
+      const m = importRe.exec(src);
+      if (!m) break;
+      const spec = m[1] ?? m[2];
+      if (!spec) continue;
+      const resolved = resolveTsModule(id, spec);
+      if (resolved) queue.push(resolved);
+    }
+  }
+
+  return order;
+};
+
+const compileWithTsc = (tsModules) => {
+  rmSync(toAbs(TMP_DIR), { recursive: true, force: true });
+  mkdirSync(toAbs(TMP_DIR), { recursive: true });
+
+  const args = [
+    "--target",
+    "ES2018",
+    "--module",
+    "CommonJS",
+    "--lib",
+    "DOM,DOM.Iterable,ES2018",
+    "--strict",
+    "--skipLibCheck",
+    "--moduleResolution",
+    "node",
+    "--outDir",
+    TMP_DIR,
+    "--rootDir",
+    ".",
+    ...tsModules,
+  ];
+
+  execFileSync("tsc", args, { cwd: ROOT, stdio: "pipe" });
+};
+
+const bundle = (tsModules) => {
+  const moduleEntries = tsModules
+    .map((tsId) => {
+      const jsId = tsId.replace(/\.ts$/, ".js");
+      const compiled = normalize(path.join(TMP_DIR, jsId));
+      const code = readText(compiled);
+      return `  ${JSON.stringify(jsId)}: function (require, module, exports) {\n${code}\n  }`;
+    })
+    .join(",\n");
+
+  return `(function () {\nconst modules = {\n${moduleEntries}\n};\n\nconst cache = {};\n\nfunction normalizePath(p) {\n  const parts = [];\n  for (const part of p.split('/')) {\n    if (!part || part === '.') continue;\n    if (part === '..') {\n      parts.pop();\n    } else {\n      parts.push(part);\n    }\n  }\n  return parts.join('/');\n}\n\nfunction resolve(fromId, specifier) {\n  if (!specifier.startsWith('.')) {\n    throw new Error('External module is not allowed in single-file build: ' + specifier);\n  }\n  const fromParts = fromId.split('/');\n  fromParts.pop();\n  const resolvedBase = normalizePath(fromParts.concat(specifier.split('/')).join('/'));\n  const candidates = [resolvedBase + '.js', resolvedBase + '/index.js'];\n  for (const c of candidates) {\n    if (Object.prototype.hasOwnProperty.call(modules, c)) return c;\n  }\n  throw new Error('Cannot resolve module at runtime: ' + specifier + ' from ' + fromId);\n}\n\nfunction load(id) {\n  if (cache[id]) return cache[id].exports;\n  const factory = modules[id];\n  if (!factory) throw new Error('Unknown module: ' + id);\n  const module = { exports: {} };\n  cache[id] = module;\n  const localRequire = function (specifier) {\n    return load(resolve(id, specifier));\n  };\n  factory(localRequire, module, module.exports);\n  return module.exports;\n}\n\nload(${JSON.stringify(ENTRY_JS)});\n})();\n`;
+};
+
+const inlineTemplate = (jsBundle) => {
+  const template = readText(TEMPLATE);
+  const css = readText(CSS_PATH);
+
+  if (!template.includes("href=\"src/css/app.css\"")) {
+    throw new Error("Template must include src/css/app.css link tag.");
+  }
+  if (!template.includes("src=\"src/js/main.js\"")) {
+    throw new Error("Template must include src/js/main.js script tag.");
+  }
+
+  const withCss = template.replace(
+    /<link\s+rel="stylesheet"\s+href="src\/css\/app\.css"\s*\/>/,
+    `<style>\n${css}\n</style>`
+  );
+
+  return withCss.replace(
+    /<script\s+src="src\/js\/main\.js"><\/script>/,
+    `<script>\n${jsBundle}\n</script>`
+  );
+};
+
+const run = () => {
+  const tsModules = collectGraph();
+  compileWithTsc(tsModules);
+
+  const jsBundle = bundle(tsModules);
+
+  mkdirSync(toAbs("src/js"), { recursive: true });
+  writeFileSync(toAbs(JS_OUT), jsBundle, "utf8");
+
+  const distHtml = inlineTemplate(jsBundle);
+  writeFileSync(toAbs(DIST), distHtml, "utf8");
+
+  rmSync(toAbs(TMP_DIR), { recursive: true, force: true });
+
+  process.stdout.write(`Built ${DIST} and ${JS_OUT}\n`);
+};
+
+run();

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -1,0 +1,157 @@
+:root {
+  --bg: #f5f7fb;
+  --card: #ffffff;
+  --text: #17212b;
+  --muted: #4b5d73;
+  --border: #d8e1ed;
+  --primary: #1456d8;
+  --danger: #c02626;
+  --warn: #9a6700;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "BIZ UDPGothic", "Hiragino Sans", "Yu Gothic", sans-serif;
+  color: var(--text);
+  background: radial-gradient(circle at top left, #e6edff 0%, var(--bg) 60%);
+}
+
+.ms-shell {
+  max-width: 980px;
+  margin: 0 auto;
+  padding: 24px;
+}
+
+.ms-card {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 18px;
+}
+
+.ms-title {
+  margin: 0 0 8px;
+}
+
+.ms-intro {
+  margin: 0 0 8px;
+  color: var(--muted);
+}
+
+.ms-steps {
+  margin: 0 0 10px;
+  padding-left: 1.2rem;
+  color: var(--muted);
+}
+
+.ms-section {
+  border-top: 1px solid var(--border);
+  padding-top: 12px;
+  margin-top: 14px;
+}
+
+.ms-section h2 {
+  margin: 0 0 10px;
+  font-size: 1rem;
+}
+
+.ms-block {
+  margin-bottom: 10px;
+}
+
+.ms-hidden {
+  display: none;
+}
+
+.ms-label {
+  display: block;
+  margin-bottom: 4px;
+  color: var(--muted);
+}
+
+.ms-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.ms-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 8px;
+}
+
+textarea,
+input,
+select,
+button {
+  width: 100%;
+  font: inherit;
+}
+
+textarea,
+input,
+select {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 8px;
+}
+
+button {
+  border: 1px solid var(--primary);
+  border-radius: 8px;
+  padding: 8px 10px;
+  background: #eff4ff;
+  color: #0f397e;
+  cursor: pointer;
+}
+
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.ms-radio-group {
+  display: flex;
+  gap: 16px;
+  margin-bottom: 8px;
+}
+
+.ms-radio-group label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.ms-radio-group input {
+  width: auto;
+}
+
+#diagArea .diag-error {
+  color: var(--danger);
+}
+
+#diagArea .diag-warning {
+  color: var(--warn);
+}
+
+#statusText {
+  margin: 0 0 8px;
+  color: var(--muted);
+}
+
+#playbackText {
+  margin: 8px 0 0;
+  color: var(--muted);
+}
+
+@media (max-width: 768px) {
+  .ms-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -1,0 +1,1466 @@
+(function () {
+const modules = {
+  "src/ts/main.js": function (require, module, exports) {
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const ScoreCore_1 = require("../../core/ScoreCore");
+const timeIndex_1 = require("../../core/timeIndex");
+const EDITABLE_VOICE = "1";
+const sampleXml = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list>
+    <score-part id="P1"><part-name>Music</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+      </attributes>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>1</duration><voice>1</voice></note>
+      <note><pitch><step>D</step><octave>4</octave></pitch><duration>1</duration><voice>1</voice></note>
+      <note><pitch><step>E</step><octave>4</octave></pitch><duration>1</duration><voice>1</voice></note>
+      <note><pitch><step>F</step><octave>4</octave></pitch><duration>1</duration><voice>1</voice></note>
+    </measure>
+  </part>
+</score-partwise>`;
+const q = (selector) => {
+    const el = document.querySelector(selector);
+    if (!el)
+        throw new Error(`Missing element: ${selector}`);
+    return el;
+};
+const inputModeFile = q("#inputModeFile");
+const inputModeSource = q("#inputModeSource");
+const fileInputBlock = q("#fileInputBlock");
+const sourceInputBlock = q("#sourceInputBlock");
+const xmlInput = q("#xmlInput");
+const fileSelectBtn = q("#fileSelectBtn");
+const fileInput = q("#fileInput");
+const fileNameText = q("#fileNameText");
+const loadBtn = q("#loadBtn");
+const loadSampleBtn = q("#loadSampleBtn");
+const noteSelect = q("#noteSelect");
+const statusText = q("#statusText");
+const pitchStep = q("#pitchStep");
+const pitchAlter = q("#pitchAlter");
+const pitchOctave = q("#pitchOctave");
+const durationInput = q("#durationInput");
+const changePitchBtn = q("#changePitchBtn");
+const changeDurationBtn = q("#changeDurationBtn");
+const insertAfterBtn = q("#insertAfterBtn");
+const deleteBtn = q("#deleteBtn");
+const saveBtn = q("#saveBtn");
+const playBtn = q("#playBtn");
+const stopBtn = q("#stopBtn");
+const downloadBtn = q("#downloadBtn");
+const saveModeText = q("#saveModeText");
+const playbackText = q("#playbackText");
+const outputXml = q("#outputXml");
+const diagArea = q("#diagArea");
+const core = new ScoreCore_1.ScoreCore({ editableVoice: EDITABLE_VOICE });
+const state = {
+    loaded: false,
+    selectedNodeId: null,
+    noteNodeIds: [],
+    lastDispatchResult: null,
+    lastSaveResult: null,
+    lastSuccessfulSaveXml: "",
+};
+xmlInput.value = sampleXml;
+let audioContext = null;
+let activeOscillators = [];
+let activeGains = [];
+let playbackTimer = null;
+let isPlaying = false;
+const DEBUG_LOG = true;
+const logDiagnostics = (phase, diagnostics, warnings = []) => {
+    if (!DEBUG_LOG)
+        return;
+    for (const d of diagnostics) {
+        console.error(`[mikuscore][${phase}][${d.code}] ${d.message}`);
+    }
+    for (const w of warnings) {
+        console.warn(`[mikuscore][${phase}][${w.code}] ${w.message}`);
+    }
+};
+const dumpOverfullContext = (xml, voice) => {
+    var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k;
+    if (!DEBUG_LOG)
+        return;
+    const doc = new DOMParser().parseFromString(xml, "application/xml");
+    if (doc.querySelector("parsererror")) {
+        console.error("[mikuscore][debug] XML parse failed while dumping overfull context.");
+        return;
+    }
+    const measures = Array.from(doc.querySelectorAll("part > measure"));
+    let found = false;
+    for (const measure of measures) {
+        const number = (_a = measure.getAttribute("number")) !== null && _a !== void 0 ? _a : "(no-number)";
+        const divisionsText = (_d = (_c = (_b = measure.querySelector("attributes > divisions")) === null || _b === void 0 ? void 0 : _b.textContent) === null || _c === void 0 ? void 0 : _c.trim()) !== null && _d !== void 0 ? _d : "(inherit)";
+        const beatsText = (_g = (_f = (_e = measure.querySelector("attributes > time > beats")) === null || _e === void 0 ? void 0 : _e.textContent) === null || _f === void 0 ? void 0 : _f.trim()) !== null && _g !== void 0 ? _g : "(inherit)";
+        const beatTypeText = (_k = (_j = (_h = measure.querySelector("attributes > time > beat-type")) === null || _h === void 0 ? void 0 : _h.textContent) === null || _j === void 0 ? void 0 : _j.trim()) !== null && _k !== void 0 ? _k : "(inherit)";
+        const noteRows = [];
+        const occupied = (0, timeIndex_1.getOccupiedTime)(measure, voice);
+        Array.from(measure.children).forEach((child, idx) => {
+            var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p;
+            if (child.tagName !== "note")
+                return;
+            const noteVoice = (_c = (_b = (_a = child.querySelector("voice")) === null || _a === void 0 ? void 0 : _a.textContent) === null || _b === void 0 ? void 0 : _b.trim()) !== null && _c !== void 0 ? _c : "";
+            const duration = Number((_f = (_e = (_d = child.querySelector("duration")) === null || _d === void 0 ? void 0 : _d.textContent) === null || _e === void 0 ? void 0 : _e.trim()) !== null && _f !== void 0 ? _f : "");
+            const isRest = Boolean(child.querySelector("rest"));
+            const step = (_j = (_h = (_g = child.querySelector("pitch > step")) === null || _g === void 0 ? void 0 : _g.textContent) === null || _h === void 0 ? void 0 : _h.trim()) !== null && _j !== void 0 ? _j : "";
+            const alter = (_l = (_k = child.querySelector("pitch > alter")) === null || _k === void 0 ? void 0 : _k.textContent) === null || _l === void 0 ? void 0 : _l.trim();
+            const octave = (_p = (_o = (_m = child.querySelector("pitch > octave")) === null || _m === void 0 ? void 0 : _m.textContent) === null || _o === void 0 ? void 0 : _o.trim()) !== null && _p !== void 0 ? _p : "";
+            const alterText = alter ? `${alter >= "0" ? "+" : ""}${alter}` : "";
+            const pitch = isRest ? "rest" : `${step}${alterText}${octave ? octave : ""}`;
+            noteRows.push({
+                idx,
+                voice: noteVoice || "(none)",
+                duration: Number.isFinite(duration) ? duration : NaN,
+                pitch,
+                isRest,
+            });
+        });
+        const capacity = (0, timeIndex_1.getMeasureCapacity)(measure);
+        if (capacity === null)
+            continue;
+        if (occupied <= capacity)
+            continue;
+        found = true;
+        console.groupCollapsed(`[mikuscore][debug][MEASURE_OVERFULL] measure=${number} occupied=${occupied} capacity=${capacity}`);
+        console.log({
+            measure: number,
+            voice,
+            divisions: divisionsText,
+            beats: beatsText,
+            beatType: beatTypeText,
+            occupied,
+            capacity,
+        });
+        console.table(noteRows);
+        console.groupEnd();
+    }
+    if (!found) {
+        console.warn("[mikuscore][debug] no overfull measure found while dumping context.");
+    }
+};
+const renderInputMode = () => {
+    const fileMode = inputModeFile.checked;
+    fileInputBlock.classList.toggle("ms-hidden", !fileMode);
+    sourceInputBlock.classList.toggle("ms-hidden", fileMode);
+};
+const renderStatus = () => {
+    const dirty = core.isDirty();
+    statusText.textContent = state.loaded
+        ? `ロード済み / dirty=${dirty} / notes=${state.noteNodeIds.length}`
+        : "未ロード（まず Load してください）";
+};
+const renderNotes = () => {
+    noteSelect.innerHTML = "";
+    const placeholder = document.createElement("option");
+    placeholder.value = "";
+    placeholder.textContent = state.noteNodeIds.length === 0 ? "(ノートなし)" : "(選択してください)";
+    noteSelect.appendChild(placeholder);
+    for (const nodeId of state.noteNodeIds) {
+        const option = document.createElement("option");
+        option.value = nodeId;
+        option.textContent = nodeId;
+        noteSelect.appendChild(option);
+    }
+    if (state.selectedNodeId && state.noteNodeIds.includes(state.selectedNodeId)) {
+        noteSelect.value = state.selectedNodeId;
+    }
+    else {
+        state.selectedNodeId = null;
+        noteSelect.value = "";
+    }
+};
+const renderDiagnostics = () => {
+    diagArea.innerHTML = "";
+    const dispatch = state.lastDispatchResult;
+    const save = state.lastSaveResult;
+    if (!dispatch && !save) {
+        diagArea.textContent = "診断なし";
+        return;
+    }
+    if (dispatch) {
+        for (const diagnostic of dispatch.diagnostics) {
+            const line = document.createElement("div");
+            line.className = "diag-error";
+            line.textContent = `[dispatch][${diagnostic.code}] ${diagnostic.message}`;
+            diagArea.appendChild(line);
+        }
+        for (const warning of dispatch.warnings) {
+            const line = document.createElement("div");
+            line.className = "diag-warning";
+            line.textContent = `[dispatch][${warning.code}] ${warning.message}`;
+            diagArea.appendChild(line);
+        }
+    }
+    if (save) {
+        for (const diagnostic of save.diagnostics) {
+            const line = document.createElement("div");
+            line.className = "diag-error";
+            line.textContent = `[save][${diagnostic.code}] ${diagnostic.message}`;
+            diagArea.appendChild(line);
+        }
+    }
+    if (!diagArea.firstChild) {
+        diagArea.textContent = "診断なし";
+    }
+};
+const renderOutput = () => {
+    var _a, _b;
+    saveModeText.textContent = state.lastSaveResult ? state.lastSaveResult.mode : "-";
+    outputXml.value = ((_a = state.lastSaveResult) === null || _a === void 0 ? void 0 : _a.ok) ? state.lastSaveResult.xml : "";
+    downloadBtn.disabled = !((_b = state.lastSaveResult) === null || _b === void 0 ? void 0 : _b.ok);
+};
+const renderControlState = () => {
+    const hasSelection = Boolean(state.selectedNodeId);
+    noteSelect.disabled = !state.loaded;
+    changePitchBtn.disabled = !state.loaded || !hasSelection;
+    changeDurationBtn.disabled = !state.loaded || !hasSelection;
+    insertAfterBtn.disabled = !state.loaded || !hasSelection;
+    deleteBtn.disabled = !state.loaded || !hasSelection;
+    saveBtn.disabled = !state.loaded;
+    playBtn.disabled = !state.loaded || isPlaying;
+    stopBtn.disabled = !isPlaying;
+};
+const renderAll = () => {
+    renderInputMode();
+    renderNotes();
+    renderStatus();
+    renderDiagnostics();
+    renderOutput();
+    renderControlState();
+};
+const refreshNotesFromCore = () => {
+    state.noteNodeIds = core.listNoteNodeIds();
+    if (state.selectedNodeId && !state.noteNodeIds.includes(state.selectedNodeId)) {
+        state.selectedNodeId = null;
+    }
+};
+const midiToHz = (midi) => 440 * Math.pow(2, (midi - 69) / 12);
+const pitchToMidi = (step, alter, octave) => {
+    const semitoneMap = {
+        C: 0,
+        D: 2,
+        E: 4,
+        F: 5,
+        G: 7,
+        A: 9,
+        B: 11,
+    };
+    const base = semitoneMap[step];
+    if (base === undefined)
+        return null;
+    return (octave + 1) * 12 + base + alter;
+};
+const getFirstNumber = (el, selector) => {
+    var _a, _b;
+    const text = (_b = (_a = el.querySelector(selector)) === null || _a === void 0 ? void 0 : _a.textContent) === null || _b === void 0 ? void 0 : _b.trim();
+    if (!text)
+        return null;
+    const n = Number(text);
+    return Number.isFinite(n) ? n : null;
+};
+const buildPlaybackEventsFromXml = (xml) => {
+    var _a, _b, _c, _d, _e, _f, _g, _h;
+    const doc = new DOMParser().parseFromString(xml, "application/xml");
+    if (doc.querySelector("parsererror"))
+        return [];
+    const part = doc.querySelector("part");
+    if (!part)
+        return [];
+    let currentDivisions = 1;
+    const defaultTempo = 120;
+    const tempo = (_a = getFirstNumber(doc, "sound[tempo]")) !== null && _a !== void 0 ? _a : defaultTempo;
+    const secPerDivision = 60 / tempo / currentDivisions;
+    const events = [];
+    let cursorSec = 0;
+    let lastNoteStartSec = 0;
+    for (const measure of Array.from(part.querySelectorAll(":scope > measure"))) {
+        const divisions = getFirstNumber(measure, "attributes > divisions");
+        if (divisions && divisions > 0) {
+            currentDivisions = divisions;
+        }
+        const measureSecPerDivision = 60 / tempo / currentDivisions;
+        for (const child of Array.from(measure.children)) {
+            if (child.tagName !== "note")
+                continue;
+            const voice = (_d = (_c = (_b = child.querySelector("voice")) === null || _b === void 0 ? void 0 : _b.textContent) === null || _c === void 0 ? void 0 : _c.trim()) !== null && _d !== void 0 ? _d : "1";
+            if (voice !== EDITABLE_VOICE)
+                continue;
+            const durationValue = getFirstNumber(child, "duration");
+            if (!durationValue || durationValue <= 0)
+                continue;
+            const durationSec = durationValue * measureSecPerDivision;
+            const isRest = Boolean(child.querySelector("rest"));
+            const isChord = Boolean(child.querySelector("chord"));
+            if (isRest) {
+                cursorSec += durationSec;
+                continue;
+            }
+            const step = (_g = (_f = (_e = child.querySelector("pitch > step")) === null || _e === void 0 ? void 0 : _e.textContent) === null || _f === void 0 ? void 0 : _f.trim()) !== null && _g !== void 0 ? _g : "";
+            const octave = getFirstNumber(child, "pitch > octave");
+            const alter = (_h = getFirstNumber(child, "pitch > alter")) !== null && _h !== void 0 ? _h : 0;
+            if (octave === null) {
+                cursorSec += durationSec;
+                continue;
+            }
+            const midi = pitchToMidi(step, alter, octave);
+            if (midi === null) {
+                if (!isChord) {
+                    cursorSec += durationSec;
+                }
+                continue;
+            }
+            const startSec = isChord ? lastNoteStartSec : cursorSec;
+            events.push({
+                freqHz: midiToHz(midi),
+                startSec,
+                durSec: Math.max(0.05, durationSec),
+            });
+            if (!isChord) {
+                lastNoteStartSec = cursorSec;
+                cursorSec += durationSec;
+            }
+        }
+    }
+    // Touch computed variable so TypeScript keeps intent explicit and avoids accidental drift.
+    void secPerDivision;
+    return events;
+};
+const stopPlayback = () => {
+    for (const osc of activeOscillators) {
+        try {
+            osc.stop();
+        }
+        catch (_a) {
+            // ignore stale node stop calls
+        }
+        osc.disconnect();
+    }
+    for (const gain of activeGains) {
+        gain.disconnect();
+    }
+    activeOscillators = [];
+    activeGains = [];
+    if (playbackTimer !== null) {
+        window.clearTimeout(playbackTimer);
+        playbackTimer = null;
+    }
+    isPlaying = false;
+    playbackText.textContent = "playback: idle";
+    renderControlState();
+};
+const startPlayback = async () => {
+    if (!state.loaded || isPlaying)
+        return;
+    const saveResult = core.save();
+    state.lastSaveResult = saveResult;
+    if (!saveResult.ok) {
+        logDiagnostics("playback", saveResult.diagnostics);
+        if (saveResult.diagnostics.some((d) => d.code === "MEASURE_OVERFULL")) {
+            const debugXml = core.debugSerializeCurrentXml();
+            if (debugXml) {
+                dumpOverfullContext(debugXml, EDITABLE_VOICE);
+            }
+            else if (DEBUG_LOG) {
+                console.warn("[mikuscore][debug] no in-memory XML to dump.");
+            }
+        }
+        renderAll();
+        playbackText.textContent = "playback: save failed";
+        return;
+    }
+    const events = buildPlaybackEventsFromXml(saveResult.xml);
+    if (events.length === 0) {
+        playbackText.textContent = "playback: no playable notes";
+        renderControlState();
+        return;
+    }
+    if (!audioContext) {
+        audioContext = new AudioContext();
+    }
+    await audioContext.resume();
+    const now = audioContext.currentTime + 0.02;
+    let maxEnd = 0;
+    for (const event of events) {
+        const gain = audioContext.createGain();
+        gain.gain.setValueAtTime(0.0001, now + event.startSec);
+        gain.gain.exponentialRampToValueAtTime(0.12, now + event.startSec + 0.01);
+        gain.gain.exponentialRampToValueAtTime(0.0001, now + event.startSec + Math.max(0.02, event.durSec * 0.9));
+        gain.connect(audioContext.destination);
+        const osc = audioContext.createOscillator();
+        osc.type = "sine";
+        osc.frequency.setValueAtTime(event.freqHz, now + event.startSec);
+        osc.connect(gain);
+        osc.start(now + event.startSec);
+        osc.stop(now + event.startSec + event.durSec);
+        activeOscillators.push(osc);
+        activeGains.push(gain);
+        maxEnd = Math.max(maxEnd, event.startSec + event.durSec);
+    }
+    isPlaying = true;
+    playbackText.textContent = `playback: playing (${events.length} notes)`;
+    renderControlState();
+    playbackTimer = window.setTimeout(() => {
+        stopPlayback();
+    }, Math.ceil(maxEnd * 1000) + 60);
+    renderAll();
+};
+const readSelectedPitch = () => {
+    const octave = Number(pitchOctave.value);
+    if (!Number.isInteger(octave))
+        return null;
+    const alterText = pitchAlter.value.trim();
+    const base = {
+        step: pitchStep.value,
+        octave,
+    };
+    if (alterText === "")
+        return base;
+    const alter = Number(alterText);
+    if (!Number.isInteger(alter) || alter < -2 || alter > 2)
+        return null;
+    return { ...base, alter: alter };
+};
+const readDuration = () => {
+    const duration = Number(durationInput.value);
+    if (!Number.isInteger(duration) || duration <= 0)
+        return null;
+    return duration;
+};
+const runCommand = (command) => {
+    if (!state.loaded)
+        return;
+    state.lastDispatchResult = core.dispatch(command);
+    if (!state.lastDispatchResult.ok || state.lastDispatchResult.warnings.length > 0) {
+        logDiagnostics("dispatch", state.lastDispatchResult.diagnostics, state.lastDispatchResult.warnings);
+    }
+    state.lastSaveResult = null;
+    if (state.lastDispatchResult.ok) {
+        refreshNotesFromCore();
+    }
+    renderAll();
+};
+const loadFromText = (xml) => {
+    try {
+        core.load(xml);
+    }
+    catch (err) {
+        if (DEBUG_LOG) {
+            console.error("[mikuscore][load] load failed:", err);
+        }
+        state.loaded = false;
+        state.lastDispatchResult = {
+            ok: false,
+            dirtyChanged: false,
+            changedNodeIds: [],
+            affectedMeasureNumbers: [],
+            diagnostics: [
+                {
+                    code: "MVP_COMMAND_EXECUTION_FAILED",
+                    message: err instanceof Error ? err.message : "Load failed.",
+                },
+            ],
+            warnings: [],
+        };
+        state.lastSaveResult = null;
+        logDiagnostics("load", state.lastDispatchResult.diagnostics);
+        renderAll();
+        return;
+    }
+    state.loaded = true;
+    state.selectedNodeId = null;
+    state.lastDispatchResult = null;
+    state.lastSaveResult = null;
+    state.lastSuccessfulSaveXml = "";
+    refreshNotesFromCore();
+    renderAll();
+};
+const onLoadClick = async () => {
+    var _a;
+    if (inputModeFile.checked) {
+        const selected = (_a = fileInput.files) === null || _a === void 0 ? void 0 : _a[0];
+        if (!selected) {
+            state.lastDispatchResult = {
+                ok: false,
+                dirtyChanged: false,
+                changedNodeIds: [],
+                affectedMeasureNumbers: [],
+                diagnostics: [{ code: "MVP_INVALID_COMMAND_PAYLOAD", message: "ファイルを選択してください。" }],
+                warnings: [],
+            };
+            renderAll();
+            return;
+        }
+        const text = await selected.text();
+        xmlInput.value = text;
+    }
+    loadFromText(xmlInput.value);
+};
+const requireSelectedNode = () => {
+    const nodeId = state.selectedNodeId;
+    if (nodeId)
+        return nodeId;
+    state.lastDispatchResult = {
+        ok: false,
+        dirtyChanged: false,
+        changedNodeIds: [],
+        affectedMeasureNumbers: [],
+        diagnostics: [{ code: "MVP_COMMAND_TARGET_MISSING", message: "ノートを選択してください。" }],
+        warnings: [],
+    };
+    renderAll();
+    return null;
+};
+const onChangePitch = () => {
+    const targetNodeId = requireSelectedNode();
+    if (!targetNodeId)
+        return;
+    const pitch = readSelectedPitch();
+    if (!pitch) {
+        state.lastDispatchResult = {
+            ok: false,
+            dirtyChanged: false,
+            changedNodeIds: [],
+            affectedMeasureNumbers: [],
+            diagnostics: [{ code: "MVP_INVALID_COMMAND_PAYLOAD", message: "pitch 入力が不正です。" }],
+            warnings: [],
+        };
+        renderAll();
+        return;
+    }
+    const command = {
+        type: "change_pitch",
+        targetNodeId,
+        voice: EDITABLE_VOICE,
+        pitch,
+    };
+    runCommand(command);
+};
+const onChangeDuration = () => {
+    const targetNodeId = requireSelectedNode();
+    if (!targetNodeId)
+        return;
+    const duration = readDuration();
+    if (!duration) {
+        state.lastDispatchResult = {
+            ok: false,
+            dirtyChanged: false,
+            changedNodeIds: [],
+            affectedMeasureNumbers: [],
+            diagnostics: [{ code: "MVP_INVALID_COMMAND_PAYLOAD", message: "duration 入力が不正です。" }],
+            warnings: [],
+        };
+        renderAll();
+        return;
+    }
+    const command = {
+        type: "change_duration",
+        targetNodeId,
+        voice: EDITABLE_VOICE,
+        duration,
+    };
+    runCommand(command);
+};
+const onInsertAfter = () => {
+    const anchorNodeId = requireSelectedNode();
+    if (!anchorNodeId)
+        return;
+    const duration = readDuration();
+    const pitch = readSelectedPitch();
+    if (!duration || !pitch) {
+        state.lastDispatchResult = {
+            ok: false,
+            dirtyChanged: false,
+            changedNodeIds: [],
+            affectedMeasureNumbers: [],
+            diagnostics: [{ code: "MVP_INVALID_COMMAND_PAYLOAD", message: "挿入ノート入力が不正です。" }],
+            warnings: [],
+        };
+        renderAll();
+        return;
+    }
+    const command = {
+        type: "insert_note_after",
+        anchorNodeId,
+        voice: EDITABLE_VOICE,
+        note: { duration, pitch },
+    };
+    runCommand(command);
+};
+const onDelete = () => {
+    const targetNodeId = requireSelectedNode();
+    if (!targetNodeId)
+        return;
+    const command = {
+        type: "delete_note",
+        targetNodeId,
+        voice: EDITABLE_VOICE,
+    };
+    runCommand(command);
+};
+const onSave = () => {
+    if (!state.loaded)
+        return;
+    const result = core.save();
+    state.lastSaveResult = result;
+    if (!result.ok) {
+        logDiagnostics("save", result.diagnostics);
+        if (result.diagnostics.some((d) => d.code === "MEASURE_OVERFULL")) {
+            const debugXml = core.debugSerializeCurrentXml();
+            if (debugXml) {
+                dumpOverfullContext(debugXml, EDITABLE_VOICE);
+            }
+            else if (DEBUG_LOG) {
+                console.warn("[mikuscore][debug] no in-memory XML to dump.");
+            }
+        }
+    }
+    if (result.ok) {
+        state.lastSuccessfulSaveXml = result.xml;
+    }
+    renderAll();
+};
+const onDownload = () => {
+    if (!state.lastSuccessfulSaveXml)
+        return;
+    const blob = new Blob([state.lastSuccessfulSaveXml], { type: "application/xml;charset=utf-8" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "mikuscore.musicxml";
+    a.click();
+    URL.revokeObjectURL(url);
+};
+inputModeFile.addEventListener("change", renderInputMode);
+inputModeSource.addEventListener("change", renderInputMode);
+fileSelectBtn.addEventListener("click", () => fileInput.click());
+fileInput.addEventListener("change", () => {
+    var _a;
+    const f = (_a = fileInput.files) === null || _a === void 0 ? void 0 : _a[0];
+    fileNameText.textContent = f ? f.name : "未選択";
+});
+loadBtn.addEventListener("click", () => {
+    void onLoadClick();
+});
+loadSampleBtn.addEventListener("click", () => {
+    inputModeSource.checked = true;
+    inputModeFile.checked = false;
+    xmlInput.value = sampleXml;
+    fileNameText.textContent = "未選択";
+    renderInputMode();
+});
+noteSelect.addEventListener("change", () => {
+    state.selectedNodeId = noteSelect.value || null;
+    renderStatus();
+    renderControlState();
+});
+changePitchBtn.addEventListener("click", onChangePitch);
+changeDurationBtn.addEventListener("click", onChangeDuration);
+insertAfterBtn.addEventListener("click", onInsertAfter);
+deleteBtn.addEventListener("click", onDelete);
+saveBtn.addEventListener("click", onSave);
+playBtn.addEventListener("click", () => {
+    void startPlayback();
+});
+stopBtn.addEventListener("click", stopPlayback);
+downloadBtn.addEventListener("click", onDownload);
+renderAll();
+
+  },
+  "core/interfaces.js": function (require, module, exports) {
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+
+  },
+  "core/timeIndex.js": function (require, module, exports) {
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.getOccupiedTime = exports.getMeasureCapacity = exports.getMeasureTimingForVoice = void 0;
+const xmlUtils_1 = require("./xmlUtils");
+const getMeasureTimingForVoice = (noteInMeasure, voice) => {
+    const measure = (0, xmlUtils_1.findAncestorMeasure)(noteInMeasure);
+    if (!measure)
+        return null;
+    const capacity = (0, exports.getMeasureCapacity)(measure);
+    if (capacity === null)
+        return null;
+    const occupied = (0, exports.getOccupiedTime)(measure, voice);
+    return { capacity, occupied };
+};
+exports.getMeasureTimingForVoice = getMeasureTimingForVoice;
+const getMeasureCapacity = (measure) => {
+    const context = resolveTimingContext(measure);
+    if (!context)
+        return null;
+    const { beats, beatType, divisions } = context;
+    if (!Number.isFinite(beats) ||
+        !Number.isFinite(beatType) ||
+        !Number.isFinite(divisions) ||
+        beatType <= 0) {
+        return null;
+    }
+    const beatUnit = (4 / beatType) * divisions;
+    return Math.round(beats * beatUnit);
+};
+exports.getMeasureCapacity = getMeasureCapacity;
+const getOccupiedTime = (measure, voice) => {
+    const directChildren = Array.from(measure.children);
+    let total = 0;
+    for (const child of directChildren) {
+        if (child.tagName !== "note")
+            continue;
+        // Chord notes share onset with the previous note and must not advance time.
+        if (Array.from(child.children).some((c) => c.tagName === "chord"))
+            continue;
+        const noteVoice = (0, xmlUtils_1.getVoiceText)(child);
+        if (noteVoice !== voice)
+            continue;
+        const duration = (0, xmlUtils_1.getDurationValue)(child);
+        if (duration !== null)
+            total += duration;
+    }
+    return total;
+};
+exports.getOccupiedTime = getOccupiedTime;
+const resolveTimingContext = (measure) => {
+    var _a, _b, _c, _d, _e, _f;
+    const part = measure.parentElement;
+    if (!part || part.tagName !== "part")
+        return null;
+    let beats = null;
+    let beatType = null;
+    let divisions = null;
+    const measures = Array.from(part.children).filter((child) => child.tagName === "measure");
+    const measureIndex = measures.indexOf(measure);
+    if (measureIndex < 0)
+        return null;
+    for (let i = measureIndex; i >= 0; i -= 1) {
+        const candidate = measures[i];
+        const attributes = candidate.querySelector("attributes");
+        if (!attributes)
+            continue;
+        if (divisions === null) {
+            const divisionsText = (_b = (_a = attributes.querySelector("divisions")) === null || _a === void 0 ? void 0 : _a.textContent) === null || _b === void 0 ? void 0 : _b.trim();
+            if (divisionsText)
+                divisions = Number(divisionsText);
+        }
+        if (beats === null) {
+            const beatsText = (_d = (_c = attributes.querySelector("time > beats")) === null || _c === void 0 ? void 0 : _c.textContent) === null || _d === void 0 ? void 0 : _d.trim();
+            if (beatsText)
+                beats = Number(beatsText);
+        }
+        if (beatType === null) {
+            const beatTypeText = (_f = (_e = attributes
+                .querySelector("time > beat-type")) === null || _e === void 0 ? void 0 : _e.textContent) === null || _f === void 0 ? void 0 : _f.trim();
+            if (beatTypeText)
+                beatType = Number(beatTypeText);
+        }
+        if (beats !== null && beatType !== null && divisions !== null) {
+            return { beats, beatType, divisions };
+        }
+    }
+    return null;
+};
+
+  },
+  "core/xmlUtils.js": function (require, module, exports) {
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.measureHasBackupOrForward = exports.findAncestorMeasure = exports.createNoteElement = exports.isUnsupportedNoteKind = exports.setPitch = exports.setDurationValue = exports.getDurationValue = exports.getVoiceText = exports.reindexNodeIds = exports.serializeXml = exports.parseXml = void 0;
+const SCORE_PARTWISE = "score-partwise";
+const parseXml = (xmlText) => {
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(xmlText, "application/xml");
+    const parserError = doc.querySelector("parsererror");
+    if (parserError) {
+        throw new Error("Invalid XML input.");
+    }
+    const root = doc.documentElement;
+    if (!root || root.tagName !== SCORE_PARTWISE) {
+        throw new Error("MusicXML root must be <score-partwise>.");
+    }
+    return doc;
+};
+exports.parseXml = parseXml;
+const serializeXml = (doc) => new XMLSerializer().serializeToString(doc);
+exports.serializeXml = serializeXml;
+/**
+ * Assigns stable-in-session node IDs without mutating XML.
+ */
+const reindexNodeIds = (doc, nodeToId, idToNode, nextId) => {
+    idToNode.clear();
+    const notes = doc.querySelectorAll("note");
+    for (const note of notes) {
+        const existing = nodeToId.get(note);
+        const id = existing !== null && existing !== void 0 ? existing : nextId();
+        nodeToId.set(note, id);
+        idToNode.set(id, note);
+    }
+};
+exports.reindexNodeIds = reindexNodeIds;
+const getVoiceText = (note) => {
+    var _a, _b;
+    const voice = getDirectChild(note, "voice");
+    return (_b = (_a = voice === null || voice === void 0 ? void 0 : voice.textContent) === null || _a === void 0 ? void 0 : _a.trim()) !== null && _b !== void 0 ? _b : null;
+};
+exports.getVoiceText = getVoiceText;
+const getDurationValue = (note) => {
+    const duration = getDirectChild(note, "duration");
+    if (!(duration === null || duration === void 0 ? void 0 : duration.textContent))
+        return null;
+    const n = Number(duration.textContent.trim());
+    return Number.isFinite(n) ? n : null;
+};
+exports.getDurationValue = getDurationValue;
+const setDurationValue = (note, duration) => {
+    let durationNode = getDirectChild(note, "duration");
+    if (!durationNode) {
+        durationNode = note.ownerDocument.createElement("duration");
+        note.appendChild(durationNode);
+    }
+    durationNode.textContent = String(duration);
+};
+exports.setDurationValue = setDurationValue;
+const setPitch = (note, pitch) => {
+    let pitchNode = getDirectChild(note, "pitch");
+    if (!pitchNode) {
+        pitchNode = note.ownerDocument.createElement("pitch");
+        // Keep patch local by adding pitch near start, but do not reorder siblings.
+        note.insertBefore(pitchNode, note.firstChild);
+    }
+    upsertSimpleChild(pitchNode, "step", pitch.step);
+    if (typeof pitch.alter === "number") {
+        upsertSimpleChild(pitchNode, "alter", String(pitch.alter));
+    }
+    else {
+        const alter = getDirectChild(pitchNode, "alter");
+        if (alter)
+            alter.remove();
+    }
+    upsertSimpleChild(pitchNode, "octave", String(pitch.octave));
+};
+exports.setPitch = setPitch;
+const isUnsupportedNoteKind = (note) => hasDirectChild(note, "grace") ||
+    hasDirectChild(note, "cue") ||
+    hasDirectChild(note, "chord") ||
+    hasDirectChild(note, "rest");
+exports.isUnsupportedNoteKind = isUnsupportedNoteKind;
+const createNoteElement = (doc, voice, duration, pitch) => {
+    const note = doc.createElement("note");
+    const pitchNode = doc.createElement("pitch");
+    upsertSimpleChild(pitchNode, "step", pitch.step);
+    if (typeof pitch.alter === "number") {
+        upsertSimpleChild(pitchNode, "alter", String(pitch.alter));
+    }
+    upsertSimpleChild(pitchNode, "octave", String(pitch.octave));
+    note.appendChild(pitchNode);
+    const durationNode = doc.createElement("duration");
+    durationNode.textContent = String(duration);
+    note.appendChild(durationNode);
+    const voiceNode = doc.createElement("voice");
+    voiceNode.textContent = voice;
+    note.appendChild(voiceNode);
+    return note;
+};
+exports.createNoteElement = createNoteElement;
+const findAncestorMeasure = (node) => {
+    let cursor = node;
+    while (cursor) {
+        if (cursor.tagName === "measure")
+            return cursor;
+        cursor = cursor.parentElement;
+    }
+    return null;
+};
+exports.findAncestorMeasure = findAncestorMeasure;
+const measureHasBackupOrForward = (measure) => Array.from(measure.children).some((child) => child.tagName === "backup" || child.tagName === "forward");
+exports.measureHasBackupOrForward = measureHasBackupOrForward;
+const upsertSimpleChild = (parent, tagName, value) => {
+    let node = getDirectChild(parent, tagName);
+    if (!node) {
+        node = parent.ownerDocument.createElement(tagName);
+        parent.appendChild(node);
+    }
+    node.textContent = value;
+};
+const hasDirectChild = (parent, tagName) => Array.from(parent.children).some((child) => child.tagName === tagName);
+const getDirectChild = (parent, tagName) => { var _a; return (_a = Array.from(parent.children).find((child) => child.tagName === tagName)) !== null && _a !== void 0 ? _a : null; };
+
+  },
+  "core/ScoreCore.js": function (require, module, exports) {
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.ScoreCore = void 0;
+const commands_1 = require("./commands");
+const timeIndex_1 = require("./timeIndex");
+const xmlUtils_1 = require("./xmlUtils");
+const validators_1 = require("./validators");
+const DEFAULT_EDITABLE_VOICE = "1";
+class ScoreCore {
+    constructor(options = {}) {
+        var _a;
+        this.originalXml = "";
+        this.doc = null;
+        this.dirty = false;
+        // Node identity is kept outside XML with WeakMap as required by spec.
+        this.nodeToId = new WeakMap();
+        this.idToNode = new Map();
+        this.nodeCounter = 0;
+        this.editableVoice = (_a = options.editableVoice) !== null && _a !== void 0 ? _a : DEFAULT_EDITABLE_VOICE;
+    }
+    load(xml) {
+        this.originalXml = xml;
+        this.doc = (0, xmlUtils_1.parseXml)(xml);
+        this.dirty = false;
+        this.reindex();
+    }
+    dispatch(command) {
+        var _a, _b;
+        if (!this.doc) {
+            return this.fail("MVP_SCORE_NOT_LOADED", "Score is not loaded.");
+        }
+        if ((0, commands_1.isUiOnlyCommand)(command)) {
+            return {
+                ok: true,
+                dirtyChanged: false,
+                changedNodeIds: [],
+                affectedMeasureNumbers: [],
+                diagnostics: [],
+                warnings: [],
+            };
+        }
+        const voiceDiagnostic = (0, validators_1.validateVoice)(command, this.editableVoice);
+        if (voiceDiagnostic)
+            return this.failWith(voiceDiagnostic);
+        const payloadDiagnostic = (0, validators_1.validateCommandPayload)(command);
+        if (payloadDiagnostic)
+            return this.failWith(payloadDiagnostic);
+        const targetId = (0, commands_1.getCommandNodeId)(command);
+        if (!targetId) {
+            return this.fail("MVP_COMMAND_TARGET_MISSING", "Command target is missing.");
+        }
+        const target = this.idToNode.get(targetId);
+        if (!target)
+            return this.fail("MVP_TARGET_NOT_FOUND", `Unknown nodeId: ${targetId}`);
+        const noteKindDiagnostic = (0, validators_1.validateSupportedNoteKind)(target);
+        if (noteKindDiagnostic)
+            return this.failWith(noteKindDiagnostic);
+        const targetVoiceDiagnostic = (0, validators_1.validateTargetVoiceMatch)(command, target);
+        if (targetVoiceDiagnostic)
+            return this.failWith(targetVoiceDiagnostic);
+        const bfDiagnostic = (0, validators_1.validateBackupForwardBoundaryForStructuralEdit)(command, target);
+        if (bfDiagnostic)
+            return this.failWith(bfDiagnostic);
+        const laneDiagnostic = (0, validators_1.validateInsertLaneBoundary)(command, target);
+        if (laneDiagnostic)
+            return this.failWith(laneDiagnostic);
+        const snapshot = (0, xmlUtils_1.serializeXml)(this.doc);
+        const warnings = [];
+        let insertedNode = null;
+        let removedNodeId = null;
+        const affectedMeasureNumbers = this.collectAffectedMeasureNumbers(target);
+        try {
+            if (command.type === "change_pitch") {
+                (0, xmlUtils_1.setPitch)(target, command.pitch);
+            }
+            else if (command.type === "change_duration") {
+                const oldDuration = (_a = (0, xmlUtils_1.getDurationValue)(target)) !== null && _a !== void 0 ? _a : 0;
+                const timing = (0, timeIndex_1.getMeasureTimingForVoice)(target, command.voice);
+                if (timing) {
+                    const projected = timing.occupied - oldDuration + command.duration;
+                    const result = (0, validators_1.validateProjectedMeasureTiming)(target, command.voice, projected);
+                    if (result.diagnostic)
+                        return this.failWith(result.diagnostic);
+                    if (result.warning)
+                        warnings.push(result.warning);
+                }
+                (0, xmlUtils_1.setDurationValue)(target, command.duration);
+            }
+            else if (command.type === "insert_note_after") {
+                const timing = (0, timeIndex_1.getMeasureTimingForVoice)(target, command.voice);
+                if (timing) {
+                    const projected = timing.occupied + command.note.duration;
+                    const result = (0, validators_1.validateProjectedMeasureTiming)(target, command.voice, projected);
+                    if (result.diagnostic)
+                        return this.failWith(result.diagnostic);
+                    if (result.warning)
+                        warnings.push(result.warning);
+                }
+                const note = (0, xmlUtils_1.createNoteElement)(this.doc, command.voice, command.note.duration, command.note.pitch);
+                target.after(note);
+                insertedNode = note;
+            }
+            else if (command.type === "delete_note") {
+                const duration = (_b = (0, xmlUtils_1.getDurationValue)(target)) !== null && _b !== void 0 ? _b : 0;
+                const timing = (0, timeIndex_1.getMeasureTimingForVoice)(target, command.voice);
+                if (timing) {
+                    const projected = timing.occupied - duration;
+                    const result = (0, validators_1.validateProjectedMeasureTiming)(target, command.voice, projected);
+                    if (result.diagnostic)
+                        return this.failWith(result.diagnostic);
+                    if (result.warning)
+                        warnings.push(result.warning);
+                }
+                removedNodeId = targetId;
+                target.remove();
+            }
+        }
+        catch (_c) {
+            this.restoreFrom(snapshot);
+            return this.fail("MVP_COMMAND_EXECUTION_FAILED", "Command failed unexpectedly.");
+        }
+        this.reindex();
+        const dirtyBefore = this.dirty;
+        this.dirty = true;
+        const changedNodeIds = this.buildChangedNodeIds(command, targetId, insertedNode, removedNodeId);
+        return {
+            ok: true,
+            dirtyChanged: !dirtyBefore,
+            changedNodeIds,
+            affectedMeasureNumbers,
+            diagnostics: [],
+            warnings,
+        };
+    }
+    save() {
+        if (!this.doc) {
+            return {
+                ok: false,
+                mode: "original_noop",
+                xml: "",
+                diagnostics: [{ code: "MVP_SCORE_NOT_LOADED", message: "Score is not loaded." }],
+            };
+        }
+        const integrity = this.findInvalidNoteDiagnostic();
+        if (integrity) {
+            return { ok: false, mode: "serialized_dirty", xml: "", diagnostics: [integrity] };
+        }
+        const overfull = this.findOverfullDiagnostic();
+        if (overfull) {
+            return { ok: false, mode: "serialized_dirty", xml: "", diagnostics: [overfull] };
+        }
+        if (!this.dirty) {
+            return {
+                ok: true,
+                mode: "original_noop",
+                xml: this.originalXml,
+                diagnostics: [],
+            };
+        }
+        return {
+            ok: true,
+            mode: "serialized_dirty",
+            xml: (0, xmlUtils_1.serializeXml)(this.doc),
+            diagnostics: [],
+        };
+    }
+    isDirty() {
+        return this.dirty;
+    }
+    listNoteNodeIds() {
+        return Array.from(this.idToNode.keys());
+    }
+    /**
+     * Debug-only helper for UI diagnostics.
+     * Returns current in-memory XML regardless of dirty/validation state.
+     */
+    debugSerializeCurrentXml() {
+        if (!this.doc)
+            return null;
+        return (0, xmlUtils_1.serializeXml)(this.doc);
+    }
+    nextNodeId() {
+        this.nodeCounter += 1;
+        return `n${this.nodeCounter}`;
+    }
+    reindex() {
+        if (!this.doc)
+            return;
+        (0, xmlUtils_1.reindexNodeIds)(this.doc, this.nodeToId, this.idToNode, () => this.nextNodeId());
+    }
+    restoreFrom(xmlSnapshot) {
+        this.doc = (0, xmlUtils_1.parseXml)(xmlSnapshot);
+        this.reindex();
+    }
+    findOverfullDiagnostic() {
+        if (!this.doc)
+            return null;
+        const measures = this.doc.querySelectorAll("measure");
+        for (const measure of measures) {
+            const note = measure.querySelector("note");
+            if (!note)
+                continue;
+            const timing = (0, timeIndex_1.getMeasureTimingForVoice)(note, this.editableVoice);
+            if (!timing)
+                continue;
+            if (timing.occupied > timing.capacity) {
+                return {
+                    code: "MEASURE_OVERFULL",
+                    message: `Occupied time ${timing.occupied} exceeds capacity ${timing.capacity}.`,
+                };
+            }
+        }
+        return null;
+    }
+    findInvalidNoteDiagnostic() {
+        if (!this.doc)
+            return null;
+        const notes = this.doc.querySelectorAll("note");
+        for (const note of notes) {
+            const voice = (0, xmlUtils_1.getVoiceText)(note);
+            if (!voice) {
+                return {
+                    code: "MVP_INVALID_NOTE_VOICE",
+                    message: "Note is missing a valid <voice> value.",
+                };
+            }
+            const duration = (0, xmlUtils_1.getDurationValue)(note);
+            if (duration === null || duration <= 0) {
+                return {
+                    code: "MVP_INVALID_NOTE_DURATION",
+                    message: "Note is missing a valid positive <duration> value.",
+                };
+            }
+            const pitchDiagnostic = this.validateNotePitch(note);
+            if (pitchDiagnostic)
+                return pitchDiagnostic;
+        }
+        return null;
+    }
+    fail(code, message) {
+        return this.failWith({ code, message });
+    }
+    failWith(diagnostic) {
+        return {
+            ok: false,
+            dirtyChanged: false,
+            changedNodeIds: [],
+            affectedMeasureNumbers: [],
+            diagnostics: [diagnostic],
+            warnings: [],
+        };
+    }
+    collectAffectedMeasureNumbers(note) {
+        var _a;
+        const measure = (0, xmlUtils_1.findAncestorMeasure)(note);
+        if (!measure)
+            return [];
+        const number = (_a = measure.getAttribute("number")) !== null && _a !== void 0 ? _a : "";
+        return number ? [number] : [];
+    }
+    validateNotePitch(note) {
+        var _a, _b, _c, _d, _e, _f, _g, _h, _j;
+        const hasRest = Array.from(note.children).some((c) => c.tagName === "rest");
+        const hasChord = Array.from(note.children).some((c) => c.tagName === "chord");
+        const pitch = (_a = Array.from(note.children).find((c) => c.tagName === "pitch")) !== null && _a !== void 0 ? _a : null;
+        if (hasRest && hasChord) {
+            return {
+                code: "MVP_INVALID_NOTE_PITCH",
+                message: "Note must not contain both <rest> and <chord>.",
+            };
+        }
+        if (hasRest && pitch) {
+            return {
+                code: "MVP_INVALID_NOTE_PITCH",
+                message: "Rest note must not contain <pitch>.",
+            };
+        }
+        if (hasChord && !pitch) {
+            return {
+                code: "MVP_INVALID_NOTE_PITCH",
+                message: "Chord note must contain a valid <pitch>.",
+            };
+        }
+        if (!pitch) {
+            if (hasRest)
+                return null;
+            return {
+                code: "MVP_INVALID_NOTE_PITCH",
+                message: "Non-rest note is missing a valid <pitch>.",
+            };
+        }
+        const step = (_d = (_c = (_b = pitch.querySelector("step")) === null || _b === void 0 ? void 0 : _b.textContent) === null || _c === void 0 ? void 0 : _c.trim()) !== null && _d !== void 0 ? _d : "";
+        if (!["A", "B", "C", "D", "E", "F", "G"].includes(step)) {
+            return {
+                code: "MVP_INVALID_NOTE_PITCH",
+                message: "Pitch step is invalid.",
+            };
+        }
+        const octaveText = (_g = (_f = (_e = pitch.querySelector("octave")) === null || _e === void 0 ? void 0 : _e.textContent) === null || _f === void 0 ? void 0 : _f.trim()) !== null && _g !== void 0 ? _g : "";
+        const octave = Number(octaveText);
+        if (!Number.isInteger(octave)) {
+            return {
+                code: "MVP_INVALID_NOTE_PITCH",
+                message: "Pitch octave is invalid.",
+            };
+        }
+        const alterText = (_j = (_h = pitch.querySelector("alter")) === null || _h === void 0 ? void 0 : _h.textContent) === null || _j === void 0 ? void 0 : _j.trim();
+        if (alterText !== undefined) {
+            const alter = Number(alterText);
+            if (!Number.isInteger(alter) || alter < -2 || alter > 2) {
+                return {
+                    code: "MVP_INVALID_NOTE_PITCH",
+                    message: "Pitch alter is invalid.",
+                };
+            }
+        }
+        return null;
+    }
+    buildChangedNodeIds(command, targetId, insertedNode, removedNodeId) {
+        var _a;
+        if (command.type === "insert_note_after") {
+            const insertedId = insertedNode ? (_a = this.nodeToId.get(insertedNode)) !== null && _a !== void 0 ? _a : null : null;
+            return insertedId ? [targetId, insertedId] : [targetId];
+        }
+        if (command.type === "delete_note") {
+            return removedNodeId ? [removedNodeId] : [targetId];
+        }
+        return [targetId];
+    }
+}
+exports.ScoreCore = ScoreCore;
+
+  },
+  "core/validators.js": function (require, module, exports) {
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.validateProjectedMeasureTiming = exports.validateBackupForwardBoundaryForStructuralEdit = exports.validateInsertLaneBoundary = exports.validateTargetVoiceMatch = exports.validateSupportedNoteKind = exports.validateCommandPayload = exports.validateVoice = void 0;
+const timeIndex_1 = require("./timeIndex");
+const xmlUtils_1 = require("./xmlUtils");
+const validateVoice = (command, editableVoice) => {
+    if (command.type === "ui_noop")
+        return null;
+    if (command.voice === editableVoice)
+        return null;
+    return {
+        code: "MVP_UNSUPPORTED_NON_EDITABLE_VOICE",
+        message: `Voice ${command.voice} is not editable in MVP.`,
+    };
+};
+exports.validateVoice = validateVoice;
+const validateCommandPayload = (command) => {
+    if (command.type === "ui_noop")
+        return null;
+    if (command.type === "change_duration") {
+        if (!isPositiveInteger(command.duration)) {
+            return {
+                code: "MVP_INVALID_COMMAND_PAYLOAD",
+                message: "change_duration.duration must be a positive integer.",
+            };
+        }
+        return null;
+    }
+    if (command.type === "insert_note_after") {
+        if (!isPositiveInteger(command.note.duration)) {
+            return {
+                code: "MVP_INVALID_COMMAND_PAYLOAD",
+                message: "insert_note_after.note.duration must be a positive integer.",
+            };
+        }
+        if (!isValidPitch(command.note.pitch)) {
+            return {
+                code: "MVP_INVALID_COMMAND_PAYLOAD",
+                message: "insert_note_after.note.pitch is invalid.",
+            };
+        }
+        return null;
+    }
+    if (command.type === "change_pitch") {
+        if (!isValidPitch(command.pitch)) {
+            return {
+                code: "MVP_INVALID_COMMAND_PAYLOAD",
+                message: "change_pitch.pitch is invalid.",
+            };
+        }
+    }
+    return null;
+};
+exports.validateCommandPayload = validateCommandPayload;
+const validateSupportedNoteKind = (note) => {
+    if (!(0, xmlUtils_1.isUnsupportedNoteKind)(note))
+        return null;
+    return {
+        code: "MVP_UNSUPPORTED_NOTE_KIND",
+        message: "Editing grace/cue/chord/rest notes is not supported in MVP.",
+    };
+};
+exports.validateSupportedNoteKind = validateSupportedNoteKind;
+const validateTargetVoiceMatch = (command, targetNote) => {
+    if (command.type === "ui_noop")
+        return null;
+    const targetVoice = (0, xmlUtils_1.getVoiceText)(targetNote);
+    if (targetVoice === command.voice)
+        return null;
+    return {
+        code: "MVP_UNSUPPORTED_NON_EDITABLE_VOICE",
+        message: `Target note voice (${targetVoice !== null && targetVoice !== void 0 ? targetVoice : "none"}) does not match command voice (${command.voice}).`,
+    };
+};
+exports.validateTargetVoiceMatch = validateTargetVoiceMatch;
+const validateInsertLaneBoundary = (command, anchorNote) => {
+    if (command.type !== "insert_note_after")
+        return null;
+    const measure = (0, xmlUtils_1.findAncestorMeasure)(anchorNote);
+    if (!measure)
+        return null;
+    const children = Array.from(measure.children);
+    const anchorIndex = children.indexOf(anchorNote);
+    if (anchorIndex < 0)
+        return null;
+    for (let i = anchorIndex + 1; i < children.length; i += 1) {
+        const node = children[i];
+        if (node.tagName !== "note")
+            continue;
+        const nextVoice = (0, xmlUtils_1.getVoiceText)(node);
+        if (nextVoice !== command.voice) {
+            return {
+                code: "MVP_UNSUPPORTED_NON_EDITABLE_VOICE",
+                message: "Insert is restricted to a continuous local voice lane in MVP.",
+            };
+        }
+        break;
+    }
+    return null;
+};
+exports.validateInsertLaneBoundary = validateInsertLaneBoundary;
+const validateBackupForwardBoundaryForStructuralEdit = (command, anchorOrTarget) => {
+    if (command.type !== "insert_note_after" && command.type !== "delete_note") {
+        return null;
+    }
+    const prev = anchorOrTarget.previousElementSibling;
+    const next = anchorOrTarget.nextElementSibling;
+    if (command.type === "insert_note_after") {
+        if (next && isBackupOrForward(next)) {
+            return {
+                code: "MVP_UNSUPPORTED_NON_EDITABLE_VOICE",
+                message: "Insert point crosses a backup/forward boundary in MVP.",
+            };
+        }
+        return null;
+    }
+    // delete_note
+    if ((prev && isBackupOrForward(prev)) || (next && isBackupOrForward(next))) {
+        return {
+            code: "MVP_UNSUPPORTED_NON_EDITABLE_VOICE",
+            message: "Delete point crosses a backup/forward boundary in MVP.",
+        };
+    }
+    return null;
+};
+exports.validateBackupForwardBoundaryForStructuralEdit = validateBackupForwardBoundaryForStructuralEdit;
+const validateProjectedMeasureTiming = (noteInMeasure, voice, projectedOccupiedTime) => {
+    const timing = (0, timeIndex_1.getMeasureTimingForVoice)(noteInMeasure, voice);
+    if (!timing)
+        return { diagnostic: null, warning: null };
+    if (projectedOccupiedTime > timing.capacity) {
+        return {
+            diagnostic: {
+                code: "MEASURE_OVERFULL",
+                message: `Projected occupied time ${projectedOccupiedTime} exceeds capacity ${timing.capacity}.`,
+            },
+            warning: null,
+        };
+    }
+    if (projectedOccupiedTime < timing.capacity) {
+        return {
+            diagnostic: null,
+            warning: {
+                code: "MEASURE_UNDERFULL",
+                message: `Projected occupied time ${projectedOccupiedTime} is below capacity ${timing.capacity}.`,
+            },
+        };
+    }
+    return { diagnostic: null, warning: null };
+};
+exports.validateProjectedMeasureTiming = validateProjectedMeasureTiming;
+const isBackupOrForward = (node) => node.tagName === "backup" || node.tagName === "forward";
+const isPositiveInteger = (value) => Number.isFinite(value) && Number.isInteger(value) && value > 0;
+const isValidPitch = (pitch) => {
+    const stepOk = ["A", "B", "C", "D", "E", "F", "G"].includes(pitch.step);
+    if (!stepOk)
+        return false;
+    if (!Number.isFinite(pitch.octave) || !Number.isInteger(pitch.octave))
+        return false;
+    if (typeof pitch.alter === "number") {
+        if (!Number.isInteger(pitch.alter))
+            return false;
+        if (pitch.alter < -2 || pitch.alter > 2)
+            return false;
+    }
+    return true;
+};
+
+  },
+  "core/commands.js": function (require, module, exports) {
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.getCommandNodeId = exports.isUiOnlyCommand = void 0;
+const isUiOnlyCommand = (command) => command.type === "ui_noop";
+exports.isUiOnlyCommand = isUiOnlyCommand;
+const getCommandNodeId = (command) => {
+    switch (command.type) {
+        case "change_pitch":
+        case "change_duration":
+        case "delete_note":
+            return command.targetNodeId;
+        case "insert_note_after":
+            return command.anchorNodeId;
+        case "ui_noop":
+            return null;
+    }
+};
+exports.getCommandNodeId = getCommandNodeId;
+
+  }
+};
+
+const cache = {};
+
+function normalizePath(p) {
+  const parts = [];
+  for (const part of p.split('/')) {
+    if (!part || part === '.') continue;
+    if (part === '..') {
+      parts.pop();
+    } else {
+      parts.push(part);
+    }
+  }
+  return parts.join('/');
+}
+
+function resolve(fromId, specifier) {
+  if (!specifier.startsWith('.')) {
+    throw new Error('External module is not allowed in single-file build: ' + specifier);
+  }
+  const fromParts = fromId.split('/');
+  fromParts.pop();
+  const resolvedBase = normalizePath(fromParts.concat(specifier.split('/')).join('/'));
+  const candidates = [resolvedBase + '.js', resolvedBase + '/index.js'];
+  for (const c of candidates) {
+    if (Object.prototype.hasOwnProperty.call(modules, c)) return c;
+  }
+  throw new Error('Cannot resolve module at runtime: ' + specifier + ' from ' + fromId);
+}
+
+function load(id) {
+  if (cache[id]) return cache[id].exports;
+  const factory = modules[id];
+  if (!factory) throw new Error('Unknown module: ' + id);
+  const module = { exports: {} };
+  cache[id] = module;
+  const localRequire = function (specifier) {
+    return load(resolve(id, specifier));
+  };
+  factory(localRequire, module, module.exports);
+  return module.exports;
+}
+
+load("src/ts/main.js");
+})();

--- a/src/ts/main.ts
+++ b/src/ts/main.ts
@@ -1,0 +1,752 @@
+import { ScoreCore } from "../../core/ScoreCore";
+import { getMeasureCapacity, getOccupiedTime } from "../../core/timeIndex";
+import type {
+  ChangeDurationCommand,
+  ChangePitchCommand,
+  CoreCommand,
+  DeleteNoteCommand,
+  DispatchResult,
+  InsertNoteAfterCommand,
+  Pitch,
+  SaveResult,
+} from "../../core/interfaces";
+
+type UiState = {
+  loaded: boolean;
+  selectedNodeId: string | null;
+  noteNodeIds: string[];
+  lastDispatchResult: DispatchResult | null;
+  lastSaveResult: SaveResult | null;
+  lastSuccessfulSaveXml: string;
+};
+
+const EDITABLE_VOICE = "1";
+
+const sampleXml = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list>
+    <score-part id="P1"><part-name>Music</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+      </attributes>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>1</duration><voice>1</voice></note>
+      <note><pitch><step>D</step><octave>4</octave></pitch><duration>1</duration><voice>1</voice></note>
+      <note><pitch><step>E</step><octave>4</octave></pitch><duration>1</duration><voice>1</voice></note>
+      <note><pitch><step>F</step><octave>4</octave></pitch><duration>1</duration><voice>1</voice></note>
+    </measure>
+  </part>
+</score-partwise>`;
+
+const q = <T extends Element>(selector: string): T => {
+  const el = document.querySelector(selector);
+  if (!el) throw new Error(`Missing element: ${selector}`);
+  return el as T;
+};
+
+const inputModeFile = q<HTMLInputElement>("#inputModeFile");
+const inputModeSource = q<HTMLInputElement>("#inputModeSource");
+const fileInputBlock = q<HTMLDivElement>("#fileInputBlock");
+const sourceInputBlock = q<HTMLDivElement>("#sourceInputBlock");
+const xmlInput = q<HTMLTextAreaElement>("#xmlInput");
+const fileSelectBtn = q<HTMLButtonElement>("#fileSelectBtn");
+const fileInput = q<HTMLInputElement>("#fileInput");
+const fileNameText = q<HTMLSpanElement>("#fileNameText");
+const loadBtn = q<HTMLButtonElement>("#loadBtn");
+const loadSampleBtn = q<HTMLButtonElement>("#loadSampleBtn");
+const noteSelect = q<HTMLSelectElement>("#noteSelect");
+const statusText = q<HTMLParagraphElement>("#statusText");
+const pitchStep = q<HTMLSelectElement>("#pitchStep");
+const pitchAlter = q<HTMLSelectElement>("#pitchAlter");
+const pitchOctave = q<HTMLInputElement>("#pitchOctave");
+const durationInput = q<HTMLInputElement>("#durationInput");
+const changePitchBtn = q<HTMLButtonElement>("#changePitchBtn");
+const changeDurationBtn = q<HTMLButtonElement>("#changeDurationBtn");
+const insertAfterBtn = q<HTMLButtonElement>("#insertAfterBtn");
+const deleteBtn = q<HTMLButtonElement>("#deleteBtn");
+const saveBtn = q<HTMLButtonElement>("#saveBtn");
+const playBtn = q<HTMLButtonElement>("#playBtn");
+const stopBtn = q<HTMLButtonElement>("#stopBtn");
+const downloadBtn = q<HTMLButtonElement>("#downloadBtn");
+const saveModeText = q<HTMLSpanElement>("#saveModeText");
+const playbackText = q<HTMLParagraphElement>("#playbackText");
+const outputXml = q<HTMLTextAreaElement>("#outputXml");
+const diagArea = q<HTMLDivElement>("#diagArea");
+
+const core = new ScoreCore({ editableVoice: EDITABLE_VOICE });
+const state: UiState = {
+  loaded: false,
+  selectedNodeId: null,
+  noteNodeIds: [],
+  lastDispatchResult: null,
+  lastSaveResult: null,
+  lastSuccessfulSaveXml: "",
+};
+
+xmlInput.value = sampleXml;
+let audioContext: AudioContext | null = null;
+let activeOscillators: OscillatorNode[] = [];
+let activeGains: GainNode[] = [];
+let playbackTimer: number | null = null;
+let isPlaying = false;
+const DEBUG_LOG = true;
+
+const logDiagnostics = (
+  phase: "load" | "dispatch" | "save" | "playback",
+  diagnostics: Array<{ code: string; message: string }>,
+  warnings: Array<{ code: string; message: string }> = []
+): void => {
+  if (!DEBUG_LOG) return;
+  for (const d of diagnostics) {
+    console.error(`[mikuscore][${phase}][${d.code}] ${d.message}`);
+  }
+  for (const w of warnings) {
+    console.warn(`[mikuscore][${phase}][${w.code}] ${w.message}`);
+  }
+};
+
+const dumpOverfullContext = (xml: string, voice: string): void => {
+  if (!DEBUG_LOG) return;
+  const doc = new DOMParser().parseFromString(xml, "application/xml");
+  if (doc.querySelector("parsererror")) {
+    console.error("[mikuscore][debug] XML parse failed while dumping overfull context.");
+    return;
+  }
+
+  const measures = Array.from(doc.querySelectorAll("part > measure"));
+  let found = false;
+  for (const measure of measures) {
+    const number = measure.getAttribute("number") ?? "(no-number)";
+    const divisionsText = measure.querySelector("attributes > divisions")?.textContent?.trim() ?? "(inherit)";
+    const beatsText = measure.querySelector("attributes > time > beats")?.textContent?.trim() ?? "(inherit)";
+    const beatTypeText =
+      measure.querySelector("attributes > time > beat-type")?.textContent?.trim() ?? "(inherit)";
+
+    const noteRows: Array<{
+      idx: number;
+      voice: string;
+      duration: number;
+      pitch: string;
+      isRest: boolean;
+    }> = [];
+
+    const occupied = getOccupiedTime(measure, voice);
+    Array.from(measure.children).forEach((child, idx) => {
+      if (child.tagName !== "note") return;
+      const noteVoice = child.querySelector("voice")?.textContent?.trim() ?? "";
+      const duration = Number(child.querySelector("duration")?.textContent?.trim() ?? "");
+      const isRest = Boolean(child.querySelector("rest"));
+      const step = child.querySelector("pitch > step")?.textContent?.trim() ?? "";
+      const alter = child.querySelector("pitch > alter")?.textContent?.trim();
+      const octave = child.querySelector("pitch > octave")?.textContent?.trim() ?? "";
+      const alterText = alter ? `${alter >= "0" ? "+" : ""}${alter}` : "";
+      const pitch = isRest ? "rest" : `${step}${alterText}${octave ? octave : ""}`;
+
+      noteRows.push({
+        idx,
+        voice: noteVoice || "(none)",
+        duration: Number.isFinite(duration) ? duration : NaN,
+        pitch,
+        isRest,
+      });
+    });
+
+    const capacity = getMeasureCapacity(measure);
+    if (capacity === null) continue;
+    if (occupied <= capacity) continue;
+    found = true;
+
+    console.groupCollapsed(
+      `[mikuscore][debug][MEASURE_OVERFULL] measure=${number} occupied=${occupied} capacity=${capacity}`
+    );
+    console.log({
+      measure: number,
+      voice,
+      divisions: divisionsText,
+      beats: beatsText,
+      beatType: beatTypeText,
+      occupied,
+      capacity,
+    });
+    console.table(noteRows);
+    console.groupEnd();
+  }
+  if (!found) {
+    console.warn("[mikuscore][debug] no overfull measure found while dumping context.");
+  }
+};
+
+const renderInputMode = (): void => {
+  const fileMode = inputModeFile.checked;
+  fileInputBlock.classList.toggle("ms-hidden", !fileMode);
+  sourceInputBlock.classList.toggle("ms-hidden", fileMode);
+};
+
+const renderStatus = (): void => {
+  const dirty = core.isDirty();
+  statusText.textContent = state.loaded
+    ? `ロード済み / dirty=${dirty} / notes=${state.noteNodeIds.length}`
+    : "未ロード（まず Load してください）";
+};
+
+const renderNotes = (): void => {
+  noteSelect.innerHTML = "";
+  const placeholder = document.createElement("option");
+  placeholder.value = "";
+  placeholder.textContent = state.noteNodeIds.length === 0 ? "(ノートなし)" : "(選択してください)";
+  noteSelect.appendChild(placeholder);
+
+  for (const nodeId of state.noteNodeIds) {
+    const option = document.createElement("option");
+    option.value = nodeId;
+    option.textContent = nodeId;
+    noteSelect.appendChild(option);
+  }
+
+  if (state.selectedNodeId && state.noteNodeIds.includes(state.selectedNodeId)) {
+    noteSelect.value = state.selectedNodeId;
+  } else {
+    state.selectedNodeId = null;
+    noteSelect.value = "";
+  }
+};
+
+const renderDiagnostics = (): void => {
+  diagArea.innerHTML = "";
+
+  const dispatch = state.lastDispatchResult;
+  const save = state.lastSaveResult;
+
+  if (!dispatch && !save) {
+    diagArea.textContent = "診断なし";
+    return;
+  }
+
+  if (dispatch) {
+    for (const diagnostic of dispatch.diagnostics) {
+      const line = document.createElement("div");
+      line.className = "diag-error";
+      line.textContent = `[dispatch][${diagnostic.code}] ${diagnostic.message}`;
+      diagArea.appendChild(line);
+    }
+    for (const warning of dispatch.warnings) {
+      const line = document.createElement("div");
+      line.className = "diag-warning";
+      line.textContent = `[dispatch][${warning.code}] ${warning.message}`;
+      diagArea.appendChild(line);
+    }
+  }
+
+  if (save) {
+    for (const diagnostic of save.diagnostics) {
+      const line = document.createElement("div");
+      line.className = "diag-error";
+      line.textContent = `[save][${diagnostic.code}] ${diagnostic.message}`;
+      diagArea.appendChild(line);
+    }
+  }
+
+  if (!diagArea.firstChild) {
+    diagArea.textContent = "診断なし";
+  }
+};
+
+const renderOutput = (): void => {
+  saveModeText.textContent = state.lastSaveResult ? state.lastSaveResult.mode : "-";
+  outputXml.value = state.lastSaveResult?.ok ? state.lastSaveResult.xml : "";
+  downloadBtn.disabled = !state.lastSaveResult?.ok;
+};
+
+const renderControlState = (): void => {
+  const hasSelection = Boolean(state.selectedNodeId);
+  noteSelect.disabled = !state.loaded;
+  changePitchBtn.disabled = !state.loaded || !hasSelection;
+  changeDurationBtn.disabled = !state.loaded || !hasSelection;
+  insertAfterBtn.disabled = !state.loaded || !hasSelection;
+  deleteBtn.disabled = !state.loaded || !hasSelection;
+  saveBtn.disabled = !state.loaded;
+  playBtn.disabled = !state.loaded || isPlaying;
+  stopBtn.disabled = !isPlaying;
+};
+
+const renderAll = (): void => {
+  renderInputMode();
+  renderNotes();
+  renderStatus();
+  renderDiagnostics();
+  renderOutput();
+  renderControlState();
+};
+
+const refreshNotesFromCore = (): void => {
+  state.noteNodeIds = core.listNoteNodeIds();
+  if (state.selectedNodeId && !state.noteNodeIds.includes(state.selectedNodeId)) {
+    state.selectedNodeId = null;
+  }
+};
+
+type PlaybackEvent = {
+  freqHz: number;
+  startSec: number;
+  durSec: number;
+};
+
+const midiToHz = (midi: number): number => 440 * Math.pow(2, (midi - 69) / 12);
+
+const pitchToMidi = (step: string, alter: number, octave: number): number | null => {
+  const semitoneMap: Record<string, number> = {
+    C: 0,
+    D: 2,
+    E: 4,
+    F: 5,
+    G: 7,
+    A: 9,
+    B: 11,
+  };
+  const base = semitoneMap[step];
+  if (base === undefined) return null;
+  return (octave + 1) * 12 + base + alter;
+};
+
+const getFirstNumber = (el: ParentNode, selector: string): number | null => {
+  const text = el.querySelector(selector)?.textContent?.trim();
+  if (!text) return null;
+  const n = Number(text);
+  return Number.isFinite(n) ? n : null;
+};
+
+const buildPlaybackEventsFromXml = (xml: string): PlaybackEvent[] => {
+  const doc = new DOMParser().parseFromString(xml, "application/xml");
+  if (doc.querySelector("parsererror")) return [];
+  const part = doc.querySelector("part");
+  if (!part) return [];
+
+  let currentDivisions = 1;
+  const defaultTempo = 120;
+  const tempo = getFirstNumber(doc, "sound[tempo]") ?? defaultTempo;
+  const secPerDivision = 60 / tempo / currentDivisions;
+
+  const events: PlaybackEvent[] = [];
+  let cursorSec = 0;
+  let lastNoteStartSec = 0;
+
+  for (const measure of Array.from(part.querySelectorAll(":scope > measure"))) {
+    const divisions = getFirstNumber(measure, "attributes > divisions");
+    if (divisions && divisions > 0) {
+      currentDivisions = divisions;
+    }
+    const measureSecPerDivision = 60 / tempo / currentDivisions;
+
+    for (const child of Array.from(measure.children)) {
+      if (child.tagName !== "note") continue;
+
+      const voice = child.querySelector("voice")?.textContent?.trim() ?? "1";
+      if (voice !== EDITABLE_VOICE) continue;
+
+      const durationValue = getFirstNumber(child, "duration");
+      if (!durationValue || durationValue <= 0) continue;
+
+      const durationSec = durationValue * measureSecPerDivision;
+      const isRest = Boolean(child.querySelector("rest"));
+      const isChord = Boolean(child.querySelector("chord"));
+      if (isRest) {
+        cursorSec += durationSec;
+        continue;
+      }
+
+      const step = child.querySelector("pitch > step")?.textContent?.trim() ?? "";
+      const octave = getFirstNumber(child, "pitch > octave");
+      const alter = getFirstNumber(child, "pitch > alter") ?? 0;
+      if (octave === null) {
+        cursorSec += durationSec;
+        continue;
+      }
+
+      const midi = pitchToMidi(step, alter, octave);
+      if (midi === null) {
+        if (!isChord) {
+          cursorSec += durationSec;
+        }
+        continue;
+      }
+
+      const startSec = isChord ? lastNoteStartSec : cursorSec;
+      events.push({
+        freqHz: midiToHz(midi),
+        startSec,
+        durSec: Math.max(0.05, durationSec),
+      });
+      if (!isChord) {
+        lastNoteStartSec = cursorSec;
+        cursorSec += durationSec;
+      }
+    }
+  }
+
+  // Touch computed variable so TypeScript keeps intent explicit and avoids accidental drift.
+  void secPerDivision;
+  return events;
+};
+
+const stopPlayback = (): void => {
+  for (const osc of activeOscillators) {
+    try {
+      osc.stop();
+    } catch {
+      // ignore stale node stop calls
+    }
+    osc.disconnect();
+  }
+  for (const gain of activeGains) {
+    gain.disconnect();
+  }
+  activeOscillators = [];
+  activeGains = [];
+  if (playbackTimer !== null) {
+    window.clearTimeout(playbackTimer);
+    playbackTimer = null;
+  }
+  isPlaying = false;
+  playbackText.textContent = "playback: idle";
+  renderControlState();
+};
+
+const startPlayback = async (): Promise<void> => {
+  if (!state.loaded || isPlaying) return;
+
+  const saveResult = core.save();
+  state.lastSaveResult = saveResult;
+  if (!saveResult.ok) {
+    logDiagnostics("playback", saveResult.diagnostics);
+    if (saveResult.diagnostics.some((d) => d.code === "MEASURE_OVERFULL")) {
+      const debugXml = core.debugSerializeCurrentXml();
+      if (debugXml) {
+        dumpOverfullContext(debugXml, EDITABLE_VOICE);
+      } else if (DEBUG_LOG) {
+        console.warn("[mikuscore][debug] no in-memory XML to dump.");
+      }
+    }
+    renderAll();
+    playbackText.textContent = "playback: save failed";
+    return;
+  }
+
+  const events = buildPlaybackEventsFromXml(saveResult.xml);
+  if (events.length === 0) {
+    playbackText.textContent = "playback: no playable notes";
+    renderControlState();
+    return;
+  }
+
+  if (!audioContext) {
+    audioContext = new AudioContext();
+  }
+  await audioContext.resume();
+
+  const now = audioContext.currentTime + 0.02;
+  let maxEnd = 0;
+
+  for (const event of events) {
+    const gain = audioContext.createGain();
+    gain.gain.setValueAtTime(0.0001, now + event.startSec);
+    gain.gain.exponentialRampToValueAtTime(0.12, now + event.startSec + 0.01);
+    gain.gain.exponentialRampToValueAtTime(
+      0.0001,
+      now + event.startSec + Math.max(0.02, event.durSec * 0.9)
+    );
+    gain.connect(audioContext.destination);
+
+    const osc = audioContext.createOscillator();
+    osc.type = "sine";
+    osc.frequency.setValueAtTime(event.freqHz, now + event.startSec);
+    osc.connect(gain);
+    osc.start(now + event.startSec);
+    osc.stop(now + event.startSec + event.durSec);
+
+    activeOscillators.push(osc);
+    activeGains.push(gain);
+    maxEnd = Math.max(maxEnd, event.startSec + event.durSec);
+  }
+
+  isPlaying = true;
+  playbackText.textContent = `playback: playing (${events.length} notes)`;
+  renderControlState();
+
+  playbackTimer = window.setTimeout(() => {
+    stopPlayback();
+  }, Math.ceil(maxEnd * 1000) + 60);
+  renderAll();
+};
+
+const readSelectedPitch = (): Pitch | null => {
+  const octave = Number(pitchOctave.value);
+  if (!Number.isInteger(octave)) return null;
+
+  const alterText = pitchAlter.value.trim();
+  const base: Pitch = {
+    step: pitchStep.value as Pitch["step"],
+    octave,
+  };
+  if (alterText === "") return base;
+
+  const alter = Number(alterText);
+  if (!Number.isInteger(alter) || alter < -2 || alter > 2) return null;
+  return { ...base, alter: alter as -2 | -1 | 0 | 1 | 2 };
+};
+
+const readDuration = (): number | null => {
+  const duration = Number(durationInput.value);
+  if (!Number.isInteger(duration) || duration <= 0) return null;
+  return duration;
+};
+
+const runCommand = (command: CoreCommand): void => {
+  if (!state.loaded) return;
+  state.lastDispatchResult = core.dispatch(command);
+  if (!state.lastDispatchResult.ok || state.lastDispatchResult.warnings.length > 0) {
+    logDiagnostics(
+      "dispatch",
+      state.lastDispatchResult.diagnostics,
+      state.lastDispatchResult.warnings
+    );
+  }
+  state.lastSaveResult = null;
+
+  if (state.lastDispatchResult.ok) {
+    refreshNotesFromCore();
+  }
+  renderAll();
+};
+
+const loadFromText = (xml: string): void => {
+  try {
+    core.load(xml);
+  } catch (err) {
+    if (DEBUG_LOG) {
+      console.error("[mikuscore][load] load failed:", err);
+    }
+    state.loaded = false;
+    state.lastDispatchResult = {
+      ok: false,
+      dirtyChanged: false,
+      changedNodeIds: [],
+      affectedMeasureNumbers: [],
+      diagnostics: [
+        {
+          code: "MVP_COMMAND_EXECUTION_FAILED",
+          message: err instanceof Error ? err.message : "Load failed.",
+        },
+      ],
+      warnings: [],
+    };
+    state.lastSaveResult = null;
+    logDiagnostics("load", state.lastDispatchResult.diagnostics);
+    renderAll();
+    return;
+  }
+
+  state.loaded = true;
+  state.selectedNodeId = null;
+  state.lastDispatchResult = null;
+  state.lastSaveResult = null;
+  state.lastSuccessfulSaveXml = "";
+  refreshNotesFromCore();
+  renderAll();
+};
+
+const onLoadClick = async (): Promise<void> => {
+  if (inputModeFile.checked) {
+    const selected = fileInput.files?.[0];
+    if (!selected) {
+      state.lastDispatchResult = {
+        ok: false,
+        dirtyChanged: false,
+        changedNodeIds: [],
+        affectedMeasureNumbers: [],
+        diagnostics: [{ code: "MVP_INVALID_COMMAND_PAYLOAD", message: "ファイルを選択してください。" }],
+        warnings: [],
+      };
+      renderAll();
+      return;
+    }
+    const text = await selected.text();
+    xmlInput.value = text;
+  }
+
+  loadFromText(xmlInput.value);
+};
+
+const requireSelectedNode = (): string | null => {
+  const nodeId = state.selectedNodeId;
+  if (nodeId) return nodeId;
+  state.lastDispatchResult = {
+    ok: false,
+    dirtyChanged: false,
+    changedNodeIds: [],
+    affectedMeasureNumbers: [],
+    diagnostics: [{ code: "MVP_COMMAND_TARGET_MISSING", message: "ノートを選択してください。" }],
+    warnings: [],
+  };
+  renderAll();
+  return null;
+};
+
+const onChangePitch = (): void => {
+  const targetNodeId = requireSelectedNode();
+  if (!targetNodeId) return;
+  const pitch = readSelectedPitch();
+  if (!pitch) {
+    state.lastDispatchResult = {
+      ok: false,
+      dirtyChanged: false,
+      changedNodeIds: [],
+      affectedMeasureNumbers: [],
+      diagnostics: [{ code: "MVP_INVALID_COMMAND_PAYLOAD", message: "pitch 入力が不正です。" }],
+      warnings: [],
+    };
+    renderAll();
+    return;
+  }
+
+  const command: ChangePitchCommand = {
+    type: "change_pitch",
+    targetNodeId,
+    voice: EDITABLE_VOICE,
+    pitch,
+  };
+  runCommand(command);
+};
+
+const onChangeDuration = (): void => {
+  const targetNodeId = requireSelectedNode();
+  if (!targetNodeId) return;
+  const duration = readDuration();
+  if (!duration) {
+    state.lastDispatchResult = {
+      ok: false,
+      dirtyChanged: false,
+      changedNodeIds: [],
+      affectedMeasureNumbers: [],
+      diagnostics: [{ code: "MVP_INVALID_COMMAND_PAYLOAD", message: "duration 入力が不正です。" }],
+      warnings: [],
+    };
+    renderAll();
+    return;
+  }
+
+  const command: ChangeDurationCommand = {
+    type: "change_duration",
+    targetNodeId,
+    voice: EDITABLE_VOICE,
+    duration,
+  };
+  runCommand(command);
+};
+
+const onInsertAfter = (): void => {
+  const anchorNodeId = requireSelectedNode();
+  if (!anchorNodeId) return;
+  const duration = readDuration();
+  const pitch = readSelectedPitch();
+  if (!duration || !pitch) {
+    state.lastDispatchResult = {
+      ok: false,
+      dirtyChanged: false,
+      changedNodeIds: [],
+      affectedMeasureNumbers: [],
+      diagnostics: [{ code: "MVP_INVALID_COMMAND_PAYLOAD", message: "挿入ノート入力が不正です。" }],
+      warnings: [],
+    };
+    renderAll();
+    return;
+  }
+
+  const command: InsertNoteAfterCommand = {
+    type: "insert_note_after",
+    anchorNodeId,
+    voice: EDITABLE_VOICE,
+    note: { duration, pitch },
+  };
+  runCommand(command);
+};
+
+const onDelete = (): void => {
+  const targetNodeId = requireSelectedNode();
+  if (!targetNodeId) return;
+  const command: DeleteNoteCommand = {
+    type: "delete_note",
+    targetNodeId,
+    voice: EDITABLE_VOICE,
+  };
+  runCommand(command);
+};
+
+const onSave = (): void => {
+  if (!state.loaded) return;
+  const result = core.save();
+  state.lastSaveResult = result;
+  if (!result.ok) {
+    logDiagnostics("save", result.diagnostics);
+    if (result.diagnostics.some((d) => d.code === "MEASURE_OVERFULL")) {
+      const debugXml = core.debugSerializeCurrentXml();
+      if (debugXml) {
+        dumpOverfullContext(debugXml, EDITABLE_VOICE);
+      } else if (DEBUG_LOG) {
+        console.warn("[mikuscore][debug] no in-memory XML to dump.");
+      }
+    }
+  }
+  if (result.ok) {
+    state.lastSuccessfulSaveXml = result.xml;
+  }
+  renderAll();
+};
+
+const onDownload = (): void => {
+  if (!state.lastSuccessfulSaveXml) return;
+  const blob = new Blob([state.lastSuccessfulSaveXml], { type: "application/xml;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = "mikuscore.musicxml";
+  a.click();
+  URL.revokeObjectURL(url);
+};
+
+inputModeFile.addEventListener("change", renderInputMode);
+inputModeSource.addEventListener("change", renderInputMode);
+fileSelectBtn.addEventListener("click", () => fileInput.click());
+fileInput.addEventListener("change", () => {
+  const f = fileInput.files?.[0];
+  fileNameText.textContent = f ? f.name : "未選択";
+});
+loadBtn.addEventListener("click", () => {
+  void onLoadClick();
+});
+loadSampleBtn.addEventListener("click", () => {
+  inputModeSource.checked = true;
+  inputModeFile.checked = false;
+  xmlInput.value = sampleXml;
+  fileNameText.textContent = "未選択";
+  renderInputMode();
+});
+noteSelect.addEventListener("change", () => {
+  state.selectedNodeId = noteSelect.value || null;
+  renderStatus();
+  renderControlState();
+});
+changePitchBtn.addEventListener("click", onChangePitch);
+changeDurationBtn.addEventListener("click", onChangeDuration);
+insertAfterBtn.addEventListener("click", onInsertAfter);
+deleteBtn.addEventListener("click", onDelete);
+saveBtn.addEventListener("click", onSave);
+playBtn.addEventListener("click", () => {
+  void startPlayback();
+});
+stopBtn.addEventListener("click", stopPlayback);
+downloadBtn.addEventListener("click", onDownload);
+
+renderAll();

--- a/tests/fixtures/with_chord_timing.musicxml
+++ b/tests/fixtures/with_chord_timing.musicxml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list>
+    <score-part id="P1"><part-name>Music</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>8</divisions>
+        <time><beats>3</beats><beat-type>4</beat-type></time>
+      </attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>8</duration>
+        <voice>1</voice>
+      </note>
+      <note>
+        <chord/>
+        <pitch><step>E</step><octave>4</octave></pitch>
+        <duration>8</duration>
+        <voice>1</voice>
+      </note>
+      <note>
+        <pitch><step>G</step><octave>4</octave></pitch>
+        <duration>8</duration>
+        <voice>1</voice>
+      </note>
+      <note>
+        <pitch><step>B</step><octave>4</octave></pitch>
+        <duration>8</duration>
+        <voice>1</voice>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/tests/unit/core.spec.ts
+++ b/tests/unit/core.spec.ts
@@ -22,6 +22,7 @@ const XML_WITH_INVALID_NOTE_VOICE = loadFixture("invalid_note_voice.musicxml");
 const XML_WITH_INVALID_NOTE_PITCH = loadFixture("invalid_note_pitch.musicxml");
 const XML_WITH_INVALID_REST_WITH_PITCH = loadFixture("invalid_rest_with_pitch.musicxml");
 const XML_WITH_INVALID_CHORD_WITHOUT_PITCH = loadFixture("invalid_chord_without_pitch.musicxml");
+const XML_WITH_CHORD_TIMING = loadFixture("with_chord_timing.musicxml");
 
 describe("ScoreCore MVP", () => {
   const expectNoopStateUnchanged = (core: ScoreCore, beforeXml: string): void => {
@@ -175,6 +176,16 @@ describe("ScoreCore MVP", () => {
     expect(result.ok).toBe(false);
     expect(result.diagnostics[0]?.code).toBe("MEASURE_OVERFULL");
     expect(core.isDirty()).toBe(false);
+  });
+
+  it("TI-6: chord notes do not advance occupied time", () => {
+    const core = new ScoreCore();
+    core.load(XML_WITH_CHORD_TIMING);
+
+    const saved = core.save();
+    expect(saved.ok).toBe(true);
+    expect(saved.mode).toBe("original_noop");
+    expect(saved.diagnostics).toEqual([]);
   });
 
   it("IN-2: insert that makes measure overfull is rejected", () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,5 +7,5 @@
     "noEmit": true,
     "lib": ["DOM", "DOM.Iterable", "ES2018"]
   },
-  "include": ["core/**/*.ts"]
+  "include": ["core/**/*.ts", "src/**/*.ts"]
 }


### PR DESCRIPTION
### 概要
`mikuscore` のMVPとして、Core単体中心だった状態から、ブラウザUI・単一HTMLビルド・デバッグ再生までを一気通貫で実装しました。 あわせて、`MEASURE_OVERFULL` の誤検出要因だった chord 時間計算を修正し、回帰テストを追加しています。

### 主な変更
- UI実装を追加
  - `mikuscore-src.html`
  - `src/css/app.css`
  - `src/ts/main.ts`
- 単一HTML生成のビルド導線を追加
  - `scripts/build.mjs`
  - `package.json` に `build` / `clean` を追加
  - `mikuscore.html` / `src/js/main.js` 生成物を追加
- TypeScript設定を更新
  - `tsconfig.json` に `src/**/*.ts` を追加
- 仕様/READMEの同期
  - `docs/spec/UI_SPEC.md` を追加
  - `README.md` を更新
- Coreのデバッグ補助APIを追加
  - `core/ScoreCore.ts`: `debugSerializeCurrentXml()`
- 時間計算の不具合修正
  - `core/timeIndex.ts`: `<chord/>` ノートは `occupiedTime` 加算対象外に修正
- デバッグ再生の挙動改善
  - `src/ts/main.ts`: chordを同時発音として扱い、再生時間カーソルを進めない
  - overfull時の診断ログ/コンテキスト出力を整備
- テスト追加/更新
  - `tests/fixtures/with_chord_timing.musicxml` を追加
  - `tests/unit/core.spec.ts` に `TI-6`（chord時間不加算）を追加

### 修正した具体的な不具合
- 症状: `MEASURE_OVERFULL` が chord を含む譜面で過剰検出される
- 原因: chordノートの duration を通常ノートと同様に加算していた
- 対応: chordを時間進行対象から除外（Core計算・再生処理の両方）

### 確認項目
- `npm run typecheck` で成功
- `npm run test:unit` で成功（33 tests）
- `npm run build` で `mikuscore.html` / `src/js/main.js` 生成成功