### PR TITLE
編集UI改善: alterボタン化と「なし」対応、pitch/accidental同期更新を実装

### DIFF
--- a/core/xmlUtils.ts
+++ b/core/xmlUtils.ts
@@ -70,9 +70,12 @@ export const setPitch = (note: Element, pitch: Pitch): void => {
   upsertSimpleChild(pitchNode, "step", pitch.step);
   if (typeof pitch.alter === "number") {
     upsertSimpleChild(pitchNode, "alter", String(pitch.alter));
+    upsertSimpleChild(note, "accidental", accidentalFromAlter(pitch.alter));
   } else {
     const alter = getDirectChild(pitchNode, "alter");
     if (alter) alter.remove();
+    const accidental = getDirectChild(note, "accidental");
+    if (accidental) accidental.remove();
   }
   upsertSimpleChild(pitchNode, "octave", String(pitch.octave));
 };
@@ -98,6 +101,9 @@ export const createNoteElement = (
   }
   upsertSimpleChild(pitchNode, "octave", String(pitch.octave));
   note.appendChild(pitchNode);
+  if (typeof pitch.alter === "number") {
+    upsertSimpleChild(note, "accidental", accidentalFromAlter(pitch.alter));
+  }
 
   const durationNode = doc.createElement("duration");
   durationNode.textContent = String(duration);
@@ -142,3 +148,11 @@ const hasDirectChild = (parent: Element, tagName: string): boolean =>
 
 const getDirectChild = (parent: Element, tagName: string): Element | null =>
   Array.from(parent.children).find((child) => child.tagName === tagName) ?? null;
+
+const accidentalFromAlter = (alter: number): string => {
+  if (alter <= -2) return "flat-flat";
+  if (alter === -1) return "flat";
+  if (alter === 0) return "natural";
+  if (alter === 1) return "sharp";
+  return "double-sharp";
+};

--- a/mikuscore-src.html
+++ b/mikuscore-src.html
@@ -134,18 +134,17 @@
               </div>
             </label>
             <label class="ms-field">変化記号(alter)
-              <select id="pitchAlter" class="md-select">
-                <option value="">none</option>
-                <option value="-2">-2</option>
-                <option value="-1">-1</option>
-                <option value="0">0</option>
-                <option value="1">1</option>
-                <option value="2">2</option>
-              </select>
+              <div class="ms-alter-row" role="group" aria-label="変化記号">
+                <input id="pitchAlter" type="hidden" value="none" />
+                <button type="button" class="md-button md-button--surface ms-alter-btn" data-alter="none" aria-label="変化記号なし">なし</button>
+                <button type="button" class="md-button md-button--surface ms-alter-btn" data-alter="-2" aria-label="ダブルフラット">♭♭</button>
+                <button type="button" class="md-button md-button--surface ms-alter-btn" data-alter="-1" aria-label="フラット">♭</button>
+                <button type="button" class="md-button md-button--surface ms-alter-btn" data-alter="0" aria-label="ナチュラル">♮</button>
+                <button type="button" class="md-button md-button--surface ms-alter-btn" data-alter="1" aria-label="シャープ">♯</button>
+                <button type="button" class="md-button md-button--surface ms-alter-btn" data-alter="2" aria-label="ダブルシャープ">♯♯</button>
+              </div>
             </label>
-            <label class="ms-field">オクターブ(octave)
-              <input id="pitchOctave" type="number" min="0" max="9" step="1" value="4" class="md-input" />
-            </label>
+            <input id="pitchOctave" type="hidden" value="4" />
             <label class="ms-field">音価(duration)
               <input id="durationInput" type="number" min="1" step="1" value="1" class="md-input" />
             </label>

--- a/mikuscore.html
+++ b/mikuscore.html
@@ -274,6 +274,24 @@ body {
   font-weight: 700;
 }
 
