### PR TITLE
ABC移調対応の強化と「新規作成」入力フロー追加（拍子・調号・記号・8小節生成）

### DIFF
--- a/mikuscore-src.html
+++ b/mikuscore-src.html
@@ -58,11 +58,52 @@
           <div class="ms-radio-group" role="radiogroup" aria-label="入力フォーマット">
             <label class="md-radio"><input id="inputTypeXml" type="radio" name="inputType" value="xml" checked /> MusicXML入力</label>
             <label class="md-radio"><input id="inputTypeAbc" type="radio" name="inputType" value="abc" /> ABC入力</label>
+            <label class="md-radio"><input id="inputTypeNew" type="radio" name="inputType" value="new" /> 新規作成</label>
           </div>
 
           <div class="ms-radio-group" role="radiogroup" aria-label="取込方法">
             <label class="md-radio"><input id="inputModeFile" type="radio" name="inputMode" value="file" checked /> ファイル読み込み</label>
             <label class="md-radio"><input id="inputModeSource" type="radio" name="inputMode" value="source" /> ソース入力</label>
+          </div>
+
+          <div id="newInputBlock" class="ms-block md-hidden">
+            <div class="ms-stack-sm">
+              <label class="ms-field">トラック数（パート数）
+                <input id="newPartCount" type="number" min="1" max="16" step="1" value="1" class="md-input" />
+              </label>
+              <label class="ms-field">拍子
+                <div class="ms-form-row">
+                  <input id="newTimeBeats" type="number" min="1" max="16" step="1" value="4" class="md-input" style="max-width: 8rem;" />
+                  <span>/</span>
+                  <select id="newTimeBeatType" class="md-select" style="max-width: 8rem;">
+                    <option value="2">2</option>
+                    <option value="4" selected>4</option>
+                    <option value="8">8</option>
+                    <option value="16">16</option>
+                  </select>
+                </div>
+              </label>
+              <label class="ms-field">調号
+                <select id="newKeyFifths" class="md-select">
+                  <option value="-7">♭7 (Cb)</option>
+                  <option value="-6">♭6 (Gb)</option>
+                  <option value="-5">♭5 (Db)</option>
+                  <option value="-4">♭4 (Ab)</option>
+                  <option value="-3">♭3 (Eb)</option>
+                  <option value="-2">♭2 (Bb)</option>
+                  <option value="-1">♭1 (F)</option>
+                  <option value="0" selected>なし (C)</option>
+                  <option value="1">♯1 (G)</option>
+                  <option value="2">♯2 (D)</option>
+                  <option value="3">♯3 (A)</option>
+                  <option value="4">♯4 (E)</option>
+                  <option value="5">♯5 (B)</option>
+                  <option value="6">♯6 (F#)</option>
+                  <option value="7">♯7 (C#)</option>
+                </select>
+              </label>
+            </div>
+            <div id="newPartClefList" class="ms-stack-sm" aria-live="polite"></div>
           </div>
 
           <div id="fileInputBlock" class="ms-block">

--- a/mikuscore.html
+++ b/mikuscore.html
@@ -473,11 +473,52 @@ body {
           <div class="ms-radio-group" role="radiogroup" aria-label="入力フォーマット">
             <label class="md-radio"><input id="inputTypeXml" type="radio" name="inputType" value="xml" checked /> MusicXML入力</label>
             <label class="md-radio"><input id="inputTypeAbc" type="radio" name="inputType" value="abc" /> ABC入力</label>
+            <label class="md-radio"><input id="inputTypeNew" type="radio" name="inputType" value="new" /> 新規作成</label>
           </div>
 
           <div class="ms-radio-group" role="radiogroup" aria-label="取込方法">
             <label class="md-radio"><input id="inputModeFile" type="radio" name="inputMode" value="file" checked /> ファイル読み込み</label>
             <label class="md-radio"><input id="inputModeSource" type="radio" name="inputMode" value="source" /> ソース入力</label>
+          </div>
+
+          <div id="newInputBlock" class="ms-block md-hidden">
+            <div class="ms-stack-sm">
+              <label class="ms-field">トラック数（パート数）
+                <input id="newPartCount" type="number" min="1" max="16" step="1" value="1" class="md-input" />
+              </label>
+              <label class="ms-field">拍子
+                <div class="ms-form-row">
+                  <input id="newTimeBeats" type="number" min="1" max="16" step="1" value="4" class="md-input" style="max-width: 8rem;" />
+                  <span>/</span>
+                  <select id="newTimeBeatType" class="md-select" style="max-width: 8rem;">
+                    <option value="2">2</option>
+                    <option value="4" selected>4</option>
+                    <option value="8">8</option>
+                    <option value="16">16</option>
+                  </select>
+                </div>
+              </label>
+              <label class="ms-field">調号
+                <select id="newKeyFifths" class="md-select">
+                  <option value="-7">♭7 (Cb)</option>
+                  <option value="-6">♭6 (Gb)</option>
+                  <option value="-5">♭5 (Db)</option>
+                  <option value="-4">♭4 (Ab)</option>
+                  <option value="-3">♭3 (Eb)</option>
+                  <option value="-2">♭2 (Bb)</option>
+                  <option value="-1">♭1 (F)</option>
+                  <option value="0" selected>なし (C)</option>
+                  <option value="1">♯1 (G)</option>
+                  <option value="2">♯2 (D)</option>
+                  <option value="3">♯3 (A)</option>
+                  <option value="4">♯4 (E)</option>
+                  <option value="5">♯5 (B)</option>
+                  <option value="6">♯6 (F#)</option>
+                  <option value="7">♯7 (C#)</option>
+                </select>
+              </label>
+            </div>
+            <div id="newPartClefList" class="ms-stack-sm" aria-live="polite"></div>
           </div>
 
           <div id="fileInputBlock" class="ms-block">
@@ -738,9 +779,16 @@ const q = (selector) => {
 };
 const inputTypeXml = q("#inputTypeXml");
 const inputTypeAbc = q("#inputTypeAbc");
+const inputTypeNew = q("#inputTypeNew");
 const inputModeFile = q("#inputModeFile");
 const inputModeSource = q("#inputModeSource");
 const inputSectionDetails = q("#inputSectionDetails");
+const newInputBlock = q("#newInputBlock");
+const newPartCountInput = q("#newPartCount");
+const newKeyFifthsSelect = q("#newKeyFifths");
+const newTimeBeatsInput = q("#newTimeBeats");
+const newTimeBeatTypeSelect = q("#newTimeBeatType");
+const newPartClefList = q("#newPartClefList");
 const fileInputBlock = q("#fileInputBlock");
 const sourceXmlInputBlock = q("#sourceXmlInputBlock");
 const abcInputBlock = q("#abcInputBlock");
@@ -810,6 +858,7 @@ let suppressDurationPresetEvent = false;
 let selectedDraftDurationValue = null;
 const NOTE_CLICK_SNAP_PX = 170;
 const DEFAULT_DIVISIONS = 480;
+const MAX_NEW_PARTS = 16;
 const logDiagnostics = (phase, diagnostics, warnings = []) => {
     if (!DEBUG_LOG)
         return;
@@ -883,13 +932,80 @@ const dumpOverfullContext = (xml, voice) => {
 };
 const renderInputMode = () => {
     const isAbcType = inputTypeAbc.checked;
+    const isNewType = inputTypeNew.checked;
     const fileMode = inputModeFile.checked;
-    fileInputBlock.classList.toggle("md-hidden", !fileMode);
-    sourceXmlInputBlock.classList.toggle("md-hidden", fileMode || isAbcType);
-    abcInputBlock.classList.toggle("md-hidden", fileMode || !isAbcType);
+    newInputBlock.classList.toggle("md-hidden", !isNewType);
+    fileInputBlock.classList.toggle("md-hidden", isNewType || !fileMode);
+    sourceXmlInputBlock.classList.toggle("md-hidden", isNewType || fileMode || isAbcType);
+    abcInputBlock.classList.toggle("md-hidden", isNewType || fileMode || !isAbcType);
+    inputModeFile.disabled = isNewType;
+    inputModeSource.disabled = isNewType;
+    const loadLabel = loadBtn.querySelector("span");
+    if (loadLabel) {
+        loadLabel.textContent = isNewType ? "新規作成" : "読み込み";
+    }
     fileInput.accept = isAbcType
         ? ".abc,text/plain"
         : ".musicxml,.xml,text/xml,application/xml";
+};
+const normalizeNewPartCount = () => {
+    const raw = Number(newPartCountInput.value);
+    const bounded = Number.isFinite(raw) ? Math.max(1, Math.min(MAX_NEW_PARTS, Math.round(raw))) : 1;
+    newPartCountInput.value = String(bounded);
+    return bounded;
+};
+const normalizeNewTimeBeats = () => {
+    const raw = Number(newTimeBeatsInput.value);
+    const bounded = Number.isFinite(raw) ? Math.max(1, Math.min(16, Math.round(raw))) : 4;
+    newTimeBeatsInput.value = String(bounded);
+    return bounded;
+};
+const normalizeNewTimeBeatType = () => {
+    const raw = Number(newTimeBeatTypeSelect.value);
+    const allowed = new Set([2, 4, 8, 16]);
+    const normalized = allowed.has(raw) ? raw : 4;
+    newTimeBeatTypeSelect.value = String(normalized);
+    return normalized;
+};
+const normalizeClefKeyword = (raw) => {
+    const clef = String(raw || "").trim().toLowerCase();
+    if (clef === "treble" || clef === "alto" || clef === "bass")
+        return clef;
+    return "treble";
+};
+const listCurrentNewPartClefs = () => {
+    return Array.from(newPartClefList.querySelectorAll("select[data-part-clef]")).map((select) => normalizeClefKeyword(select.value));
+};
+const renderNewPartClefControls = () => {
+    var _a;
+    const count = normalizeNewPartCount();
+    const previous = listCurrentNewPartClefs();
+    newPartClefList.innerHTML = "";
+    for (let i = 0; i < count; i += 1) {
+        const row = document.createElement("div");
+        row.className = "ms-form-row";
+        const label = document.createElement("label");
+        label.className = "ms-field";
+        label.textContent = `パート${i + 1} 記号`;
+        const select = document.createElement("select");
+        select.className = "md-select";
+        select.setAttribute("data-part-clef", "true");
+        const options = [
+            { value: "treble", label: "ト音記号" },
+            { value: "alto", label: "ハ音記号" },
+            { value: "bass", label: "ヘ音記号" },
+        ];
+        for (const optionDef of options) {
+            const option = document.createElement("option");
+            option.value = optionDef.value;
+            option.textContent = optionDef.label;
+            select.appendChild(option);
+        }
+        select.value = normalizeClefKeyword((_a = previous[i]) !== null && _a !== void 0 ? _a : "treble");
+        label.appendChild(select);
+        row.appendChild(label);
+        newPartClefList.appendChild(row);
+    }
 };
 const renderStatus = () => {
     const dirty = core.isDirty();
@@ -2367,6 +2483,9 @@ const buildMusicXmlFromAbcParsed = (parsed) => {
                     "<divisions>960</divisions>",
                     `<key><fifths>${Math.round(fifths)}</fifths></key>`,
                     `<time><beats>${Math.round(beats)}</beats><beat-type>${Math.round(beatType)}</beat-type></time>`,
+                    part.transpose && Number.isFinite(part.transpose.chromatic)
+                        ? `<transpose><chromatic>${Math.round(part.transpose.chromatic)}</chromatic></transpose>`
+                        : "",
                     clefXmlFromAbcClef(part.clef),
                     "</attributes>",
                 ].join("")
@@ -2484,6 +2603,12 @@ const loadFromText = (xml, collapseInputSection) => {
 };
 const onLoadClick = async () => {
     var _a;
+    if (inputTypeNew.checked) {
+        const sourceText = createNewMusicXml();
+        xmlInput.value = sourceText;
+        loadFromText(sourceText, true);
+        return;
+    }
     let sourceText = "";
     const treatAsAbc = inputTypeAbc.checked;
     if (inputModeFile.checked) {
@@ -2539,6 +2664,71 @@ const onLoadClick = async () => {
         return;
     }
     loadFromText(sourceText, true);
+};
+const createNewMusicXml = () => {
+    const partCount = normalizeNewPartCount();
+    const parsedFifths = Number(newKeyFifthsSelect.value);
+    const fifths = Number.isFinite(parsedFifths) ? Math.max(-7, Math.min(7, Math.round(parsedFifths))) : 0;
+    const beats = normalizeNewTimeBeats();
+    const beatType = normalizeNewTimeBeatType();
+    const divisions = 960;
+    const measureCount = 8;
+    const measureDuration = Math.max(1, Math.round(divisions * beats * (4 / beatType)));
+    const clefs = listCurrentNewPartClefs();
+    const partListXml = Array.from({ length: partCount }, (_, i) => {
+        const partId = `P${i + 1}`;
+        const midiChannel = ((i % 16) + 1 === 10) ? 11 : ((i % 16) + 1);
+        return [
+            `<score-part id="${partId}">`,
+            `<part-name>Part ${i + 1}</part-name>`,
+            `<midi-instrument id="${partId}-I1">`,
+            `<midi-channel>${midiChannel}</midi-channel>`,
+            `<midi-program>6</midi-program>`,
+            "</midi-instrument>",
+            "</score-part>",
+        ].join("");
+    }).join("");
+    const partsXml = Array.from({ length: partCount }, (_, i) => {
+        var _a;
+        const partId = `P${i + 1}`;
+        const clefKeyword = normalizeClefKeyword((_a = clefs[i]) !== null && _a !== void 0 ? _a : "treble");
+        const clefXml = clefXmlFromAbcClef(clefKeyword);
+        const measuresXml = Array.from({ length: measureCount }, (_unused, m) => {
+            const number = m + 1;
+            const attrs = m === 0
+                ? [
+                    "<attributes>",
+                    `<divisions>${divisions}</divisions>`,
+                    `<key><fifths>${fifths}</fifths><mode>major</mode></key>`,
+                    `<time><beats>${beats}</beats><beat-type>${beatType}</beat-type></time>`,
+                    clefXml,
+                    "</attributes>",
+                ].join("")
+                : "";
+            return [
+                `<measure number="${number}">`,
+                attrs,
+                `<note><rest measure="yes"/><duration>${measureDuration}</duration><voice>1</voice></note>`,
+                "</measure>",
+            ].join("");
+        }).join("");
+        return [
+            `<part id="${partId}">`,
+            measuresXml,
+            "</part>",
+        ].join("");
+    }).join("");
+    return `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <work>
+    <work-title>Untitled</work-title>
+  </work>
+  <identification>
+    <creator type="composer">Unknown</creator>
+  </identification>
+  <part-list>${partListXml}</part-list>
+  ${partsXml}
+</score-partwise>`;
 };
 const requireSelectedNode = () => {
     if (!draftCore) {
@@ -3037,8 +3227,11 @@ const onDownloadAbc = () => {
 };
 inputTypeXml.addEventListener("change", renderInputMode);
 inputTypeAbc.addEventListener("change", renderInputMode);
+inputTypeNew.addEventListener("change", renderInputMode);
 inputModeFile.addEventListener("change", renderInputMode);
 inputModeSource.addEventListener("change", renderInputMode);
+newPartCountInput.addEventListener("change", renderNewPartClefControls);
+newPartCountInput.addEventListener("input", renderNewPartClefControls);
 fileSelectBtn.addEventListener("click", () => fileInput.click());
 fileInput.addEventListener("change", () => {
     var _a;
@@ -3088,6 +3281,7 @@ measureDiscardBtn.addEventListener("click", onMeasureDiscard);
 playMeasureBtn.addEventListener("click", () => {
     void startMeasurePlayback();
 });
+renderNewPartClefControls();
 loadFromText(xmlInput.value, false);
 
   },
@@ -17703,6 +17897,7 @@ function parseForMusicXml(source, settings) {
     const declaredVoiceIds = [];
     const voiceNameById = {};
     const voiceClefById = {};
+    const voiceTransposeById = {};
     let currentVoiceId = "1";
     let scoreDirective = "";
     for (let i = 0; i < lines.length; i += 1) {
@@ -17738,6 +17933,9 @@ function parseForMusicXml(source, settings) {
                 }
                 if (parsedVoice.clef) {
                     voiceClefById[currentVoiceId] = parsedVoice.clef;
+                }
+                if (parsedVoice.transpose) {
+                    voiceTransposeById[currentVoiceId] = parsedVoice.transpose;
                 }
                 if (parsedVoice.bodyText) {
                     bodyEntries.push({ text: parsedVoice.bodyText, lineNo, voiceId: currentVoiceId });
@@ -18024,11 +18222,13 @@ function parseForMusicXml(source, settings) {
     const orderedVoiceIds = parseScoreVoiceOrder(scoreDirective, declaredVoiceIds);
     const parts = orderedVoiceIds.map((voiceId, index) => {
         const partName = voiceNameById[voiceId] || ("Voice " + voiceId);
+        const transpose = voiceTransposeById[voiceId] ||
+            (settings.inferTransposeFromPartName ? inferTransposeFromPartName(partName) : null);
         return {
             partId: "P" + String(index + 1),
             partName,
             clef: voiceClefById[voiceId] || "",
-            transpose: settings.inferTransposeFromPartName ? inferTransposeFromPartName(partName) : null,
+            transpose,
             voiceId,
             measures: measuresByVoice[voiceId] || [[]]
         };
@@ -18085,11 +18285,12 @@ function parseScoreVoiceOrder(raw, declaredVoiceIds) {
 }
 function parseVoiceDirectiveTail(raw) {
     if (!raw) {
-        return { name: "", clef: "", bodyText: "" };
+        return { name: "", clef: "", transpose: null, bodyText: "" };
     }
     let bodyText = String(raw);
     let name = "";
     let clef = "";
+    let transpose = null;
     const attrRegex = /([A-Za-z][A-Za-z0-9_-]*)\s*=\s*("([^"]*)"|(\S+))/g;
     bodyText = bodyText.replace(attrRegex, (_full, key, _quotedValue, quotedInner, bareValue) => {
         const lowerKey = String(key).toLowerCase();
@@ -18099,11 +18300,18 @@ function parseVoiceDirectiveTail(raw) {
         else if (lowerKey === "clef") {
             clef = String(quotedInner || bareValue || "").trim().toLowerCase();
         }
+        else if (lowerKey === "transpose") {
+            const parsed = Number.parseInt(String(quotedInner || bareValue || "").trim(), 10);
+            if (Number.isFinite(parsed) && parsed >= -24 && parsed <= 24) {
+                transpose = { chromatic: parsed };
+            }
+        }
         return " ";
     });
     return {
         name: name.trim(),
         clef: clef.trim(),
+        transpose,
         bodyText: bodyText.trim()
     };
 }

--- a/src/ts/main.ts
+++ b/src/ts/main.ts
@@ -55,9 +55,16 @@ const q = <T extends Element>(selector: string): T => {
 
 const inputTypeXml = q<HTMLInputElement>("#inputTypeXml");
 const inputTypeAbc = q<HTMLInputElement>("#inputTypeAbc");
+const inputTypeNew = q<HTMLInputElement>("#inputTypeNew");
 const inputModeFile = q<HTMLInputElement>("#inputModeFile");
 const inputModeSource = q<HTMLInputElement>("#inputModeSource");
 const inputSectionDetails = q<HTMLDetailsElement>("#inputSectionDetails");
+const newInputBlock = q<HTMLDivElement>("#newInputBlock");
+const newPartCountInput = q<HTMLInputElement>("#newPartCount");
+const newKeyFifthsSelect = q<HTMLSelectElement>("#newKeyFifths");
+const newTimeBeatsInput = q<HTMLInputElement>("#newTimeBeats");
+const newTimeBeatTypeSelect = q<HTMLSelectElement>("#newTimeBeatType");
+const newPartClefList = q<HTMLDivElement>("#newPartClefList");
 const fileInputBlock = q<HTMLDivElement>("#fileInputBlock");
 const sourceXmlInputBlock = q<HTMLDivElement>("#sourceXmlInputBlock");
 const abcInputBlock = q<HTMLDivElement>("#abcInputBlock");
@@ -129,6 +136,7 @@ let suppressDurationPresetEvent = false;
 let selectedDraftDurationValue: number | null = null;
 const NOTE_CLICK_SNAP_PX = 170;
 const DEFAULT_DIVISIONS = 480;
+const MAX_NEW_PARTS = 16;
 
 const logDiagnostics = (
   phase: "load" | "dispatch" | "save" | "playback",
@@ -217,14 +225,93 @@ const dumpOverfullContext = (xml: string, voice: string): void => {
 
 const renderInputMode = (): void => {
   const isAbcType = inputTypeAbc.checked;
+  const isNewType = inputTypeNew.checked;
   const fileMode = inputModeFile.checked;
-  fileInputBlock.classList.toggle("md-hidden", !fileMode);
-  sourceXmlInputBlock.classList.toggle("md-hidden", fileMode || isAbcType);
-  abcInputBlock.classList.toggle("md-hidden", fileMode || !isAbcType);
+  newInputBlock.classList.toggle("md-hidden", !isNewType);
+  fileInputBlock.classList.toggle("md-hidden", isNewType || !fileMode);
+  sourceXmlInputBlock.classList.toggle("md-hidden", isNewType || fileMode || isAbcType);
+  abcInputBlock.classList.toggle("md-hidden", isNewType || fileMode || !isAbcType);
+
+  inputModeFile.disabled = isNewType;
+  inputModeSource.disabled = isNewType;
+  const loadLabel = loadBtn.querySelector("span");
+  if (loadLabel) {
+    loadLabel.textContent = isNewType ? "新規作成" : "読み込み";
+  }
 
   fileInput.accept = isAbcType
     ? ".abc,text/plain"
     : ".musicxml,.xml,text/xml,application/xml";
+};
+
+const normalizeNewPartCount = (): number => {
+  const raw = Number(newPartCountInput.value);
+  const bounded = Number.isFinite(raw) ? Math.max(1, Math.min(MAX_NEW_PARTS, Math.round(raw))) : 1;
+  newPartCountInput.value = String(bounded);
+  return bounded;
+};
+
+const normalizeNewTimeBeats = (): number => {
+  const raw = Number(newTimeBeatsInput.value);
+  const bounded = Number.isFinite(raw) ? Math.max(1, Math.min(16, Math.round(raw))) : 4;
+  newTimeBeatsInput.value = String(bounded);
+  return bounded;
+};
+
+const normalizeNewTimeBeatType = (): number => {
+  const raw = Number(newTimeBeatTypeSelect.value);
+  const allowed = new Set([2, 4, 8, 16]);
+  const normalized = allowed.has(raw) ? raw : 4;
+  newTimeBeatTypeSelect.value = String(normalized);
+  return normalized;
+};
+
+const normalizeClefKeyword = (raw: string): string => {
+  const clef = String(raw || "").trim().toLowerCase();
+  if (clef === "treble" || clef === "alto" || clef === "bass") return clef;
+  return "treble";
+};
+
+const listCurrentNewPartClefs = (): string[] => {
+  return Array.from(newPartClefList.querySelectorAll<HTMLSelectElement>("select[data-part-clef]")).map((select) =>
+    normalizeClefKeyword(select.value)
+  );
+};
+
+const renderNewPartClefControls = (): void => {
+  const count = normalizeNewPartCount();
+  const previous = listCurrentNewPartClefs();
+  newPartClefList.innerHTML = "";
+
+  for (let i = 0; i < count; i += 1) {
+    const row = document.createElement("div");
+    row.className = "ms-form-row";
+
+    const label = document.createElement("label");
+    label.className = "ms-field";
+    label.textContent = `パート${i + 1} 記号`;
+
+    const select = document.createElement("select");
+    select.className = "md-select";
+    select.setAttribute("data-part-clef", "true");
+
+    const options: Array<{ value: string; label: string }> = [
+      { value: "treble", label: "ト音記号" },
+      { value: "alto", label: "ハ音記号" },
+      { value: "bass", label: "ヘ音記号" },
+    ];
+    for (const optionDef of options) {
+      const option = document.createElement("option");
+      option.value = optionDef.value;
+      option.textContent = optionDef.label;
+      select.appendChild(option);
+    }
+
+    select.value = normalizeClefKeyword(previous[i] ?? "treble");
+    label.appendChild(select);
+    row.appendChild(label);
+    newPartClefList.appendChild(row);
+  }
 };
 
 const renderStatus = (): void => {
@@ -1737,6 +1824,7 @@ type AbcParsedPart = {
   partId: string;
   partName: string;
   clef?: string;
+  transpose?: { chromatic: number } | null;
   measures: AbcParsedNote[][];
 };
 
@@ -1813,6 +1901,9 @@ const buildMusicXmlFromAbcParsed = (parsed: AbcParsedResult): string => {
                 "<divisions>960</divisions>",
                 `<key><fifths>${Math.round(fifths)}</fifths></key>`,
                 `<time><beats>${Math.round(beats)}</beats><beat-type>${Math.round(beatType)}</beat-type></time>`,
+                part.transpose && Number.isFinite(part.transpose.chromatic)
+                  ? `<transpose><chromatic>${Math.round(part.transpose.chromatic)}</chromatic></transpose>`
+                  : "",
                 clefXmlFromAbcClef(part.clef),
                 "</attributes>",
               ].join("")
@@ -1930,6 +2021,13 @@ const loadFromText = (xml: string, collapseInputSection: boolean): void => {
 };
 
 const onLoadClick = async (): Promise<void> => {
+  if (inputTypeNew.checked) {
+    const sourceText = createNewMusicXml();
+    xmlInput.value = sourceText;
+    loadFromText(sourceText, true);
+    return;
+  }
+
   let sourceText = "";
   const treatAsAbc = inputTypeAbc.checked;
 
@@ -1984,6 +2082,74 @@ const onLoadClick = async (): Promise<void> => {
   }
 
   loadFromText(sourceText, true);
+};
+
+const createNewMusicXml = (): string => {
+  const partCount = normalizeNewPartCount();
+  const parsedFifths = Number(newKeyFifthsSelect.value);
+  const fifths = Number.isFinite(parsedFifths) ? Math.max(-7, Math.min(7, Math.round(parsedFifths))) : 0;
+  const beats = normalizeNewTimeBeats();
+  const beatType = normalizeNewTimeBeatType();
+  const divisions = 960;
+  const measureCount = 8;
+  const measureDuration = Math.max(1, Math.round(divisions * beats * (4 / beatType)));
+  const clefs = listCurrentNewPartClefs();
+
+  const partListXml = Array.from({ length: partCount }, (_, i) => {
+    const partId = `P${i + 1}`;
+    const midiChannel = ((i % 16) + 1 === 10) ? 11 : ((i % 16) + 1);
+    return [
+      `<score-part id="${partId}">`,
+      `<part-name>Part ${i + 1}</part-name>`,
+      `<midi-instrument id="${partId}-I1">`,
+      `<midi-channel>${midiChannel}</midi-channel>`,
+      `<midi-program>6</midi-program>`,
+      "</midi-instrument>",
+      "</score-part>",
+    ].join("");
+  }).join("");
+
+  const partsXml = Array.from({ length: partCount }, (_, i) => {
+    const partId = `P${i + 1}`;
+    const clefKeyword = normalizeClefKeyword(clefs[i] ?? "treble");
+    const clefXml = clefXmlFromAbcClef(clefKeyword);
+    const measuresXml = Array.from({ length: measureCount }, (_unused, m) => {
+      const number = m + 1;
+      const attrs = m === 0
+        ? [
+            "<attributes>",
+            `<divisions>${divisions}</divisions>`,
+            `<key><fifths>${fifths}</fifths><mode>major</mode></key>`,
+            `<time><beats>${beats}</beats><beat-type>${beatType}</beat-type></time>`,
+            clefXml,
+            "</attributes>",
+          ].join("")
+        : "";
+      return [
+        `<measure number="${number}">`,
+        attrs,
+        `<note><rest measure="yes"/><duration>${measureDuration}</duration><voice>1</voice></note>`,
+        "</measure>",
+      ].join("");
+    }).join("");
+    return [
+      `<part id="${partId}">`,
+      measuresXml,
+      "</part>",
+    ].join("");
+  }).join("");
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <work>
+    <work-title>Untitled</work-title>
+  </work>
+  <identification>
+    <creator type="composer">Unknown</creator>
+  </identification>
+  <part-list>${partListXml}</part-list>
+  ${partsXml}
+</score-partwise>`;
 };
 
 const requireSelectedNode = (): string | null => {
@@ -2488,8 +2654,11 @@ const onDownloadAbc = (): void => {
 
 inputTypeXml.addEventListener("change", renderInputMode);
 inputTypeAbc.addEventListener("change", renderInputMode);
+inputTypeNew.addEventListener("change", renderInputMode);
 inputModeFile.addEventListener("change", renderInputMode);
 inputModeSource.addEventListener("change", renderInputMode);
+newPartCountInput.addEventListener("change", renderNewPartClefControls);
+newPartCountInput.addEventListener("input", renderNewPartClefControls);
 fileSelectBtn.addEventListener("click", () => fileInput.click());
 fileInput.addEventListener("change", () => {
   const f = fileInput.files?.[0];
@@ -2538,4 +2707,5 @@ playMeasureBtn.addEventListener("click", () => {
   void startMeasurePlayback();
 });
 
+renderNewPartClefControls();
 loadFromText(xmlInput.value, false);


### PR DESCRIPTION
### 概要
このPRでは、ABC読み込み時の移調楽器対応を強化し、入力UIに「新規作成」フローを追加しました。
あわせて、新規作成時に拍子・調号・パート数・記号を指定して、8小節の空譜（休符）を自動生成できるようにしています。

### 変更内容
1. ABCの移調情報対応を強化
- `src/ts/abc-compat-parser.ts`
  - `V:` 属性から `transpose=` をパースして保持
  - `name` 由来推定より `transpose` 明示指定を優先
- `src/ts/main.ts`
  - ABC→MusicXML変換時に `<transpose><chromatic>...</chromatic></transpose>` を出力
  - `AbcParsedPart` 型に `transpose` を追加

2. 入力UIに「新規作成」を追加
- `mikuscore-src.html`
  - 入力フォーマットに `新規作成` ラジオを追加
  - 新規作成専用設定ブロックを追加:
    - トラック数（パート数）
    - 拍子（拍数 / 拍の単位）
    - 調号
    - 各パートの記号（ト音 / ハ音 / ヘ音）

3. 新規MusicXML生成ロジックを実装
- `src/ts/main.ts`
  - `inputTypeNew` 選択時の読み込み処理を追加
  - `createNewMusicXml()` を実装し、設定値を反映
  - 生成内容:
    - 指定パート数の `part-list` / `part`
    - 先頭小節に拍子・調号・記号設定
    - 各パートに **8小節** の休符（`rest measure="yes"`）を生成

4. UIの挙動調整
- `src/ts/main.ts`
  - `renderInputMode()` で新規作成時の表示切替・入力モード無効化
  - 新規作成時はボタン文言を `新規作成` に切替
  - パート数変更に応じて記号選択UIを動的再生成

### 変更ファイル
- `mikuscore-src.html`
- `src/ts/main.ts`
- `src/ts/abc-compat-parser.ts`
- `mikuscore.html`（build成果物）
- `src/js/main.js`（build成果物）

### 期待効果
- ABC入力での移調楽器（例: clarinet in A など）の扱いが正確になる
- 新規譜面作成の初期セットアップがUI上で完結する
- モバイル利用時も含め、初期作業の操作負荷を下げられる