### PR TITLE
編集UX改善: 音名ステップを↑/↓操作化し、小節単体再生を追加

### DIFF
--- a/mikuscore-src.html
+++ b/mikuscore-src.html
@@ -121,19 +121,17 @@
           <div class="ms-actions">
             <button id="measureApplyBtn" type="button" class="md-button md-button--primary" disabled>確定</button>
             <button id="measureDiscardBtn" type="button" class="md-button md-button--surface" disabled>破棄</button>
+            <button id="playMeasureBtn" type="button" class="md-button md-button--tonal" disabled>この小節を再生</button>
           </div>
 
           <div class="ms-grid">
             <label class="ms-field">音名(step)
-              <select id="pitchStep" class="md-select">
-                <option value="C">C</option>
-                <option value="D">D</option>
-                <option value="E">E</option>
-                <option value="F">F</option>
-                <option value="G">G</option>
-                <option value="A">A</option>
-                <option value="B">B</option>
-              </select>
+              <div class="ms-step-row">
+                <input id="pitchStep" type="hidden" value="" />
+                <span id="pitchStepValue" class="ms-step-value" aria-live="polite">休符</span>
+                <button id="pitchStepDownBtn" type="button" class="md-button md-button--surface ms-step-btn" aria-label="音名を下げる">↓</button>
+                <button id="pitchStepUpBtn" type="button" class="md-button md-button--surface ms-step-btn" aria-label="音名を上げる">↑</button>
+              </div>
             </label>
             <label class="ms-field">変化記号(alter)
               <select id="pitchAlter" class="md-select">
@@ -154,7 +152,6 @@
           </div>
 
           <div class="ms-actions">
-            <button id="changePitchBtn" type="button" class="md-button md-button--primary">音高変更</button>
             <button id="changeDurationBtn" type="button" class="md-button md-button--primary">音価変更</button>
             <button id="insertAfterBtn" type="button" class="md-button md-button--tonal">後ろに音符追加</button>
             <button id="deleteBtn" type="button" class="md-button md-button--surface">音符削除</button>

--- a/mikuscore.html
+++ b/mikuscore.html
@@ -253,6 +253,27 @@ body {
   color: var(--md-sys-color-on-surface-variant);
 }
 
