### PR TITLE
refactor: MusicXML処理をDOM中心に統一し、設計方針をARCHITECTUREへ明記

### DIFF
--- a/docs/spec/ARCHITECTURE.md
+++ b/docs/spec/ARCHITECTURE.md
@@ -26,6 +26,21 @@ This document defines high-level architecture boundaries for mikuscore MVP.
 
 UI MUST NOT mutate XML DOM directly.
 
+## DOM-Centric Data Flow
+
+- Internal processing SHOULD be DOM-centric:
+  - parse once to `Document`
+  - pass `Document` between I/O / transform / render-prep modules
+  - serialize only at strict external boundaries
+- This reduces repeated parse/serialize cycles and keeps transformation intent explicit.
+
+### Exceptions (Text Boundaries)
+
+- The following boundaries are intentionally text-based in current architecture:
+  - `ScoreCore` public API boundary (`load(xmlText)`, `save().xml`, `debugSerializeCurrentXml()`)
+  - Verovio toolkit boundary (`toolkit.loadData(xmlText)`)
+- Outside these boundaries, modules SHOULD prefer `Document` interfaces.
+
 ## Rendering Boundary (Verovio)
 
 - `Verovio` is the ground-truth notation renderer in UI layer.

--- a/mikuscore.html
+++ b/mikuscore.html
@@ -873,8 +873,8 @@ const dumpOverfullContext = (xml, voice) => {
     var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k;
     if (!DEBUG_LOG)
         return;
-    const doc = new DOMParser().parseFromString(xml, "application/xml");
-    if (doc.querySelector("parsererror")) {
+    const doc = (0, musicxml_io_1.parseMusicXmlDocument)(xml);
+    if (!doc) {
         console.error("[mikuscore][debug] XML parse failed while dumping overfull context.");
         return;
     }
@@ -1227,8 +1227,8 @@ const syncStepFromSelectedDraftNote = () => {
         renderAlterButtons();
         return;
     }
-    const doc = new DOMParser().parseFromString(xml, "application/xml");
-    if (doc.querySelector("parsererror")) {
+    const doc = (0, musicxml_io_1.parseMusicXmlDocument)(xml);
+    if (!doc) {
         selectedDraftVoice = EDITABLE_VOICE;
         selectedDraftDurationValue = null;
         rebuildDurationPresetOptions(DEFAULT_DIVISIONS);
@@ -1499,12 +1499,9 @@ const setUiMappingDiagnostic = (message) => {
     };
     renderAll();
 };
-const rebuildNodeLocationMap = (xml) => {
+const rebuildNodeLocationMap = (doc) => {
     var _a, _b;
     nodeIdToLocation = new Map();
-    const doc = new DOMParser().parseFromString(xml, "application/xml");
-    if (doc.querySelector("parsererror"))
-        return;
     const notes = Array.from(doc.querySelectorAll("part > measure > note"));
     const count = Math.min(notes.length, state.noteNodeIds.length);
     for (let i = 0; i < count; i += 1) {
@@ -1521,12 +1518,9 @@ const rebuildNodeLocationMap = (xml) => {
         nodeIdToLocation.set(nodeId, { partId, measureNumber });
     }
 };
-const rebuildPartNameMap = (xml) => {
+const rebuildPartNameMap = (doc) => {
     var _a, _b, _c, _d, _e, _f;
     partIdToName = new Map();
-    const doc = new DOMParser().parseFromString(xml, "application/xml");
-    if (doc.querySelector("parsererror"))
-        return;
     for (const scorePart of Array.from(doc.querySelectorAll("score-partwise > part-list > score-part"))) {
         const partId = (_b = (_a = scorePart.getAttribute("id")) === null || _a === void 0 ? void 0 : _a.trim()) !== null && _b !== void 0 ? _b : "";
         if (!partId)
@@ -1897,8 +1891,15 @@ const refreshNotesFromCore = () => {
     state.noteNodeIds = core.listNoteNodeIds();
     const currentXml = core.debugSerializeCurrentXml();
     if (currentXml) {
-        rebuildNodeLocationMap(currentXml);
-        rebuildPartNameMap(currentXml);
+        const currentDoc = (0, musicxml_io_1.parseMusicXmlDocument)(currentXml);
+        if (currentDoc) {
+            rebuildNodeLocationMap(currentDoc);
+            rebuildPartNameMap(currentDoc);
+        }
+        else {
+            nodeIdToLocation = new Map();
+            partIdToName = new Map();
+        }
     }
     else {
         nodeIdToLocation = new Map();
@@ -2824,12 +2825,8 @@ const onDownload = () => {
     a.click();
     URL.revokeObjectURL(url);
 };
-const convertMusicXmlToAbc = (xml) => {
+const convertMusicXmlToAbc = (doc) => {
     var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p, _q, _r, _s;
-    const doc = new DOMParser().parseFromString(xml, "application/xml");
-    if (doc.querySelector("parsererror")) {
-        throw new Error("MusicXMLの解析に失敗しました。");
-    }
     const title = ((_b = (_a = doc.querySelector("work > work-title")) === null || _a === void 0 ? void 0 : _a.textContent) === null || _b === void 0 ? void 0 : _b.trim()) ||
         ((_d = (_c = doc.querySelector("movement-title")) === null || _c === void 0 ? void 0 : _c.textContent) === null || _d === void 0 ? void 0 : _d.trim()) ||
         "mikuscore";
@@ -3033,9 +3030,12 @@ const onDownloadMidi = () => {
 const onDownloadAbc = () => {
     if (!state.lastSuccessfulSaveXml)
         return;
+    const musicXmlDoc = (0, musicxml_io_1.parseMusicXmlDocument)(state.lastSuccessfulSaveXml);
+    if (!musicXmlDoc)
+        return;
     let abcText = "";
     try {
-        abcText = convertMusicXmlToAbc(state.lastSuccessfulSaveXml);
+        abcText = convertMusicXmlToAbc(musicXmlDoc);
     }
     catch (_a) {
         return;


### PR DESCRIPTION
### 概要
`main.ts` 内に残っていた `DOMParser` 直利用箇所を `parseMusicXmlDocument` ベースへ寄せ、MusicXML処理のインタフェースをより DOM 中心に統一しました。 あわせて、アーキテクチャ仕様に「DOM-Centric Data Flow」と例外境界を追記しました。

### 変更内容
1. `docs/spec/ARCHITECTURE.md` の更新
- `DOM-Centric Data Flow` セクションを追加
- 例外的に文字列境界となる箇所を明記:
  - `ScoreCore` API (`load/save/debugSerializeCurrentXml`)
  - Verovio `toolkit.loadData(xmlText)`

2. `src/ts/main.ts` のDOM寄せ
- `dumpOverfullContext` のXML解析を `parseMusicXmlDocument` に統一
- `syncStepFromSelectedDraftNote` のXML解析を `parseMusicXmlDocument` に統一
- `rebuildNodeLocationMap` / `rebuildPartNameMap` を `Document` 受け取りへ変更
- `refreshNotesFromCore` で一度 `Document` 化してから上記関数を呼ぶ構造に変更
- `convertMusicXmlToAbc` を `string` 受け取りから `Document` 受け取りへ変更
- `onDownloadAbc` で事前に `Document` 化してからABC変換を実行

3. ビルド成果物更新
- `src/js/main.js`
- `mikuscore.html`

### 意図
- `main.ts` 側のXML文字列パース重複を減らす
- 「内部はDOM中心、境界のみ文字列」の設計を実装と仕様で一致させる
- 今後の分割・再利用（I/Oモジュール化）を進めやすくする