### PR TITLE
小節単位編集フローを実装し、クリック選択・ハイライト・詳細情報UIを強化

### DIFF
--- a/mikuscore-src.html
+++ b/mikuscore-src.html
@@ -113,9 +113,15 @@
 
         <section class="md-section ms-flow-step">
           <h2 class="md-section-title"><span class="ms-step-no">3</span>編集</h2>
-          <p id="statusText" class="ms-status">未ロード</p>
-          <label for="noteSelect" class="md-label">ノート選択 (nodeId)</label>
-          <select id="noteSelect" class="md-select"></select>
+          <p id="measurePartNameText" class="ms-track-label">トラック名: -</p>
+          <p id="measureSelectionText" class="ms-status">小節未選択（譜面プレビューをクリックしてください）</p>
+          <div id="measureEditorWrap" class="ms-measure-editor md-hidden">
+            <div id="measureEditorArea" class="ms-debug-score"></div>
+          </div>
+          <div class="ms-actions">
+            <button id="measureApplyBtn" type="button" class="md-button md-button--primary" disabled>確定</button>
+            <button id="measureDiscardBtn" type="button" class="md-button md-button--surface" disabled>破棄</button>
+          </div>
 
           <div class="ms-grid">
             <label class="ms-field">音名(step)
@@ -167,8 +173,14 @@
         <summary>詳細情報</summary>
         <section class="md-section">
           <h2 class="md-section-title">状態</h2>
+          <p id="statusText" class="ms-status">未ロード</p>
           <p id="playbackText" class="ms-status">再生: 停止中</p>
           <p class="ms-status">保存モード: <span id="saveModeText">-</span></p>
+        </section>
+        <section class="md-section">
+          <h2 class="md-section-title">ノート選択</h2>
+          <label for="noteSelect" class="md-label">ノート選択 (nodeId)</label>
+          <select id="noteSelect" class="md-select"></select>
         </section>
         <section class="md-section">
           <h2 class="md-section-title">診断</h2>

--- a/mikuscore.html
+++ b/mikuscore.html
@@ -233,6 +233,13 @@ body {
   color: var(--md-sys-color-on-surface-variant);
 }
 
