### PR TITLE
`mikuscore` に MD3 スタイルを適用し、ヘッダー/譜面プレビュー UI を改善

### DIFF
--- a/mikuscore-src.html
+++ b/mikuscore-src.html
@@ -4,63 +4,88 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>mikuscore</title>
+  <link rel="stylesheet" href="src/css/md3/token-spec.css" />
+  <link rel="stylesheet" href="src/css/md3/core-spec.css" />
   <link rel="stylesheet" href="src/css/app.css" />
 </head>
-<body>
-  <main class="ms-shell">
-    <section class="ms-card">
-      <h1 class="ms-title">mikuscore</h1>
-      <p class="ms-intro">
-        ブラウザ上で完結し、既存MusicXMLを壊さずに編集することを重視したスコアエディタです。
-      </p>
-      <ol class="ms-steps">
-        <li>入力を選んで読み込み</li>
-        <li>譜面プレビューで選択</li>
-        <li>ノートを編集</li>
-        <li>再生で確認して保存 / ダウンロード</li>
-      </ol>
+<body class="md-page">
+  <main class="md-shell">
+    <section class="md-card ms-app">
+      <header class="ms-hero">
+        <div class="ms-hero-top">
+          <p class="ms-hero-eyebrow">LOCAL SCORE TOOL</p>
+          <span class="md-chip ms-hero-chip">v0.1.0</span>
+        </div>
+        <h1 class="md-headline ms-hero-title">
+          <span class="ms-hero-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none">
+              <path d="M9 3v12.4a3.6 3.6 0 1 1-1.2-2.7V6.2l9-2.2v9.6a3.6 3.6 0 1 1-1.2-2.7V5.6L9 7.1Z" />
+            </svg>
+          </span>
+          <span>mikuscore</span>
+          <span class="md-tooltip-group">
+            <span class="md-info-chip" aria-label="mikuscore の詳細説明">
+              <svg aria-hidden="true" viewBox="0 0 24 24" class="md-info-icon" fill="none">
+                <circle cx="12" cy="12" r="9" fill="#cbbcf0"></circle>
+                <rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"></rect>
+                <circle cx="12" cy="7.5" r="1" fill="#ffffff"></circle>
+              </svg>
+            </span>
+            <span class="md-tooltip-content md-tooltip md-tooltip--rich md-tooltip--wide">
+              mikuscore は、MusicXML の既存構造をできるだけ保持しながら編集することを重視したローカル完結型エディタです。
+              入力（ファイル/ソース）から譜面プレビュー、ノート編集、再生確認、保存/ダウンロードまでを一画面で行えます。
+              操作手順: 1) 入力を選んで読み込み 2) 譜面プレビューで選択 3) ノートを編集 4) 再生で確認して保存 / ダウンロード。
+              まず読み込み後に譜面をクリックして対象ノートを選び、音高・音価を調整してください。
+            </span>
+          </span>
+        </h1>
+        <p class="md-subtitle ms-hero-subtitle">
+          ブラウザ上で完結し、既存MusicXMLを壊さずに編集することを重視したスコアエディタです。
+        </p>
+      </header>
+
       <div class="ms-flow">
-        <section class="ms-section ms-flow-step">
-          <h2><span class="ms-step-no">1</span>MusicXML入力</h2>
+        <section class="md-section ms-flow-step">
+          <h2 class="md-section-title"><span class="ms-step-no">1</span>MusicXML入力</h2>
           <div class="ms-radio-group" role="radiogroup" aria-label="入力方式">
-            <label><input id="inputModeFile" type="radio" name="inputMode" value="file" checked /> ファイル読込</label>
-            <label><input id="inputModeSource" type="radio" name="inputMode" value="source" /> ソース入力</label>
+            <label class="md-radio"><input id="inputModeFile" type="radio" name="inputMode" value="file" checked /> ファイル読込</label>
+            <label class="md-radio"><input id="inputModeSource" type="radio" name="inputMode" value="source" /> ソース入力</label>
           </div>
 
           <div id="fileInputBlock" class="ms-block">
-            <button id="fileSelectBtn" type="button">ファイルを選択</button>
-            <span id="fileNameText">未選択</span>
+            <button id="fileSelectBtn" type="button" class="md-button md-button--tonal">ファイルを選択</button>
+            <span id="fileNameText" class="ms-file-name">未選択</span>
             <input id="fileInput" type="file" accept=".musicxml,.xml,text/xml,application/xml" hidden />
           </div>
 
-          <div id="sourceInputBlock" class="ms-block ms-hidden">
-            <label for="xmlInput" class="ms-label">MusicXML</label>
-            <textarea id="xmlInput" rows="12" spellcheck="false"></textarea>
+          <div id="sourceInputBlock" class="ms-block md-hidden">
+            <label for="xmlInput" class="md-label">MusicXML</label>
+            <textarea id="xmlInput" rows="12" spellcheck="false" class="md-textarea"></textarea>
           </div>
 
           <div class="ms-actions">
-            <button id="loadBtn" type="button">読み込み</button>
+            <button id="loadBtn" type="button" class="md-button md-button--primary">読み込み</button>
           </div>
         </section>
 
-        <section class="ms-section ms-flow-step">
-          <h2><span class="ms-step-no">2</span>譜面プレビュー（クリックで選択）</h2>
-          <p class="ms-label">Verovioレンダリング上の音符をクリックすると、編集対象として選択します。</p>
+        <section class="md-section ms-flow-step">
+          <h2 class="md-section-title"><span class="ms-step-no">2</span>譜面プレビュー（クリックで選択）</h2>
+          <p class="md-label">Verovioレンダリング上の音符をクリックすると、編集対象として選択します。</p>
           <p id="debugScoreMeta" class="ms-debug-meta">未描画</p>
           <div id="debugScoreWrap" class="ms-debug-wrap">
             <div id="debugScoreArea" class="ms-debug-score"></div>
           </div>
         </section>
 
-        <section class="ms-section ms-flow-step">
-          <h2><span class="ms-step-no">3</span>編集</h2>
-          <p id="statusText">未ロード</p>
-          <label for="noteSelect" class="ms-label">ノート選択 (nodeId)</label>
-          <select id="noteSelect"></select>
+        <section class="md-section ms-flow-step">
+          <h2 class="md-section-title"><span class="ms-step-no">3</span>編集</h2>
+          <p id="statusText" class="ms-status">未ロード</p>
+          <label for="noteSelect" class="md-label">ノート選択 (nodeId)</label>
+          <select id="noteSelect" class="md-select"></select>
 
           <div class="ms-grid">
-            <label>音名(step)
-              <select id="pitchStep">
+            <label class="ms-field">音名(step)
+              <select id="pitchStep" class="md-select">
                 <option value="C">C</option>
                 <option value="D">D</option>
                 <option value="E">E</option>
@@ -70,8 +95,8 @@
                 <option value="B">B</option>
               </select>
             </label>
-            <label>変化記号(alter)
-              <select id="pitchAlter">
+            <label class="ms-field">変化記号(alter)
+              <select id="pitchAlter" class="md-select">
                 <option value="">none</option>
                 <option value="-2">-2</option>
                 <option value="-1">-1</option>
@@ -80,42 +105,41 @@
                 <option value="2">2</option>
               </select>
             </label>
-            <label>オクターブ(octave)
-              <input id="pitchOctave" type="number" min="0" max="9" step="1" value="4" />
+            <label class="ms-field">オクターブ(octave)
+              <input id="pitchOctave" type="number" min="0" max="9" step="1" value="4" class="md-input" />
             </label>
-            <label>音価(duration)
-              <input id="durationInput" type="number" min="1" step="1" value="1" />
+            <label class="ms-field">音価(duration)
+              <input id="durationInput" type="number" min="1" step="1" value="1" class="md-input" />
             </label>
           </div>
 
           <div class="ms-actions">
