### PR TITLE
編集コマンド体系を整理し、`split_note` と休符音符化UIを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ MVPが尖って見えるのは、機能を削ってでも round-trip の信頼�
 - `dirty === false` の保存は入力 XML 文字列をそのまま返す（`original_noop`）
 - 小節 overfull は `MEASURE_OVERFULL` で拒否
 - 非編集対象 voice は `MVP_UNSUPPORTED_NON_EDITABLE_VOICE` で拒否
-- 実用最低限として `change_pitch` / `change_duration` / `insert_note_after` / `delete_note` をMVPに含める
+- 実用最低限として `change_to_pitch` / `change_duration` / `insert_note_after` / `delete_note` をMVPに含める
 - `grace` / `cue` / `chord` / `rest` はMVPでは編集対象外（`MVP_UNSUPPORTED_NOTE_KIND`）
 - underfull は許容可能（警告を出す場合あり）
 - pretty-print なしでシリアライズ
@@ -83,6 +83,6 @@ MVPが尖って見えるのは、機能を削ってでも round-trip の信頼�
 ## 現在のステータス
 
 仕様策定フェーズは完了し、Core 実装（TypeScript）とテスト基盤は稼働中です。  
-UI 側では Verovio レンダリングを正式採用し、譜面クリックによる単音選択（`change_pitch` 先行）まで実装済みです。  
+UI 側では Verovio レンダリングを正式採用し、譜面クリックによる単音選択（`change_to_pitch` 先行）まで実装済みです。  
 再生系は `midi-writer.js` 経由の内蔵再生を組み込み、移調楽器（例: Clarinet in A）の `transpose` 反映も対応済みです。  
 テストは `tests/unit`（仕様契約）と `tests/property`（ランダム不変条件）の2系統で運用しています。