+.ms-step-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  gap: 0.4rem;
+  align-items: center;
+}
+
+.ms-step-value {
+  display: inline-block;
+  padding: 0.1rem 0.1rem 0.1rem 0;
+  font-weight: 700;
+  color: var(--md-sys-color-on-surface);
+  line-height: 1.2;
+}
+
+.ms-step-btn {
+  min-width: 2.4rem;
+  padding: 0.5rem 0.6rem;
+  font-weight: 700;
+}
+
 .ms-debug-meta {
   margin: 0.35rem 0;
   color: var(--md-sys-color-on-surface-variant);
@@ -472,19 +493,17 @@ body {
           <div class="ms-actions">
             <button id="measureApplyBtn" type="button" class="md-button md-button--primary" disabled>確定</button>
             <button id="measureDiscardBtn" type="button" class="md-button md-button--surface" disabled>破棄</button>
+            <button id="playMeasureBtn" type="button" class="md-button md-button--tonal" disabled>この小節を再生</button>
           </div>
 
           <div class="ms-grid">
             <label class="ms-field">音名(step)
-              <select id="pitchStep" class="md-select">
-                <option value="C">C</option>
-                <option value="D">D</option>
-                <option value="E">E</option>
-                <option value="F">F</option>
-                <option value="G">G</option>
-                <option value="A">A</option>
-                <option value="B">B</option>
-              </select>
+              <div class="ms-step-row">
+                <input id="pitchStep" type="hidden" value="" />
+                <span id="pitchStepValue" class="ms-step-value" aria-live="polite">休符</span>
+                <button id="pitchStepDownBtn" type="button" class="md-button md-button--surface ms-step-btn" aria-label="音名を下げる">↓</button>
+                <button id="pitchStepUpBtn" type="button" class="md-button md-button--surface ms-step-btn" aria-label="音名を上げる">↑</button>
+              </div>
             </label>
             <label class="ms-field">変化記号(alter)
               <select id="pitchAlter" class="md-select">
@@ -505,7 +524,6 @@ body {
           </div>
 
           <div class="ms-actions">
-            <button id="changePitchBtn" type="button" class="md-button md-button--primary">音高変更</button>
             <button id="changeDurationBtn" type="button" class="md-button md-button--primary">音価変更</button>
             <button id="insertAfterBtn" type="button" class="md-button md-button--tonal">後ろに音符追加</button>
             <button id="deleteBtn" type="button" class="md-button md-button--surface">音符削除</button>
@@ -580,10 +598,12 @@ const loadBtn = q("#loadBtn");
 const noteSelect = q("#noteSelect");
 const statusText = q("#statusText");
 const pitchStep = q("#pitchStep");
+const pitchStepValue = q("#pitchStepValue");
+const pitchStepDownBtn = q("#pitchStepDownBtn");
+const pitchStepUpBtn = q("#pitchStepUpBtn");
 const pitchAlter = q("#pitchAlter");
 const pitchOctave = q("#pitchOctave");
 const durationInput = q("#durationInput");
-const changePitchBtn = q("#changePitchBtn");
 const changeDurationBtn = q("#changeDurationBtn");
 const insertAfterBtn = q("#insertAfterBtn");
 const deleteBtn = q("#deleteBtn");
@@ -602,6 +622,7 @@ const measureEditorWrap = q("#measureEditorWrap");
 const measureEditorArea = q("#measureEditorArea");
 const measureApplyBtn = q("#measureApplyBtn");
 const measureDiscardBtn = q("#measureDiscardBtn");
+const playMeasureBtn = q("#playMeasureBtn");
 const core = new ScoreCore_1.ScoreCore({ editableVoice: EDITABLE_VOICE });
 const state = {
     loaded: false,
@@ -624,6 +645,7 @@ let selectedMeasure = null;
 let draftCore = null;
 let draftNoteNodeIds = [];
 let draftSvgIdToNodeId = new Map();
+let selectedDraftNoteIsRest = false;
 const NOTE_CLICK_SNAP_PX = 170;
 const logDiagnostics = (phase, diagnostics, warnings = []) => {
     if (!DEBUG_LOG)
@@ -726,6 +748,70 @@ const renderNotes = () => {
         state.selectedNodeId = null;
         noteSelect.value = "";
     }
+};
+const isPitchStepValue = (value) => {
+    return value === "A" || value === "B" || value === "C" || value === "D" || value === "E" || value === "F" || value === "G";
+};
+const renderPitchStepValue = () => {
+    const step = pitchStep.value.trim();
+    if (isPitchStepValue(step)) {
+        pitchStepValue.textContent = step;
+    }
+    else {
+        pitchStepValue.textContent = "休符";
+    }
+};
+const syncStepFromSelectedDraftNote = () => {
+    var _a, _b, _c;
+    selectedDraftNoteIsRest = false;
+    pitchStep.disabled = false;
+    pitchAlter.disabled = false;
+    pitchOctave.disabled = false;
+    pitchStep.title = "";
+    pitchAlter.title = "";
+    pitchOctave.title = "";
+    if (!draftCore || !state.selectedNodeId) {
+        pitchStep.value = "";
+        renderPitchStepValue();
+        return;
+    }
+    const xml = draftCore.debugSerializeCurrentXml();
+    if (!xml) {
+        pitchStep.value = "";
+        renderPitchStepValue();
+        return;
+    }
+    const doc = new DOMParser().parseFromString(xml, "application/xml");
+    if (doc.querySelector("parsererror")) {
+        pitchStep.value = "";
+        renderPitchStepValue();
+        return;
+    }
+    const notes = Array.from(doc.querySelectorAll("note"));
+    const count = Math.min(notes.length, draftNoteNodeIds.length);
+    for (let i = 0; i < count; i += 1) {
+        if (draftNoteNodeIds[i] !== state.selectedNodeId)
+            continue;
+        if (notes[i].querySelector(":scope > rest")) {
+            selectedDraftNoteIsRest = true;
+            pitchStep.value = "";
+            pitchStep.disabled = true;
+            pitchAlter.disabled = true;
+            pitchOctave.disabled = true;
+            pitchStep.title = "休符は音高を持たないため、音高変更はできません。";
+            pitchAlter.title = "休符は音高を持たないため、音高変更はできません。";
+            pitchOctave.title = "休符は音高を持たないため、音高変更はできません。";
+            renderPitchStepValue();
+            return;
+        }
+        const stepText = (_c = (_b = (_a = notes[i].querySelector(":scope > pitch > step")) === null || _a === void 0 ? void 0 : _a.textContent) === null || _b === void 0 ? void 0 : _b.trim()) !== null && _c !== void 0 ? _c : "";
+        if (isPitchStepValue(stepText)) {
+            pitchStep.value = stepText;
+        }
+        renderPitchStepValue();
+        return;
+    }
+    renderPitchStepValue();
 };
 const renderMeasureEditorState = () => {
     var _a;
@@ -833,16 +919,19 @@ const renderControlState = () => {
     const hasDraft = Boolean(draftCore);
     const hasSelection = Boolean(state.selectedNodeId);
     noteSelect.disabled = !hasDraft;
-    changePitchBtn.disabled = !hasDraft || !hasSelection;
+    pitchStepDownBtn.disabled = !hasDraft || !hasSelection || selectedDraftNoteIsRest;
+    pitchStepUpBtn.disabled = !hasDraft || !hasSelection || selectedDraftNoteIsRest;
     changeDurationBtn.disabled = !hasDraft || !hasSelection;
     insertAfterBtn.disabled = !hasDraft || !hasSelection;
     deleteBtn.disabled = !hasDraft || !hasSelection;
+    playMeasureBtn.disabled = !hasDraft || isPlaying;
     playBtn.disabled = !state.loaded || isPlaying;
     stopBtn.disabled = !isPlaying;
 };
 const renderAll = () => {
     renderInputMode();
     renderNotes();
+    syncStepFromSelectedDraftNote();
     renderStatus();
     renderDiagnostics();
     renderOutput();
@@ -1804,13 +1893,69 @@ const startPlayback = async () => {
     renderControlState();
     renderAll();
 };
+const startMeasurePlayback = async () => {
+    if (!draftCore || isPlaying)
+        return;
+    const saveResult = draftCore.save();
+    if (!saveResult.ok) {
+        state.lastDispatchResult = {
+            ok: false,
+            dirtyChanged: false,
+            changedNodeIds: [],
+            affectedMeasureNumbers: [],
+            diagnostics: saveResult.diagnostics,
+            warnings: [],
+        };
+        logDiagnostics("playback", saveResult.diagnostics);
+        playbackText.textContent = "再生: 小節保存失敗";
+        renderAll();
+        return;
+    }
+    const parsedPlayback = buildPlaybackEventsFromXml(saveResult.xml);
+    const events = parsedPlayback.events;
+    if (events.length === 0) {
+        playbackText.textContent = "再生: この小節に再生可能ノートなし";
+        renderControlState();
+        return;
+    }
+    try {
+        await synthEngine.playSchedule({
+            tempo: parsedPlayback.tempo,
+            events: events
+                .slice()
+                .sort((a, b) => a.startTicks === b.startTicks ? a.midiNumber - b.midiNumber : a.startTicks - b.startTicks)
+                .map((event) => ({
+                midiNumber: event.midiNumber,
+                start: event.startTicks,
+                ticks: event.durTicks,
+                channel: event.channel,
+            })),
+        }, FIXED_PLAYBACK_WAVEFORM, () => {
+            isPlaying = false;
+            playbackText.textContent = "再生: 停止中";
+            renderControlState();
+        });
+    }
+    catch (error) {
+        playbackText.textContent =
+            "再生: 小節再生失敗 (" + (error instanceof Error ? error.message : String(error)) + ")";
+        renderControlState();
+        return;
+    }
+    isPlaying = true;
+    playbackText.textContent = `再生中: 選択小節 ノート${events.length}件 / 波形 sine`;
+    renderControlState();
+};
 const readSelectedPitch = () => {
+    const step = pitchStep.value.trim();
+    if (!isPitchStepValue(step))
+        return null;
     const octave = Number(pitchOctave.value);
     if (!Number.isInteger(octave))
         return null;
     const alterText = pitchAlter.value.trim();
     const base = {
-        step: pitchStep.value,
+        step,
         octave,
     };
     if (alterText === "")
@@ -1981,6 +2126,26 @@ const onChangePitch = () => {
     };
     runCommand(command);
 };
+const onPitchStepAutoChange = () => {
+    if (!draftCore || !state.selectedNodeId || selectedDraftNoteIsRest)
+        return;
+    onChangePitch();
+};
+const shiftPitchStep = (delta) => {
+    if (!draftCore || !state.selectedNodeId || selectedDraftNoteIsRest)
+        return;
+    const order = ["C", "D", "E", "F", "G", "A", "B"];
+    const current = pitchStep.value.trim();
+    if (!isPitchStepValue(current))
+        return;
+    const index = order.indexOf(current);
+    if (index < 0)
+        return;
+    const next = order[(index + delta + order.length) % order.length];
+    pitchStep.value = next;
+    renderPitchStepValue();
+    onPitchStepAutoChange();
+};
 const replaceMeasureInMainXml = (sourceXml, partId, measureNumber, measureXml) => {
     const mainDoc = new DOMParser().parseFromString(sourceXml, "application/xml");
     const measureDoc = new DOMParser().parseFromString(measureXml, "application/xml");
@@ -2130,7 +2295,12 @@ noteSelect.addEventListener("change", () => {
     state.selectedNodeId = noteSelect.value || null;
     renderAll();
 });
-changePitchBtn.addEventListener("click", onChangePitch);
+pitchStepDownBtn.addEventListener("click", () => {
+    shiftPitchStep(-1);
+});
+pitchStepUpBtn.addEventListener("click", () => {
+    shiftPitchStep(1);
+});
 changeDurationBtn.addEventListener("click", onChangeDuration);
 insertAfterBtn.addEventListener("click", onInsertAfter);
 deleteBtn.addEventListener("click", onDelete);
@@ -2143,6 +2313,9 @@ debugScoreArea.addEventListener("click", onVerovioScoreClick);
 measureEditorArea.addEventListener("click", onMeasureEditorClick);
 measureApplyBtn.addEventListener("click", onMeasureApply);
 measureDiscardBtn.addEventListener("click", onMeasureDiscard);
+playMeasureBtn.addEventListener("click", () => {
+    void startMeasurePlayback();
+});
 loadFromText(xmlInput.value, false);
 
   },

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -244,6 +244,27 @@ body {
   color: var(--md-sys-color-on-surface-variant);
 }
 
+.ms-step-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  gap: 0.4rem;
+  align-items: center;
+}
+
+.ms-step-value {
+  display: inline-block;
+  padding: 0.1rem 0.1rem 0.1rem 0;
+  font-weight: 700;
+  color: var(--md-sys-color-on-surface);
+  line-height: 1.2;
+}
+
+.ms-step-btn {
+  min-width: 2.4rem;
+  padding: 0.5rem 0.6rem;
+  font-weight: 700;
+}
+
 .ms-debug-meta {
   margin: 0.35rem 0;
   color: var(--md-sys-color-on-surface-variant);


### PR DESCRIPTION
## 概要
`a8aa3dac9204250d0287cac5e95b9e4f20c901ed` では、編集セクションの操作性を改善しました。 主に「音名(step)編集の簡略化」と「選択小節だけの再生機能追加」を行っています。

## 変更内容

### 1. 小節単体再生ボタンを追加
- 編集エリアに `この小節を再生` ボタンを追加
- `draftCore`（選択中小節の編集用XML）を保存して、その小節だけ再生
- 停止ボタンは追加せず、短尺再生前提のUXに
- 再生中はボタンを無効化

### 2. 音名(step)UIを刷新
- `音名(step)` のドロップダウンを廃止
- 代わりに以下へ変更
  - 非表示の内部値 (`input#pitchStep`)
  - 表示用テキスト (`#pitchStepValue`)
  - `↑ / ↓` ボタンでステップ変更
- `C-D-E-F-G-A-B` を循環移動
- 表示が「入力欄」に見えないプレーンテキスト風デザインに調整

### 3. 音高変更を自動化
- `音高変更` ボタンを削除
- `↑ / ↓` 操作時に即時で `change_pitch` を実行
- 休符選択時は音高編集不可を維持し、関連操作を無効化

### 4. 休符時の扱いを明確化
- 休符選択時は `pitchStep` 内部値を空にし、表示を `休符` に統一
- `readSelectedPitch()` で `step` の妥当性チェックを追加（A-Gのみ有効）

## 変更ファイル
- `mikuscore-src.html`
- `src/ts/main.ts`
- `src/css/app.css`
- `src/js/main.js`（ビルド成果物）
- `mikuscore.html`（ビルド成果物）

## 期待効果
- 音名編集のクリック回数を削減し、編集フローを高速化
- 編集中の試聴（小節単位）を即座に行えるようにし、確認作業を短縮
- 休符・音名の状態がUI上で明確になり、誤操作を減らせる