### PR TITLE
MIDI出力対応と再生ロジック分離、編集UI文言/アイコン改善

### DIFF
--- a/mikuscore-src.html
+++ b/mikuscore-src.html
@@ -120,9 +120,25 @@
             <div id="measureEditorArea" class="ms-debug-score"></div>
           </div>
           <div class="ms-actions">
-            <button id="measureApplyBtn" type="button" class="md-button md-button--primary" disabled>編集確定</button>
-            <button id="measureDiscardBtn" type="button" class="md-button md-button--surface" disabled>編集破棄</button>
-            <button id="playMeasureBtn" type="button" class="md-button md-button--tonal" disabled>小節を再生</button>
+            <button id="measureApplyBtn" type="button" class="md-button md-button--primary ms-icon-button" disabled>
+              <svg aria-hidden="true" viewBox="0 0 24 24" class="ms-btn-icon" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M20 7L9 18l-5-5"></path>
+              </svg>
+              <span>小節編集確定</span>
+            </button>
+            <button id="measureDiscardBtn" type="button" class="md-button md-button--surface ms-icon-button" disabled>
+              <svg aria-hidden="true" viewBox="0 0 24 24" class="ms-btn-icon" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M18 6L6 18"></path>
+                <path d="M6 6l12 12"></path>
+              </svg>
+              <span>小節編集破棄</span>
+            </button>
+            <button id="playMeasureBtn" type="button" class="md-button md-button--tonal ms-icon-button" disabled>
+              <svg aria-hidden="true" viewBox="0 0 24 24" class="ms-btn-icon" fill="currentColor">
+                <path d="M8 6.5v11l9-5.5z"></path>
+              </svg>
+              <span>小節再生</span>
+            </button>
           </div>
 
           <div class="ms-grid">
@@ -154,9 +170,41 @@
           </div>
 
           <div class="ms-actions">
-            <button id="splitNoteBtn" type="button" class="md-button md-button--tonal">音符分割</button>
-            <button id="convertRestBtn" type="button" class="md-button md-button--tonal">休符を音符化</button>
-            <button id="deleteBtn" type="button" class="md-button md-button--surface">音符削除</button>
+            <button id="convertRestBtn" type="button" class="md-button md-button--tonal ms-icon-button">
+              <svg aria-hidden="true" viewBox="0 0 34 24" class="ms-btn-icon ms-btn-icon--wide" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round">
+                <!-- quarter rest (wide, readable silhouette) -->
+                <path d="M6.5 3.6c4 1.7 5.4 4.2 2.9 7.3-1.2 1.4-1.2 2.7.6 4.1 1.5 1.2 3.6 2 5.2 3.5"></path>
+                <path d="M9.2 7.6c2.2 1.2 3.4 2.8 2 4.6"></path>
+                <path d="M11.8 15.3c1.6.8 2.8 1.5 4 2.6"></path>
+                <!-- convert arrow -->
+                <path d="M16.8 12h5.2"></path>
+                <path d="M20.2 9.5l2.6 2.5-2.6 2.5"></path>
+                <!-- quarter note -->
+                <circle cx="27.3" cy="15.9" r="2.2" fill="currentColor" stroke="none"></circle>
+                <path d="M29.3 15.9V7.1"></path>
+              </svg>
+              <span>休符を音符化</span>
+            </button>
+            <button id="splitNoteBtn" type="button" class="md-button md-button--tonal ms-icon-button">
+              <svg aria-hidden="true" viewBox="0 0 24 24" class="ms-btn-icon" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round">
+                <circle cx="7.5" cy="15.5" r="2.5" fill="currentColor" stroke="none"></circle>
+                <path d="M10 15.5V8"></path>
+                <path d="M12 6v12"></path>
+                <circle cx="16.5" cy="15.5" r="2.5" fill="currentColor" stroke="none"></circle>
+                <path d="M19 15.5V8"></path>
+              </svg>
+              <span>音符分割</span>
+            </button>
+            <button id="deleteBtn" type="button" class="md-button md-button--surface ms-icon-button">
+              <svg aria-hidden="true" viewBox="0 0 24 24" class="ms-btn-icon" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M4 7h16"></path>
+                <path d="M9 7V5h6v2"></path>
+                <rect x="6.5" y="7" width="11" height="13" rx="1.5"></rect>
+                <path d="M10 10v7"></path>
+                <path d="M14 10v7"></path>
+              </svg>
+              <span>音符削除</span>
+            </button>
           </div>
         </section>
 
@@ -164,6 +212,7 @@
           <h2 class="md-section-title"><span class="ms-step-no">4</span>保存</h2>
           <div class="ms-actions">
             <button id="downloadBtn" type="button" class="md-button md-button--secondary" disabled>MusicXML出力</button>
+            <button id="downloadMidiBtn" type="button" class="md-button md-button--tonal" disabled>MIDI出力</button>
           </div>
         </section>
       </div>

--- a/mikuscore.html
+++ b/mikuscore.html
@@ -228,6 +228,10 @@ body {
   flex: 0 0 auto;
 }
 