--- a/core/commands.ts
+++ b/core/commands.ts
@@ -5,9 +5,10 @@ export const isUiOnlyCommand = (command: CoreCommand): boolean =>
 
 export const getCommandNodeId = (command: CoreCommand): NodeId | null => {
   switch (command.type) {
-    case "change_pitch":
+    case "change_to_pitch":
     case "change_duration":
     case "delete_note":
+    case "split_note":
       return command.targetNodeId;
     case "insert_note_after":
       return command.anchorNodeId;

--- a/core/interfaces.ts
+++ b/core/interfaces.ts
@@ -51,7 +51,7 @@ export type Pitch = {
 };
 
 export type ChangePitchCommand = {
-  type: "change_pitch";
+  type: "change_to_pitch";
   targetNodeId: NodeId;
   voice: VoiceId;
   pitch: Pitch;
@@ -80,6 +80,12 @@ export type DeleteNoteCommand = {
   voice: VoiceId;
 };
 
+export type SplitNoteCommand = {
+  type: "split_note";
+  targetNodeId: NodeId;
+  voice: VoiceId;
+};
+
 export type UiNoopCommand = {
   type: "ui_noop";
   reason: "selection_change" | "cursor_move" | "viewport_change";
@@ -90,6 +96,7 @@ export type CoreCommand =
   | ChangeDurationCommand
   | InsertNoteAfterCommand
   | DeleteNoteCommand
+  | SplitNoteCommand
   | UiNoopCommand;
 
 export type ScoreCoreOptions = {

--- a/core/xmlUtils.ts
+++ b/core/xmlUtils.ts
@@ -71,6 +71,9 @@ export const getDurationNotationHint = (
 };
 
 export const setPitch = (note: Element, pitch: Pitch): void => {
+  const restNode = getDirectChild(note, "rest");
+  if (restNode) restNode.remove();
+
   let pitchNode = getDirectChild(note, "pitch");
   if (!pitchNode) {
     pitchNode = note.ownerDocument.createElement("pitch");

--- a/docs/spec/ARCHITECTURE.md
+++ b/docs/spec/ARCHITECTURE.md
@@ -37,7 +37,7 @@ UI MUST NOT mutate XML DOM directly.
 
 ### Click-Edit Mapping Contract
 
-- Initial click-edit scope is `change_pitch` on a single selected note.
+- Initial click-edit scope is `change_to_pitch` on a single selected note.
 - Click operation selects target note only; command execution is explicit via UI action.
 - For clickable note editing, MusicXML notes SHOULD expose stable identifiers (prefer `xml:id`).
 - For MVP, identifiers SHOULD be session-scoped temporary IDs and SHOULD NOT be written to final saved XML.

--- a/docs/spec/COMMAND_CATALOG.md
+++ b/docs/spec/COMMAND_CATALOG.md
@@ -35,11 +35,11 @@ type DispatchResult = {
 
 ## Command Definitions
 
-### 1. `change_pitch`
+### 1. `change_to_pitch`
 
 ```ts
 type ChangePitchCommand = {
-  type: "change_pitch";
+  type: "change_to_pitch";
   targetNodeId: NodeId; // note node
   voice: VoiceId; // must match editable voice in MVP
   pitch: {

--- a/docs/spec/TEST_MATRIX.md
+++ b/docs/spec/TEST_MATRIX.md
@@ -224,7 +224,7 @@ Executable test planning mapped from `SPEC.md` requirements.
 
 31. `PL-2 Dispatch rejects invalid pitch payload`
 - Given: command payload with invalid pitch fields
-- When: `dispatch(change_pitch|insert_note_after)`
+- When: `dispatch(change_to_pitch|insert_note_after)`
 - Then:
   - result `ok=false`
   - diagnostic `MVP_INVALID_COMMAND_PAYLOAD`

--- a/docs/spec/UI_SPEC.md
+++ b/docs/spec/UI_SPEC.md
@@ -78,7 +78,7 @@ Goal: Enable direct editing from rendered notation:
 
 Current scope (agreed):
 
-- First release targets `change_pitch` only.
+- First release targets `change_to_pitch` only.
 - Selection model is single-note only.
 - Click action is selection only; edit execution remains explicit via existing UI controls.
 - Mapping failure behavior is warning/diagnostics only (no mutation, no implicit fallback edit).
@@ -90,7 +90,7 @@ Current scope (agreed):
   - DOM traversal from click target (`closest('[id]')`)
   - `elementsFromPoint(clientX, clientY)` fallback when target id is non-note/container
 - UI MUST convert SVG element id into core target (`nodeId`) through a deterministic mapping layer.
-- After mapping, UI MUST invoke core command APIs only (`dispatch(change_pitch, ...)`, etc.).
+- After mapping, UI MUST invoke core command APIs only (`dispatch(change_to_pitch, ...)`, etc.).
 - After successful dispatch, UI MUST re-render both quick preview and Verovio confirmation preview.
 
 Implementation notes:

--- a/mikuscore-src.html
+++ b/mikuscore-src.html
@@ -120,9 +120,9 @@
             <div id="measureEditorArea" class="ms-debug-score"></div>
           </div>
           <div class="ms-actions">
-            <button id="measureApplyBtn" type="button" class="md-button md-button--primary" disabled>確定</button>
-            <button id="measureDiscardBtn" type="button" class="md-button md-button--surface" disabled>破棄</button>
-            <button id="playMeasureBtn" type="button" class="md-button md-button--tonal" disabled>この小節を再生</button>
+            <button id="measureApplyBtn" type="button" class="md-button md-button--primary" disabled>編集確定</button>
+            <button id="measureDiscardBtn" type="button" class="md-button md-button--surface" disabled>編集破棄</button>
+            <button id="playMeasureBtn" type="button" class="md-button md-button--tonal" disabled>小節を再生</button>
           </div>
 
           <div class="ms-grid">
@@ -154,7 +154,8 @@
           </div>
 
           <div class="ms-actions">
-            <button id="insertAfterBtn" type="button" class="md-button md-button--tonal">後ろに音符追加</button>
+            <button id="splitNoteBtn" type="button" class="md-button md-button--tonal">音符分割</button>
+            <button id="convertRestBtn" type="button" class="md-button md-button--tonal">休符を音符化</button>
             <button id="deleteBtn" type="button" class="md-button md-button--surface">音符削除</button>
           </div>
         </section>

--- a/mikuscore.html
+++ b/mikuscore.html
@@ -531,9 +531,9 @@ body {
             <div id="measureEditorArea" class="ms-debug-score"></div>
           </div>
           <div class="ms-actions">
-            <button id="measureApplyBtn" type="button" class="md-button md-button--primary" disabled>確定</button>
-            <button id="measureDiscardBtn" type="button" class="md-button md-button--surface" disabled>破棄</button>
-            <button id="playMeasureBtn" type="button" class="md-button md-button--tonal" disabled>この小節を再生</button>
+            <button id="measureApplyBtn" type="button" class="md-button md-button--primary" disabled>編集確定</button>
+            <button id="measureDiscardBtn" type="button" class="md-button md-button--surface" disabled>編集破棄</button>
+            <button id="playMeasureBtn" type="button" class="md-button md-button--tonal" disabled>小節を再生</button>
           </div>
 
           <div class="ms-grid">
@@ -565,7 +565,8 @@ body {
           </div>
 
           <div class="ms-actions">
-            <button id="insertAfterBtn" type="button" class="md-button md-button--tonal">後ろに音符追加</button>
+            <button id="splitNoteBtn" type="button" class="md-button md-button--tonal">音符分割</button>
+            <button id="convertRestBtn" type="button" class="md-button md-button--tonal">休符を音符化</button>
             <button id="deleteBtn" type="button" class="md-button md-button--surface">音符削除</button>
           </div>
         </section>
@@ -645,7 +646,8 @@ const pitchAlter = q("#pitchAlter");
 const pitchAlterBtns = Array.from(document.querySelectorAll(".ms-alter-btn"));
 const pitchOctave = q("#pitchOctave");
 const durationPreset = q("#durationPreset");
-const insertAfterBtn = q("#insertAfterBtn");
+const splitNoteBtn = q("#splitNoteBtn");
+const convertRestBtn = q("#convertRestBtn");
 const deleteBtn = q("#deleteBtn");
 const playBtn = q("#playBtn");
 const stopBtn = q("#stopBtn");
@@ -1217,7 +1219,8 @@ const renderControlState = () => {
     for (const btn of pitchAlterBtns) {
         btn.disabled = !hasDraft || !hasSelection || selectedDraftNoteIsRest;
     }
-    insertAfterBtn.disabled = !hasDraft || !hasSelection;
+    splitNoteBtn.disabled = !hasDraft || !hasSelection || selectedDraftNoteIsRest;
+    convertRestBtn.disabled = !hasDraft || !hasSelection || !selectedDraftNoteIsRest;
     deleteBtn.disabled = !hasDraft || !hasSelection;
     playMeasureBtn.disabled = !hasDraft || isPlaying;
     playBtn.disabled = !state.loaded || isPlaying;
@@ -2451,7 +2454,7 @@ const onChangePitch = () => {
         return;
     }
     const command = {
-        type: "change_pitch",
+        type: "change_to_pitch",
         targetNodeId,
         voice: EDITABLE_VOICE,
         pitch,
@@ -2633,6 +2636,42 @@ const onDelete = () => {
     };
     runCommand(command);
 };
+const onSplitNote = () => {
+    if (selectedDraftNoteIsRest)
+        return;
+    const targetNodeId = requireSelectedNode();
+    if (!targetNodeId)
+        return;
+    const command = {
+        type: "split_note",
+        targetNodeId,
+        voice: EDITABLE_VOICE,
+    };
+    runCommand(command);
+};
+const onConvertRestToNote = () => {
+    if (!selectedDraftNoteIsRest)
+        return;
+    const targetNodeId = requireSelectedNode();
+    if (!targetNodeId)
+        return;
+    const stepRaw = pitchStep.value.trim();
+    const step = isPitchStepValue(stepRaw) ? stepRaw : "C";
+    const octaveRaw = Number(pitchOctave.value);
+    const octave = Number.isInteger(octaveRaw) ? octaveRaw : 4;
+    const alterText = normalizeAlterValue(pitchAlter.value);
+    const alterNum = Number(alterText);
+    const pitch = alterText !== "none" && Number.isInteger(alterNum) && alterNum >= -2 && alterNum <= 2
+        ? { step, octave, alter: alterNum }
+        : { step, octave };
+    const command = {
+        type: "change_to_pitch",
+        targetNodeId,
+        voice: EDITABLE_VOICE,
+        pitch,
+    };
+    runCommand(command);
+};
 const onDownload = () => {
     if (!state.lastSuccessfulSaveXml)
         return;
@@ -2678,8 +2717,9 @@ for (const btn of pitchAlterBtns) {
         onAlterAutoChange();
     });
 }
-insertAfterBtn.addEventListener("click", onInsertAfter);
 deleteBtn.addEventListener("click", onDelete);
+splitNoteBtn.addEventListener("click", onSplitNote);
+convertRestBtn.addEventListener("click", onConvertRestToNote);
 playBtn.addEventListener("click", () => {
     void startPlayback();
 });
@@ -17169,6 +17209,9 @@ const getDurationNotationHint = (note, duration) => {
 };
 exports.getDurationNotationHint = getDurationNotationHint;
 const setPitch = (note, pitch) => {
+    const restNode = getDirectChild(note, "rest");
+    if (restNode)
+        restNode.remove();
     let pitchNode = getDirectChild(note, "pitch");
     if (!pitchNode) {
         pitchNode = note.ownerDocument.createElement("pitch");
@@ -17453,7 +17496,7 @@ class ScoreCore {
         const target = this.idToNode.get(targetId);
         if (!target)
             return this.fail("MVP_TARGET_NOT_FOUND", `Unknown nodeId: ${targetId}`);
-        const noteKindDiagnostic = (0, validators_1.validateSupportedNoteKind)(target);
+        const noteKindDiagnostic = (0, validators_1.validateSupportedNoteKind)(command, target);
         if (noteKindDiagnostic)
             return this.failWith(noteKindDiagnostic);
         const targetVoiceDiagnostic = (0, validators_1.validateTargetVoiceMatch)(command, target);
@@ -17471,7 +17514,7 @@ class ScoreCore {
         let removedNodeId = null;
         const affectedMeasureNumbers = this.collectAffectedMeasureNumbers(target);
         try {
-            if (command.type === "change_pitch") {
+            if (command.type === "change_to_pitch") {
                 (0, xmlUtils_1.setPitch)(target, command.pitch);
             }
             else if (command.type === "change_duration") {
@@ -17522,6 +17565,22 @@ class ScoreCore {
                 else if (projectedWarning) {
                     warnings.push(projectedWarning);
                 }
+            }
+            else if (command.type === "split_note") {
+                const currentDuration = (0, xmlUtils_1.getDurationValue)(target);
+                if (!Number.isInteger(currentDuration) || (currentDuration !== null && currentDuration !== void 0 ? currentDuration : 0) <= 1) {
+                    return this.fail("MVP_INVALID_COMMAND_PAYLOAD", "split_note requires duration >= 2.");
+                }
+                if (currentDuration % 2 !== 0) {
+                    return this.fail("MVP_INVALID_COMMAND_PAYLOAD", "split_note requires an even duration value.");
+                }
+                const half = currentDuration / 2;
+                const duplicated = target.cloneNode(true);
+                // Attach clone first so duration->notation sync can resolve measure divisions.
+                target.after(duplicated);
+                (0, xmlUtils_1.setDurationValue)(target, half);
+                (0, xmlUtils_1.setDurationValue)(duplicated, half);
+                insertedNode = duplicated;
             }
             else if (command.type === "insert_note_after") {
                 const timing = (0, timeIndex_1.getMeasureTimingForVoice)(target, command.voice);
@@ -17759,13 +17818,17 @@ class ScoreCore {
         return null;
     }
     buildChangedNodeIds(command, targetId, insertedNode, removedNodeId) {
-        var _a;
+        var _a, _b;
         if (command.type === "insert_note_after") {
             const insertedId = insertedNode ? (_a = this.nodeToId.get(insertedNode)) !== null && _a !== void 0 ? _a : null : null;
             return insertedId ? [targetId, insertedId] : [targetId];
         }
         if (command.type === "delete_note") {
             return removedNodeId ? [removedNodeId] : [targetId];
+        }
+        if (command.type === "split_note") {
+            const insertedId = insertedNode ? (_b = this.nodeToId.get(insertedNode)) !== null && _b !== void 0 ? _b : null : null;
+            return insertedId ? [targetId, insertedId] : [targetId];
         }
         return [targetId];
     }
@@ -17943,18 +18006,29 @@ const validateCommandPayload = (command) => {
         }
         return null;
     }
-    if (command.type === "change_pitch") {
+    if (command.type === "change_to_pitch") {
         if (!isValidPitch(command.pitch)) {
             return {
                 code: "MVP_INVALID_COMMAND_PAYLOAD",
-                message: "change_pitch.pitch is invalid.",
+                message: "change_to_pitch.pitch is invalid.",
             };
         }
     }
     return null;
 };
 exports.validateCommandPayload = validateCommandPayload;
-const validateSupportedNoteKind = (note) => {
+const validateSupportedNoteKind = (command, note) => {
+    // Allow rest -> pitched note conversion via change_to_pitch.
+    if (command.type === "change_to_pitch") {
+        const hasUnsupportedExceptRest = note.querySelector(":scope > grace") !== null ||
+            note.querySelector(":scope > cue") !== null ||
+            note.querySelector(":scope > chord") !== null;
+        if (!hasUnsupportedExceptRest)
+            return null;
+    }
+    else if (!(0, xmlUtils_1.isUnsupportedNoteKind)(note)) {
+        return null;
+    }
     if (!(0, xmlUtils_1.isUnsupportedNoteKind)(note))
         return null;
     return {
@@ -18002,7 +18076,9 @@ const validateInsertLaneBoundary = (command, anchorNote) => {
 };
 exports.validateInsertLaneBoundary = validateInsertLaneBoundary;
 const validateBackupForwardBoundaryForStructuralEdit = (command, anchorOrTarget) => {
-    if (command.type !== "insert_note_after" && command.type !== "delete_note") {
+    if (command.type !== "insert_note_after" &&
+        command.type !== "delete_note" &&
+        command.type !== "split_note") {
         return null;
     }
     const prev = anchorOrTarget.previousElementSibling;
@@ -18012,6 +18088,15 @@ const validateBackupForwardBoundaryForStructuralEdit = (command, anchorOrTarget)
             return {
                 code: "MVP_UNSUPPORTED_NON_EDITABLE_VOICE",
                 message: "Insert point crosses a backup/forward boundary in MVP.",
+            };
+        }
+        return null;
+    }
+    if (command.type === "split_note") {
+        if (next && isBackupOrForward(next)) {
+            return {
+                code: "MVP_UNSUPPORTED_NON_EDITABLE_VOICE",
+                message: "Split point crosses a backup/forward boundary in MVP.",
             };
         }
         return null;
@@ -18077,9 +18162,10 @@ const isUiOnlyCommand = (command) => command.type === "ui_noop";
 exports.isUiOnlyCommand = isUiOnlyCommand;
 const getCommandNodeId = (command) => {
     switch (command.type) {
-        case "change_pitch":
+        case "change_to_pitch":
         case "change_duration":
         case "delete_note":
+        case "split_note":
             return command.targetNodeId;
         case "insert_note_after":
             return command.anchorNodeId;

--- a/tests/property/core.property.spec.ts
+++ b/tests/property/core.property.spec.ts
@@ -46,9 +46,9 @@ const makeCommand = (rng: Lcg, nodeIds: string[]): CoreCommand => {
   }
 
   const target = rng.pick(nodeIds);
-  const type = rng.pick(["change_pitch", "change_duration", "insert_note_after", "delete_note"]);
+  const type = rng.pick(["change_to_pitch", "change_duration", "insert_note_after", "delete_note"]);
 
-  if (type === "change_pitch") {
+  if (type === "change_to_pitch") {
     return {
       type,
       targetNodeId: target,
@@ -90,8 +90,8 @@ const makeNonStructuralCommand = (rng: Lcg, nodeIds: string[]): CoreCommand => {
     return { type: "ui_noop", reason: "cursor_move" };
   }
   const target = rng.pick(nodeIds);
-  const type = rng.pick(["change_pitch", "change_duration"]);
-  if (type === "change_pitch") {
+  const type = rng.pick(["change_to_pitch", "change_duration"]);
+  if (type === "change_to_pitch") {
     return {
       type,
       targetNodeId: target,


### PR DESCRIPTION
## 概要
編集機能の実運用に向けて、コマンド命名の明確化と編集操作の拡張を行いました。
主に以下を含みます。

- `change_pitch` を `change_to_pitch` にリネーム（意図を明示）
- 新コマンド `split_note` を追加（選択音符を 1/2 + 1/2 に分割）
- UIに `音符分割` / `休符を音符化` を追加
- 編集ボタン文言をわかりやすく更新（編集確定/編集破棄/小節を再生）
- テスト・仕様書を更新

## 変更内容

### 1. コマンド命名の明確化
- `change_pitch` -> `change_to_pitch` に変更
- 対象:
  - Core型定義/分岐
  - UI呼び出し
  - テスト
  - 仕様ドキュメント

### 2. 新コマンド `split_note` を追加
- 追加ファイル/主変更:
  - `core/interfaces.ts`
  - `core/commands.ts`
  - `core/ScoreCore.ts`
  - `core/validators.ts`
- 挙動:
  - 対象ノートの `duration` を半分にし、同内容のノートを直後へ複製
  - `duration` が偶数かつ `>=2` の場合のみ許可
  - 不正値は `MVP_INVALID_COMMAND_PAYLOAD` を返却
  - `backup/forward` 境界での構造編集制約を適用
- 分割時の記譜同期:
  - 複製ノートをDOM接続後に `setDurationValue` することで、`divisions` 解決と `type` 同期を保証

### 3. 休符→音符化の許可
- `change_to_pitch` 実行時のみ、休符ノートを編集対象として許可
- `setPitch` で `<rest>` を除去して `<pitch>` を設定するよう修正
- これにより「休符を音符化」操作がCore上で正しく成立

### 4. UI改善
- `mikuscore-src.html` / `src/ts/main.ts` 更新
  - `音符分割` ボタン追加
  - `休符を音符化` ボタン追加
  - ボタン活性制御（休符選択時のみ音符化有効、音符選択時のみ分割有効）
- 文言更新:
  - `確定` -> `編集確定`
  - `破棄` -> `編集破棄`
  - `この小節を再生` -> `小節を再生`

### 5. テストとドキュメント更新
- `tests/unit/core.spec.ts`
  - 休符音符化ケース追加
  - `split_note` 成功/失敗ケース追加
- `tests/property/core.property.spec.ts`
  - コマンド名変更に追従
- 仕様書更新:
  - `docs/spec/COMMAND_CATALOG.md`
  - `docs/spec/UI_SPEC.md`
  - `docs/spec/ARCHITECTURE.md`
  - `docs/spec/TEST_MATRIX.md`
  - `README.md`

## 影響範囲
- Core APIのコマンド名変更が入るため、外部呼び出し側は `change_to_pitch` へ追従が必要です。
- 既存の `change_pitch` 呼び出しは互換対象外です（本PRで一括置換済み）。

## 確認項目
- `change_to_pitch` が音符/休符の双方で意図通り動作すること
- `split_note` で分割後2音とも `duration/type` が半分に同期されること
- 編集UIの新ボタン活性制御が期待通りであること
- build成果物（`mikuscore.html`, `src/js/main.js`）が更新されていること