-            <button id="changePitchBtn" type="button">音高変更</button>
-            <button id="changeDurationBtn" type="button">音価変更</button>
-            <button id="insertAfterBtn" type="button">後ろに音符追加</button>
-            <button id="deleteBtn" type="button">音符削除</button>
+            <button id="changePitchBtn" type="button" class="md-button md-button--primary">音高変更</button>
+            <button id="changeDurationBtn" type="button" class="md-button md-button--primary">音価変更</button>
+            <button id="insertAfterBtn" type="button" class="md-button md-button--tonal">後ろに音符追加</button>
+            <button id="deleteBtn" type="button" class="md-button md-button--surface">音符削除</button>
           </div>
         </section>
 
-        <section class="ms-section ms-flow-step">
-          <h2><span class="ms-step-no">4</span>検証 / 保存</h2>
+        <section class="md-section ms-flow-step">
+          <h2 class="md-section-title"><span class="ms-step-no">4</span>検証 / 保存</h2>
           <div class="ms-actions">
-            <button id="playBtn" type="button">再生</button>
-            <button id="stopBtn" type="button" disabled>停止</button>
-            <button id="saveBtn" type="button">保存</button>
-            <button id="downloadBtn" type="button" disabled>XMLダウンロード</button>
+            <button id="playBtn" type="button" class="md-button md-button--primary">再生</button>
+            <button id="stopBtn" type="button" class="md-button md-button--surface" disabled>停止</button>
+            <button id="saveBtn" type="button" class="md-button md-button--tonal">保存</button>
+            <button id="downloadBtn" type="button" class="md-button md-button--secondary" disabled>XMLダウンロード</button>
           </div>
-          <p id="playbackText">再生: 停止中</p>
-          <p>保存モード: <span id="saveModeText">-</span></p>
-          <label for="outputXml" class="ms-label">出力XML</label>
-          <textarea id="outputXml" rows="12" readonly></textarea>
+          <p id="playbackText" class="ms-status">再生: 停止中</p>
+          <p class="ms-status">保存モード: <span id="saveModeText">-</span></p>
+          <label for="outputXml" class="md-label">出力XML</label>
+          <textarea id="outputXml" rows="12" readonly class="md-textarea"></textarea>
         </section>
       </div>
 
       <details class="ms-dev">
         <summary>詳細情報</summary>
-
-        <section class="ms-section">
-          <h2>診断</h2>
+        <section class="md-section">
+          <h2 class="md-section-title">診断</h2>
           <div id="diagArea" aria-live="polite"></div>
         </section>
       </details>

--- a/mikuscore.html
+++ b/mikuscore.html
@@ -4,18 +4,9 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>mikuscore</title>
+  <link rel="stylesheet" href="src/css/md3/token-spec.css" />
+  <link rel="stylesheet" href="src/css/md3/core-spec.css" />
   <style>
-:root {
-  --bg: #f5f7fb;
-  --card: #ffffff;
-  --text: #17212b;
-  --muted: #4b5d73;
-  --border: #d8e1ed;
-  --primary: #1456d8;
-  --danger: #c02626;
-  --warn: #9a6700;
-}
-
 * {
   box-sizing: border-box;
 }