+.ms-btn-icon--wide {
+  width: 1.7rem;
+}
+
 .ms-status {
   margin: 0.35rem 0;
   color: var(--md-sys-color-on-surface-variant);
@@ -531,9 +535,25 @@ body {
             <div id="measureEditorArea" class="ms-debug-score"></div>
           </div>
           <div class="ms-actions">
-            <button id="measureApplyBtn" type="button" class="md-button md-button--primary" disabled>編集確定</button>
-            <button id="measureDiscardBtn" type="button" class="md-button md-button--surface" disabled>編集破棄</button>
-            <button id="playMeasureBtn" type="button" class="md-button md-button--tonal" disabled>小節を再生</button>
+            <button id="measureApplyBtn" type="button" class="md-button md-button--primary ms-icon-button" disabled>
+              <svg aria-hidden="true" viewBox="0 0 24 24" class="ms-btn-icon" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M20 7L9 18l-5-5"></path>
+              </svg>
+              <span>小節編集確定</span>
+            </button>
+            <button id="measureDiscardBtn" type="button" class="md-button md-button--surface ms-icon-button" disabled>
+              <svg aria-hidden="true" viewBox="0 0 24 24" class="ms-btn-icon" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M18 6L6 18"></path>
+                <path d="M6 6l12 12"></path>
+              </svg>
+              <span>小節編集破棄</span>
+            </button>
+            <button id="playMeasureBtn" type="button" class="md-button md-button--tonal ms-icon-button" disabled>
+              <svg aria-hidden="true" viewBox="0 0 24 24" class="ms-btn-icon" fill="currentColor">
+                <path d="M8 6.5v11l9-5.5z"></path>
+              </svg>
+              <span>小節再生</span>
+            </button>
           </div>
 
           <div class="ms-grid">
@@ -565,9 +585,41 @@ body {
           </div>
 
           <div class="ms-actions">
-            <button id="splitNoteBtn" type="button" class="md-button md-button--tonal">音符分割</button>
-            <button id="convertRestBtn" type="button" class="md-button md-button--tonal">休符を音符化</button>
-            <button id="deleteBtn" type="button" class="md-button md-button--surface">音符削除</button>
+            <button id="convertRestBtn" type="button" class="md-button md-button--tonal ms-icon-button">
+              <svg aria-hidden="true" viewBox="0 0 34 24" class="ms-btn-icon ms-btn-icon--wide" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round">
+                <!-- quarter rest (wide, readable silhouette) -->
+                <path d="M6.5 3.6c4 1.7 5.4 4.2 2.9 7.3-1.2 1.4-1.2 2.7.6 4.1 1.5 1.2 3.6 2 5.2 3.5"></path>
+                <path d="M9.2 7.6c2.2 1.2 3.4 2.8 2 4.6"></path>
+                <path d="M11.8 15.3c1.6.8 2.8 1.5 4 2.6"></path>
+                <!-- convert arrow -->
+                <path d="M16.8 12h5.2"></path>
+                <path d="M20.2 9.5l2.6 2.5-2.6 2.5"></path>
+                <!-- quarter note -->
+                <circle cx="27.3" cy="15.9" r="2.2" fill="currentColor" stroke="none"></circle>
+                <path d="M29.3 15.9V7.1"></path>
+              </svg>
+              <span>休符を音符化</span>
+            </button>
+            <button id="splitNoteBtn" type="button" class="md-button md-button--tonal ms-icon-button">
+              <svg aria-hidden="true" viewBox="0 0 24 24" class="ms-btn-icon" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round">
+                <circle cx="7.5" cy="15.5" r="2.5" fill="currentColor" stroke="none"></circle>
+                <path d="M10 15.5V8"></path>
+                <path d="M12 6v12"></path>
+                <circle cx="16.5" cy="15.5" r="2.5" fill="currentColor" stroke="none"></circle>
+                <path d="M19 15.5V8"></path>
+              </svg>
+              <span>音符分割</span>
+            </button>
+            <button id="deleteBtn" type="button" class="md-button md-button--surface ms-icon-button">
+              <svg aria-hidden="true" viewBox="0 0 24 24" class="ms-btn-icon" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M4 7h16"></path>
+                <path d="M9 7V5h6v2"></path>
+                <rect x="6.5" y="7" width="11" height="13" rx="1.5"></rect>
+                <path d="M10 10v7"></path>
+                <path d="M14 10v7"></path>
+              </svg>
+              <span>音符削除</span>
+            </button>
           </div>
         </section>
 
@@ -575,6 +627,7 @@ body {
           <h2 class="md-section-title"><span class="ms-step-no">4</span>保存</h2>
           <div class="ms-actions">
             <button id="downloadBtn" type="button" class="md-button md-button--secondary" disabled>MusicXML出力</button>
+            <button id="downloadMidiBtn" type="button" class="md-button md-button--tonal" disabled>MIDI出力</button>
           </div>
         </section>
       </div>
@@ -618,6 +671,7 @@ const modules = {
 Object.defineProperty(exports, "__esModule", { value: true });
 const ScoreCore_1 = require("../../core/ScoreCore");
 const timeIndex_1 = require("../../core/timeIndex");
+const playback_1 = require("./playback");
 const sampleXml_1 = require("./sampleXml");
 const EDITABLE_VOICE = "1";
 const q = (selector) => {
@@ -652,6 +706,7 @@ const deleteBtn = q("#deleteBtn");
 const playBtn = q("#playBtn");
 const stopBtn = q("#stopBtn");
 const downloadBtn = q("#downloadBtn");
+const downloadMidiBtn = q("#downloadMidiBtn");
 const saveModeText = q("#saveModeText");
 const playbackText = q("#playbackText");
 const outputXml = q("#outputXml");
@@ -1205,10 +1260,11 @@ const renderUiMessage = () => {
     uiMessage.classList.add("md-hidden");
 };
 const renderOutput = () => {
-    var _a, _b;
+    var _a, _b, _c;
     saveModeText.textContent = state.lastSaveResult ? state.lastSaveResult.mode : "-";
     outputXml.value = ((_a = state.lastSaveResult) === null || _a === void 0 ? void 0 : _a.ok) ? state.lastSaveResult.xml : "";
     downloadBtn.disabled = !((_b = state.lastSaveResult) === null || _b === void 0 ? void 0 : _b.ok);
+    downloadMidiBtn.disabled = !((_c = state.lastSaveResult) === null || _c === void 0 ? void 0 : _c.ok);
 };
 const renderControlState = () => {
     const hasDraft = Boolean(draftCore);
@@ -1845,36 +1901,8 @@ const refreshNotesFromCore = () => {
     }
 };
 const midiToHz = (midi) => 440 * Math.pow(2, (midi - 69) / 12);
-const pitchToMidi = (step, alter, octave) => {
-    const semitoneMap = {
-        C: 0,
-        D: 2,
-        E: 4,
-        F: 5,
-        G: 7,
-        A: 9,
-        B: 11,
-    };
-    const base = semitoneMap[step];
-    if (base === undefined)
-        return null;
-    return (octave + 1) * 12 + base + alter;
-};
-const getFirstNumber = (el, selector) => {
-    var _a, _b;
-    const text = (_b = (_a = el.querySelector(selector)) === null || _a === void 0 ? void 0 : _a.textContent) === null || _b === void 0 ? void 0 : _b.trim();
-    if (!text)
-        return null;
-    const n = Number(text);
-    return Number.isFinite(n) ? n : null;
-};
 const PLAYBACK_TICKS_PER_QUARTER = 128;
 const FIXED_PLAYBACK_WAVEFORM = "sine";
-const clampTempo = (tempo) => {
-    if (!Number.isFinite(tempo))
-        return 120;
-    return Math.max(20, Math.min(300, Math.round(tempo)));
-};
 const normalizeWaveform = (value) => {
     if (value === "square" || value === "triangle")
         return value;
@@ -1969,154 +1997,6 @@ const createBasicWaveSynthEngine = (options) => {
     return { playSchedule, stop };
 };
 const synthEngine = createBasicWaveSynthEngine({ ticksPerQuarter: PLAYBACK_TICKS_PER_QUARTER });
-const midiToPitchText = (midiNumber) => {
-    const names = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"];
-    const n = Math.max(0, Math.min(127, Math.round(midiNumber)));
-    const octave = Math.floor(n / 12) - 1;
-    return `${names[n % 12]}${octave}`;
-};
-const getMidiWriterRuntime = () => {
-    var _a;
-    return (_a = window.MidiWriter) !== null && _a !== void 0 ? _a : null;
-};
-const buildMidiBytesForPlayback = (events, tempo) => {
-    const midiWriter = getMidiWriterRuntime();
-    if (!midiWriter) {
-        throw new Error("midi-writer.js が読み込まれていません。");
-    }
-    const track = new midiWriter.Track();
-    track.setTempo(clampTempo(tempo));
-    const ordered = events
-        .slice()
-        .sort((a, b) => (a.startTicks === b.startTicks ? a.midiNumber - b.midiNumber : a.startTicks - b.startTicks));
-    let cursorTicks = 0;
-    for (const event of ordered) {
-        const waitTicks = Math.max(0, event.startTicks - cursorTicks);
-        const fields = {
-            pitch: [midiToPitchText(event.midiNumber)],
-            duration: `T${event.durTicks}`,
-            velocity: 80,
-            channel: Math.max(1, Math.min(16, Math.round(event.channel || 1))),
-        };
-        if (waitTicks > 0) {
-            fields.wait = `T${waitTicks}`;
-        }
-        track.addEvent(new midiWriter.NoteEvent(fields));
-        cursorTicks = Math.max(cursorTicks, event.startTicks + event.durTicks);
-    }
-    const writer = new midiWriter.Writer([track]);
-    const built = writer.buildFile();
-    return built instanceof Uint8Array ? built : Uint8Array.from(built);
-};
-const buildPlaybackEventsFromXml = (xml) => {
-    var _a, _b, _c, _d;
-    const doc = new DOMParser().parseFromString(xml, "application/xml");
-    if (doc.querySelector("parsererror"))
-        return { tempo: 120, events: [] };
-    const partNodes = Array.from(doc.querySelectorAll("score-partwise > part"));
-    if (partNodes.length === 0)
-        return { tempo: 120, events: [] };
-    const channelMap = new Map();
-    for (const scorePart of Array.from(doc.querySelectorAll("part-list > score-part"))) {
-        const partId = (_a = scorePart.getAttribute("id")) !== null && _a !== void 0 ? _a : "";
-        if (!partId)
-            continue;
-        const midiChannelText = (_c = (_b = scorePart.querySelector("midi-instrument > midi-channel")) === null || _b === void 0 ? void 0 : _b.textContent) === null || _c === void 0 ? void 0 : _c.trim();
-        const midiChannel = midiChannelText ? Number.parseInt(midiChannelText, 10) : NaN;
-        if (Number.isFinite(midiChannel) && midiChannel >= 1 && midiChannel <= 16) {
-            channelMap.set(partId, midiChannel);
-        }
-    }
-    const defaultTempo = 120;
-    const tempo = clampTempo((_d = getFirstNumber(doc, "sound[tempo]")) !== null && _d !== void 0 ? _d : defaultTempo);
-    const events = [];
-    partNodes.forEach((part, partIndex) => {
-        var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m;
-        const partId = (_a = part.getAttribute("id")) !== null && _a !== void 0 ? _a : "";
-        const fallbackChannel = ((partIndex % 16) + 1 === 10) ? 11 : ((partIndex % 16) + 1);
-        const channel = (_b = channelMap.get(partId)) !== null && _b !== void 0 ? _b : fallbackChannel;
-        let currentDivisions = 1;
-        let currentBeats = 4;
-        let currentBeatType = 4;
-        let currentTransposeSemitones = 0;
-        let timelineDiv = 0;
-        for (const measure of Array.from(part.querySelectorAll(":scope > measure"))) {
-            const divisions = getFirstNumber(measure, "attributes > divisions");
-            if (divisions && divisions > 0) {
-                currentDivisions = divisions;
-            }
-            const beats = getFirstNumber(measure, "attributes > time > beats");
-            const beatType = getFirstNumber(measure, "attributes > time > beat-type");
-            if (beats && beats > 0 && beatType && beatType > 0) {
-                currentBeats = beats;
-                currentBeatType = beatType;
-            }
-            const hasTranspose = Boolean(measure.querySelector("attributes > transpose > chromatic")) ||
-                Boolean(measure.querySelector("attributes > transpose > octave-change"));
-            if (hasTranspose) {
-                const chromatic = (_c = getFirstNumber(measure, "attributes > transpose > chromatic")) !== null && _c !== void 0 ? _c : 0;
-                const octaveChange = (_d = getFirstNumber(measure, "attributes > transpose > octave-change")) !== null && _d !== void 0 ? _d : 0;
-                currentTransposeSemitones = Math.round(chromatic + octaveChange * 12);
-            }
-            let cursorDiv = 0;
-            let measureMaxDiv = 0;
-            const lastStartByVoice = new Map();
-            for (const child of Array.from(measure.children)) {
-                if (child.tagName === "backup" || child.tagName === "forward") {
-                    const dur = getFirstNumber(child, "duration");
-                    if (!dur || dur <= 0)
-                        continue;
-                    if (child.tagName === "backup") {
-                        cursorDiv = Math.max(0, cursorDiv - dur);
-                    }
-                    else {
-                        cursorDiv += dur;
-                        measureMaxDiv = Math.max(measureMaxDiv, cursorDiv);
-                    }
-                    continue;
-                }
-                if (child.tagName !== "note")
-                    continue;
-                const durationDiv = getFirstNumber(child, "duration");
-                if (!durationDiv || durationDiv <= 0)
-                    continue;
-                const voice = (_g = (_f = (_e = child.querySelector("voice")) === null || _e === void 0 ? void 0 : _e.textContent) === null || _f === void 0 ? void 0 : _f.trim()) !== null && _g !== void 0 ? _g : "1";
-                const isChord = Boolean(child.querySelector("chord"));
-                const isRest = Boolean(child.querySelector("rest"));
-                const startDiv = isChord ? ((_h = lastStartByVoice.get(voice)) !== null && _h !== void 0 ? _h : cursorDiv) : cursorDiv;
-                if (!isChord) {
-                    lastStartByVoice.set(voice, startDiv);
-                }
-                if (!isRest) {
-                    const step = (_l = (_k = (_j = child.querySelector("pitch > step")) === null || _j === void 0 ? void 0 : _j.textContent) === null || _k === void 0 ? void 0 : _k.trim()) !== null && _l !== void 0 ? _l : "";
-                    const octave = getFirstNumber(child, "pitch > octave");
-                    const alter = (_m = getFirstNumber(child, "pitch > alter")) !== null && _m !== void 0 ? _m : 0;
-                    if (octave !== null) {
-                        const midi = pitchToMidi(step, alter, octave);
-                        if (midi !== null) {
-                            const soundingMidi = midi + currentTransposeSemitones;
-                            if (soundingMidi < 0 || soundingMidi > 127) {
-                                continue;
-                            }
-                            const startTicks = Math.max(0, Math.round(((timelineDiv + startDiv) / currentDivisions) * PLAYBACK_TICKS_PER_QUARTER));
-                            const durTicks = Math.max(1, Math.round((durationDiv / currentDivisions) * PLAYBACK_TICKS_PER_QUARTER));
-                            events.push({ midiNumber: soundingMidi, startTicks, durTicks, channel });
-                        }
-                    }
-                }
-                if (!isChord) {
-                    cursorDiv += durationDiv;
-                }
-                measureMaxDiv = Math.max(measureMaxDiv, cursorDiv, startDiv + durationDiv);
-            }
-            if (measureMaxDiv <= 0) {
-                measureMaxDiv = Math.max(1, Math.round((currentDivisions * 4 * currentBeats) / Math.max(1, currentBeatType)));
-            }
-            timelineDiv += measureMaxDiv;
-        }
-    });
-    return { tempo, events };
-};
 const stopPlayback = () => {
     synthEngine.stop();
     isPlaying = false;
@@ -2143,7 +2023,7 @@ const startPlayback = async () => {
         playbackText.textContent = "再生: 保存失敗";
         return;
     }
-    const parsedPlayback = buildPlaybackEventsFromXml(saveResult.xml);
+    const parsedPlayback = (0, playback_1.buildPlaybackEventsFromXml)(saveResult.xml, PLAYBACK_TICKS_PER_QUARTER);
     const events = parsedPlayback.events;
     if (events.length === 0) {
         playbackText.textContent = "再生: 再生可能ノートなし";
@@ -2152,7 +2032,7 @@ const startPlayback = async () => {
     }
     let midiBytes;
     try {
-        midiBytes = buildMidiBytesForPlayback(events, parsedPlayback.tempo);
+        midiBytes = (0, playback_1.buildMidiBytesForPlayback)(events, parsedPlayback.tempo);
     }
     catch (error) {
         playbackText.textContent =
@@ -2210,7 +2090,7 @@ const startMeasurePlayback = async () => {
         renderAll();
         return;
     }
-    const parsedPlayback = buildPlaybackEventsFromXml(saveResult.xml);
+    const parsedPlayback = (0, playback_1.buildPlaybackEventsFromXml)(saveResult.xml, PLAYBACK_TICKS_PER_QUARTER);
     const events = parsedPlayback.events;
     if (events.length === 0) {
         playbackText.textContent = "再生: この小節に再生可能ノートなし";
@@ -2683,6 +2563,29 @@ const onDownload = () => {
     a.click();
     URL.revokeObjectURL(url);
 };
+const onDownloadMidi = () => {
+    if (!state.lastSuccessfulSaveXml)
+        return;
+    const parsedPlayback = (0, playback_1.buildPlaybackEventsFromXml)(state.lastSuccessfulSaveXml, PLAYBACK_TICKS_PER_QUARTER);
+    if (parsedPlayback.events.length === 0)
+        return;
+    let midiBytes;
+    try {
+        midiBytes = (0, playback_1.buildMidiBytesForPlayback)(parsedPlayback.events, parsedPlayback.tempo);
+    }
+    catch (_a) {
+        return;
+    }
+    const midiArrayBuffer = new ArrayBuffer(midiBytes.byteLength);
+    new Uint8Array(midiArrayBuffer).set(midiBytes);
+    const blob = new Blob([midiArrayBuffer], { type: "audio/midi" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "mikuscore.mid";
+    a.click();
+    URL.revokeObjectURL(url);
+};
 inputModeFile.addEventListener("change", renderInputMode);
 inputModeSource.addEventListener("change", renderInputMode);
 fileSelectBtn.addEventListener("click", () => fileInput.click());
@@ -2725,6 +2628,7 @@ playBtn.addEventListener("click", () => {
 });
 stopBtn.addEventListener("click", stopPlayback);
 downloadBtn.addEventListener("click", onDownload);
+downloadMidiBtn.addEventListener("click", onDownloadMidi);
 debugScoreArea.addEventListener("click", onVerovioScoreClick);
 measureEditorArea.addEventListener("click", onMeasureEditorClick);
 measureApplyBtn.addEventListener("click", onMeasureApply);
@@ -17042,6 +16946,256 @@ exports.sampleXml = `<?xml version="1.0" encoding="UTF-8"?>
     </measure>
   </part>
 </score-partwise>`;
+
+  },
+  "src/ts/playback.js": function (require, module, exports) {
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.buildPlaybackEventsFromXml = exports.buildMidiBytesForPlayback = void 0;
+const clampTempo = (tempo) => {
+    if (!Number.isFinite(tempo))
+        return 120;
+    return Math.max(20, Math.min(300, Math.round(tempo)));
+};
+const pitchToMidi = (step, alter, octave) => {
+    const semitoneMap = {
+        C: 0,
+        D: 2,
+        E: 4,
+        F: 5,
+        G: 7,
+        A: 9,
+        B: 11,
+    };
+    const base = semitoneMap[step];
+    if (base === undefined)
+        return null;
+    return (octave + 1) * 12 + base + alter;
+};
+const keySignatureAlterByStep = (fifths) => {
+    const map = { C: 0, D: 0, E: 0, F: 0, G: 0, A: 0, B: 0 };
+    const sharpOrder = ["F", "C", "G", "D", "A", "E", "B"];
+    const flatOrder = ["B", "E", "A", "D", "G", "C", "F"];
+    const safeFifths = Math.max(-7, Math.min(7, Math.round(fifths)));
+    if (safeFifths > 0) {
+        for (let i = 0; i < safeFifths; i += 1)
+            map[sharpOrder[i]] = 1;
+    }
+    else if (safeFifths < 0) {
+        for (let i = 0; i < Math.abs(safeFifths); i += 1)
+            map[flatOrder[i]] = -1;
+    }
+    return map;
+};
+const accidentalTextToAlter = (text) => {
+    const normalized = text.trim().toLowerCase();
+    if (!normalized)
+        return null;
+    if (normalized === "sharp")
+        return 1;
+    if (normalized === "flat")
+        return -1;
+    if (normalized === "natural")
+        return 0;
+    if (normalized === "double-sharp")
+        return 2;
+    if (normalized === "flat-flat")
+        return -2;
+    return null;
+};
+const getFirstNumber = (el, selector) => {
+    var _a, _b;
+    const text = (_b = (_a = el.querySelector(selector)) === null || _a === void 0 ? void 0 : _a.textContent) === null || _b === void 0 ? void 0 : _b.trim();
+    if (!text)
+        return null;
+    const n = Number(text);
+    return Number.isFinite(n) ? n : null;
+};
+const midiToPitchText = (midiNumber) => {
+    const names = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"];
+    const n = Math.max(0, Math.min(127, Math.round(midiNumber)));
+    const octave = Math.floor(n / 12) - 1;
+    return `${names[n % 12]}${octave}`;
+};
+const getMidiWriterRuntime = () => {
+    var _a;
+    return (_a = window.MidiWriter) !== null && _a !== void 0 ? _a : null;
+};
+const normalizeTicksPerQuarter = (ticksPerQuarter) => {
+    if (!Number.isFinite(ticksPerQuarter))
+        return 128;
+    return Math.max(1, Math.round(ticksPerQuarter));
+};
+const buildMidiBytesForPlayback = (events, tempo) => {
+    const midiWriter = getMidiWriterRuntime();
+    if (!midiWriter) {
+        throw new Error("midi-writer.js が読み込まれていません。");
+    }
+    const track = new midiWriter.Track();
+    track.setTempo(clampTempo(tempo));
+    const ordered = events
+        .slice()
+        .sort((a, b) => (a.startTicks === b.startTicks ? a.midiNumber - b.midiNumber : a.startTicks - b.startTicks));
+    const channels = Array.from(new Set(ordered.map((event) => Math.max(1, Math.min(16, Math.round(event.channel || 1)))))).sort((a, b) => a - b);
+    for (const channel of channels) {
+        if (channel === 10)
+            continue;
+        track.addEvent(new midiWriter.ProgramChangeEvent({
+            channel,
+            instrument: 5, // GM: Electric Piano 2
+            delta: 0,
+        }));
+    }
+    for (const event of ordered) {
+        const fields = {
+            pitch: [midiToPitchText(event.midiNumber)],
+            duration: `T${event.durTicks}`,
+            startTick: Math.max(0, Math.round(event.startTicks)),
+            velocity: 80,
+            channel: Math.max(1, Math.min(16, Math.round(event.channel || 1))),
+        };
+        track.addEvent(new midiWriter.NoteEvent(fields));
+    }
+    const writer = new midiWriter.Writer([track]);
+    const built = writer.buildFile();
+    return built instanceof Uint8Array ? built : Uint8Array.from(built);
+};
+exports.buildMidiBytesForPlayback = buildMidiBytesForPlayback;
+const buildPlaybackEventsFromXml = (xml, ticksPerQuarter) => {
+    var _a, _b, _c, _d;
+    const normalizedTicksPerQuarter = normalizeTicksPerQuarter(ticksPerQuarter);
+    const doc = new DOMParser().parseFromString(xml, "application/xml");
+    if (doc.querySelector("parsererror"))
+        return { tempo: 120, events: [] };
+    const partNodes = Array.from(doc.querySelectorAll("score-partwise > part"));
+    if (partNodes.length === 0)
+        return { tempo: 120, events: [] };
+    const channelMap = new Map();
+    for (const scorePart of Array.from(doc.querySelectorAll("part-list > score-part"))) {
+        const partId = (_a = scorePart.getAttribute("id")) !== null && _a !== void 0 ? _a : "";
+        if (!partId)
+            continue;
+        const midiChannelText = (_c = (_b = scorePart.querySelector("midi-instrument > midi-channel")) === null || _b === void 0 ? void 0 : _b.textContent) === null || _c === void 0 ? void 0 : _c.trim();
+        const midiChannel = midiChannelText ? Number.parseInt(midiChannelText, 10) : NaN;
+        if (Number.isFinite(midiChannel) && midiChannel >= 1 && midiChannel <= 16) {
+            channelMap.set(partId, midiChannel);
+        }
+    }
+    const defaultTempo = 120;
+    const tempo = clampTempo((_d = getFirstNumber(doc, "sound[tempo]")) !== null && _d !== void 0 ? _d : defaultTempo);
+    const events = [];
+    partNodes.forEach((part, partIndex) => {
+        var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p, _q, _r;
+        const partId = (_a = part.getAttribute("id")) !== null && _a !== void 0 ? _a : "";
+        const fallbackChannel = (partIndex % 16) + 1 === 10 ? 11 : (partIndex % 16) + 1;
+        const channel = (_b = channelMap.get(partId)) !== null && _b !== void 0 ? _b : fallbackChannel;
+        let currentDivisions = 1;
+        let currentBeats = 4;
+        let currentBeatType = 4;
+        let currentFifths = 0;
+        let currentTransposeSemitones = 0;
+        let timelineDiv = 0;
+        for (const measure of Array.from(part.querySelectorAll(":scope > measure"))) {
+            const divisions = getFirstNumber(measure, "attributes > divisions");
+            if (divisions && divisions > 0) {
+                currentDivisions = divisions;
+            }
+            const beats = getFirstNumber(measure, "attributes > time > beats");
+            const beatType = getFirstNumber(measure, "attributes > time > beat-type");
+            if (beats && beats > 0 && beatType && beatType > 0) {
+                currentBeats = beats;
+                currentBeatType = beatType;
+            }
+            const fifths = getFirstNumber(measure, "attributes > key > fifths");
+            if (fifths !== null) {
+                currentFifths = Math.max(-7, Math.min(7, Math.round(fifths)));
+            }
+            const hasTranspose = Boolean(measure.querySelector("attributes > transpose > chromatic")) ||
+                Boolean(measure.querySelector("attributes > transpose > octave-change"));
+            if (hasTranspose) {
+                const chromatic = (_c = getFirstNumber(measure, "attributes > transpose > chromatic")) !== null && _c !== void 0 ? _c : 0;
+                const octaveChange = (_d = getFirstNumber(measure, "attributes > transpose > octave-change")) !== null && _d !== void 0 ? _d : 0;
+                currentTransposeSemitones = Math.round(chromatic + octaveChange * 12);
+            }
+            let cursorDiv = 0;
+            let measureMaxDiv = 0;
+            const lastStartByVoice = new Map();
+            const measureAccidentalByStepOctave = new Map();
+            const keyAlterMap = keySignatureAlterByStep(currentFifths);
+            for (const child of Array.from(measure.children)) {
+                if (child.tagName === "backup" || child.tagName === "forward") {
+                    const dur = getFirstNumber(child, "duration");
+                    if (!dur || dur <= 0)
+                        continue;
+                    if (child.tagName === "backup") {
+                        cursorDiv = Math.max(0, cursorDiv - dur);
+                    }
+                    else {
+                        cursorDiv += dur;
+                        measureMaxDiv = Math.max(measureMaxDiv, cursorDiv);
+                    }
+                    continue;
+                }
+                if (child.tagName !== "note")
+                    continue;
+                const durationDiv = getFirstNumber(child, "duration");
+                if (!durationDiv || durationDiv <= 0)
+                    continue;
+                const voice = (_g = (_f = (_e = child.querySelector("voice")) === null || _e === void 0 ? void 0 : _e.textContent) === null || _f === void 0 ? void 0 : _f.trim()) !== null && _g !== void 0 ? _g : "1";
+                const isChord = Boolean(child.querySelector("chord"));
+                const isRest = Boolean(child.querySelector("rest"));
+                const startDiv = isChord ? ((_h = lastStartByVoice.get(voice)) !== null && _h !== void 0 ? _h : cursorDiv) : cursorDiv;
+                if (!isChord) {
+                    lastStartByVoice.set(voice, startDiv);
+                }
+                if (!isRest) {
+                    const step = (_l = (_k = (_j = child.querySelector("pitch > step")) === null || _j === void 0 ? void 0 : _j.textContent) === null || _k === void 0 ? void 0 : _k.trim()) !== null && _l !== void 0 ? _l : "";
+                    const octave = getFirstNumber(child, "pitch > octave");
+                    const explicitAlter = getFirstNumber(child, "pitch > alter");
+                    const accidentalAlter = accidentalTextToAlter((_p = (_o = (_m = child.querySelector("accidental")) === null || _m === void 0 ? void 0 : _m.textContent) === null || _o === void 0 ? void 0 : _o.trim()) !== null && _p !== void 0 ? _p : "");
+                    if (octave !== null) {
+                        const stepOctaveKey = `${step}${octave}`;
+                        let effectiveAlter = 0;
+                        if (explicitAlter !== null) {
+                            effectiveAlter = Math.round(explicitAlter);
+                            measureAccidentalByStepOctave.set(stepOctaveKey, effectiveAlter);
+                        }
+                        else if (accidentalAlter !== null) {
+                            effectiveAlter = accidentalAlter;
+                            measureAccidentalByStepOctave.set(stepOctaveKey, effectiveAlter);
+                        }
+                        else if (measureAccidentalByStepOctave.has(stepOctaveKey)) {
+                            effectiveAlter = (_q = measureAccidentalByStepOctave.get(stepOctaveKey)) !== null && _q !== void 0 ? _q : 0;
+                        }
+                        else {
+                            effectiveAlter = (_r = keyAlterMap[step]) !== null && _r !== void 0 ? _r : 0;
+                        }
+                        const midi = pitchToMidi(step, effectiveAlter, octave);
+                        if (midi !== null) {
+                            const soundingMidi = midi + currentTransposeSemitones;
+                            if (soundingMidi < 0 || soundingMidi > 127) {
+                                continue;
+                            }
+                            const startTicks = Math.max(0, Math.round(((timelineDiv + startDiv) / currentDivisions) * normalizedTicksPerQuarter));
+                            const durTicks = Math.max(1, Math.round((durationDiv / currentDivisions) * normalizedTicksPerQuarter));
+                            events.push({ midiNumber: soundingMidi, startTicks, durTicks, channel });
+                        }
+                    }
+                }
+                if (!isChord) {
+                    cursorDiv += durationDiv;
+                }
+                measureMaxDiv = Math.max(measureMaxDiv, cursorDiv, startDiv + durationDiv);
+            }
+            if (measureMaxDiv <= 0) {
+                measureMaxDiv = Math.max(1, Math.round((currentDivisions * 4 * currentBeats) / Math.max(1, currentBeatType)));
+            }
+            timelineDiv += measureMaxDiv;
+        }
+    });
+    return { tempo, events };
+};
+exports.buildPlaybackEventsFromXml = buildPlaybackEventsFromXml;
 
   },
   "core/interfaces.js": function (require, module, exports) {

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -219,6 +219,10 @@ body {
   flex: 0 0 auto;
 }
 
+.ms-btn-icon--wide {
+  width: 1.7rem;
+}
+
 .ms-status {
   margin: 0.35rem 0;
   color: var(--md-sys-color-on-surface-variant);

--- a/src/ts/playback.ts
+++ b/src/ts/playback.ts
@@ -1,0 +1,289 @@
+export type PlaybackEvent = {
+  midiNumber: number;
+  startTicks: number;
+  durTicks: number;
+  channel: number;
+};
+
+type MidiWriterTrackApi = {
+  setTempo: (tempo: number) => void;
+  addEvent: (event: unknown) => void;
+};
+
+type MidiWriterNoteEventFields = {
+  pitch: string[];
+  duration: string;
+  wait?: string;
+  startTick?: number | null;
+  velocity?: number;
+  channel?: number;
+};
+
+type MidiWriterRuntime = {
+  Track: new () => MidiWriterTrackApi;
+  NoteEvent: new (fields: MidiWriterNoteEventFields) => unknown;
+  ProgramChangeEvent: new (fields: { instrument: number; channel?: number; delta?: number }) => unknown;
+  Writer: new (tracks: unknown[] | unknown) => {
+    buildFile: () => Uint8Array | number[];
+  };
+};
+
+const clampTempo = (tempo: number): number => {
+  if (!Number.isFinite(tempo)) return 120;
+  return Math.max(20, Math.min(300, Math.round(tempo)));
+};
+
+const pitchToMidi = (step: string, alter: number, octave: number): number | null => {
+  const semitoneMap: Record<string, number> = {
+    C: 0,
+    D: 2,
+    E: 4,
+    F: 5,
+    G: 7,
+    A: 9,
+    B: 11,
+  };
+  const base = semitoneMap[step];
+  if (base === undefined) return null;
+  return (octave + 1) * 12 + base + alter;
+};
+
+const keySignatureAlterByStep = (fifths: number): Record<string, number> => {
+  const map: Record<string, number> = { C: 0, D: 0, E: 0, F: 0, G: 0, A: 0, B: 0 };
+  const sharpOrder = ["F", "C", "G", "D", "A", "E", "B"] as const;
+  const flatOrder = ["B", "E", "A", "D", "G", "C", "F"] as const;
+  const safeFifths = Math.max(-7, Math.min(7, Math.round(fifths)));
+  if (safeFifths > 0) {
+    for (let i = 0; i < safeFifths; i += 1) map[sharpOrder[i]] = 1;
+  } else if (safeFifths < 0) {
+    for (let i = 0; i < Math.abs(safeFifths); i += 1) map[flatOrder[i]] = -1;
+  }
+  return map;
+};
+
+const accidentalTextToAlter = (text: string): number | null => {
+  const normalized = text.trim().toLowerCase();
+  if (!normalized) return null;
+  if (normalized === "sharp") return 1;
+  if (normalized === "flat") return -1;
+  if (normalized === "natural") return 0;
+  if (normalized === "double-sharp") return 2;
+  if (normalized === "flat-flat") return -2;
+  return null;
+};
+
+const getFirstNumber = (el: ParentNode, selector: string): number | null => {
+  const text = el.querySelector(selector)?.textContent?.trim();
+  if (!text) return null;
+  const n = Number(text);
+  return Number.isFinite(n) ? n : null;
+};
+
+const midiToPitchText = (midiNumber: number): string => {
+  const names = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"];
+  const n = Math.max(0, Math.min(127, Math.round(midiNumber)));
+  const octave = Math.floor(n / 12) - 1;
+  return `${names[n % 12]}${octave}`;
+};
+
+const getMidiWriterRuntime = (): MidiWriterRuntime | null => {
+  return (window as unknown as { MidiWriter?: MidiWriterRuntime }).MidiWriter ?? null;
+};
+
+const normalizeTicksPerQuarter = (ticksPerQuarter: number): number => {
+  if (!Number.isFinite(ticksPerQuarter)) return 128;
+  return Math.max(1, Math.round(ticksPerQuarter));
+};
+
+export const buildMidiBytesForPlayback = (events: PlaybackEvent[], tempo: number): Uint8Array => {
+  const midiWriter = getMidiWriterRuntime();
+  if (!midiWriter) {
+    throw new Error("midi-writer.js が読み込まれていません。");
+  }
+  const track = new midiWriter.Track();
+  track.setTempo(clampTempo(tempo));
+
+  const ordered = events
+    .slice()
+    .sort((a, b) => (a.startTicks === b.startTicks ? a.midiNumber - b.midiNumber : a.startTicks - b.startTicks));
+
+  const channels = Array.from(
+    new Set(ordered.map((event) => Math.max(1, Math.min(16, Math.round(event.channel || 1)))))
+  ).sort((a, b) => a - b);
+  for (const channel of channels) {
+    if (channel === 10) continue;
+    track.addEvent(
+      new midiWriter.ProgramChangeEvent({
+        channel,
+        instrument: 5, // GM: Electric Piano 2
+        delta: 0,
+      })
+    );
+  }
+
+  for (const event of ordered) {
+    const fields: MidiWriterNoteEventFields = {
+      pitch: [midiToPitchText(event.midiNumber)],
+      duration: `T${event.durTicks}`,
+      startTick: Math.max(0, Math.round(event.startTicks)),
+      velocity: 80,
+      channel: Math.max(1, Math.min(16, Math.round(event.channel || 1))),
+    };
+    track.addEvent(new midiWriter.NoteEvent(fields));
+  }
+
+  const writer = new midiWriter.Writer([track]);
+  const built = writer.buildFile();
+  return built instanceof Uint8Array ? built : Uint8Array.from(built);
+};
+
+export const buildPlaybackEventsFromXml = (
+  xml: string,
+  ticksPerQuarter: number
+): { tempo: number; events: PlaybackEvent[] } => {
+  const normalizedTicksPerQuarter = normalizeTicksPerQuarter(ticksPerQuarter);
+  const doc = new DOMParser().parseFromString(xml, "application/xml");
+  if (doc.querySelector("parsererror")) return { tempo: 120, events: [] };
+  const partNodes = Array.from(doc.querySelectorAll("score-partwise > part"));
+  if (partNodes.length === 0) return { tempo: 120, events: [] };
+
+  const channelMap = new Map<string, number>();
+  for (const scorePart of Array.from(doc.querySelectorAll("part-list > score-part"))) {
+    const partId = scorePart.getAttribute("id") ?? "";
+    if (!partId) continue;
+    const midiChannelText = scorePart.querySelector("midi-instrument > midi-channel")?.textContent?.trim();
+    const midiChannel = midiChannelText ? Number.parseInt(midiChannelText, 10) : NaN;
+    if (Number.isFinite(midiChannel) && midiChannel >= 1 && midiChannel <= 16) {
+      channelMap.set(partId, midiChannel);
+    }
+  }
+
+  const defaultTempo = 120;
+  const tempo = clampTempo(getFirstNumber(doc, "sound[tempo]") ?? defaultTempo);
+  const events: PlaybackEvent[] = [];
+
+  partNodes.forEach((part, partIndex) => {
+    const partId = part.getAttribute("id") ?? "";
+    const fallbackChannel = (partIndex % 16) + 1 === 10 ? 11 : (partIndex % 16) + 1;
+    const channel = channelMap.get(partId) ?? fallbackChannel;
+
+    let currentDivisions = 1;
+    let currentBeats = 4;
+    let currentBeatType = 4;
+    let currentFifths = 0;
+    let currentTransposeSemitones = 0;
+    let timelineDiv = 0;
+
+    for (const measure of Array.from(part.querySelectorAll(":scope > measure"))) {
+      const divisions = getFirstNumber(measure, "attributes > divisions");
+      if (divisions && divisions > 0) {
+        currentDivisions = divisions;
+      }
+      const beats = getFirstNumber(measure, "attributes > time > beats");
+      const beatType = getFirstNumber(measure, "attributes > time > beat-type");
+      if (beats && beats > 0 && beatType && beatType > 0) {
+        currentBeats = beats;
+        currentBeatType = beatType;
+      }
+      const fifths = getFirstNumber(measure, "attributes > key > fifths");
+      if (fifths !== null) {
+        currentFifths = Math.max(-7, Math.min(7, Math.round(fifths)));
+      }
+      const hasTranspose =
+        Boolean(measure.querySelector("attributes > transpose > chromatic")) ||
+        Boolean(measure.querySelector("attributes > transpose > octave-change"));
+      if (hasTranspose) {
+        const chromatic = getFirstNumber(measure, "attributes > transpose > chromatic") ?? 0;
+        const octaveChange = getFirstNumber(measure, "attributes > transpose > octave-change") ?? 0;
+        currentTransposeSemitones = Math.round(chromatic + octaveChange * 12);
+      }
+
+      let cursorDiv = 0;
+      let measureMaxDiv = 0;
+      const lastStartByVoice = new Map<string, number>();
+      const measureAccidentalByStepOctave = new Map<string, number>();
+      const keyAlterMap = keySignatureAlterByStep(currentFifths);
+
+      for (const child of Array.from(measure.children)) {
+        if (child.tagName === "backup" || child.tagName === "forward") {
+          const dur = getFirstNumber(child, "duration");
+          if (!dur || dur <= 0) continue;
+          if (child.tagName === "backup") {
+            cursorDiv = Math.max(0, cursorDiv - dur);
+          } else {
+            cursorDiv += dur;
+            measureMaxDiv = Math.max(measureMaxDiv, cursorDiv);
+          }
+          continue;
+        }
+
+        if (child.tagName !== "note") continue;
+        const durationDiv = getFirstNumber(child, "duration");
+        if (!durationDiv || durationDiv <= 0) continue;
+
+        const voice = child.querySelector("voice")?.textContent?.trim() ?? "1";
+        const isChord = Boolean(child.querySelector("chord"));
+        const isRest = Boolean(child.querySelector("rest"));
+        const startDiv = isChord ? (lastStartByVoice.get(voice) ?? cursorDiv) : cursorDiv;
+        if (!isChord) {
+          lastStartByVoice.set(voice, startDiv);
+        }
+
+        if (!isRest) {
+          const step = child.querySelector("pitch > step")?.textContent?.trim() ?? "";
+          const octave = getFirstNumber(child, "pitch > octave");
+          const explicitAlter = getFirstNumber(child, "pitch > alter");
+          const accidentalAlter = accidentalTextToAlter(
+            child.querySelector("accidental")?.textContent?.trim() ?? ""
+          );
+          if (octave !== null) {
+            const stepOctaveKey = `${step}${octave}`;
+            let effectiveAlter = 0;
+            if (explicitAlter !== null) {
+              effectiveAlter = Math.round(explicitAlter);
+              measureAccidentalByStepOctave.set(stepOctaveKey, effectiveAlter);
+            } else if (accidentalAlter !== null) {
+              effectiveAlter = accidentalAlter;
+              measureAccidentalByStepOctave.set(stepOctaveKey, effectiveAlter);
+            } else if (measureAccidentalByStepOctave.has(stepOctaveKey)) {
+              effectiveAlter = measureAccidentalByStepOctave.get(stepOctaveKey) ?? 0;
+            } else {
+              effectiveAlter = keyAlterMap[step] ?? 0;
+            }
+            const midi = pitchToMidi(step, effectiveAlter, octave);
+            if (midi !== null) {
+              const soundingMidi = midi + currentTransposeSemitones;
+              if (soundingMidi < 0 || soundingMidi > 127) {
+                continue;
+              }
+              const startTicks = Math.max(
+                0,
+                Math.round(((timelineDiv + startDiv) / currentDivisions) * normalizedTicksPerQuarter)
+              );
+              const durTicks = Math.max(
+                1,
+                Math.round((durationDiv / currentDivisions) * normalizedTicksPerQuarter)
+              );
+              events.push({ midiNumber: soundingMidi, startTicks, durTicks, channel });
+            }
+          }
+        }
+
+        if (!isChord) {
+          cursorDiv += durationDiv;
+        }
+        measureMaxDiv = Math.max(measureMaxDiv, cursorDiv, startDiv + durationDiv);
+      }
+
+      if (measureMaxDiv <= 0) {
+        measureMaxDiv = Math.max(
+          1,
+          Math.round((currentDivisions * 4 * currentBeats) / Math.max(1, currentBeatType))
+        );
+      }
+      timelineDiv += measureMaxDiv;
+    }
+  });
+
+  return { tempo, events };
+};


### PR DESCRIPTION
### 概要
以下をまとめて実施しました。

- 保存セクションに `MIDI出力` ボタンを追加
- 再生イベント変換・MIDI生成ロジックを `main.ts` から `playback.ts` に分離
- 編集アクションの文言を明確化し、各ボタンにSVGアイコンを追加
- 操作ボタンの並びと視認性を改善（休符を音符化 / 音符分割 / 音符削除）

### 主な変更点

1. MIDI出力機能の追加
- `mikuscore-src.html` に `MIDI出力` ボタン（`#downloadMidiBtn`）を追加
- `src/ts/main.ts` に `onDownloadMidi()` を追加し、`.mid` ダウンロードを実装
- 保存成功時のみ MusicXML/MIDI 出力ボタンを有効化

2. 再生処理のモジュール分離
- `src/ts/playback.ts` を新規追加
  - `buildPlaybackEventsFromXml(xml, ticksPerQuarter)`
  - `buildMidiBytesForPlayback(events, tempo)`
- `main.ts` から再生イベント生成・MIDI生成関連の実装を削除し、`playback.ts` を import する構成へ整理

3. MIDI生成品質の改善
- イベント配置を `startTick` 指定ベースに対応（時間位置の明示）
- チャンネルごとの `ProgramChangeEvent` を追加し、GM `Electric Piano 2 (instrument: 5)` を指定（ch10除外）

4. 編集UI改善
- 文言変更
  - `編集確定` → `小節編集確定`
  - `編集破棄` → `小節編集破棄`
  - `小節を再生` → `小節再生`
- SVGアイコン付きボタンへ更新
- 休符を音符化ボタンのアイコン視認性を改善（横長アイコン対応）

### 変更ファイル
- `mikuscore-src.html`
- `mikuscore.html`
- `src/css/app.css`
- `src/js/main.js`
- `src/ts/main.ts`
- `src/ts/playback.ts`（新規）

### 期待効果
- 出力形式の拡張（MusicXML + MIDI）
- `main.ts` の責務分離による保守性向上
- 編集操作の意味が伝わりやすいUIへ改善
- MIDI側のタイミング/音色指定の再現性向上