+.ms-track-label {
+  margin: 0.15rem 0;
+  color: var(--md-sys-color-on-surface-variant);
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
 .ms-grid {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
@@ -274,6 +281,37 @@ body {
   display: block;
   max-width: none;
   height: auto;
+}
+
+.ms-measure-editor {
+  border: 1px solid var(--md-sys-color-outline);
+  border-radius: 12px;
+  padding: 0.7rem;
+  overflow-x: auto;
+  overflow-y: hidden;
+  white-space: nowrap;
+  background: var(--md-sys-color-surface);
+  margin-bottom: 0.6rem;
+}
+
+.ms-measure-editor .ms-note-selected {
+  fill: #d32f2f !important;
+  stroke: #d32f2f !important;
+}
+
+.ms-measure-editor .ms-note-selected * {
+  fill: #d32f2f !important;
+  stroke: #d32f2f !important;
+}
+
+.ms-debug-score .ms-measure-selected {
+  fill: #c62828 !important;
+  stroke: #c62828 !important;
+}
+
+.ms-debug-score .ms-measure-selected * {
+  fill: #c62828 !important;
+  stroke: #c62828 !important;
 }
 
 .ms-dev {
@@ -426,9 +464,15 @@ body {
 
         <section class="md-section ms-flow-step">
           <h2 class="md-section-title"><span class="ms-step-no">3</span>編集</h2>
-          <p id="statusText" class="ms-status">未ロード</p>
-          <label for="noteSelect" class="md-label">ノート選択 (nodeId)</label>
-          <select id="noteSelect" class="md-select"></select>
+          <p id="measurePartNameText" class="ms-track-label">トラック名: -</p>
+          <p id="measureSelectionText" class="ms-status">小節未選択（譜面プレビューをクリックしてください）</p>
+          <div id="measureEditorWrap" class="ms-measure-editor md-hidden">
+            <div id="measureEditorArea" class="ms-debug-score"></div>
+          </div>
+          <div class="ms-actions">
+            <button id="measureApplyBtn" type="button" class="md-button md-button--primary" disabled>確定</button>
+            <button id="measureDiscardBtn" type="button" class="md-button md-button--surface" disabled>破棄</button>
+          </div>
 
           <div class="ms-grid">
             <label class="ms-field">音名(step)
@@ -480,8 +524,14 @@ body {
         <summary>詳細情報</summary>
         <section class="md-section">
           <h2 class="md-section-title">状態</h2>
+          <p id="statusText" class="ms-status">未ロード</p>
           <p id="playbackText" class="ms-status">再生: 停止中</p>
           <p class="ms-status">保存モード: <span id="saveModeText">-</span></p>
+        </section>
+        <section class="md-section">
+          <h2 class="md-section-title">ノート選択</h2>
+          <label for="noteSelect" class="md-label">ノート選択 (nodeId)</label>
+          <select id="noteSelect" class="md-select"></select>
         </section>
         <section class="md-section">
           <h2 class="md-section-title">診断</h2>
@@ -546,6 +596,12 @@ const outputXml = q("#outputXml");
 const diagArea = q("#diagArea");
 const debugScoreMeta = q("#debugScoreMeta");
 const debugScoreArea = q("#debugScoreArea");
+const measurePartNameText = q("#measurePartNameText");
+const measureSelectionText = q("#measureSelectionText");
+const measureEditorWrap = q("#measureEditorWrap");
+const measureEditorArea = q("#measureEditorArea");
+const measureApplyBtn = q("#measureApplyBtn");
+const measureDiscardBtn = q("#measureDiscardBtn");
 const core = new ScoreCore_1.ScoreCore({ editableVoice: EDITABLE_VOICE });
 const state = {
     loaded: false,
@@ -562,6 +618,13 @@ let verovioToolkit = null;
 let verovioInitPromise = null;
 let verovioRenderSeq = 0;
 let currentSvgIdToNodeId = new Map();
+let nodeIdToLocation = new Map();
+let partIdToName = new Map();
+let selectedMeasure = null;
+let draftCore = null;
+let draftNoteNodeIds = [];
+let draftSvgIdToNodeId = new Map();
+const NOTE_CLICK_SNAP_PX = 170;
 const logDiagnostics = (phase, diagnostics, warnings = []) => {
     if (!DEBUG_LOG)
         return;
@@ -648,20 +711,82 @@ const renderNotes = () => {
     noteSelect.innerHTML = "";
     const placeholder = document.createElement("option");
     placeholder.value = "";
-    placeholder.textContent = state.noteNodeIds.length === 0 ? "(ノートなし)" : "(選択してください)";
+    placeholder.textContent = draftNoteNodeIds.length === 0 ? "(ノートなし)" : "(選択してください)";
     noteSelect.appendChild(placeholder);
-    for (const nodeId of state.noteNodeIds) {
+    for (const nodeId of draftNoteNodeIds) {
         const option = document.createElement("option");
         option.value = nodeId;
         option.textContent = nodeId;
         noteSelect.appendChild(option);
     }
-    if (state.selectedNodeId && state.noteNodeIds.includes(state.selectedNodeId)) {
+    if (state.selectedNodeId && draftNoteNodeIds.includes(state.selectedNodeId)) {
         noteSelect.value = state.selectedNodeId;
     }
     else {
         state.selectedNodeId = null;
         noteSelect.value = "";
+    }
+};
+const renderMeasureEditorState = () => {
+    var _a;
+    if (!selectedMeasure || !draftCore) {
+        measurePartNameText.textContent = "小節未選択（譜面プレビューをクリックしてください）";
+        measureSelectionText.textContent = "小節未選択（譜面プレビューをクリックしてください）";
+        measureSelectionText.classList.add("md-hidden");
+        measureEditorWrap.classList.add("md-hidden");
+        measureApplyBtn.disabled = true;
+        measureDiscardBtn.disabled = true;
+        return;
+    }
+    const partName = (_a = partIdToName.get(selectedMeasure.partId)) !== null && _a !== void 0 ? _a : selectedMeasure.partId;
+    measurePartNameText.textContent =
+        `トラック名: ${partName} / 選択中: トラック=${selectedMeasure.partId} / 小節=${selectedMeasure.measureNumber}`;
+    measureSelectionText.textContent = "";
+    measureSelectionText.classList.add("md-hidden");
+    measureEditorWrap.classList.remove("md-hidden");
+    measureDiscardBtn.disabled = false;
+    measureApplyBtn.disabled = !draftCore.isDirty();
+};
+const highlightSelectedDraftNoteInEditor = () => {
+    measureEditorArea
+        .querySelectorAll(".ms-note-selected")
+        .forEach((el) => el.classList.remove("ms-note-selected"));
+    if (!state.selectedNodeId || draftSvgIdToNodeId.size === 0)
+        return;
+    for (const [svgId, nodeId] of draftSvgIdToNodeId.entries()) {
+        if (nodeId !== state.selectedNodeId)
+            continue;
+        const target = document.getElementById(svgId);
+        if (!target || !measureEditorArea.contains(target))
+            continue;
+        target.classList.add("ms-note-selected");
+        const group = target.closest("g");
+        if (group && measureEditorArea.contains(group)) {
+            group.classList.add("ms-note-selected");
+        }
+    }
+};
+const highlightSelectedMeasureInMainPreview = () => {
+    debugScoreArea
+        .querySelectorAll(".ms-measure-selected")
+        .forEach((el) => el.classList.remove("ms-measure-selected"));
+    if (!selectedMeasure || currentSvgIdToNodeId.size === 0)
+        return;
+    for (const [svgId, nodeId] of currentSvgIdToNodeId.entries()) {
+        const location = nodeIdToLocation.get(nodeId);
+        if (!location)
+            continue;
+        if (location.partId !== selectedMeasure.partId || location.measureNumber !== selectedMeasure.measureNumber) {
+            continue;
+        }
+        const target = document.getElementById(svgId);
+        if (!target || !debugScoreArea.contains(target))
+            continue;
+        target.classList.add("ms-measure-selected");
+        const group = target.closest("g");
+        if (group && debugScoreArea.contains(group)) {
+            group.classList.add("ms-measure-selected");
+        }
     }
 };
 const renderDiagnostics = () => {
@@ -705,12 +830,13 @@ const renderOutput = () => {
     downloadBtn.disabled = !((_b = state.lastSaveResult) === null || _b === void 0 ? void 0 : _b.ok);
 };
 const renderControlState = () => {
+    const hasDraft = Boolean(draftCore);
     const hasSelection = Boolean(state.selectedNodeId);
-    noteSelect.disabled = !state.loaded;
-    changePitchBtn.disabled = !state.loaded || !hasSelection;
-    changeDurationBtn.disabled = !state.loaded || !hasSelection;
-    insertAfterBtn.disabled = !state.loaded || !hasSelection;
-    deleteBtn.disabled = !state.loaded || !hasSelection;
+    noteSelect.disabled = !hasDraft;
+    changePitchBtn.disabled = !hasDraft || !hasSelection;
+    changeDurationBtn.disabled = !hasDraft || !hasSelection;
+    insertAfterBtn.disabled = !hasDraft || !hasSelection;
+    deleteBtn.disabled = !hasDraft || !hasSelection;
     playBtn.disabled = !state.loaded || isPlaying;
     stopBtn.disabled = !isPlaying;
 };
@@ -720,7 +846,10 @@ const renderAll = () => {
     renderStatus();
     renderDiagnostics();
     renderOutput();
+    renderMeasureEditorState();
     renderControlState();
+    highlightSelectedMeasureInMainPreview();
+    highlightSelectedDraftNoteInEditor();
 };
 const setUiMappingDiagnostic = (message) => {
     if (DEBUG_LOG) {
@@ -736,16 +865,46 @@ const setUiMappingDiagnostic = (message) => {
     };
     renderAll();
 };
-const buildRenderXmlForVerovio = (xml) => {
-    const map = new Map();
-    if (!state.loaded) {
-        return {
-            renderXml: xml,
-            svgIdToNodeId: map,
-            noteCount: 0,
-        };
+const rebuildNodeLocationMap = (xml) => {
+    var _a, _b;
+    nodeIdToLocation = new Map();
+    const doc = new DOMParser().parseFromString(xml, "application/xml");
+    if (doc.querySelector("parsererror"))
+        return;
+    const notes = Array.from(doc.querySelectorAll("part > measure > note"));
+    const count = Math.min(notes.length, state.noteNodeIds.length);
+    for (let i = 0; i < count; i += 1) {
+        const note = notes[i];
+        const part = note.closest("part");
+        const measure = note.closest("measure");
+        if (!part || !measure)
+            continue;
+        const nodeId = state.noteNodeIds[i];
+        const partId = (_a = part.getAttribute("id")) !== null && _a !== void 0 ? _a : "";
+        const measureNumber = (_b = measure.getAttribute("number")) !== null && _b !== void 0 ? _b : "";
+        if (!partId || !measureNumber)
+            continue;
+        nodeIdToLocation.set(nodeId, { partId, measureNumber });
     }
-    const nodeIds = state.noteNodeIds.slice();
+};
+const rebuildPartNameMap = (xml) => {
+    var _a, _b, _c, _d, _e, _f;
+    partIdToName = new Map();
+    const doc = new DOMParser().parseFromString(xml, "application/xml");
+    if (doc.querySelector("parsererror"))
+        return;
+    for (const scorePart of Array.from(doc.querySelectorAll("score-partwise > part-list > score-part"))) {
+        const partId = (_b = (_a = scorePart.getAttribute("id")) === null || _a === void 0 ? void 0 : _a.trim()) !== null && _b !== void 0 ? _b : "";
+        if (!partId)
+            continue;
+        const partName = ((_d = (_c = scorePart.querySelector(":scope > part-name")) === null || _c === void 0 ? void 0 : _c.textContent) === null || _d === void 0 ? void 0 : _d.trim()) ||
+            ((_f = (_e = scorePart.querySelector(":scope > part-abbreviation")) === null || _e === void 0 ? void 0 : _e.textContent) === null || _f === void 0 ? void 0 : _f.trim()) ||
+            partId;
+        partIdToName.set(partId, partName);
+    }
+};
+const buildRenderXmlWithNodeIds = (xml, nodeIds, idPrefix) => {
+    const map = new Map();
     if (nodeIds.length === 0) {
         return { renderXml: xml, svgIdToNodeId: map, noteCount: 0 };
     }
@@ -757,7 +916,7 @@ const buildRenderXmlForVerovio = (xml) => {
     const count = Math.min(notes.length, nodeIds.length);
     for (let i = 0; i < count; i += 1) {
         const nodeId = nodeIds[i];
-        const svgId = `mks-tmp-${nodeId}`;
+        const svgId = `${idPrefix}-${nodeId}`;
         notes[i].setAttribute("xml:id", svgId);
         notes[i].setAttribute("id", svgId);
         map.set(svgId, nodeId);
@@ -768,8 +927,18 @@ const buildRenderXmlForVerovio = (xml) => {
         noteCount: count,
     };
 };
+const buildRenderXmlForVerovio = (xml) => {
+    if (!state.loaded) {
+        return {
+            renderXml: xml,
+            svgIdToNodeId: new Map(),
+            noteCount: 0,
+        };
+    }
+    return buildRenderXmlWithNodeIds(xml, state.noteNodeIds.slice(), "mks-main");
+};
 const deriveRenderedNoteIds = (root) => {
-    const direct = Array.from(root.querySelectorAll('[id^="mks-tmp-"], [id*="mks-tmp-"]')).map((el) => el.id);
+    const direct = Array.from(root.querySelectorAll('[id^="mks-"], [id*="mks-"]')).map((el) => el.id);
     if (direct.length > 0) {
         return Array.from(new Set(direct));
     }
@@ -791,14 +960,14 @@ const buildFallbackSvgIdMap = (sourceNodeIds, renderedNoteIds) => {
     }
     return map;
 };
-const resolveNodeIdFromCandidateIds = (candidateIds) => {
+const resolveNodeIdFromCandidateIds = (candidateIds, svgIdMap) => {
     for (const entry of candidateIds) {
-        const exact = currentSvgIdToNodeId.get(entry);
+        const exact = svgIdMap.get(entry);
         if (exact)
             return exact;
     }
     for (const entry of candidateIds) {
-        for (const [knownSvgId, nodeId] of currentSvgIdToNodeId.entries()) {
+        for (const [knownSvgId, nodeId] of svgIdMap.entries()) {
             if (entry.startsWith(`${knownSvgId}-`) || knownSvgId.startsWith(`${entry}-`)) {
                 return nodeId;
             }
@@ -834,7 +1003,7 @@ const resolveNodeIdFromSvgTarget = (target, clickEvent) => {
     if (!target || !(target instanceof Element))
         return null;
     const directCandidates = collectCandidateIdsFromElement(target);
-    const resolvedFromDirect = resolveNodeIdFromCandidateIds(directCandidates);
+    const resolvedFromDirect = resolveNodeIdFromCandidateIds(directCandidates, currentSvgIdToNodeId);
     if (resolvedFromDirect)
         return resolvedFromDirect;
     if (clickEvent && typeof document.elementsFromPoint === "function") {
@@ -843,7 +1012,7 @@ const resolveNodeIdFromSvgTarget = (target, clickEvent) => {
             if (!(hit instanceof Element))
                 continue;
             const hitCandidates = collectCandidateIdsFromElement(hit);
-            const resolvedFromHit = resolveNodeIdFromCandidateIds(hitCandidates);
+            const resolvedFromHit = resolveNodeIdFromCandidateIds(hitCandidates, currentSvgIdToNodeId);
             if (resolvedFromHit)
                 return resolvedFromHit;
         }
@@ -857,15 +1026,209 @@ const resolveNodeIdFromSvgTarget = (target, clickEvent) => {
     }
     return null;
 };
-const onVerovioScoreClick = (event) => {
+const resolveDraftNodeIdFromSvgTarget = (target, clickEvent) => {
+    if (!target || !(target instanceof Element))
+        return null;
+    const directCandidates = collectCandidateIdsFromElement(target);
+    const resolvedFromDirect = resolveNodeIdFromCandidateIds(directCandidates, draftSvgIdToNodeId);
+    if (resolvedFromDirect)
+        return resolvedFromDirect;
+    if (clickEvent && typeof document.elementsFromPoint === "function") {
+        const hitElements = document.elementsFromPoint(clickEvent.clientX, clickEvent.clientY);
+        for (const hit of hitElements) {
+            if (!(hit instanceof Element))
+                continue;
+            const hitCandidates = collectCandidateIdsFromElement(hit);
+            const resolvedFromHit = resolveNodeIdFromCandidateIds(hitCandidates, draftSvgIdToNodeId);
+            if (resolvedFromHit)
+                return resolvedFromHit;
+        }
+    }
+    return null;
+};
+const resolveNodeIdFromNearestPointInArea = (clickEvent, area, svgIdToNodeId, snapPx = NOTE_CLICK_SNAP_PX) => {
+    let bestNodeId = null;
+    let bestScore = Number.POSITIVE_INFINITY;
+    for (const [svgId, nodeId] of svgIdToNodeId.entries()) {
+        const el = area.querySelector(`#${CSS.escape(svgId)}`);
+        if (!el)
+            continue;
+        const rect = el.getBoundingClientRect();
+        if (!Number.isFinite(rect.left) || rect.width <= 0 || rect.height <= 0)
+            continue;
+        const dx = clickEvent.clientX < rect.left
+            ? rect.left - clickEvent.clientX
+            : clickEvent.clientX > rect.right
+                ? clickEvent.clientX - rect.right
+                : 0;
+        const dy = clickEvent.clientY < rect.top
+            ? rect.top - clickEvent.clientY
+            : clickEvent.clientY > rect.bottom
+                ? clickEvent.clientY - rect.bottom
+                : 0;
+        const score = Math.hypot(dx, dy);
+        if (score < bestScore) {
+            bestScore = score;
+            bestNodeId = nodeId;
+        }
+    }
+    return bestScore <= snapPx ? bestNodeId : null;
+};
+const resolveNodeIdFromNearestPoint = (clickEvent) => {
+    return resolveNodeIdFromNearestPointInArea(clickEvent, debugScoreArea, currentSvgIdToNodeId, NOTE_CLICK_SNAP_PX);
+};
+const resolveDraftNodeIdFromNearestPoint = (clickEvent) => {
+    return resolveNodeIdFromNearestPointInArea(clickEvent, measureEditorArea, draftSvgIdToNodeId, NOTE_CLICK_SNAP_PX);
+};
+const extractMeasureEditorXml = (xml, partId, measureNumber) => {
     var _a;
+    const source = new DOMParser().parseFromString(xml, "application/xml");
+    if (source.querySelector("parsererror"))
+        return null;
+    const srcRoot = source.querySelector("score-partwise");
+    const srcPart = source.querySelector(`score-partwise > part[id="${CSS.escape(partId)}"]`);
+    if (!srcRoot || !srcPart)
+        return null;
+    const srcMeasure = Array.from(srcPart.querySelectorAll(":scope > measure")).find((m) => { var _a; return ((_a = m.getAttribute("number")) !== null && _a !== void 0 ? _a : "") === measureNumber; });
+    if (!srcMeasure)
+        return null;
+    const collectEffectiveAttributes = (part, targetMeasure) => {
+        var _a;
+        let divisions = null;
+        let key = null;
+        let time = null;
+        let staves = null;
+        const clefByNo = new Map();
+        for (const measure of Array.from(part.querySelectorAll(":scope > measure"))) {
+            const attrs = measure.querySelector(":scope > attributes");
+            if (attrs) {
+                const nextDivisions = attrs.querySelector(":scope > divisions");
+                if (nextDivisions)
+                    divisions = nextDivisions.cloneNode(true);
+                const nextKey = attrs.querySelector(":scope > key");
+                if (nextKey)
+                    key = nextKey.cloneNode(true);
+                const nextTime = attrs.querySelector(":scope > time");
+                if (nextTime)
+                    time = nextTime.cloneNode(true);
+                const nextStaves = attrs.querySelector(":scope > staves");
+                if (nextStaves)
+                    staves = nextStaves.cloneNode(true);
+                for (const clef of Array.from(attrs.querySelectorAll(":scope > clef"))) {
+                    const no = (_a = clef.getAttribute("number")) !== null && _a !== void 0 ? _a : "1";
+                    clefByNo.set(no, clef.cloneNode(true));
+                }
+            }
+            if (measure === targetMeasure)
+                break;
+        }
+        const doc = targetMeasure.ownerDocument;
+        const effective = doc.createElement("attributes");
+        if (divisions)
+            effective.appendChild(divisions);
+        if (key)
+            effective.appendChild(key);
+        if (time)
+            effective.appendChild(time);
+        if (staves)
+            effective.appendChild(staves);
+        for (const no of Array.from(clefByNo.keys()).sort()) {
+            const clef = clefByNo.get(no);
+            if (clef)
+                effective.appendChild(clef);
+        }
+        return effective.childElementCount > 0 ? effective : null;
+    };
+    const patchedMeasure = srcMeasure.cloneNode(true);
+    const effectiveAttrs = collectEffectiveAttributes(srcPart, srcMeasure);
+    if (effectiveAttrs) {
+        const existing = patchedMeasure.querySelector(":scope > attributes");
+        if (!existing) {
+            patchedMeasure.insertBefore(effectiveAttrs, patchedMeasure.firstChild);
+        }
+        else {
+            const ensureSingle = (selector) => {
+                if (existing.querySelector(`:scope > ${selector}`))
+                    return;
+                const src = effectiveAttrs.querySelector(`:scope > ${selector}`);
+                if (src)
+                    existing.appendChild(src.cloneNode(true));
+            };
+            ensureSingle("divisions");
+            ensureSingle("key");
+            ensureSingle("time");
+            ensureSingle("staves");
+            const existingClefNos = new Set(Array.from(existing.querySelectorAll(":scope > clef")).map((c) => { var _a; return (_a = c.getAttribute("number")) !== null && _a !== void 0 ? _a : "1"; }));
+            for (const clef of Array.from(effectiveAttrs.querySelectorAll(":scope > clef"))) {
+                const no = (_a = clef.getAttribute("number")) !== null && _a !== void 0 ? _a : "1";
+                if (existingClefNos.has(no))
+                    continue;
+                existing.appendChild(clef.cloneNode(true));
+            }
+        }
+    }
+    const dst = document.implementation.createDocument("", "score-partwise", null);
+    const dstRoot = dst.documentElement;
+    if (!dstRoot)
+        return null;
+    const version = srcRoot.getAttribute("version");
+    if (version)
+        dstRoot.setAttribute("version", version);
+    const srcPartList = source.querySelector("score-partwise > part-list");
+    const srcScorePart = source.querySelector(`score-partwise > part-list > score-part[id="${CSS.escape(partId)}"]`);
+    if (srcPartList && srcScorePart) {
+        const dstPartList = dst.importNode(srcPartList, false);
+        const dstScorePart = dst.importNode(srcScorePart, true);
+        const dstPartName = dstScorePart.querySelector(":scope > part-name");
+        if (dstPartName)
+            dstPartName.textContent = "";
+        const dstPartAbbreviation = dstScorePart.querySelector(":scope > part-abbreviation");
+        if (dstPartAbbreviation)
+            dstPartAbbreviation.textContent = "";
+        dstPartList.appendChild(dstScorePart);
+        dstRoot.appendChild(dstPartList);
+    }
+    const dstPart = dst.importNode(srcPart, false);
+    dstPart.appendChild(dst.importNode(patchedMeasure, true));
+    dstRoot.appendChild(dstPart);
+    return new XMLSerializer().serializeToString(dst);
+};
+const initializeMeasureEditor = (location) => {
+    var _a;
+    const xml = core.debugSerializeCurrentXml();
+    if (!xml)
+        return;
+    const extracted = extractMeasureEditorXml(xml, location.partId, location.measureNumber);
+    if (!extracted) {
+        setUiMappingDiagnostic("選択小節の抽出に失敗しました。");
+        return;
+    }
+    const nextDraft = new ScoreCore_1.ScoreCore({ editableVoice: EDITABLE_VOICE });
+    try {
+        nextDraft.load(extracted);
+    }
+    catch (error) {
+        setUiMappingDiagnostic(`選択小節の読み込みに失敗しました: ${error instanceof Error ? error.message : String(error)}`);
+        return;
+    }
+    draftCore = nextDraft;
+    draftNoteNodeIds = nextDraft.listNoteNodeIds();
+    state.selectedNodeId = (_a = draftNoteNodeIds[0]) !== null && _a !== void 0 ? _a : null;
+    selectedMeasure = location;
+    state.lastDispatchResult = null;
+    draftSvgIdToNodeId = new Map();
+    renderAll();
+    renderMeasureEditorPreview();
+};
+const onVerovioScoreClick = (event) => {
+    var _a, _b;
     if (!state.loaded)
         return;
-    const nodeId = resolveNodeIdFromSvgTarget(event.target, event);
+    const nodeId = (_a = resolveNodeIdFromSvgTarget(event.target, event)) !== null && _a !== void 0 ? _a : resolveNodeIdFromNearestPoint(event);
     if (DEBUG_LOG) {
         const clicked = event.target instanceof Element ? event.target.closest("[id]") : null;
         console.warn("[mikuscore][click-map] resolution:", {
-            clickedId: (_a = clicked === null || clicked === void 0 ? void 0 : clicked.getAttribute("id")) !== null && _a !== void 0 ? _a : null,
+            clickedId: (_b = clicked === null || clicked === void 0 ? void 0 : clicked.getAttribute("id")) !== null && _b !== void 0 ? _b : null,
             mappedNodeId: nodeId,
             mapSize: currentSvgIdToNodeId.size,
         });
@@ -878,6 +1241,20 @@ const onVerovioScoreClick = (event) => {
         setUiMappingDiagnostic(`クリック要素に対応する nodeId が見つかりませんでした: ${nodeId}`);
         return;
     }
+    const location = nodeIdToLocation.get(nodeId);
+    if (!location) {
+        setUiMappingDiagnostic(`nodeId からトラック/小節を特定できませんでした: ${nodeId}`);
+        return;
+    }
+    initializeMeasureEditor(location);
+};
+const onMeasureEditorClick = (event) => {
+    var _a;
+    if (!draftCore)
+        return;
+    const nodeId = (_a = resolveDraftNodeIdFromSvgTarget(event.target, event)) !== null && _a !== void 0 ? _a : resolveDraftNodeIdFromNearestPoint(event);
+    if (!nodeId || !draftNoteNodeIds.includes(nodeId))
+        return;
     state.selectedNodeId = nodeId;
     state.lastDispatchResult = null;
     renderAll();
@@ -963,6 +1340,7 @@ const renderScorePreview = () => {
             pageHeight: 3000,
             scale: 40,
             breaks: "none",
+            mnumInterval: 1,
             adjustPageHeight: 1,
             footer: "none",
             header: "none",
@@ -985,7 +1363,7 @@ const renderScorePreview = () => {
         debugScoreArea.innerHTML = svg;
         const renderedNoteIds = deriveRenderedNoteIds(debugScoreArea);
         let mapMode = "direct";
-        if (renderedNoteIds.length > 0 && !renderedNoteIds.some((id) => id.startsWith("mks-tmp-"))) {
+        if (renderedNoteIds.length > 0 && !renderedNoteIds.some((id) => id.startsWith("mks-"))) {
             currentSvgIdToNodeId = buildFallbackSvgIdMap(state.noteNodeIds, renderedNoteIds);
             mapMode = "fallback-seq";
         }
@@ -999,6 +1377,7 @@ const renderScorePreview = () => {
                 renderedNoteIds: renderedNoteIds.slice(0, 20),
             });
         }
+        highlightSelectedMeasureInMainPreview();
         debugScoreMeta.textContent = [
             "engine=verovio",
             "measures=" + measures,
@@ -1017,10 +1396,64 @@ const renderScorePreview = () => {
         currentSvgIdToNodeId = new Map();
     });
 };
+const renderMeasureEditorPreview = () => {
+    if (!draftCore || !selectedMeasure) {
+        measureEditorArea.innerHTML = "";
+        draftSvgIdToNodeId = new Map();
+        return;
+    }
+    const xml = draftCore.debugSerializeCurrentXml();
+    if (!xml) {
+        measureEditorArea.innerHTML = "";
+        draftSvgIdToNodeId = new Map();
+        return;
+    }
+    const renderBundle = buildRenderXmlWithNodeIds(xml, draftNoteNodeIds.slice(), "mks-draft");
+    measureEditorArea.innerHTML = "描画中...";
+    void ensureVerovioToolkit()
+        .then((toolkit) => {
+        if (!toolkit)
+            throw new Error("verovio toolkit の初期化に失敗しました。");
+        toolkit.setOptions({
+            pageWidth: 6000,
+            pageHeight: 2200,
+            scale: 46,
+            breaks: "none",
+            adjustPageHeight: 1,
+            footer: "none",
+            header: "none",
+        });
+        if (!toolkit.loadData(renderBundle.renderXml)) {
+            throw new Error("verovio loadData が失敗しました。");
+        }
+        const svg = toolkit.renderToSVG(1, {});
+        if (!svg)
+            throw new Error("verovio SVG 生成に失敗しました。");
+        measureEditorArea.innerHTML = svg;
+        const renderedNoteIds = deriveRenderedNoteIds(measureEditorArea);
+        if (renderedNoteIds.length > 0 && !renderedNoteIds.some((id) => id.startsWith("mks-"))) {
+            draftSvgIdToNodeId = buildFallbackSvgIdMap(draftNoteNodeIds, renderedNoteIds);
+        }
+        else {
+            draftSvgIdToNodeId = renderBundle.svgIdToNodeId;
+        }
+        highlightSelectedDraftNoteInEditor();
+    })
+        .catch((error) => {
+        measureEditorArea.innerHTML = `描画失敗: ${error instanceof Error ? error.message : String(error)}`;
+        draftSvgIdToNodeId = new Map();
+    });
+};
 const refreshNotesFromCore = () => {
     state.noteNodeIds = core.listNoteNodeIds();
-    if (state.selectedNodeId && !state.noteNodeIds.includes(state.selectedNodeId)) {
-        state.selectedNodeId = null;
+    const currentXml = core.debugSerializeCurrentXml();
+    if (currentXml) {
+        rebuildNodeLocationMap(currentXml);
+        rebuildPartNameMap(currentXml);
+    }
+    else {
+        nodeIdToLocation = new Map();
+        partIdToName = new Map();
     }
 };
 const midiToHz = (midi) => 440 * Math.pow(2, (midi - 69) / 12);
@@ -1394,19 +1827,22 @@ const readDuration = () => {
     return duration;
 };
 const runCommand = (command) => {
-    if (!state.loaded)
+    var _a;
+    if (!draftCore)
         return;
-    state.lastDispatchResult = core.dispatch(command);
+    state.lastDispatchResult = draftCore.dispatch(command);
     if (!state.lastDispatchResult.ok || state.lastDispatchResult.warnings.length > 0) {
         logDiagnostics("dispatch", state.lastDispatchResult.diagnostics, state.lastDispatchResult.warnings);
     }
     state.lastSaveResult = null;
     if (state.lastDispatchResult.ok) {
-        refreshNotesFromCore();
-        autoSaveCurrentXml();
+        draftNoteNodeIds = draftCore.listNoteNodeIds();
+        if (state.selectedNodeId && !draftNoteNodeIds.includes(state.selectedNodeId)) {
+            state.selectedNodeId = (_a = draftNoteNodeIds[0]) !== null && _a !== void 0 ? _a : null;
+        }
     }
     renderAll();
-    renderScorePreview();
+    renderMeasureEditorPreview();
 };
 const autoSaveCurrentXml = () => {
     if (!state.loaded)
@@ -1460,6 +1896,10 @@ const loadFromText = (xml, collapseInputSection) => {
     state.lastDispatchResult = null;
     state.lastSaveResult = null;
     state.lastSuccessfulSaveXml = "";
+    selectedMeasure = null;
+    draftCore = null;
+    draftNoteNodeIds = [];
+    draftSvgIdToNodeId = new Map();
     refreshNotesFromCore();
     autoSaveCurrentXml();
     if (collapseInputSection) {
@@ -1490,6 +1930,18 @@ const onLoadClick = async () => {
     loadFromText(xmlInput.value, true);
 };
 const requireSelectedNode = () => {
+    if (!draftCore) {
+        state.lastDispatchResult = {
+            ok: false,
+            dirtyChanged: false,
+            changedNodeIds: [],
+            affectedMeasureNumbers: [],
+            diagnostics: [{ code: "MVP_COMMAND_TARGET_MISSING", message: "先に小節を選択してください。" }],
+            warnings: [],
+        };
+        renderAll();
+        return null;
+    }
     const nodeId = state.selectedNodeId;
     if (nodeId)
         return nodeId;
@@ -1528,6 +1980,67 @@ const onChangePitch = () => {
         pitch,
     };
     runCommand(command);
+};
+const replaceMeasureInMainXml = (sourceXml, partId, measureNumber, measureXml) => {
+    const mainDoc = new DOMParser().parseFromString(sourceXml, "application/xml");
+    const measureDoc = new DOMParser().parseFromString(measureXml, "application/xml");
+    if (mainDoc.querySelector("parsererror") || measureDoc.querySelector("parsererror"))
+        return null;
+    const replacementMeasure = measureDoc.querySelector("part > measure");
+    if (!replacementMeasure)
+        return null;
+    const targetPart = mainDoc.querySelector(`score-partwise > part[id="${CSS.escape(partId)}"]`);
+    if (!targetPart)
+        return null;
+    const targetMeasure = Array.from(targetPart.querySelectorAll(":scope > measure")).find((m) => { var _a; return ((_a = m.getAttribute("number")) !== null && _a !== void 0 ? _a : "") === measureNumber; });
+    if (!targetMeasure)
+        return null;
+    targetMeasure.replaceWith(mainDoc.importNode(replacementMeasure, true));
+    return new XMLSerializer().serializeToString(mainDoc);
+};
+const onMeasureApply = () => {
+    if (!draftCore || !selectedMeasure)
+        return;
+    const draftSave = draftCore.save();
+    if (!draftSave.ok) {
+        state.lastDispatchResult = {
+            ok: false,
+            dirtyChanged: false,
+            changedNodeIds: [],
+            affectedMeasureNumbers: [],
+            diagnostics: draftSave.diagnostics,
+            warnings: [],
+        };
+        renderAll();
+        return;
+    }
+    const mainXml = core.debugSerializeCurrentXml();
+    if (!mainXml)
+        return;
+    const merged = replaceMeasureInMainXml(mainXml, selectedMeasure.partId, selectedMeasure.measureNumber, draftSave.xml);
+    if (!merged) {
+        setUiMappingDiagnostic("小節確定に失敗しました。");
+        return;
+    }
+    try {
+        core.load(merged);
+    }
+    catch (error) {
+        setUiMappingDiagnostic(`小節確定後の再読込に失敗しました: ${error instanceof Error ? error.message : String(error)}`);
+        return;
+    }
+    state.loaded = true;
+    state.lastDispatchResult = null;
+    refreshNotesFromCore();
+    autoSaveCurrentXml();
+    renderAll();
+    renderScorePreview();
+    initializeMeasureEditor(selectedMeasure);
+};
+const onMeasureDiscard = () => {
+    if (!selectedMeasure)
+        return;
+    initializeMeasureEditor(selectedMeasure);
 };
 const onChangeDuration = () => {
     const targetNodeId = requireSelectedNode();
@@ -1615,8 +2128,7 @@ loadBtn.addEventListener("click", () => {
 });
 noteSelect.addEventListener("change", () => {
     state.selectedNodeId = noteSelect.value || null;
-    renderStatus();
-    renderControlState();
+    renderAll();
 });
 changePitchBtn.addEventListener("click", onChangePitch);
 changeDurationBtn.addEventListener("click", onChangeDuration);
@@ -1628,6 +2140,9 @@ playBtn.addEventListener("click", () => {
 stopBtn.addEventListener("click", stopPlayback);
 downloadBtn.addEventListener("click", onDownload);
 debugScoreArea.addEventListener("click", onVerovioScoreClick);
+measureEditorArea.addEventListener("click", onMeasureEditorClick);
+measureApplyBtn.addEventListener("click", onMeasureApply);
+measureDiscardBtn.addEventListener("click", onMeasureDiscard);
 loadFromText(xmlInput.value, false);
 
   },

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -224,6 +224,13 @@ body {
   color: var(--md-sys-color-on-surface-variant);
 }
 
+.ms-track-label {
+  margin: 0.15rem 0;
+  color: var(--md-sys-color-on-surface-variant);
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
 .ms-grid {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
@@ -265,6 +272,37 @@ body {
   display: block;
   max-width: none;
   height: auto;
+}
+
+.ms-measure-editor {
+  border: 1px solid var(--md-sys-color-outline);
+  border-radius: 12px;
+  padding: 0.7rem;
+  overflow-x: auto;
+  overflow-y: hidden;
+  white-space: nowrap;
+  background: var(--md-sys-color-surface);
+  margin-bottom: 0.6rem;
+}
+
+.ms-measure-editor .ms-note-selected {
+  fill: #d32f2f !important;
+  stroke: #d32f2f !important;
+}
+
+.ms-measure-editor .ms-note-selected * {
+  fill: #d32f2f !important;
+  stroke: #d32f2f !important;
+}
+
+.ms-debug-score .ms-measure-selected {
+  fill: #c62828 !important;
+  stroke: #c62828 !important;
+}
+
+.ms-debug-score .ms-measure-selected * {
+  fill: #c62828 !important;
+  stroke: #c62828 !important;
 }
 
 .ms-dev {

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -42,6 +42,12 @@ const outputXml = q("#outputXml");
 const diagArea = q("#diagArea");
 const debugScoreMeta = q("#debugScoreMeta");
 const debugScoreArea = q("#debugScoreArea");
+const measurePartNameText = q("#measurePartNameText");
+const measureSelectionText = q("#measureSelectionText");
+const measureEditorWrap = q("#measureEditorWrap");
+const measureEditorArea = q("#measureEditorArea");
+const measureApplyBtn = q("#measureApplyBtn");
+const measureDiscardBtn = q("#measureDiscardBtn");
 const core = new ScoreCore_1.ScoreCore({ editableVoice: EDITABLE_VOICE });
 const state = {
     loaded: false,
@@ -58,6 +64,13 @@ let verovioToolkit = null;
 let verovioInitPromise = null;
 let verovioRenderSeq = 0;
 let currentSvgIdToNodeId = new Map();
+let nodeIdToLocation = new Map();
+let partIdToName = new Map();
+let selectedMeasure = null;
+let draftCore = null;
+let draftNoteNodeIds = [];
+let draftSvgIdToNodeId = new Map();
+const NOTE_CLICK_SNAP_PX = 170;
 const logDiagnostics = (phase, diagnostics, warnings = []) => {
     if (!DEBUG_LOG)
         return;
@@ -144,20 +157,82 @@ const renderNotes = () => {
     noteSelect.innerHTML = "";
     const placeholder = document.createElement("option");
     placeholder.value = "";
-    placeholder.textContent = state.noteNodeIds.length === 0 ? "(ノートなし)" : "(選択してください)";
+    placeholder.textContent = draftNoteNodeIds.length === 0 ? "(ノートなし)" : "(選択してください)";
     noteSelect.appendChild(placeholder);
-    for (const nodeId of state.noteNodeIds) {
+    for (const nodeId of draftNoteNodeIds) {
         const option = document.createElement("option");
         option.value = nodeId;
         option.textContent = nodeId;
         noteSelect.appendChild(option);
     }
-    if (state.selectedNodeId && state.noteNodeIds.includes(state.selectedNodeId)) {
+    if (state.selectedNodeId && draftNoteNodeIds.includes(state.selectedNodeId)) {
         noteSelect.value = state.selectedNodeId;
     }
     else {
         state.selectedNodeId = null;
         noteSelect.value = "";
+    }
+};
+const renderMeasureEditorState = () => {
+    var _a;
+    if (!selectedMeasure || !draftCore) {
+        measurePartNameText.textContent = "小節未選択（譜面プレビューをクリックしてください）";
+        measureSelectionText.textContent = "小節未選択（譜面プレビューをクリックしてください）";
+        measureSelectionText.classList.add("md-hidden");
+        measureEditorWrap.classList.add("md-hidden");
+        measureApplyBtn.disabled = true;
+        measureDiscardBtn.disabled = true;
+        return;
+    }
+    const partName = (_a = partIdToName.get(selectedMeasure.partId)) !== null && _a !== void 0 ? _a : selectedMeasure.partId;
+    measurePartNameText.textContent =
+        `トラック名: ${partName} / 選択中: トラック=${selectedMeasure.partId} / 小節=${selectedMeasure.measureNumber}`;
+    measureSelectionText.textContent = "";
+    measureSelectionText.classList.add("md-hidden");
+    measureEditorWrap.classList.remove("md-hidden");
+    measureDiscardBtn.disabled = false;
+    measureApplyBtn.disabled = !draftCore.isDirty();
+};
+const highlightSelectedDraftNoteInEditor = () => {
+    measureEditorArea
+        .querySelectorAll(".ms-note-selected")
+        .forEach((el) => el.classList.remove("ms-note-selected"));
+    if (!state.selectedNodeId || draftSvgIdToNodeId.size === 0)
+        return;
+    for (const [svgId, nodeId] of draftSvgIdToNodeId.entries()) {
+        if (nodeId !== state.selectedNodeId)
+            continue;
+        const target = document.getElementById(svgId);
+        if (!target || !measureEditorArea.contains(target))
+            continue;
+        target.classList.add("ms-note-selected");
+        const group = target.closest("g");
+        if (group && measureEditorArea.contains(group)) {
+            group.classList.add("ms-note-selected");
+        }
+    }
+};
+const highlightSelectedMeasureInMainPreview = () => {
+    debugScoreArea
+        .querySelectorAll(".ms-measure-selected")
+        .forEach((el) => el.classList.remove("ms-measure-selected"));
+    if (!selectedMeasure || currentSvgIdToNodeId.size === 0)
+        return;
+    for (const [svgId, nodeId] of currentSvgIdToNodeId.entries()) {
+        const location = nodeIdToLocation.get(nodeId);
+        if (!location)
+            continue;
+        if (location.partId !== selectedMeasure.partId || location.measureNumber !== selectedMeasure.measureNumber) {
+            continue;
+        }
+        const target = document.getElementById(svgId);
+        if (!target || !debugScoreArea.contains(target))
+            continue;
+        target.classList.add("ms-measure-selected");
+        const group = target.closest("g");
+        if (group && debugScoreArea.contains(group)) {
+            group.classList.add("ms-measure-selected");
+        }
     }
 };
 const renderDiagnostics = () => {
@@ -201,12 +276,13 @@ const renderOutput = () => {
     downloadBtn.disabled = !((_b = state.lastSaveResult) === null || _b === void 0 ? void 0 : _b.ok);
 };
 const renderControlState = () => {
+    const hasDraft = Boolean(draftCore);
     const hasSelection = Boolean(state.selectedNodeId);
-    noteSelect.disabled = !state.loaded;
-    changePitchBtn.disabled = !state.loaded || !hasSelection;
-    changeDurationBtn.disabled = !state.loaded || !hasSelection;
-    insertAfterBtn.disabled = !state.loaded || !hasSelection;
-    deleteBtn.disabled = !state.loaded || !hasSelection;
+    noteSelect.disabled = !hasDraft;
+    changePitchBtn.disabled = !hasDraft || !hasSelection;
+    changeDurationBtn.disabled = !hasDraft || !hasSelection;
+    insertAfterBtn.disabled = !hasDraft || !hasSelection;
+    deleteBtn.disabled = !hasDraft || !hasSelection;
     playBtn.disabled = !state.loaded || isPlaying;
     stopBtn.disabled = !isPlaying;
 };
@@ -216,7 +292,10 @@ const renderAll = () => {
     renderStatus();
     renderDiagnostics();
     renderOutput();
+    renderMeasureEditorState();
     renderControlState();
+    highlightSelectedMeasureInMainPreview();
+    highlightSelectedDraftNoteInEditor();
 };
 const setUiMappingDiagnostic = (message) => {
     if (DEBUG_LOG) {
@@ -232,16 +311,46 @@ const setUiMappingDiagnostic = (message) => {
     };
     renderAll();
 };
-const buildRenderXmlForVerovio = (xml) => {
-    const map = new Map();
-    if (!state.loaded) {
-        return {
-            renderXml: xml,
-            svgIdToNodeId: map,
-            noteCount: 0,
-        };
+const rebuildNodeLocationMap = (xml) => {
+    var _a, _b;
+    nodeIdToLocation = new Map();
+    const doc = new DOMParser().parseFromString(xml, "application/xml");
+    if (doc.querySelector("parsererror"))
+        return;
+    const notes = Array.from(doc.querySelectorAll("part > measure > note"));
+    const count = Math.min(notes.length, state.noteNodeIds.length);
+    for (let i = 0; i < count; i += 1) {
+        const note = notes[i];
+        const part = note.closest("part");
+        const measure = note.closest("measure");
+        if (!part || !measure)
+            continue;
+        const nodeId = state.noteNodeIds[i];
+        const partId = (_a = part.getAttribute("id")) !== null && _a !== void 0 ? _a : "";
+        const measureNumber = (_b = measure.getAttribute("number")) !== null && _b !== void 0 ? _b : "";
+        if (!partId || !measureNumber)
+            continue;
+        nodeIdToLocation.set(nodeId, { partId, measureNumber });
     }
-    const nodeIds = state.noteNodeIds.slice();
+};
+const rebuildPartNameMap = (xml) => {
+    var _a, _b, _c, _d, _e, _f;
+    partIdToName = new Map();
+    const doc = new DOMParser().parseFromString(xml, "application/xml");
+    if (doc.querySelector("parsererror"))
+        return;
+    for (const scorePart of Array.from(doc.querySelectorAll("score-partwise > part-list > score-part"))) {
+        const partId = (_b = (_a = scorePart.getAttribute("id")) === null || _a === void 0 ? void 0 : _a.trim()) !== null && _b !== void 0 ? _b : "";
+        if (!partId)
+            continue;
+        const partName = ((_d = (_c = scorePart.querySelector(":scope > part-name")) === null || _c === void 0 ? void 0 : _c.textContent) === null || _d === void 0 ? void 0 : _d.trim()) ||
+            ((_f = (_e = scorePart.querySelector(":scope > part-abbreviation")) === null || _e === void 0 ? void 0 : _e.textContent) === null || _f === void 0 ? void 0 : _f.trim()) ||
+            partId;
+        partIdToName.set(partId, partName);
+    }
+};
+const buildRenderXmlWithNodeIds = (xml, nodeIds, idPrefix) => {
+    const map = new Map();
     if (nodeIds.length === 0) {
         return { renderXml: xml, svgIdToNodeId: map, noteCount: 0 };
     }
@@ -253,7 +362,7 @@ const buildRenderXmlForVerovio = (xml) => {
     const count = Math.min(notes.length, nodeIds.length);
     for (let i = 0; i < count; i += 1) {
         const nodeId = nodeIds[i];
-        const svgId = `mks-tmp-${nodeId}`;
+        const svgId = `${idPrefix}-${nodeId}`;
         notes[i].setAttribute("xml:id", svgId);
         notes[i].setAttribute("id", svgId);
         map.set(svgId, nodeId);
@@ -264,8 +373,18 @@ const buildRenderXmlForVerovio = (xml) => {
         noteCount: count,
     };
 };
+const buildRenderXmlForVerovio = (xml) => {
+    if (!state.loaded) {
+        return {
+            renderXml: xml,
+            svgIdToNodeId: new Map(),
+            noteCount: 0,
+        };
+    }
+    return buildRenderXmlWithNodeIds(xml, state.noteNodeIds.slice(), "mks-main");
+};
 const deriveRenderedNoteIds = (root) => {
-    const direct = Array.from(root.querySelectorAll('[id^="mks-tmp-"], [id*="mks-tmp-"]')).map((el) => el.id);
+    const direct = Array.from(root.querySelectorAll('[id^="mks-"], [id*="mks-"]')).map((el) => el.id);
     if (direct.length > 0) {
         return Array.from(new Set(direct));
     }
@@ -287,14 +406,14 @@ const buildFallbackSvgIdMap = (sourceNodeIds, renderedNoteIds) => {
     }
     return map;
 };
-const resolveNodeIdFromCandidateIds = (candidateIds) => {
+const resolveNodeIdFromCandidateIds = (candidateIds, svgIdMap) => {
     for (const entry of candidateIds) {
-        const exact = currentSvgIdToNodeId.get(entry);
+        const exact = svgIdMap.get(entry);
         if (exact)
             return exact;
     }
     for (const entry of candidateIds) {
-        for (const [knownSvgId, nodeId] of currentSvgIdToNodeId.entries()) {
+        for (const [knownSvgId, nodeId] of svgIdMap.entries()) {
             if (entry.startsWith(`${knownSvgId}-`) || knownSvgId.startsWith(`${entry}-`)) {
                 return nodeId;
             }
@@ -330,7 +449,7 @@ const resolveNodeIdFromSvgTarget = (target, clickEvent) => {
     if (!target || !(target instanceof Element))
         return null;
     const directCandidates = collectCandidateIdsFromElement(target);
-    const resolvedFromDirect = resolveNodeIdFromCandidateIds(directCandidates);
+    const resolvedFromDirect = resolveNodeIdFromCandidateIds(directCandidates, currentSvgIdToNodeId);
     if (resolvedFromDirect)
         return resolvedFromDirect;
     if (clickEvent && typeof document.elementsFromPoint === "function") {
@@ -339,7 +458,7 @@ const resolveNodeIdFromSvgTarget = (target, clickEvent) => {
             if (!(hit instanceof Element))
                 continue;
             const hitCandidates = collectCandidateIdsFromElement(hit);
-            const resolvedFromHit = resolveNodeIdFromCandidateIds(hitCandidates);
+            const resolvedFromHit = resolveNodeIdFromCandidateIds(hitCandidates, currentSvgIdToNodeId);
             if (resolvedFromHit)
                 return resolvedFromHit;
         }
@@ -353,15 +472,209 @@ const resolveNodeIdFromSvgTarget = (target, clickEvent) => {
     }
     return null;
 };
-const onVerovioScoreClick = (event) => {
+const resolveDraftNodeIdFromSvgTarget = (target, clickEvent) => {
+    if (!target || !(target instanceof Element))
+        return null;
+    const directCandidates = collectCandidateIdsFromElement(target);
+    const resolvedFromDirect = resolveNodeIdFromCandidateIds(directCandidates, draftSvgIdToNodeId);
+    if (resolvedFromDirect)
+        return resolvedFromDirect;
+    if (clickEvent && typeof document.elementsFromPoint === "function") {
+        const hitElements = document.elementsFromPoint(clickEvent.clientX, clickEvent.clientY);
+        for (const hit of hitElements) {
+            if (!(hit instanceof Element))
+                continue;
+            const hitCandidates = collectCandidateIdsFromElement(hit);
+            const resolvedFromHit = resolveNodeIdFromCandidateIds(hitCandidates, draftSvgIdToNodeId);
+            if (resolvedFromHit)
+                return resolvedFromHit;
+        }
+    }
+    return null;
+};
+const resolveNodeIdFromNearestPointInArea = (clickEvent, area, svgIdToNodeId, snapPx = NOTE_CLICK_SNAP_PX) => {
+    let bestNodeId = null;
+    let bestScore = Number.POSITIVE_INFINITY;
+    for (const [svgId, nodeId] of svgIdToNodeId.entries()) {
+        const el = area.querySelector(`#${CSS.escape(svgId)}`);
+        if (!el)
+            continue;
+        const rect = el.getBoundingClientRect();
+        if (!Number.isFinite(rect.left) || rect.width <= 0 || rect.height <= 0)
+            continue;
+        const dx = clickEvent.clientX < rect.left
+            ? rect.left - clickEvent.clientX
+            : clickEvent.clientX > rect.right
+                ? clickEvent.clientX - rect.right
+                : 0;
+        const dy = clickEvent.clientY < rect.top
+            ? rect.top - clickEvent.clientY
+            : clickEvent.clientY > rect.bottom
+                ? clickEvent.clientY - rect.bottom
+                : 0;
+        const score = Math.hypot(dx, dy);
+        if (score < bestScore) {
+            bestScore = score;
+            bestNodeId = nodeId;
+        }
+    }
+    return bestScore <= snapPx ? bestNodeId : null;
+};
+const resolveNodeIdFromNearestPoint = (clickEvent) => {
+    return resolveNodeIdFromNearestPointInArea(clickEvent, debugScoreArea, currentSvgIdToNodeId, NOTE_CLICK_SNAP_PX);
+};
+const resolveDraftNodeIdFromNearestPoint = (clickEvent) => {
+    return resolveNodeIdFromNearestPointInArea(clickEvent, measureEditorArea, draftSvgIdToNodeId, NOTE_CLICK_SNAP_PX);
+};
+const extractMeasureEditorXml = (xml, partId, measureNumber) => {
     var _a;
+    const source = new DOMParser().parseFromString(xml, "application/xml");
+    if (source.querySelector("parsererror"))
+        return null;
+    const srcRoot = source.querySelector("score-partwise");
+    const srcPart = source.querySelector(`score-partwise > part[id="${CSS.escape(partId)}"]`);
+    if (!srcRoot || !srcPart)
+        return null;
+    const srcMeasure = Array.from(srcPart.querySelectorAll(":scope > measure")).find((m) => { var _a; return ((_a = m.getAttribute("number")) !== null && _a !== void 0 ? _a : "") === measureNumber; });
+    if (!srcMeasure)
+        return null;
+    const collectEffectiveAttributes = (part, targetMeasure) => {
+        var _a;
+        let divisions = null;
+        let key = null;
+        let time = null;
+        let staves = null;
+        const clefByNo = new Map();
+        for (const measure of Array.from(part.querySelectorAll(":scope > measure"))) {
+            const attrs = measure.querySelector(":scope > attributes");
+            if (attrs) {
+                const nextDivisions = attrs.querySelector(":scope > divisions");
+                if (nextDivisions)
+                    divisions = nextDivisions.cloneNode(true);
+                const nextKey = attrs.querySelector(":scope > key");
+                if (nextKey)
+                    key = nextKey.cloneNode(true);
+                const nextTime = attrs.querySelector(":scope > time");
+                if (nextTime)
+                    time = nextTime.cloneNode(true);
+                const nextStaves = attrs.querySelector(":scope > staves");
+                if (nextStaves)
+                    staves = nextStaves.cloneNode(true);
+                for (const clef of Array.from(attrs.querySelectorAll(":scope > clef"))) {
+                    const no = (_a = clef.getAttribute("number")) !== null && _a !== void 0 ? _a : "1";
+                    clefByNo.set(no, clef.cloneNode(true));
+                }
+            }
+            if (measure === targetMeasure)
+                break;
+        }
+        const doc = targetMeasure.ownerDocument;
+        const effective = doc.createElement("attributes");
+        if (divisions)
+            effective.appendChild(divisions);
+        if (key)
+            effective.appendChild(key);
+        if (time)
+            effective.appendChild(time);
+        if (staves)
+            effective.appendChild(staves);
+        for (const no of Array.from(clefByNo.keys()).sort()) {
+            const clef = clefByNo.get(no);
+            if (clef)
+                effective.appendChild(clef);
+        }
+        return effective.childElementCount > 0 ? effective : null;
+    };
+    const patchedMeasure = srcMeasure.cloneNode(true);
+    const effectiveAttrs = collectEffectiveAttributes(srcPart, srcMeasure);
+    if (effectiveAttrs) {
+        const existing = patchedMeasure.querySelector(":scope > attributes");
+        if (!existing) {
+            patchedMeasure.insertBefore(effectiveAttrs, patchedMeasure.firstChild);
+        }
+        else {
+            const ensureSingle = (selector) => {
+                if (existing.querySelector(`:scope > ${selector}`))
+                    return;
+                const src = effectiveAttrs.querySelector(`:scope > ${selector}`);
+                if (src)
+                    existing.appendChild(src.cloneNode(true));
+            };
+            ensureSingle("divisions");
+            ensureSingle("key");
+            ensureSingle("time");
+            ensureSingle("staves");
+            const existingClefNos = new Set(Array.from(existing.querySelectorAll(":scope > clef")).map((c) => { var _a; return (_a = c.getAttribute("number")) !== null && _a !== void 0 ? _a : "1"; }));
+            for (const clef of Array.from(effectiveAttrs.querySelectorAll(":scope > clef"))) {
+                const no = (_a = clef.getAttribute("number")) !== null && _a !== void 0 ? _a : "1";
+                if (existingClefNos.has(no))
+                    continue;
+                existing.appendChild(clef.cloneNode(true));
+            }
+        }
+    }
+    const dst = document.implementation.createDocument("", "score-partwise", null);
+    const dstRoot = dst.documentElement;
+    if (!dstRoot)
+        return null;
+    const version = srcRoot.getAttribute("version");
+    if (version)
+        dstRoot.setAttribute("version", version);
+    const srcPartList = source.querySelector("score-partwise > part-list");
+    const srcScorePart = source.querySelector(`score-partwise > part-list > score-part[id="${CSS.escape(partId)}"]`);
+    if (srcPartList && srcScorePart) {
+        const dstPartList = dst.importNode(srcPartList, false);
+        const dstScorePart = dst.importNode(srcScorePart, true);
+        const dstPartName = dstScorePart.querySelector(":scope > part-name");
+        if (dstPartName)
+            dstPartName.textContent = "";
+        const dstPartAbbreviation = dstScorePart.querySelector(":scope > part-abbreviation");
+        if (dstPartAbbreviation)
+            dstPartAbbreviation.textContent = "";
+        dstPartList.appendChild(dstScorePart);
+        dstRoot.appendChild(dstPartList);
+    }
+    const dstPart = dst.importNode(srcPart, false);
+    dstPart.appendChild(dst.importNode(patchedMeasure, true));
+    dstRoot.appendChild(dstPart);
+    return new XMLSerializer().serializeToString(dst);
+};
+const initializeMeasureEditor = (location) => {
+    var _a;
+    const xml = core.debugSerializeCurrentXml();
+    if (!xml)
+        return;
+    const extracted = extractMeasureEditorXml(xml, location.partId, location.measureNumber);
+    if (!extracted) {
+        setUiMappingDiagnostic("選択小節の抽出に失敗しました。");
+        return;
+    }
+    const nextDraft = new ScoreCore_1.ScoreCore({ editableVoice: EDITABLE_VOICE });
+    try {
+        nextDraft.load(extracted);
+    }
+    catch (error) {
+        setUiMappingDiagnostic(`選択小節の読み込みに失敗しました: ${error instanceof Error ? error.message : String(error)}`);
+        return;
+    }
+    draftCore = nextDraft;
+    draftNoteNodeIds = nextDraft.listNoteNodeIds();
+    state.selectedNodeId = (_a = draftNoteNodeIds[0]) !== null && _a !== void 0 ? _a : null;
+    selectedMeasure = location;
+    state.lastDispatchResult = null;
+    draftSvgIdToNodeId = new Map();
+    renderAll();
+    renderMeasureEditorPreview();
+};
+const onVerovioScoreClick = (event) => {
+    var _a, _b;
     if (!state.loaded)
         return;
-    const nodeId = resolveNodeIdFromSvgTarget(event.target, event);
+    const nodeId = (_a = resolveNodeIdFromSvgTarget(event.target, event)) !== null && _a !== void 0 ? _a : resolveNodeIdFromNearestPoint(event);
     if (DEBUG_LOG) {
         const clicked = event.target instanceof Element ? event.target.closest("[id]") : null;
         console.warn("[mikuscore][click-map] resolution:", {
-            clickedId: (_a = clicked === null || clicked === void 0 ? void 0 : clicked.getAttribute("id")) !== null && _a !== void 0 ? _a : null,
+            clickedId: (_b = clicked === null || clicked === void 0 ? void 0 : clicked.getAttribute("id")) !== null && _b !== void 0 ? _b : null,
             mappedNodeId: nodeId,
             mapSize: currentSvgIdToNodeId.size,
         });
@@ -374,6 +687,20 @@ const onVerovioScoreClick = (event) => {
         setUiMappingDiagnostic(`クリック要素に対応する nodeId が見つかりませんでした: ${nodeId}`);
         return;
     }
+    const location = nodeIdToLocation.get(nodeId);
+    if (!location) {
+        setUiMappingDiagnostic(`nodeId からトラック/小節を特定できませんでした: ${nodeId}`);
+        return;
+    }
+    initializeMeasureEditor(location);
+};
+const onMeasureEditorClick = (event) => {
+    var _a;
+    if (!draftCore)
+        return;
+    const nodeId = (_a = resolveDraftNodeIdFromSvgTarget(event.target, event)) !== null && _a !== void 0 ? _a : resolveDraftNodeIdFromNearestPoint(event);
+    if (!nodeId || !draftNoteNodeIds.includes(nodeId))
+        return;
     state.selectedNodeId = nodeId;
     state.lastDispatchResult = null;
     renderAll();
@@ -459,6 +786,7 @@ const renderScorePreview = () => {
             pageHeight: 3000,
             scale: 40,
             breaks: "none",
+            mnumInterval: 1,
             adjustPageHeight: 1,
             footer: "none",
             header: "none",
@@ -481,7 +809,7 @@ const renderScorePreview = () => {
         debugScoreArea.innerHTML = svg;
         const renderedNoteIds = deriveRenderedNoteIds(debugScoreArea);
         let mapMode = "direct";
-        if (renderedNoteIds.length > 0 && !renderedNoteIds.some((id) => id.startsWith("mks-tmp-"))) {
+        if (renderedNoteIds.length > 0 && !renderedNoteIds.some((id) => id.startsWith("mks-"))) {
             currentSvgIdToNodeId = buildFallbackSvgIdMap(state.noteNodeIds, renderedNoteIds);
             mapMode = "fallback-seq";
         }
@@ -495,6 +823,7 @@ const renderScorePreview = () => {
                 renderedNoteIds: renderedNoteIds.slice(0, 20),
             });
         }
+        highlightSelectedMeasureInMainPreview();
         debugScoreMeta.textContent = [
             "engine=verovio",
             "measures=" + measures,
@@ -513,10 +842,64 @@ const renderScorePreview = () => {
         currentSvgIdToNodeId = new Map();
     });
 };
+const renderMeasureEditorPreview = () => {
+    if (!draftCore || !selectedMeasure) {
+        measureEditorArea.innerHTML = "";
+        draftSvgIdToNodeId = new Map();
+        return;
+    }
+    const xml = draftCore.debugSerializeCurrentXml();
+    if (!xml) {
+        measureEditorArea.innerHTML = "";
+        draftSvgIdToNodeId = new Map();
+        return;
+    }
+    const renderBundle = buildRenderXmlWithNodeIds(xml, draftNoteNodeIds.slice(), "mks-draft");
+    measureEditorArea.innerHTML = "描画中...";
+    void ensureVerovioToolkit()
+        .then((toolkit) => {
+        if (!toolkit)
+            throw new Error("verovio toolkit の初期化に失敗しました。");
+        toolkit.setOptions({
+            pageWidth: 6000,
+            pageHeight: 2200,
+            scale: 46,
+            breaks: "none",
+            adjustPageHeight: 1,
+            footer: "none",
+            header: "none",
+        });
+        if (!toolkit.loadData(renderBundle.renderXml)) {
+            throw new Error("verovio loadData が失敗しました。");
+        }
+        const svg = toolkit.renderToSVG(1, {});
+        if (!svg)
+            throw new Error("verovio SVG 生成に失敗しました。");
+        measureEditorArea.innerHTML = svg;
+        const renderedNoteIds = deriveRenderedNoteIds(measureEditorArea);
+        if (renderedNoteIds.length > 0 && !renderedNoteIds.some((id) => id.startsWith("mks-"))) {
+            draftSvgIdToNodeId = buildFallbackSvgIdMap(draftNoteNodeIds, renderedNoteIds);
+        }
+        else {
+            draftSvgIdToNodeId = renderBundle.svgIdToNodeId;
+        }
+        highlightSelectedDraftNoteInEditor();
+    })
+        .catch((error) => {
+        measureEditorArea.innerHTML = `描画失敗: ${error instanceof Error ? error.message : String(error)}`;
+        draftSvgIdToNodeId = new Map();
+    });
+};
 const refreshNotesFromCore = () => {
     state.noteNodeIds = core.listNoteNodeIds();
-    if (state.selectedNodeId && !state.noteNodeIds.includes(state.selectedNodeId)) {
-        state.selectedNodeId = null;
+    const currentXml = core.debugSerializeCurrentXml();
+    if (currentXml) {
+        rebuildNodeLocationMap(currentXml);
+        rebuildPartNameMap(currentXml);
+    }
+    else {
+        nodeIdToLocation = new Map();
+        partIdToName = new Map();
     }
 };
 const midiToHz = (midi) => 440 * Math.pow(2, (midi - 69) / 12);
@@ -890,19 +1273,22 @@ const readDuration = () => {
     return duration;
 };
 const runCommand = (command) => {
-    if (!state.loaded)
+    var _a;
+    if (!draftCore)
         return;
-    state.lastDispatchResult = core.dispatch(command);
+    state.lastDispatchResult = draftCore.dispatch(command);
     if (!state.lastDispatchResult.ok || state.lastDispatchResult.warnings.length > 0) {
         logDiagnostics("dispatch", state.lastDispatchResult.diagnostics, state.lastDispatchResult.warnings);
     }
     state.lastSaveResult = null;
     if (state.lastDispatchResult.ok) {
-        refreshNotesFromCore();
-        autoSaveCurrentXml();
+        draftNoteNodeIds = draftCore.listNoteNodeIds();
+        if (state.selectedNodeId && !draftNoteNodeIds.includes(state.selectedNodeId)) {
+            state.selectedNodeId = (_a = draftNoteNodeIds[0]) !== null && _a !== void 0 ? _a : null;
+        }
     }
     renderAll();
-    renderScorePreview();
+    renderMeasureEditorPreview();
 };
 const autoSaveCurrentXml = () => {
     if (!state.loaded)
@@ -956,6 +1342,10 @@ const loadFromText = (xml, collapseInputSection) => {
     state.lastDispatchResult = null;
     state.lastSaveResult = null;
     state.lastSuccessfulSaveXml = "";
+    selectedMeasure = null;
+    draftCore = null;
+    draftNoteNodeIds = [];
+    draftSvgIdToNodeId = new Map();
     refreshNotesFromCore();
     autoSaveCurrentXml();
     if (collapseInputSection) {
@@ -986,6 +1376,18 @@ const onLoadClick = async () => {
     loadFromText(xmlInput.value, true);
 };
 const requireSelectedNode = () => {
+    if (!draftCore) {
+        state.lastDispatchResult = {
+            ok: false,
+            dirtyChanged: false,
+            changedNodeIds: [],
+            affectedMeasureNumbers: [],
+            diagnostics: [{ code: "MVP_COMMAND_TARGET_MISSING", message: "先に小節を選択してください。" }],
+            warnings: [],
+        };
+        renderAll();
+        return null;
+    }
     const nodeId = state.selectedNodeId;
     if (nodeId)
         return nodeId;
@@ -1024,6 +1426,67 @@ const onChangePitch = () => {
         pitch,
     };
     runCommand(command);
+};
+const replaceMeasureInMainXml = (sourceXml, partId, measureNumber, measureXml) => {
+    const mainDoc = new DOMParser().parseFromString(sourceXml, "application/xml");
+    const measureDoc = new DOMParser().parseFromString(measureXml, "application/xml");
+    if (mainDoc.querySelector("parsererror") || measureDoc.querySelector("parsererror"))
+        return null;
+    const replacementMeasure = measureDoc.querySelector("part > measure");
+    if (!replacementMeasure)
+        return null;
+    const targetPart = mainDoc.querySelector(`score-partwise > part[id="${CSS.escape(partId)}"]`);
+    if (!targetPart)
+        return null;
+    const targetMeasure = Array.from(targetPart.querySelectorAll(":scope > measure")).find((m) => { var _a; return ((_a = m.getAttribute("number")) !== null && _a !== void 0 ? _a : "") === measureNumber; });
+    if (!targetMeasure)
+        return null;
+    targetMeasure.replaceWith(mainDoc.importNode(replacementMeasure, true));
+    return new XMLSerializer().serializeToString(mainDoc);
+};
+const onMeasureApply = () => {
+    if (!draftCore || !selectedMeasure)
+        return;
+    const draftSave = draftCore.save();
+    if (!draftSave.ok) {
+        state.lastDispatchResult = {
+            ok: false,
+            dirtyChanged: false,
+            changedNodeIds: [],
+            affectedMeasureNumbers: [],
+            diagnostics: draftSave.diagnostics,
+            warnings: [],
+        };
+        renderAll();
+        return;
+    }
+    const mainXml = core.debugSerializeCurrentXml();
+    if (!mainXml)
+        return;
+    const merged = replaceMeasureInMainXml(mainXml, selectedMeasure.partId, selectedMeasure.measureNumber, draftSave.xml);
+    if (!merged) {
+        setUiMappingDiagnostic("小節確定に失敗しました。");
+        return;
+    }
+    try {
+        core.load(merged);
+    }
+    catch (error) {
+        setUiMappingDiagnostic(`小節確定後の再読込に失敗しました: ${error instanceof Error ? error.message : String(error)}`);
+        return;
+    }
+    state.loaded = true;
+    state.lastDispatchResult = null;
+    refreshNotesFromCore();
+    autoSaveCurrentXml();
+    renderAll();
+    renderScorePreview();
+    initializeMeasureEditor(selectedMeasure);
+};
+const onMeasureDiscard = () => {
+    if (!selectedMeasure)
+        return;
+    initializeMeasureEditor(selectedMeasure);
 };
 const onChangeDuration = () => {
     const targetNodeId = requireSelectedNode();
@@ -1111,8 +1574,7 @@ loadBtn.addEventListener("click", () => {
 });
 noteSelect.addEventListener("change", () => {
     state.selectedNodeId = noteSelect.value || null;
-    renderStatus();
-    renderControlState();
+    renderAll();
 });
 changePitchBtn.addEventListener("click", onChangePitch);
 changeDurationBtn.addEventListener("click", onChangeDuration);
@@ -1124,6 +1586,9 @@ playBtn.addEventListener("click", () => {
 stopBtn.addEventListener("click", stopPlayback);
 downloadBtn.addEventListener("click", onDownload);
 debugScoreArea.addEventListener("click", onVerovioScoreClick);
+measureEditorArea.addEventListener("click", onMeasureEditorClick);
+measureApplyBtn.addEventListener("click", onMeasureApply);
+measureDiscardBtn.addEventListener("click", onMeasureDiscard);
 loadFromText(xmlInput.value, false);
 
   },


### PR DESCRIPTION
## 概要
譜面プレビューで選択した `トラック + 小節` を編集対象として切り出し、専用の小節編集エリアで仮編集→確定反映できるようにしました。 あわせて、クリック選択精度・視覚フィードバック・情報配置（詳細情報への移動）を改善しています。

## 主な変更内容

### 1. 小節単位編集フローを追加
- メイン譜面クリック時に `partId + measureNumber` を特定
- 選択小節を MusicXML から抽出して編集用 `draftCore` にロード
- 編集エリアに Verovio で1小節のみ描画
- `確定` で対象小節を本体XMLへ丸ごと置換
- `破棄` で選択小節の編集状態を再初期化

### 2. 選択体験の改善（クリック判定）
- クリックID解決処理をメイン譜面/編集譜面で分離
- ヒットしない場合の近傍スナップを導入（`NOTE_CLICK_SNAP_PX`）
- `elementsFromPoint` + 近傍探索で選択の取りこぼしを低減

### 3. ハイライト表示の追加
- 編集小節内の選択ノートを赤系で強調 (`.ms-note-selected`)
- メイン譜面上の選択小節ノート群を赤系で強調 (`.ms-measure-selected`)
- 描画後DOMにクラス付与する方式で実装

### 4. 小節抽出XMLの安定化
- 抽出小節に不足しがちな `attributes`（divisions/key/time/staves/clef）を補完
- 単小節描画時の崩れ・表示失敗を抑制

### 5. UI再編・文言整理
- 編集セクションに小節編集UIを追加
  - `measurePartNameText`
  - `measureSelectionText`
  - `measureEditorArea`
  - `確定 / 破棄`
- `ノート選択(nodeId)` を常時表示から「詳細情報」へ移動
- 状態/再生/保存モードなどの情報を詳細情報側へ集約
- 小節表示は1行で要約（トラック名 + 選択中トラック/小節）

### 6. 譜面表示情報の改善
- メイン譜面に小節番号表示オプションを有効化（`mnumInterval: 1`）
- 編集用プレビューでは楽器名表示を抑制（`part-name` / `part-abbreviation` を空化）

## 変更ファイル
- `mikuscore-src.html`
- `src/ts/main.ts`
- `src/css/app.css`
- `src/js/main.js`（ビルド成果物）
- `mikuscore.html`（ビルド成果物）

## 期待効果
- 「譜面で選ぶ → 小節だけ編集 → 確定反映」の操作が明確になり、編集作業の認知負荷を軽減
- クリックしづらさ・選択状態の見えづらさを改善
- 情報の主従を整理し、メイン画面を編集中心に最適化