+.ms-alter-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.ms-alter-btn {
+  min-width: 2.6rem;
+  padding: 0.5rem 0.65rem;
+  font-weight: 700;
+}
+
+.ms-alter-btn.is-active {
+  background: rgba(98, 0, 238, 0.12);
+  border-color: rgba(98, 0, 238, 0.45);
+  color: var(--md-sys-color-primary);
+}
+
 .ms-debug-meta {
   margin: 0.35rem 0;
   color: var(--md-sys-color-on-surface-variant);
@@ -506,18 +524,17 @@ body {
               </div>
             </label>
             <label class="ms-field">変化記号(alter)
-              <select id="pitchAlter" class="md-select">
-                <option value="">none</option>
-                <option value="-2">-2</option>
-                <option value="-1">-1</option>
-                <option value="0">0</option>
-                <option value="1">1</option>
-                <option value="2">2</option>
-              </select>
+              <div class="ms-alter-row" role="group" aria-label="変化記号">
+                <input id="pitchAlter" type="hidden" value="none" />
+                <button type="button" class="md-button md-button--surface ms-alter-btn" data-alter="none" aria-label="変化記号なし">なし</button>
+                <button type="button" class="md-button md-button--surface ms-alter-btn" data-alter="-2" aria-label="ダブルフラット">♭♭</button>
+                <button type="button" class="md-button md-button--surface ms-alter-btn" data-alter="-1" aria-label="フラット">♭</button>
+                <button type="button" class="md-button md-button--surface ms-alter-btn" data-alter="0" aria-label="ナチュラル">♮</button>
+                <button type="button" class="md-button md-button--surface ms-alter-btn" data-alter="1" aria-label="シャープ">♯</button>
+                <button type="button" class="md-button md-button--surface ms-alter-btn" data-alter="2" aria-label="ダブルシャープ">♯♯</button>
+              </div>
             </label>
-            <label class="ms-field">オクターブ(octave)
-              <input id="pitchOctave" type="number" min="0" max="9" step="1" value="4" class="md-input" />
-            </label>
+            <input id="pitchOctave" type="hidden" value="4" />
             <label class="ms-field">音価(duration)
               <input id="durationInput" type="number" min="1" step="1" value="1" class="md-input" />
             </label>
@@ -602,6 +619,7 @@ const pitchStepValue = q("#pitchStepValue");
 const pitchStepDownBtn = q("#pitchStepDownBtn");
 const pitchStepUpBtn = q("#pitchStepUpBtn");
 const pitchAlter = q("#pitchAlter");
+const pitchAlterBtns = Array.from(document.querySelectorAll(".ms-alter-btn"));
 const pitchOctave = q("#pitchOctave");
 const durationInput = q("#durationInput");
 const changeDurationBtn = q("#changeDurationBtn");
@@ -761,30 +779,58 @@ const renderPitchStepValue = () => {
         pitchStepValue.textContent = "休符";
     }
 };
+const normalizeAlterValue = (value) => {
+    const v = value.trim();
+    if (v === "none")
+        return "none";
+    if (v === "-2" || v === "-1" || v === "0" || v === "1" || v === "2")
+        return v;
+    if (v === "")
+        return "none";
+    return "none";
+};
+const renderAlterButtons = () => {
+    var _a;
+    const active = normalizeAlterValue(pitchAlter.value);
+    pitchAlter.value = active;
+    for (const btn of pitchAlterBtns) {
+        const value = normalizeAlterValue((_a = btn.dataset.alter) !== null && _a !== void 0 ? _a : "");
+        const isActive = value === active;
+        btn.classList.toggle("is-active", isActive);
+        btn.setAttribute("aria-pressed", isActive ? "true" : "false");
+    }
+};
 const syncStepFromSelectedDraftNote = () => {
-    var _a, _b, _c;
+    var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p, _q;
     selectedDraftNoteIsRest = false;
     pitchStep.disabled = false;
-    pitchAlter.disabled = false;
-    pitchOctave.disabled = false;
     pitchStep.title = "";
-    pitchAlter.title = "";
-    pitchOctave.title = "";
+    pitchOctave.title = "音名 ↑/↓ に連動して自動調整されます。";
+    for (const btn of pitchAlterBtns) {
+        btn.disabled = false;
+        btn.title = "";
+    }
     if (!draftCore || !state.selectedNodeId) {
         pitchStep.value = "";
+        pitchAlter.value = "none";
         renderPitchStepValue();
+        renderAlterButtons();
         return;
     }
     const xml = draftCore.debugSerializeCurrentXml();
     if (!xml) {
         pitchStep.value = "";
+        pitchAlter.value = "none";
         renderPitchStepValue();
+        renderAlterButtons();
         return;
     }
     const doc = new DOMParser().parseFromString(xml, "application/xml");
     if (doc.querySelector("parsererror")) {
         pitchStep.value = "";
+        pitchAlter.value = "none";
         renderPitchStepValue();
+        renderAlterButtons();
         return;
     }
     const notes = Array.from(doc.querySelectorAll("note"));
@@ -792,26 +838,69 @@ const syncStepFromSelectedDraftNote = () => {
     for (let i = 0; i < count; i += 1) {
         if (draftNoteNodeIds[i] !== state.selectedNodeId)
             continue;
+        const durationText = (_c = (_b = (_a = notes[i].querySelector(":scope > duration")) === null || _a === void 0 ? void 0 : _a.textContent) === null || _b === void 0 ? void 0 : _b.trim()) !== null && _c !== void 0 ? _c : "";
+        const durationNumber = Number(durationText);
+        if (Number.isInteger(durationNumber) && durationNumber > 0) {
+            durationInput.value = String(durationNumber);
+        }
+        const alterText = (_f = (_e = (_d = notes[i].querySelector(":scope > pitch > alter")) === null || _d === void 0 ? void 0 : _d.textContent) === null || _e === void 0 ? void 0 : _e.trim()) !== null && _f !== void 0 ? _f : "";
+        const accidentalText = (_j = (_h = (_g = notes[i].querySelector(":scope > accidental")) === null || _g === void 0 ? void 0 : _g.textContent) === null || _h === void 0 ? void 0 : _h.trim()) !== null && _j !== void 0 ? _j : "";
+        const alterNumber = Number(alterText);
+        if (alterText === "") {
+            if (accidentalText === "natural") {
+                pitchAlter.value = "0";
+            }
+            else if (accidentalText === "flat") {
+                pitchAlter.value = "-1";
+            }
+            else if (accidentalText === "flat-flat") {
+                pitchAlter.value = "-2";
+            }
+            else if (accidentalText === "sharp") {
+                pitchAlter.value = "1";
+            }
+            else if (accidentalText === "double-sharp") {
+                pitchAlter.value = "2";
+            }
+            else {
+                pitchAlter.value = "none";
+            }
+        }
+        else if (Number.isInteger(alterNumber) && alterNumber >= -2 && alterNumber <= 2) {
+            pitchAlter.value = String(alterNumber);
+        }
+        else {
+            pitchAlter.value = "none";
+        }
         if (notes[i].querySelector(":scope > rest")) {
             selectedDraftNoteIsRest = true;
             pitchStep.value = "";
             pitchStep.disabled = true;
-            pitchAlter.disabled = true;
-            pitchOctave.disabled = true;
             pitchStep.title = "休符は音高を持たないため、音高変更はできません。";
-            pitchAlter.title = "休符は音高を持たないため、音高変更はできません。";
-            pitchOctave.title = "休符は音高を持たないため、音高変更はできません。";
+            for (const btn of pitchAlterBtns) {
+                btn.disabled = true;
+                btn.title = "休符は音高を持たないため、音高変更はできません。";
+            }
+            pitchOctave.title = "音名 ↑/↓ に連動して自動調整されます。";
             renderPitchStepValue();
+            renderAlterButtons();
             return;
         }
-        const stepText = (_c = (_b = (_a = notes[i].querySelector(":scope > pitch > step")) === null || _a === void 0 ? void 0 : _a.textContent) === null || _b === void 0 ? void 0 : _b.trim()) !== null && _c !== void 0 ? _c : "";
+        const stepText = (_m = (_l = (_k = notes[i].querySelector(":scope > pitch > step")) === null || _k === void 0 ? void 0 : _k.textContent) === null || _l === void 0 ? void 0 : _l.trim()) !== null && _m !== void 0 ? _m : "";
         if (isPitchStepValue(stepText)) {
             pitchStep.value = stepText;
         }
+        const octaveText = (_q = (_p = (_o = notes[i].querySelector(":scope > pitch > octave")) === null || _o === void 0 ? void 0 : _o.textContent) === null || _p === void 0 ? void 0 : _p.trim()) !== null && _q !== void 0 ? _q : "";
+        const octaveNumber = Number(octaveText);
+        if (Number.isInteger(octaveNumber) && octaveNumber >= 0 && octaveNumber <= 9) {
+            pitchOctave.value = String(octaveNumber);
+        }
         renderPitchStepValue();
+        renderAlterButtons();
         return;
     }
     renderPitchStepValue();
+    renderAlterButtons();
 };
 const renderMeasureEditorState = () => {
     var _a;
@@ -921,6 +1010,9 @@ const renderControlState = () => {
     noteSelect.disabled = !hasDraft;
     pitchStepDownBtn.disabled = !hasDraft || !hasSelection || selectedDraftNoteIsRest;
     pitchStepUpBtn.disabled = !hasDraft || !hasSelection || selectedDraftNoteIsRest;
+    for (const btn of pitchAlterBtns) {
+        btn.disabled = !hasDraft || !hasSelection || selectedDraftNoteIsRest;
+    }
     changeDurationBtn.disabled = !hasDraft || !hasSelection;
     insertAfterBtn.disabled = !hasDraft || !hasSelection;
     deleteBtn.disabled = !hasDraft || !hasSelection;
@@ -1953,13 +2045,14 @@ const readSelectedPitch = () => {
     const octave = Number(pitchOctave.value);
     if (!Number.isInteger(octave))
         return null;
-    const alterText = pitchAlter.value.trim();
+    const alterText = normalizeAlterValue(pitchAlter.value);
     const base = {
         step,
         octave,
     };
-    if (alterText === "")
+    if (alterText === "none") {
         return base;
+    }
     const alter = Number(alterText);
     if (!Number.isInteger(alter) || alter < -2 || alter > 2)
         return null;
@@ -2131,6 +2224,12 @@ const onPitchStepAutoChange = () => {
         return;
     onChangePitch();
 };
+const onAlterAutoChange = () => {
+    if (!draftCore || !state.selectedNodeId || selectedDraftNoteIsRest)
+        return;
+    renderAlterButtons();
+    onChangePitch();
+};
 const shiftPitchStep = (delta) => {
     if (!draftCore || !state.selectedNodeId || selectedDraftNoteIsRest)
         return;
@@ -2141,8 +2240,34 @@ const shiftPitchStep = (delta) => {
     const index = order.indexOf(current);
     if (index < 0)
         return;
-    const next = order[(index + delta + order.length) % order.length];
-    pitchStep.value = next;
+    // Clamp lower bound to A0.
+    if (delta === -1) {
+        const currentOctave = Number(pitchOctave.value);
+        if (Number.isInteger(currentOctave) && currentOctave === 0 && current !== "B") {
+            return;
+        }
+    }
+    const rawNext = index + delta;
+    let nextIndex = rawNext;
+    let octave = Number(pitchOctave.value);
+    if (!Number.isInteger(octave))
+        octave = 4;
+    if (rawNext < 0) {
+        if (octave <= 0) {
+            return;
+        }
+        octave -= 1;
+        nextIndex = order.length - 1;
+    }
+    else if (rawNext >= order.length) {
+        if (octave >= 9) {
+            return;
+        }
+        octave += 1;
+        nextIndex = 0;
+    }
+    pitchOctave.value = String(octave);
+    pitchStep.value = order[nextIndex];
     renderPitchStepValue();
     onPitchStepAutoChange();
 };
@@ -2301,6 +2426,13 @@ pitchStepDownBtn.addEventListener("click", () => {
 pitchStepUpBtn.addEventListener("click", () => {
     shiftPitchStep(1);
 });
+for (const btn of pitchAlterBtns) {
+    btn.addEventListener("click", () => {
+        var _a;
+        pitchAlter.value = normalizeAlterValue((_a = btn.dataset.alter) !== null && _a !== void 0 ? _a : "");
+        onAlterAutoChange();
+    });
+}
 changeDurationBtn.addEventListener("click", onChangeDuration);
 insertAfterBtn.addEventListener("click", onInsertAfter);
 deleteBtn.addEventListener("click", onDelete);
@@ -16792,11 +16924,15 @@ const setPitch = (note, pitch) => {
     upsertSimpleChild(pitchNode, "step", pitch.step);
     if (typeof pitch.alter === "number") {
         upsertSimpleChild(pitchNode, "alter", String(pitch.alter));
+        upsertSimpleChild(note, "accidental", accidentalFromAlter(pitch.alter));
     }
     else {
         const alter = getDirectChild(pitchNode, "alter");
         if (alter)
             alter.remove();
+        const accidental = getDirectChild(note, "accidental");
+        if (accidental)
+            accidental.remove();
     }
     upsertSimpleChild(pitchNode, "octave", String(pitch.octave));
 };
@@ -16815,6 +16951,9 @@ const createNoteElement = (doc, voice, duration, pitch) => {
     }
     upsertSimpleChild(pitchNode, "octave", String(pitch.octave));
     note.appendChild(pitchNode);
+    if (typeof pitch.alter === "number") {
+        upsertSimpleChild(note, "accidental", accidentalFromAlter(pitch.alter));
+    }
     const durationNode = doc.createElement("duration");
     durationNode.textContent = String(duration);
     note.appendChild(durationNode);
@@ -16846,6 +16985,17 @@ const upsertSimpleChild = (parent, tagName, value) => {
 };
 const hasDirectChild = (parent, tagName) => Array.from(parent.children).some((child) => child.tagName === tagName);
 const getDirectChild = (parent, tagName) => { var _a; return (_a = Array.from(parent.children).find((child) => child.tagName === tagName)) !== null && _a !== void 0 ? _a : null; };
+const accidentalFromAlter = (alter) => {
+    if (alter <= -2)
+        return "flat-flat";
+    if (alter === -1)
+        return "flat";
+    if (alter === 0)
+        return "natural";
+    if (alter === 1)
+        return "sharp";
+    return "double-sharp";
+};
 
   },
   "core/ScoreCore.js": function (require, module, exports) {

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -265,6 +265,24 @@ body {
   font-weight: 700;
 }
 
+.ms-alter-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.ms-alter-btn {
+  min-width: 2.6rem;
+  padding: 0.5rem 0.65rem;
+  font-weight: 700;
+}
+
+.ms-alter-btn.is-active {
+  background: rgba(98, 0, 238, 0.12);
+  border-color: rgba(98, 0, 238, 0.45);
+  color: var(--md-sys-color-primary);
+}
+
 .ms-debug-meta {
   margin: 0.35rem 0;
   color: var(--md-sys-color-on-surface-variant);


### PR DESCRIPTION
## 概要
`ab108e891f8fe9028f4317f7108d1985c363c2c1` では、編集画面の音高編集UXを強化し、MusicXMLの表記整合性を改善しました。 特に `alter` の操作をボタン化し、`pitch/alter` と `accidental` を同時に扱うように変更しています。

## 主な変更点

### 1. 変化記号(alter) UIをボタン化
- `select` を廃止し、以下のボタン群に変更
  - `なし / ♭♭ / ♭ / ♮ / ♯ / ♯♯`
- 現在選択中の記号を `.is-active` で着色表示
- ボタンクリックで即時に `change_pitch` を実行

### 2. 「なし」の意味を明確化
- `なし` は「変化記号なし（alter未指定）」として扱う
- `readSelectedPitch()` で `none` の場合は `alter` を付与しない

### 3. MusicXMLの2箇所整合を実装
- `core/xmlUtils.ts` の `setPitch()` / `createNoteElement()` で
  - `pitch/alter`
  - `accidental` を同期更新
- `alter` を削除する場合は `accidental` も削除
- `alter` 値に応じて `accidental` を生成
  - `-2: flat-flat`
  - `-1: flat`
  - `0: natural`
  - `1: sharp`
  - `2: double-sharp`

### 4. 選択同期ロジックを拡張
- 編集小節でノート選択時に以下を同期
  - `step`
  - `alter`（`pitch/alter` と `accidental` 両方を考慮）
  - `octave`
  - `duration`
- `rest` 選択時は音高関連ボタンを無効化

### 5. octave表示の簡素化
- `オクターブ`入力欄を表示から外し、`hidden`で内部保持
- `step ↑/↓` の移動で内部オクターブを自動調整（下限考慮）

## 変更ファイル
- `core/xmlUtils.ts`
- `mikuscore-src.html`
- `src/css/app.css`
- `src/ts/main.ts`
- `src/js/main.js`（ビルド成果物）
- `mikuscore.html`（ビルド成果物）

## 効果
- 記号操作が直感的になり、編集速度が向上
- `alter` と `accidental` の不整合を抑制し、表示反映の一貫性を改善
- ノート選択時のフォーム同期が進み、編集時の状態把握が容易