@@ -23,46 +14,101 @@
 body {
   margin: 0;
   font-family: "BIZ UDPGothic", "Hiragino Sans", "Yu Gothic", sans-serif;
-  color: var(--text);
-  background: radial-gradient(circle at top left, #e6edff 0%, var(--bg) 60%);
 }
 
-.ms-shell {
-  max-width: 980px;
-  margin: 0 auto;
-  padding: 24px;
+.ms-app {
+  margin: 24px auto;
 }
 
-.ms-card {
-  background: var(--card);
-  border: 1px solid var(--border);
-  border-radius: 14px;
-  padding: 18px;
+.ms-hero {
+  position: relative;
+  margin: -6px -6px 14px;
+  padding: 16px 16px 14px;
+  border-radius: 16px;
+  border: 1px solid #dacdf2;
+  background:
+    radial-gradient(circle at 8% 10%, rgba(98, 0, 238, 0.26), transparent 46%),
+    radial-gradient(circle at 92% 18%, rgba(3, 218, 198, 0.14), transparent 40%),
+    linear-gradient(135deg, #f8f3ff 0%, #efe8fb 100%);
+  box-shadow: 0 8px 20px rgba(86, 58, 132, 0.12);
 }
 
-.ms-title {
-  margin: 0 0 8px;
+.ms-hero-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.8rem;
 }
 
-.ms-intro {
-  margin: 0 0 8px;
-  color: var(--muted);
+.ms-hero-eyebrow {
+  margin: 0;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  color: #6f5c92;
+}
+
+.ms-hero-chip {
+  margin-left: 0;
+  background: rgba(98, 0, 238, 0.16);
+}
+
+.ms-hero-title {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  margin: 0.25rem 0 0.2rem;
+}
+
+.ms-hero-subtitle {
+  margin: 0;
+  max-width: 70ch;
+}
+
+.ms-hero-icon {
+  width: 1.95rem;
+  height: 1.95rem;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(98, 0, 238, 0.14);
+  color: #5b33a8;
+  border: 1px solid rgba(98, 0, 238, 0.22);
+}
+
+.ms-hero-icon svg {
+  width: 1.05rem;
+  height: 1.05rem;
+  stroke: currentColor;
+  stroke-width: 1.7;
+  stroke-linecap: round;
+  stroke-linejoin: round;
 }
 
 .ms-steps {
-  margin: 0 0 10px;
+  margin: 0.25rem 0 1rem;
   padding-left: 1.2rem;
-  color: var(--muted);
+  color: var(--md-sys-color-on-surface-variant);
 }
 
 .ms-flow {
-  margin-top: 8px;
+  margin-top: 0.5rem;
+  display: grid;
+  gap: 1.2rem;
 }
 
-.ms-flow-step h2 {
+.ms-flow-step {
+  border-top: 1px solid #ece7f3;
+  padding-top: 0.8rem;
+  min-width: 0;
+}
+
+.ms-flow-step .md-section-title {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 0.5rem;
+  margin-bottom: 0.8rem;
 }
 
 .ms-step-no {
@@ -72,224 +118,216 @@ body {
   width: 1.35rem;
   height: 1.35rem;
   border-radius: 999px;
-  background: #e7efff;
-  color: #0f397e;
-  font-size: 0.8rem;
+  background: rgba(98, 0, 238, 0.12);
+  color: var(--md-sys-color-primary);
+  font-size: 0.78rem;
   font-weight: 700;
-}
-
-.ms-section {
-  border-top: 1px solid var(--border);
-  padding-top: 12px;
-  margin-top: 14px;
-}
-
-.ms-section h2 {
-  margin: 0 0 10px;
-  font-size: 1rem;
-}
-
-.ms-block {
-  margin-bottom: 10px;
-}
-
-.ms-hidden {
-  display: none;
-}
-
-.ms-label {
-  display: block;
-  margin-bottom: 4px;
-  color: var(--muted);
-}
-
-.ms-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  margin-top: 8px;
-}
-
-.ms-grid {
-  display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 8px;
-}
-
-textarea,
-input,
-select,
-button {
-  width: 100%;
-  font: inherit;
-}
-
-textarea,
-input,
-select {
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  padding: 8px;
-}
-
-button {
-  border: 1px solid var(--primary);
-  border-radius: 8px;
-  padding: 8px 10px;
-  background: #eff4ff;
-  color: #0f397e;
-  cursor: pointer;
-}
-
-button:disabled {
-  cursor: not-allowed;
-  opacity: 0.6;
 }
 
 .ms-radio-group {
   display: flex;
-  gap: 16px;
-  margin-bottom: 8px;
-}
-
-.ms-radio-group label {
-  display: flex;
-  align-items: center;
-  gap: 6px;
+  gap: 1rem;
+  margin-bottom: 0.75rem;
+  flex-wrap: wrap;
 }
 
 .ms-radio-group input {
   width: auto;
 }
 
-#diagArea .diag-error {
-  color: var(--danger);
+.ms-block {
+  margin-bottom: 0.8rem;
 }
 
-#diagArea .diag-warning {
-  color: var(--warn);
+.ms-file-name {
+  display: inline-block;
+  margin-top: 0.5rem;
+  color: var(--md-sys-color-on-surface-variant);
+  font-size: 0.9rem;
 }
 
-#statusText {
-  margin: 0 0 8px;
-  color: var(--muted);
+.ms-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  margin-top: 0.8rem;
 }
 
-#playbackText {
-  margin: 8px 0 0;
-  color: var(--muted);
-}
-
-.ms-inline-check {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
+.ms-actions .md-button {
   width: auto;
-  color: var(--muted);
 }
 
-.ms-inline-check input {
-  width: auto;
+.ms-status {
+  margin: 0.35rem 0;
+  color: var(--md-sys-color-on-surface-variant);
+}
+
+.ms-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.7rem;
+}
+
+.ms-field {
+  display: grid;
+  gap: 0.35rem;
+  font-size: 0.88rem;
+  color: var(--md-sys-color-on-surface-variant);
 }
 
 .ms-debug-meta {
-  margin: 8px 0;
-  color: var(--muted);
+  margin: 0.35rem 0;
+  color: var(--md-sys-color-on-surface-variant);
 }
 
 .ms-debug-wrap {
-  border: 1px solid var(--border);
-  border-radius: 10px;
-  padding: 8px;
+  width: 100%;
+  max-width: 100%;
+  border: 1px solid var(--md-sys-color-outline);
+  border-radius: 12px;
+  padding: 0.7rem;
   overflow-x: auto;
-  background: #fbfcff;
+  overflow-y: hidden;
+  white-space: nowrap;
+  background: var(--md-sys-color-surface);
+  -webkit-overflow-scrolling: touch;
 }
 
 .ms-debug-score {
+  display: inline-block;
   min-height: 100px;
+  min-width: max-content;
+}
+
+.ms-debug-score svg {
+  display: block;
+  max-width: none;
+  height: auto;
 }
 
 .ms-dev {
-  margin-top: 18px;
-  border: 1px solid var(--border);
-  border-radius: 12px;
-  background: #f9fbff;
-  padding: 8px 12px 12px;
+  margin-top: 1.1rem;
+  border: 1px solid #e6e1ee;
+  border-radius: 14px;
+  background: var(--md-sys-color-surface-variant);
+  padding: 0.55rem 0.9rem 0.9rem;
 }
 
 .ms-dev > summary {
   cursor: pointer;
-  color: #214a93;
+  color: var(--md-sys-color-primary);
   font-weight: 700;
 }
 
 .ms-dev[open] > summary {
-  margin-bottom: 6px;
+  margin-bottom: 0.5rem;
 }
 
-@media (max-width: 768px) {
+#diagArea .diag-error {
+  color: var(--md-danger);
+}
+
+#diagArea .diag-warning {
+  color: #8a4b0f;
+}
+
+@media (max-width: 900px) {
   .ms-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 
+@media (max-width: 640px) {
+  .ms-hero {
+    margin: -2px -2px 12px;
+    padding: 14px 12px 12px;
+  }
+
+  .ms-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
 </style>
 </head>
-<body>
-  <main class="ms-shell">
-    <section class="ms-card">
-      <h1 class="ms-title">mikuscore</h1>
-      <p class="ms-intro">
-        ブラウザ上で完結し、既存MusicXMLを壊さずに編集することを重視したスコアエディタです。
-      </p>
-      <ol class="ms-steps">
-        <li>入力を選んで読み込み</li>
-        <li>譜面プレビューで選択</li>
-        <li>ノートを編集</li>
-        <li>再生で確認して保存 / ダウンロード</li>
-      </ol>
+<body class="md-page">
+  <main class="md-shell">
+    <section class="md-card ms-app">
+      <header class="ms-hero">
+        <div class="ms-hero-top">
+          <p class="ms-hero-eyebrow">LOCAL SCORE TOOL</p>
+          <span class="md-chip ms-hero-chip">v0.1.0</span>
+        </div>
+        <h1 class="md-headline ms-hero-title">
+          <span class="ms-hero-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none">
+              <path d="M9 3v12.4a3.6 3.6 0 1 1-1.2-2.7V6.2l9-2.2v9.6a3.6 3.6 0 1 1-1.2-2.7V5.6L9 7.1Z" />
+            </svg>
+          </span>
+          <span>mikuscore</span>
+          <span class="md-tooltip-group">
+            <span class="md-info-chip" aria-label="mikuscore の詳細説明">
+              <svg aria-hidden="true" viewBox="0 0 24 24" class="md-info-icon" fill="none">
+                <circle cx="12" cy="12" r="9" fill="#cbbcf0"></circle>
+                <rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"></rect>
+                <circle cx="12" cy="7.5" r="1" fill="#ffffff"></circle>
+              </svg>
+            </span>
+            <span class="md-tooltip-content md-tooltip md-tooltip--rich md-tooltip--wide">
+              mikuscore は、MusicXML の既存構造をできるだけ保持しながら編集することを重視したローカル完結型エディタです。
+              入力（ファイル/ソース）から譜面プレビュー、ノート編集、再生確認、保存/ダウンロードまでを一画面で行えます。
+              操作手順: 1) 入力を選んで読み込み 2) 譜面プレビューで選択 3) ノートを編集 4) 再生で確認して保存 / ダウンロード。
+              まず読み込み後に譜面をクリックして対象ノートを選び、音高・音価を調整してください。
+            </span>
+          </span>
+        </h1>
+        <p class="md-subtitle ms-hero-subtitle">
+          ブラウザ上で完結し、既存MusicXMLを壊さずに編集することを重視したスコアエディタです。
+        </p>
+      </header>
+
       <div class="ms-flow">
-        <section class="ms-section ms-flow-step">
-          <h2><span class="ms-step-no">1</span>MusicXML入力</h2>
+        <section class="md-section ms-flow-step">
+          <h2 class="md-section-title"><span class="ms-step-no">1</span>MusicXML入力</h2>
           <div class="ms-radio-group" role="radiogroup" aria-label="入力方式">
-            <label><input id="inputModeFile" type="radio" name="inputMode" value="file" checked /> ファイル読込</label>
-            <label><input id="inputModeSource" type="radio" name="inputMode" value="source" /> ソース入力</label>
+            <label class="md-radio"><input id="inputModeFile" type="radio" name="inputMode" value="file" checked /> ファイル読込</label>
+            <label class="md-radio"><input id="inputModeSource" type="radio" name="inputMode" value="source" /> ソース入力</label>
           </div>
 
           <div id="fileInputBlock" class="ms-block">
-            <button id="fileSelectBtn" type="button">ファイルを選択</button>
-            <span id="fileNameText">未選択</span>
+            <button id="fileSelectBtn" type="button" class="md-button md-button--tonal">ファイルを選択</button>
+            <span id="fileNameText" class="ms-file-name">未選択</span>
             <input id="fileInput" type="file" accept=".musicxml,.xml,text/xml,application/xml" hidden />
           </div>
 
-          <div id="sourceInputBlock" class="ms-block ms-hidden">
-            <label for="xmlInput" class="ms-label">MusicXML</label>
-            <textarea id="xmlInput" rows="12" spellcheck="false"></textarea>
+          <div id="sourceInputBlock" class="ms-block md-hidden">
+            <label for="xmlInput" class="md-label">MusicXML</label>
+            <textarea id="xmlInput" rows="12" spellcheck="false" class="md-textarea"></textarea>
           </div>
 
           <div class="ms-actions">
-            <button id="loadBtn" type="button">読み込み</button>
+            <button id="loadBtn" type="button" class="md-button md-button--primary">読み込み</button>
           </div>
         </section>
 
-        <section class="ms-section ms-flow-step">
-          <h2><span class="ms-step-no">2</span>譜面プレビュー（クリックで選択）</h2>
-          <p class="ms-label">Verovioレンダリング上の音符をクリックすると、編集対象として選択します。</p>
+        <section class="md-section ms-flow-step">
+          <h2 class="md-section-title"><span class="ms-step-no">2</span>譜面プレビュー（クリックで選択）</h2>
+          <p class="md-label">Verovioレンダリング上の音符をクリックすると、編集対象として選択します。</p>
           <p id="debugScoreMeta" class="ms-debug-meta">未描画</p>
           <div id="debugScoreWrap" class="ms-debug-wrap">
             <div id="debugScoreArea" class="ms-debug-score"></div>
           </div>
         </section>
 
-        <section class="ms-section ms-flow-step">
-          <h2><span class="ms-step-no">3</span>編集</h2>
-          <p id="statusText">未ロード</p>
-          <label for="noteSelect" class="ms-label">ノート選択 (nodeId)</label>
-          <select id="noteSelect"></select>
+        <section class="md-section ms-flow-step">
+          <h2 class="md-section-title"><span class="ms-step-no">3</span>編集</h2>
+          <p id="statusText" class="ms-status">未ロード</p>
+          <label for="noteSelect" class="md-label">ノート選択 (nodeId)</label>
+          <select id="noteSelect" class="md-select"></select>
 
           <div class="ms-grid">
-            <label>音名(step)
-              <select id="pitchStep">
+            <label class="ms-field">音名(step)
+              <select id="pitchStep" class="md-select">
                 <option value="C">C</option>
                 <option value="D">D</option>
                 <option value="E">E</option>
@@ -299,8 +337,8 @@ button:disabled {
                 <option value="B">B</option>
               </select>
             </label>
-            <label>変化記号(alter)
-              <select id="pitchAlter">
+            <label class="ms-field">変化記号(alter)
+              <select id="pitchAlter" class="md-select">
                 <option value="">none</option>
                 <option value="-2">-2</option>
                 <option value="-1">-1</option>
@@ -309,42 +347,41 @@ button:disabled {
                 <option value="2">2</option>
               </select>
             </label>
-            <label>オクターブ(octave)
-              <input id="pitchOctave" type="number" min="0" max="9" step="1" value="4" />
+            <label class="ms-field">オクターブ(octave)
+              <input id="pitchOctave" type="number" min="0" max="9" step="1" value="4" class="md-input" />
             </label>
-            <label>音価(duration)
-              <input id="durationInput" type="number" min="1" step="1" value="1" />
+            <label class="ms-field">音価(duration)
+              <input id="durationInput" type="number" min="1" step="1" value="1" class="md-input" />
             </label>
           </div>
 
           <div class="ms-actions">
-            <button id="changePitchBtn" type="button">音高変更</button>
-            <button id="changeDurationBtn" type="button">音価変更</button>
-            <button id="insertAfterBtn" type="button">後ろに音符追加</button>
-            <button id="deleteBtn" type="button">音符削除</button>
+            <button id="changePitchBtn" type="button" class="md-button md-button--primary">音高変更</button>
+            <button id="changeDurationBtn" type="button" class="md-button md-button--primary">音価変更</button>
+            <button id="insertAfterBtn" type="button" class="md-button md-button--tonal">後ろに音符追加</button>
+            <button id="deleteBtn" type="button" class="md-button md-button--surface">音符削除</button>
           </div>
         </section>
 
-        <section class="ms-section ms-flow-step">
-          <h2><span class="ms-step-no">4</span>検証 / 保存</h2>
+        <section class="md-section ms-flow-step">
+          <h2 class="md-section-title"><span class="ms-step-no">4</span>検証 / 保存</h2>
           <div class="ms-actions">
-            <button id="playBtn" type="button">再生</button>
-            <button id="stopBtn" type="button" disabled>停止</button>
-            <button id="saveBtn" type="button">保存</button>
-            <button id="downloadBtn" type="button" disabled>XMLダウンロード</button>
+            <button id="playBtn" type="button" class="md-button md-button--primary">再生</button>
+            <button id="stopBtn" type="button" class="md-button md-button--surface" disabled>停止</button>
+            <button id="saveBtn" type="button" class="md-button md-button--tonal">保存</button>
+            <button id="downloadBtn" type="button" class="md-button md-button--secondary" disabled>XMLダウンロード</button>
           </div>
-          <p id="playbackText">再生: 停止中</p>
-          <p>保存モード: <span id="saveModeText">-</span></p>
-          <label for="outputXml" class="ms-label">出力XML</label>
-          <textarea id="outputXml" rows="12" readonly></textarea>
+          <p id="playbackText" class="ms-status">再生: 停止中</p>
+          <p class="ms-status">保存モード: <span id="saveModeText">-</span></p>
+          <label for="outputXml" class="md-label">出力XML</label>
+          <textarea id="outputXml" rows="12" readonly class="md-textarea"></textarea>
         </section>
       </div>
 
       <details class="ms-dev">
         <summary>詳細情報</summary>
-
-        <section class="ms-section">
-          <h2>診断</h2>
+        <section class="md-section">
+          <h2 class="md-section-title">診断</h2>
           <div id="diagArea" aria-live="polite"></div>
         </section>
       </details>
@@ -487,8 +524,8 @@ const dumpOverfullContext = (xml, voice) => {
 };
 const renderInputMode = () => {
     const fileMode = inputModeFile.checked;
-    fileInputBlock.classList.toggle("ms-hidden", !fileMode);
-    sourceInputBlock.classList.toggle("ms-hidden", fileMode);
+    fileInputBlock.classList.toggle("md-hidden", !fileMode);
+    sourceInputBlock.classList.toggle("md-hidden", fileMode);
 };
 const renderStatus = () => {
     const dirty = core.isDirty();

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -1,14 +1,3 @@
-:root {
-  --bg: #f5f7fb;
-  --card: #ffffff;
-  --text: #17212b;
-  --muted: #4b5d73;
-  --border: #d8e1ed;
-  --primary: #1456d8;
-  --danger: #c02626;
-  --warn: #9a6700;
-}
-
 * {
   box-sizing: border-box;
 }
@@ -16,46 +5,101 @@
 body {
   margin: 0;
   font-family: "BIZ UDPGothic", "Hiragino Sans", "Yu Gothic", sans-serif;
-  color: var(--text);
-  background: radial-gradient(circle at top left, #e6edff 0%, var(--bg) 60%);
 }
 
-.ms-shell {
-  max-width: 980px;
-  margin: 0 auto;
-  padding: 24px;
+.ms-app {
+  margin: 24px auto;
 }
 
-.ms-card {
-  background: var(--card);
-  border: 1px solid var(--border);
-  border-radius: 14px;
-  padding: 18px;
+.ms-hero {
+  position: relative;
+  margin: -6px -6px 14px;
+  padding: 16px 16px 14px;
+  border-radius: 16px;
+  border: 1px solid #dacdf2;
+  background:
+    radial-gradient(circle at 8% 10%, rgba(98, 0, 238, 0.26), transparent 46%),
+    radial-gradient(circle at 92% 18%, rgba(3, 218, 198, 0.14), transparent 40%),
+    linear-gradient(135deg, #f8f3ff 0%, #efe8fb 100%);
+  box-shadow: 0 8px 20px rgba(86, 58, 132, 0.12);
 }
 
-.ms-title {
-  margin: 0 0 8px;
+.ms-hero-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.8rem;
 }
 
-.ms-intro {
-  margin: 0 0 8px;
-  color: var(--muted);
+.ms-hero-eyebrow {
+  margin: 0;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  color: #6f5c92;
+}
+
+.ms-hero-chip {
+  margin-left: 0;
+  background: rgba(98, 0, 238, 0.16);
+}
+
+.ms-hero-title {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  margin: 0.25rem 0 0.2rem;
+}
+
+.ms-hero-subtitle {
+  margin: 0;
+  max-width: 70ch;
+}
+
+.ms-hero-icon {
+  width: 1.95rem;
+  height: 1.95rem;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(98, 0, 238, 0.14);
+  color: #5b33a8;
+  border: 1px solid rgba(98, 0, 238, 0.22);
+}
+
+.ms-hero-icon svg {
+  width: 1.05rem;
+  height: 1.05rem;
+  stroke: currentColor;
+  stroke-width: 1.7;
+  stroke-linecap: round;
+  stroke-linejoin: round;
 }
 
 .ms-steps {
-  margin: 0 0 10px;
+  margin: 0.25rem 0 1rem;
   padding-left: 1.2rem;
-  color: var(--muted);
+  color: var(--md-sys-color-on-surface-variant);
 }
 
 .ms-flow {
-  margin-top: 8px;
+  margin-top: 0.5rem;
+  display: grid;
+  gap: 1.2rem;
 }
 
-.ms-flow-step h2 {
+.ms-flow-step {
+  border-top: 1px solid #ece7f3;
+  padding-top: 0.8rem;
+  min-width: 0;
+}
+
+.ms-flow-step .md-section-title {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 0.5rem;
+  margin-bottom: 0.8rem;
 }
 
 .ms-step-no {
@@ -65,163 +109,132 @@ body {
   width: 1.35rem;
   height: 1.35rem;
   border-radius: 999px;
-  background: #e7efff;
-  color: #0f397e;
-  font-size: 0.8rem;
+  background: rgba(98, 0, 238, 0.12);
+  color: var(--md-sys-color-primary);
+  font-size: 0.78rem;
   font-weight: 700;
-}
-
-.ms-section {
-  border-top: 1px solid var(--border);
-  padding-top: 12px;
-  margin-top: 14px;
-}
-
-.ms-section h2 {
-  margin: 0 0 10px;
-  font-size: 1rem;
-}
-
-.ms-block {
-  margin-bottom: 10px;
-}
-
-.ms-hidden {
-  display: none;
-}
-
-.ms-label {
-  display: block;
-  margin-bottom: 4px;
-  color: var(--muted);
-}
-
-.ms-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  margin-top: 8px;
-}
-
-.ms-grid {
-  display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 8px;
-}
-
-textarea,
-input,
-select,
-button {
-  width: 100%;
-  font: inherit;
-}
-
-textarea,
-input,
-select {
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  padding: 8px;
-}
-
-button {
-  border: 1px solid var(--primary);
-  border-radius: 8px;
-  padding: 8px 10px;
-  background: #eff4ff;
-  color: #0f397e;
-  cursor: pointer;
-}
-
-button:disabled {
-  cursor: not-allowed;
-  opacity: 0.6;
 }
 
 .ms-radio-group {
   display: flex;
-  gap: 16px;
-  margin-bottom: 8px;
-}
-
-.ms-radio-group label {
-  display: flex;
-  align-items: center;
-  gap: 6px;
+  gap: 1rem;
+  margin-bottom: 0.75rem;
+  flex-wrap: wrap;
 }
 
 .ms-radio-group input {
   width: auto;
 }
 
-#diagArea .diag-error {
-  color: var(--danger);
+.ms-block {
+  margin-bottom: 0.8rem;
 }
 
-#diagArea .diag-warning {
-  color: var(--warn);
+.ms-file-name {
+  display: inline-block;
+  margin-top: 0.5rem;
+  color: var(--md-sys-color-on-surface-variant);
+  font-size: 0.9rem;
 }
 
-#statusText {
-  margin: 0 0 8px;
-  color: var(--muted);
+.ms-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  margin-top: 0.8rem;
 }
 
-#playbackText {
-  margin: 8px 0 0;
-  color: var(--muted);
-}
-
-.ms-inline-check {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
+.ms-actions .md-button {
   width: auto;
-  color: var(--muted);
 }
 
-.ms-inline-check input {
-  width: auto;
+.ms-status {
+  margin: 0.35rem 0;
+  color: var(--md-sys-color-on-surface-variant);
+}
+
+.ms-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.7rem;
+}
+
+.ms-field {
+  display: grid;
+  gap: 0.35rem;
+  font-size: 0.88rem;
+  color: var(--md-sys-color-on-surface-variant);
 }
 
 .ms-debug-meta {
-  margin: 8px 0;
-  color: var(--muted);
+  margin: 0.35rem 0;
+  color: var(--md-sys-color-on-surface-variant);
 }
 
 .ms-debug-wrap {
-  border: 1px solid var(--border);
-  border-radius: 10px;
-  padding: 8px;
+  width: 100%;
+  max-width: 100%;
+  border: 1px solid var(--md-sys-color-outline);
+  border-radius: 12px;
+  padding: 0.7rem;
   overflow-x: auto;
-  background: #fbfcff;
+  overflow-y: hidden;
+  white-space: nowrap;
+  background: var(--md-sys-color-surface);
+  -webkit-overflow-scrolling: touch;
 }
 
 .ms-debug-score {
+  display: inline-block;
   min-height: 100px;
+  min-width: max-content;
+}
+
+.ms-debug-score svg {
+  display: block;
+  max-width: none;
+  height: auto;
 }
 
 .ms-dev {
-  margin-top: 18px;
-  border: 1px solid var(--border);
-  border-radius: 12px;
-  background: #f9fbff;
-  padding: 8px 12px 12px;
+  margin-top: 1.1rem;
+  border: 1px solid #e6e1ee;
+  border-radius: 14px;
+  background: var(--md-sys-color-surface-variant);
+  padding: 0.55rem 0.9rem 0.9rem;
 }
 
 .ms-dev > summary {
   cursor: pointer;
-  color: #214a93;
+  color: var(--md-sys-color-primary);
   font-weight: 700;
 }
 
 .ms-dev[open] > summary {
-  margin-bottom: 6px;
+  margin-bottom: 0.5rem;
 }
 
-@media (max-width: 768px) {
+#diagArea .diag-error {
+  color: var(--md-danger);
+}
+
+#diagArea .diag-warning {
+  color: #8a4b0f;
+}
+
+@media (max-width: 900px) {
   .ms-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 640px) {
+  .ms-hero {
+    margin: -2px -2px 12px;
+    padding: 14px 12px 12px;
+  }
+
+  .ms-grid {
+    grid-template-columns: 1fr;
   }
 }

--- a/src/css/md3/VERSION.md
+++ b/src/css/md3/VERSION.md
@@ -1,0 +1,23 @@
+# MD3 Spec Versions
+
+- local-html-tools MD3 Token Spec: `v1.0.0`
+- local-html-tools MD3 Core Spec: `v1.0.2`
+- local-html-tools MD3 Icon Spec: `v1.0.0`
+
+## Policy
+
+- `token-spec.css` は `local-html-tools MD3 Token Spec`（`:root` / `--md-sys-*` の標準トークン定義）。
+- `core-spec.css` は `local-html-tools MD3 Core Spec`（共通コンポーネントの標準スタイル定義）。
+- `icon-spec.svg` は `local-html-tools MD3 Icon Spec`（menu/copy/refresh の標準SVG定義）。
+- `docs/*.html` には、未使用定義を含む標準セットを貼り付けてよい（仕様準拠を優先）。
+
+## Change Log
+
+- `v1.0.0` (2026-02-08)
+  - `md3/index.html` 掲載の Token/Core を初回切り出し。
+- `v1.0.1` (2026-02-08)
+  - `md-switch` の checked ノブ色を白に変更（`md-switch-input:checked + .md-switch::after`）。
+- `v1.0.2` (2026-02-08)
+  - `md-switch-label` の `font-weight` を削除し、ページ側タイポグラフィを優先する。
+- `v1.0.0` (2026-02-08, Icon Spec)
+  - menu / copy / refresh の標準SVGシンボルを追加（`href` + `xlink:href` 併記運用）。

--- a/src/css/md3/core-spec.css
+++ b/src/css/md3/core-spec.css
@@ -1,0 +1,786 @@
+/* local-html-tools MD3 Core Spec v1.0.2 (2026-02-08) */
+.md-page {
+  background: var(--md-sys-color-background); color: var(--md-sys-color-on-surface); padding: 24px; min-height: 100vh;
+}
+
+.md-shell {
+  max-width: 980px; margin: 0 auto;
+}
+
+.md-card {
+  background: var(--md-sys-color-surface);
+  border-radius: 18px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08), 0 16px 30px rgba(0, 0, 0, 0.06);
+  border: 1px solid #e9e3f0;
+  padding: 28px;
+}
+
+.md-headline {
+  font-size: 1.8rem; font-weight: 700; margin-bottom: 0.75rem;
+}
+
+.md-subtitle {
+  color: var(--md-sys-color-on-surface-variant); font-size: 0.95rem;
+}
+
+.md-section {
+  margin-top: 28px;
+}
+
+.md-section-title {
+  font-size: 1.1rem; font-weight: 700; margin-bottom: 0.75rem;
+}
+
+.md-title-info-row {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.1rem;
+}
+
+.md-title-info-row .md-section-title {
+  margin: 0;
+}
+
+.md-title-info-row .md-info-chip {
+  margin-left: 0;
+}
+
+.md-grid {
+  display: grid; gap: 16px;
+}
+
+.md-label {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.35rem;
+  font-weight: 600;
+  color: var(--md-sys-color-on-surface);
+  margin-bottom: 0.35rem;
+}
+
+.md-required {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.15rem 0.4rem;
+  border-radius: 999px;
+  font-size: 0.54rem;
+  font-weight: 600;
+  background: #ECEAF1;
+  color: #49454F;
+}
+
+.md-input, .md-textarea {
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid var(--md-sys-color-outline);
+  background: var(--md-sys-color-surface);
+  padding: 0.75rem;
+  font-size: 0.95rem;
+  color: var(--md-sys-color-on-surface);
+  transition: border-color 150ms ease, box-shadow 150ms ease;
+}
+
+.md-textarea {
+  min-height: 6.5rem;
+}
+
+.md-input:focus, .md-textarea:focus {
+  outline: none;
+  border-color: var(--md-sys-color-primary);
+  box-shadow: 0 0 0 3px rgba(98, 0, 238, 0.2);
+}
+
+.md-field-block {
+  margin-bottom: 1rem;
+}
+
+.md-button {
+  border-radius: 999px;
+  padding: 0.6rem 1.2rem;
+  font-weight: 600;
+  font-size: 0.95rem;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  transition: background 150ms ease, box-shadow 150ms ease, transform 150ms ease;
+}
+
+.md-button--primary {
+  background: var(--md-sys-color-primary);
+  color: var(--md-sys-color-on-primary);
+  box-shadow: 0 3px 8px rgba(98, 0, 238, 0.28);
+}
+
+.md-button--primary:hover {
+  background: #4f00c9;
+}
+
+.md-icon-btn {
+  width: 40px;
+  height: 40px;
+  border-radius: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #f0edf5;
+  color: #3f3b46;
+  border: none;
+  cursor: pointer;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+}
+
+.md-tooltip-group {
+  position: relative; display: inline-flex; align-items: center;
+}
+
+.md-tooltip-content {
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  margin-top: 0.5rem;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 150ms ease;
+  z-index: 50;
+  width: 20rem;
+  max-width: 90vw;
+}
+
+.md-tooltip-group:hover .md-tooltip-content {
+  opacity: 1;
+}
+
+.md-tooltip {
+  background: #2b2831;
+  color: #f7f4fb;
+  border-radius: 12px;
+  padding: 0.75rem 1rem;
+  font-size: 0.8125rem;
+  font-weight: 400;
+  line-height: 1.35;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.md-info-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 9999px;
+  background: transparent;
+  color: #4a4458;
+  margin-left: 0.2rem;
+}
+
+.md-info-icon {
+  width: 18px; height: 18px;
+}
+
+.md-code-block {
+  position: relative; margin-top: 0.5rem;
+}
+
+.md-code {
+  display: block;
+  padding: 0.75rem;
+  padding-right: 2.5rem;
+  border-radius: 12px;
+  overflow-x: auto;
+  white-space: pre;
+  background: var(--md-sys-color-surface-variant);
+  border: 1px solid #e5e0ec;
+  color: #1f1b2d;
+  min-height: 2.5rem;
+}
+
+.md-copy-button {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  width: 32px;
+  height: 32px;
+  border-radius: 16px;
+  background: #f7f2fa;
+  border: none;
+  cursor: pointer;
+}
+
+.md-snackbar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: #2b2831;
+  color: #f7f4fb;
+  padding: 0.6rem 1rem;
+  border-radius: 12px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+  font-size: 0.85rem;
+}
+
+.md-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  padding: 2px 10px;
+  font-size: 0.7rem;
+  font-weight: 700;
+  background: rgba(98, 0, 238, 0.12);
+  color: var(--md-sys-color-primary);
+  margin-left: 6px;
+}
+
+.md-section-wrap {
+  display: grid; gap: 1.75rem;
+}
+
+.md-section-card {
+  padding: 1.25rem 1.25rem 1.5rem;
+  border-radius: 24px;
+  background: var(--md-sys-color-surface);
+  border: 1px solid #ece7f3;
+  box-shadow: 0 2px 10px rgba(41, 35, 58, 0.06);
+}
+
+.md-section-subtitle {
+  font-size: var(--md-typography-body-small);
+  color: #6a6675;
+  margin-bottom: 1rem;
+}
+
+.md-section-title--spaced {
+  margin-top: 1rem;
+}
+
+.md-grid-3 {
+  grid-template-columns: repeat(1, minmax(0, 1fr));
+}
+
+.md-card-head {
+  display: flex; align-items: center; justify-content: space-between; gap: 0.75rem;
+}
+
+.md-card-title {
+  font-size: var(--md-typography-title-small); font-weight: 600; color: #2f2a35;
+}
+
+.md-card-arrow {
+  color: #8f8a98; font-size: 1.2rem;
+}
+
+.md-card-desc {
+  margin-top: 0.5rem;
+  font-size: var(--md-typography-body-small);
+  color: #5f5a6b;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.md-info-chip:focus-visible {
+  box-shadow: 0 0 0 3px var(--md-sys-color-focus-ring);
+}
+
+.md-tooltip--wide {
+  width: min(32rem, 90vw);
+}
+
+.md-tooltip--rich {
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.md-menu-button {
+  position: absolute; top: 16px; right: 16px;
+}
+
+.md-menu-panel {
+  position: absolute;
+  top: 56px;
+  right: 16px;
+  background: var(--md-sys-color-surface);
+  border: 1px solid #e6e1ee;
+  border-radius: 12px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+  padding: 4px 0;
+  min-width: 160px;
+  z-index: 20;
+}
+
+.md-menu-link {
+  display: block; padding: 8px 16px; color: var(--md-sys-color-on-surface);
+}
+
+.md-menu-link:hover {
+  background: #f2edf8;
+}
+
+.md-headline__icon {
+  margin-right: 0.5rem;
+}
+
+.md-section-title--lg {
+  font-size: 1.1rem;
+}
+
+.md-input, .md-select, .md-textarea {
+  display: block;
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid var(--md-sys-color-outline);
+  background: var(--md-sys-color-surface);
+  padding: 0.75rem;
+  font-size: 0.95rem;
+  color: var(--md-sys-color-on-surface);
+  transition: border-color 150ms ease, box-shadow 150ms ease;
+  box-sizing: border-box;
+}
+
+.md-input:focus, .md-select:focus, .md-textarea:focus {
+  outline: none;
+  border-color: var(--md-sys-color-primary);
+  box-shadow: 0 0 0 3px rgba(98, 0, 238, 0.2);
+}
+
+.md-icon-btn:hover {
+  background: #e6e1ee;
+}
+
+.md-icon-btn--small {
+  width: 32px; height: 32px; border-radius: 16px;
+}
+
+.md-icon-btn--surface {
+  background: #f7f2fa;
+}
+
+.md-snackbar.md-visible {
+  opacity: 1; pointer-events: auto;
+}
+
+.md-hidden {
+  display: none;
+}
+
+    .md-sr-only {
+      position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border-width: 0;
+    }
+    .md-preview .md-sr-only { display: none !important; }
+
+.md-stack-sm > * + * {
+  margin-top: 0.75rem;
+}
+
+.md-radio-row { display: flex; align-items: flex-start; gap: 0.5rem; }
+.md-radio {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.95rem;
+  color: #3f3b46;
+}
+
+.md-radio input {
+  accent-color: var(--md-sys-color-primary);
+}
+
+.md-switch-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-size: 0.95rem;
+  color: var(--md-sys-color-on-surface);
+}
+
+.md-switch {
+  position: relative;
+  width: 44px;
+  height: 24px;
+  background: #f0ebf7;
+  border-radius: 9999px;
+  display: inline-flex;
+  align-items: center;
+  padding: 2px;
+  transition: background 150ms ease, box-shadow 150ms ease;
+  box-shadow: inset 0 0 0 1px #cfc7dc;
+}
+
+.md-switch::after {
+  content: "";
+  width: 20px;
+  height: 20px;
+  border-radius: 9999px;
+  background: #ffffff;
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+  transition: transform 150ms ease, background 150ms ease;
+}
+
+.md-switch-input {
+  position: absolute; opacity: 0; pointer-events: none;
+}
+
+.md-switch-input:checked + .md-switch {
+  background: rgba(98, 0, 238, 0.32);
+  box-shadow: inset 0 0 0 1px rgba(98, 0, 238, 0.6);
+}
+
+.md-switch-input:checked + .md-switch::after {
+  transform: translateX(20px);
+  background: #ffffff;
+}
+
+.md-tab-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  border-bottom: 1px solid #e6e1ee;
+  margin-bottom: 1rem;
+}
+
+.md-tab-button {
+  border: 1px solid #e6e1ee;
+  border-bottom: none;
+  background: #f3f1f7;
+  padding: 0.4rem 0.9rem;
+  margin-bottom: -1px;
+  border-top-left-radius: 12px;
+  border-top-right-radius: 12px;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #3f3b46;
+}
+
+.md-tab-button[aria-selected="true"] {
+  background: #ffffff;
+  border-color: #c8c5d0;
+  color: #1c1b1f;
+}
+
+.md-tab-panel {
+  border: 1px solid #e6e1ee;
+  border-top: none;
+  padding: 1rem;
+  background: #ffffff;
+  border-bottom-left-radius: 12px;
+  border-bottom-right-radius: 12px;
+  margin-bottom: 1rem;
+}
+
+.md-label--row {
+  margin-bottom: 0.5rem;
+}
+
+.md-input, .md-select {
+  display: block;
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid var(--md-sys-color-outline);
+  background: var(--md-sys-color-surface);
+  padding: 0.75rem;
+  font-size: 0.95rem;
+  color: var(--md-sys-color-on-surface);
+  transition: border-color 150ms ease, box-shadow 150ms ease;
+  box-sizing: border-box;
+}
+
+.md-input:focus, .md-select:focus {
+  outline: none;
+  border-color: var(--md-sys-color-primary);
+  box-shadow: 0 0 0 3px rgba(98, 0, 238, 0.2);
+}
+
+.md-form-grid {
+  display: grid; gap: 0.75rem;
+}
+
+.md-button--tonal {
+  background: #f0edf5;
+  color: #3f3b46;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+}
+
+.md-button--tonal:hover {
+  background: #e6e1ee;
+}
+
+.md-chip-row {
+  display: flex; flex-wrap: wrap; gap: 0.5rem; margin-bottom: 0.75rem;
+}
+
+.md-tooltip--narrow {
+  width: 18rem;
+}
+
+.md-surface-card {
+  max-width: 48rem; margin: 0 auto; padding: 24px; position: relative;
+}
+
+.md-choice {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  padding: 0.25rem 0;
+}
+
+.md-input {
+  width: 100%;
+  padding: 0.65rem 0.75rem;
+  border-radius: 12px;
+  border: 1px solid var(--md-sys-color-outline);
+  background: var(--md-sys-color-surface);
+  font-size: 1rem;
+  color: var(--md-sys-color-on-surface);
+  transition: border-color 150ms ease, box-shadow 150ms ease;
+}
+
+.md-input:focus {
+  outline: none;
+  border-color: var(--md-sys-color-primary);
+  box-shadow: 0 0 0 3px rgba(98, 0, 238, 0.2);
+}
+
+.md-button:hover {
+  box-shadow: 0 4px 10px rgba(98, 0, 238, 0.35);
+}
+
+.md-button:active {
+  opacity: 0.7;
+}
+
+.md-button--surface {
+  background: var(--md-sys-color-surface-variant); color: var(--md-sys-color-on-surface); border: 1px solid var(--md-sys-color-outline);
+}
+
+.md-button--secondary {
+  background: var(--md-sys-color-secondary); color: var(--md-sys-color-on-secondary); margin-bottom: 10px;
+}
+
+.md-button-row {
+  display: flex; gap: 15px; height: clamp(120px, 20vh, 220px); margin-bottom: 10px;
+}
+
+.md-button--hero {
+  font-size: clamp(1.2rem, 4vw, 1.6rem);
+}
+
+.md-field {
+  position: relative; min-width: 200px;
+}
+
+.md-field__label {
+  position: absolute;
+  top: -9px;
+  left: 12px;
+  padding: 0 6px;
+  background: var(--md-sys-color-surface);
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: var(--md-sys-color-on-surface-variant);
+  letter-spacing: 0.02em;
+}
+
+.md-field .md-select {
+  appearance: none;
+  border-radius: 12px;
+  border: 1px solid var(--md-sys-color-outline);
+  background: var(--md-sys-color-surface);
+  padding: 0.8rem 2.2rem 0.8rem 0.9rem;
+  font-size: 0.9rem;
+  color: var(--md-sys-color-on-surface);
+  min-width: 200px;
+  line-height: 1.2;
+  background-image: linear-gradient(45deg, transparent 50%, #6c6775 50%), linear-gradient(135deg, #6c6775 50%, transparent 50%);
+  background-position: calc(100% - 18px) calc(50% - 2px), calc(100% - 12px) calc(50% - 2px);
+  background-size: 6px 6px, 6px 6px;
+  background-repeat: no-repeat;
+}
+
+.md-field .md-select:focus {
+  outline: none; border-color: var(--md-sys-color-primary); box-shadow: 0 0 0 3px rgba(98, 0, 238, 0.2);
+}
+
+.md-stack-md > * + * {
+  margin-top: 0.75rem;
+}
+
+.md-grid-2 {
+  grid-template-columns: repeat(1, minmax(0, 1fr));
+}
+
+.md-form-row {
+  display: flex; align-items: center; gap: 0.75rem; flex-wrap: wrap;
+}
+
+.md-form-row--nowrap {
+  flex-wrap: nowrap;
+}
+
+.md-label--muted {
+  color: #3f3b46;
+}
+
+.md-label--block {
+  margin-bottom: 0.5rem;
+}
+
+.md-snackbar-host {
+  position: fixed;
+  right: 1.25rem;
+  bottom: 1.25rem;
+  padding: 0.5rem 1rem;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 200ms ease;
+}
+
+.md-snackbar-host.md-visible {
+  opacity: 1; pointer-events: auto;
+}
+
+.md-button:disabled {
+  background: #e6e1ee;
+  color: #9a94a7;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.md-textarea:focus {
+  outline: none;
+  border-color: var(--md-sys-color-primary);
+  box-shadow: 0 0 0 3px rgba(98, 0, 238, 0.2);
+}
+
+.md-input-block {
+  margin-bottom: 1rem;
+}
+
+.md-section-title-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.md-output-wrap {
+  position: relative;
+}
+
+.md-output {
+  background: var(--md-sys-color-surface-variant);
+}
+
+.md-stack-lg > * + * {
+  margin-top: 1.5rem;
+}
+
+.md-form-row--start {
+  align-items: flex-start;
+}
+
+.md-input:disabled, .md-select:disabled {
+  background: #f3f0f7;
+}
+
+.md-choice-card {
+  border: 1px solid #e2dcec;
+  border-radius: 16px;
+  padding: 1rem;
+  background: #ffffff;
+}
+
+.md-choice-card--muted {
+  background: #f7f3fb;
+}
+
+.md-choice-row {
+  display: flex; align-items: center; gap: 0.75rem;
+}
+
+.md-choice-row input {
+  margin: 0;
+}
+
+.md-choice-sub {
+  display: flex; flex-wrap: wrap; align-items: center; gap: 0.5rem; font-size: 0.875rem; color: #6a6675;
+}
+
+.md-choice-sub small {
+  font-size: 0.75rem; color: #7b7784;
+}
+
+.md-chip--primary {
+  background: #e2d9f7;
+  color: #4a1e9e;
+}
+
+.md-chip--warn {
+  background: #f7ece1;
+  color: #8a4b0f;
+}
+
+.md-field-stack {
+  display: flex; flex-direction: column; align-items: stretch; gap: 0.5rem;
+}
+
+.md-label--full {
+  width: 100%;
+}
+
+.md-switch-row {
+  display: flex; flex-wrap: wrap; align-items: center; gap: 0.75rem; color: var(--md-sys-color-on-surface); font-size: 0.95rem;
+}
+
+.md-input-wrap {
+  position: relative;
+  flex: 1 1 16rem;
+  min-width: 12rem;
+}
+
+.md-input-wrap .md-input {
+  padding-right: 3rem;
+}
+
+.md-input-action {
+  position: absolute;
+  top: 50%;
+  right: -0.5rem;
+  transform: translateY(-50%);
+  box-shadow: 0 6px 14px rgba(0, 0, 0, 0.12);
+}
+
+.md-field-stack .md-input, .md-field-stack .md-select {
+  flex: 0 0 auto;
+}
+
+.md-field--dropdown {
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23635b75' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><path d='M6 9l6 6 6-6'/></svg>");
+  background-repeat: no-repeat;
+  background-position: right 0.75rem center;
+  background-size: 1rem 1rem;
+  padding-right: 2.25rem;
+}
+
+.md-select--inline {
+  flex: 1 1 18rem; min-width: 14rem;
+}
+
+.md-input.md-disabled, .md-select.md-disabled {
+  background: #f3f0f7;
+}
+
+.md-choice-inline {
+  display: flex; flex-wrap: wrap; gap: 1.25rem; row-gap: 0.5rem;
+}
+
+.md-choice-text {
+  font-size: 0.9rem; color: #4a4458;
+}

--- a/src/css/md3/icon-spec.svg
+++ b/src/css/md3/icon-spec.svg
@@ -1,0 +1,24 @@
+<!-- local-html-tools MD3 Icon Spec v1.0.0 (2026-02-08) -->
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:xlink="http://www.w3.org/1999/xlink"
+     aria-hidden="true"
+     width="0"
+     height="0"
+     viewBox="0 0 0 0"
+     style="position:absolute;width:0;height:0;overflow:hidden">
+  <defs>
+    <symbol id="md-icon-menu" viewBox="0 0 24 24">
+      <path d="M4 6h16"/>
+      <path d="M4 12h16"/>
+      <path d="M4 18h16"/>
+    </symbol>
+    <symbol id="md-icon-copy" viewBox="0 0 24 24">
+      <rect x="9" y="9" width="11" height="11" rx="2"/>
+      <rect x="4" y="4" width="11" height="11" rx="2"/>
+    </symbol>
+    <symbol id="md-icon-refresh" viewBox="0 0 24 24">
+      <path d="M20 12a8 8 0 1 1-2.34-5.66"/>
+      <path d="M20 4v6h-6"/>
+    </symbol>
+  </defs>
+</svg>

--- a/src/css/md3/token-spec.css
+++ b/src/css/md3/token-spec.css
@@ -1,0 +1,30 @@
+/* local-html-tools MD3 Token Spec v1.0.0 (2026-02-08) */
+:root {
+  --md-danger: #b3261e;
+  --md-state-layer: rgba(98, 0, 238, 0.12);
+  --md-sys-color-background: #f6f4f8;
+  --md-sys-color-focus-ring: rgba(98, 0, 238, 0.35);
+  --md-sys-color-on-primary: #ffffff;
+  --md-sys-color-on-secondary: #00332c;
+  --md-sys-color-on-surface: #1c1b1f;
+  --md-sys-color-on-surface-variant: #49454f;
+  --md-sys-color-on-tertiary: #FFFFFF;
+  --md-sys-color-on-tertiary-container: #3d2e5a;
+  --md-sys-color-outline: #c8c5d0;
+  --md-sys-color-primary: #6200ee;
+  --md-sys-color-secondary: #03dac6;
+  --md-sys-color-shadow: rgba(0, 0, 0, 0.2);
+  --md-sys-color-state-layer: rgba(98, 0, 238, 0.08);
+  --md-sys-color-surface: #ffffff;
+  --md-sys-color-surface-variant: #f4f1f7;
+  --md-sys-color-tertiary: #7D5260;
+  --md-sys-color-tertiary-container: #f3e8fd;
+  --md-typography-body-medium: 1rem;
+  --md-typography-body-small: 0.875rem;
+  --md-typography-headline-large: 1.85rem;
+  --md-typography-title-medium: 1.1rem;
+  --md-typography-title-small: 1.05rem;
+  --status-later: #ff9800;
+  --status-ok: #4caf50;
+  --status-todo: #00bcd4;
+}

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -131,8 +131,8 @@ const dumpOverfullContext = (xml, voice) => {
 };
 const renderInputMode = () => {
     const fileMode = inputModeFile.checked;
-    fileInputBlock.classList.toggle("ms-hidden", !fileMode);
-    sourceInputBlock.classList.toggle("ms-hidden", fileMode);
+    fileInputBlock.classList.toggle("md-hidden", !fileMode);
+    sourceInputBlock.classList.toggle("md-hidden", fileMode);
 };
 const renderStatus = () => {
     const dirty = core.isDirty();

--- a/src/ts/main.ts
+++ b/src/ts/main.ts
@@ -202,8 +202,8 @@ const dumpOverfullContext = (xml: string, voice: string): void => {
 
 const renderInputMode = (): void => {
   const fileMode = inputModeFile.checked;
-  fileInputBlock.classList.toggle("ms-hidden", !fileMode);
-  sourceInputBlock.classList.toggle("ms-hidden", fileMode);
+  fileInputBlock.classList.toggle("md-hidden", !fileMode);
+  sourceInputBlock.classList.toggle("md-hidden", fileMode);
 };
 
 const renderStatus = (): void => {


### PR DESCRIPTION
### 概要
`mikuscore` の画面を `md3` 標準セットへ寄せ、見た目と操作導線を整理しました。
あわせて譜面プレビューの横スクロール表示を安定化しています。

### 変更内容
- `src/css/md3/` を追加
  - `token-spec.css`
  - `core-spec.css`
  - `icon-spec.svg`
  - `VERSION.md`
- `mikuscore-src.html` を MD3 コンポーネント構成へ移行
  - `md-page / md-shell / md-card / md-*` 系クラスへ置換
  - `md3` の token/core CSS 読み込み追加
- ヘッダーデザインを追加
  - タイトル装飾（アイコン・バージョン表示）
  - タイトル右に `(i)` ツールチップを追加
  - 操作手順説明を `(i)` ツールチップ内へ移動
  - 画面常時表示の手順リストは削除
- 譜面プレビューの表示改善
  - プレビュー枠内で横スクロールするよう調整
  - レイアウトが横に突き抜ける挙動を抑制（`min-width: 0` / `max-width: 100%` 等）
- `src/ts/main.ts` の表示切替クラスを更新
  - `ms-hidden` → `md-hidden`
- ビルド成果物を更新
  - `mikuscore.html`
  - `src/js/main.js`

### 動作確認
- `npm run build` 実行済み（成功）

### 影響範囲
- 主に UI（HTML/CSS）変更
- コア編集ロジックの挙動変更はなし（表示切替クラス変更のみ）