### PR TITLE
fix: 小節置換時の不要attributes混入を防止し、休符音符化の初期音をC4に固定

### DIFF
--- a/mikuscore.html
+++ b/mikuscore.html
@@ -2362,15 +2362,7 @@ const onConvertRestToNote = () => {
     const targetNodeId = requireSelectedNode();
     if (!targetNodeId)
         return;
-    const stepRaw = pitchStep.value.trim();
-    const step = isPitchStepValue(stepRaw) ? stepRaw : "C";
-    const octaveRaw = Number(pitchOctave.value);
-    const octave = Number.isInteger(octaveRaw) ? octaveRaw : 4;
-    const alterText = normalizeAlterValue(pitchAlter.value);
-    const alterNum = Number(alterText);
-    const pitch = alterText !== "none" && Number.isInteger(alterNum) && alterNum >= -2 && alterNum <= 2
-        ? { step, octave, alter: alterNum }
-        : { step, octave };
+    const pitch = { step: "C", octave: 4 };
     const command = {
         type: "change_to_pitch",
         targetNodeId,
@@ -17160,6 +17152,14 @@ const replaceMeasureInMainDocument = (mainDoc, partId, measureNumber, measureDoc
     const targetMeasure = findMeasureByNumber(targetPart, measureNumber);
     if (!targetMeasure)
         return null;
+    const replacementForMain = replacementMeasure.cloneNode(true);
+    const replacementAttrs = replacementForMain.querySelector(":scope > attributes");
+    const targetAttrs = targetMeasure.querySelector(":scope > attributes");
+    // Editing preview injects effective attributes for rendering.
+    // Do not introduce them into the main score when the original measure had none.
+    if (replacementAttrs && !targetAttrs) {
+        replacementAttrs.remove();
+    }
     const next = cloneXmlDocument(mainDoc);
     const nextPart = findPartById(next, partId);
     if (!nextPart)
@@ -17167,7 +17167,7 @@ const replaceMeasureInMainDocument = (mainDoc, partId, measureNumber, measureDoc
     const nextTargetMeasure = findMeasureByNumber(nextPart, measureNumber);
     if (!nextTargetMeasure)
         return null;
-    nextTargetMeasure.replaceWith(next.importNode(replacementMeasure, true));
+    nextTargetMeasure.replaceWith(next.importNode(replacementForMain, true));
     return next;
 };
 exports.replaceMeasureInMainDocument = replaceMeasureInMainDocument;

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -1601,15 +1601,7 @@ const onConvertRestToNote = () => {
     const targetNodeId = requireSelectedNode();
     if (!targetNodeId)
         return;
-    const stepRaw = pitchStep.value.trim();
-    const step = isPitchStepValue(stepRaw) ? stepRaw : "C";
-    const octaveRaw = Number(pitchOctave.value);
-    const octave = Number.isInteger(octaveRaw) ? octaveRaw : 4;
-    const alterText = normalizeAlterValue(pitchAlter.value);
-    const alterNum = Number(alterText);
-    const pitch = alterText !== "none" && Number.isInteger(alterNum) && alterNum >= -2 && alterNum <= 2
-        ? { step, octave, alter: alterNum }
-        : { step, octave };
+    const pitch = { step: "C", octave: 4 };
     const command = {
         type: "change_to_pitch",
         targetNodeId,
@@ -16399,6 +16391,14 @@ const replaceMeasureInMainDocument = (mainDoc, partId, measureNumber, measureDoc
     const targetMeasure = findMeasureByNumber(targetPart, measureNumber);
     if (!targetMeasure)
         return null;
+    const replacementForMain = replacementMeasure.cloneNode(true);
+    const replacementAttrs = replacementForMain.querySelector(":scope > attributes");
+    const targetAttrs = targetMeasure.querySelector(":scope > attributes");
+    // Editing preview injects effective attributes for rendering.
+    // Do not introduce them into the main score when the original measure had none.
+    if (replacementAttrs && !targetAttrs) {
+        replacementAttrs.remove();
+    }
     const next = cloneXmlDocument(mainDoc);
     const nextPart = findPartById(next, partId);
     if (!nextPart)
@@ -16406,7 +16406,7 @@ const replaceMeasureInMainDocument = (mainDoc, partId, measureNumber, measureDoc
     const nextTargetMeasure = findMeasureByNumber(nextPart, measureNumber);
     if (!nextTargetMeasure)
         return null;
-    nextTargetMeasure.replaceWith(next.importNode(replacementMeasure, true));
+    nextTargetMeasure.replaceWith(next.importNode(replacementForMain, true));
     return next;
 };
 exports.replaceMeasureInMainDocument = replaceMeasureInMainDocument;

--- a/src/ts/main.ts
+++ b/src/ts/main.ts
@@ -1711,17 +1711,7 @@ const onConvertRestToNote = (): void => {
   if (!selectedDraftNoteIsRest) return;
   const targetNodeId = requireSelectedNode();
   if (!targetNodeId) return;
-
-  const stepRaw = pitchStep.value.trim();
-  const step: Pitch["step"] = isPitchStepValue(stepRaw) ? stepRaw : "C";
-  const octaveRaw = Number(pitchOctave.value);
-  const octave = Number.isInteger(octaveRaw) ? octaveRaw : 4;
-  const alterText = normalizeAlterValue(pitchAlter.value);
-  const alterNum = Number(alterText);
-  const pitch: Pitch =
-    alterText !== "none" && Number.isInteger(alterNum) && alterNum >= -2 && alterNum <= 2
-      ? { step, octave, alter: alterNum as -2 | -1 | 0 | 1 | 2 }
-      : { step, octave };
+  const pitch: Pitch = { step: "C", octave: 4 };
 
   const command: ChangePitchCommand = {
     type: "change_to_pitch",

--- a/src/ts/musicxml-io.ts
+++ b/src/ts/musicxml-io.ts
@@ -184,12 +184,20 @@ export const replaceMeasureInMainDocument = (
   const targetMeasure = findMeasureByNumber(targetPart, measureNumber);
   if (!targetMeasure) return null;
 
+  const replacementForMain = replacementMeasure.cloneNode(true) as Element;
+  const replacementAttrs = replacementForMain.querySelector(":scope > attributes");
+  const targetAttrs = targetMeasure.querySelector(":scope > attributes");
+  // Editing preview injects effective attributes for rendering.
+  // Do not introduce them into the main score when the original measure had none.
+  if (replacementAttrs && !targetAttrs) {
+    replacementAttrs.remove();
+  }
+
   const next = cloneXmlDocument(mainDoc);
   const nextPart = findPartById(next, partId);
   if (!nextPart) return null;
   const nextTargetMeasure = findMeasureByNumber(nextPart, measureNumber);
   if (!nextTargetMeasure) return null;
-  nextTargetMeasure.replaceWith(next.importNode(replacementMeasure, true));
+  nextTargetMeasure.replaceWith(next.importNode(replacementForMain, true));
   return next;
 };
-


### PR DESCRIPTION
## 概要
編集後に本体譜面へ不要な記号（ト音記号・拍子など）が混入する問題を修正し、
「休符を音符化」のデフォルト音高を中央ド（C4）に統一しました。

## 変更内容

### 1. 小節置換時の `attributes` 混入防止
- 対象: `src/ts/musicxml-io.ts`
- `replaceMeasureInMainDocument` で、編集用プレビューが補完した `attributes` を本体へ持ち込まないよう修正
- 具体的には、置換元小節に `attributes` がない場合、置換用小節側の `attributes` を削除してから置換

### 2. 休符を音符化のデフォルト音高を固定
- 対象: `src/ts/main.ts`
- `onConvertRestToNote` のピッチ決定ロジックを変更
- UI入力値（step/octave/alter）参照をやめ、`{ step: "C", octave: 4 }` を固定適用

## 期待効果
- 編集確定後に、意図しないト音記号・拍子・調号が途中小節へ生える問題を抑止
- 休符の音符化結果が常に一貫（中央ド）し、操作の予測可能性が向上

## 変更ファイル
- `src/ts/musicxml-io.ts`
- `src/ts/main.ts`
- （ビルド成果物）`src/js/main.js`, `mikuscore.html`