### PR TITLE
編集タブの未選択UIをカード化し、音高/変化記号/音価コントロールのレイアウトを再設計

### DIFF
--- a/mikuscore-src.html
+++ b/mikuscore-src.html
@@ -202,41 +202,20 @@
 
         <section class="md-section ms-flow-step ms-tab-panel" data-tab-panel="edit" hidden>
           <h2 class="md-section-title"><span class="ms-step-no">3</span>編集</h2>
-          <div id="uiMessage" class="ms-ui-message md-hidden" role="status" aria-live="polite"></div>
-          <p id="measurePartNameText" class="ms-track-label">トラック名: -</p>
-          <p id="measureSelectionText" class="ms-status">小節未選択（譜面から小節クリックして選択）</p>
+          <div id="measureEmptyState" class="ms-empty-state" role="status" aria-live="polite">
+            <div class="ms-empty-state-inner">
+              <div class="ms-empty-state-title">小節が未選択です</div>
+              <div class="ms-empty-state-body">譜面から小節クリックして選択してください</div>
+              <div class="ms-empty-state-actions">
+                <button id="measureSelectGuideBtn" type="button" class="md-button md-button--surface">
+                  譜面へ移動
+                </button>
+              </div>
+            </div>
+          </div>
           <div id="measureEditorWrap" class="ms-measure-editor md-hidden">
             <div id="measureEditorArea" class="ms-debug-score"></div>
           </div>
-
-          <div class="ms-grid">
-            <label class="ms-field">音名(step)
-              <div class="ms-step-row">
-                <input id="pitchStep" type="hidden" value="" />
-                <span id="pitchStepValue" class="ms-step-value" aria-live="polite">休符</span>
-                <button id="pitchStepDownBtn" type="button" class="md-button md-button--surface ms-step-btn" aria-label="音名を下げる">↓</button>
-                <button id="pitchStepUpBtn" type="button" class="md-button md-button--surface ms-step-btn" aria-label="音名を上げる">↑</button>
-              </div>
-            </label>
-            <label class="ms-field">変化記号(alter)
-              <div class="ms-alter-row" role="group" aria-label="変化記号">
-                <input id="pitchAlter" type="hidden" value="none" />
-                <button type="button" class="md-button md-button--surface ms-alter-btn" data-alter="none" aria-label="変化記号なし">なし</button>
-                <button type="button" class="md-button md-button--surface ms-alter-btn" data-alter="-2" aria-label="ダブルフラット">♭♭</button>
-                <button type="button" class="md-button md-button--surface ms-alter-btn" data-alter="-1" aria-label="フラット">♭</button>
-                <button type="button" class="md-button md-button--surface ms-alter-btn" data-alter="0" aria-label="ナチュラル">♮</button>
-                <button type="button" class="md-button md-button--surface ms-alter-btn" data-alter="1" aria-label="シャープ">♯</button>
-                <button type="button" class="md-button md-button--surface ms-alter-btn" data-alter="2" aria-label="ダブルシャープ">♯♯</button>
-              </div>
-            </label>
-            <input id="pitchOctave" type="hidden" value="4" />
-            <label class="ms-field">音価(duration)
-              <select id="durationPreset" class="md-select" aria-label="音価プリセット">
-                <option value="">（音価を選択）</option>
-              </select>
-            </label>
-          </div>
-
           <div class="ms-actions">
             <button id="convertRestBtn" type="button" class="md-button md-button--tonal ms-icon-button">
               <svg aria-hidden="true" viewBox="0 0 34 24" class="ms-btn-icon ms-btn-icon--wide" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round">
@@ -274,6 +253,40 @@
               <span>音符削除</span>
             </button>
           </div>
+
+          <div class="ms-grid">
+            <label class="ms-field">
+              <span class="ms-field-label">音名(step)</span>
+              <div class="ms-step-row">
+                <input id="pitchStep" type="hidden" value="" />
+                <span id="pitchStepValue" class="ms-step-value" aria-live="polite">休符</span>
+                <button id="pitchStepDownBtn" type="button" class="md-button md-button--surface ms-step-btn" aria-label="音名を下げる">↓</button>
+                <button id="pitchStepUpBtn" type="button" class="md-button md-button--surface ms-step-btn" aria-label="音名を上げる">↑</button>
+              </div>
+            </label>
+            <label class="ms-field">
+              <span class="ms-field-label">変化記号(alter)</span>
+              <div class="ms-alter-row" role="group" aria-label="変化記号">
+                <input id="pitchAlter" type="hidden" value="none" />
+                <button type="button" class="md-button md-button--surface ms-alter-btn" data-alter="none" aria-label="変化記号なし">なし</button>
+                <button type="button" class="md-button md-button--surface ms-alter-btn" data-alter="-2" aria-label="ダブルフラット">♭♭</button>
+                <button type="button" class="md-button md-button--surface ms-alter-btn" data-alter="-1" aria-label="フラット">♭</button>
+                <button type="button" class="md-button md-button--surface ms-alter-btn" data-alter="0" aria-label="ナチュラル">♮</button>
+                <button type="button" class="md-button md-button--surface ms-alter-btn" data-alter="1" aria-label="シャープ">♯</button>
+                <button type="button" class="md-button md-button--surface ms-alter-btn" data-alter="2" aria-label="ダブルシャープ">♯♯</button>
+              </div>
+            </label>
+            <input id="pitchOctave" type="hidden" value="4" />
+            <label class="ms-field">
+              <span class="ms-field-label">音価(duration)</span>
+              <select id="durationPreset" class="md-select" aria-label="音価プリセット">
+                <option value="">（音価を選択）</option>
+              </select>
+              <div id="uiMessage" class="ms-ui-message ms-ui-message--inline md-hidden" role="status" aria-live="polite"></div>
+            </label>
+          </div>
+
+          <p id="measurePartNameText" class="ms-track-label md-hidden">トラック名: -</p>
           <div class="ms-actions">
             <button id="measureApplyBtn" type="button" class="md-button md-button--primary ms-icon-button" disabled>
               <svg aria-hidden="true" viewBox="0 0 24 24" class="ms-btn-icon" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round">

--- a/mikuscore.html
+++ b/mikuscore.html
@@ -1092,11 +1092,48 @@ body {
   color: var(--md-sys-color-on-surface-variant);
 }
 
-.ms-track-label {
-  margin: 0.15rem 0;
-  color: var(--md-sys-color-on-surface-variant);
+.ms-empty-state {
+  border: 1px solid #dfd9e9;
+  border-radius: 12px;
+  background: #f4f1f7;
+  min-height: 140px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  margin-bottom: 0.6rem;
+}
+
+.ms-empty-state.md-hidden {
+  display: none !important;
+}
+
+.ms-empty-state-inner {
+  text-align: center;
+}
+
+.ms-empty-state-title {
+  font-size: 1rem;
+  font-weight: 700;
+  color: #3d3947;
+}
+
+.ms-empty-state-body {
+  margin-top: 0.35rem;
   font-size: 0.9rem;
-  font-weight: 600;
+  color: #6a6675;
+}
+
+.ms-empty-state-actions {
+  margin-top: 0.7rem;
+}
+
+.ms-track-label {
+  margin: 0.05rem 0 0.35rem;
+  color: #7a7587;
+  font-size: 0.72rem;
+  font-weight: 400;
+  letter-spacing: 0.005em;
 }
 
 .ms-ui-message {
@@ -1106,6 +1143,11 @@ body {
   border: 1px solid transparent;
   font-size: 0.88rem;
   line-height: 1.4;
+}
+
+.ms-ui-message--inline {
+  margin-top: 0.35rem;
+  margin-bottom: 0;
 }
 
 .ms-ui-message--error {
@@ -1133,39 +1175,110 @@ body {
   color: var(--md-sys-color-on-surface-variant);
 }
 
+.ms-field-label {
+  display: none;
+}
+
+/* Keep duration selector on its own row for compact editing flow */
+.ms-grid .ms-field:nth-of-type(3) {
+  grid-column: 1 / -1;
+}
+
+.ms-grid .ms-field:nth-of-type(3) .md-select {
+  width: min(26rem, 100%);
+}
+
+.ms-grid .ms-field:nth-of-type(1) {
+  align-self: stretch;
+  display: flex;
+  align-items: center;
+}
+
+.ms-grid .ms-field:nth-of-type(2) {
+  align-self: start;
+}
+
 .ms-step-row {
   display: grid;
-  grid-template-columns: auto auto auto;
-  gap: 0.4rem;
+  grid-template-columns: auto auto;
+  grid-template-rows: auto auto;
+  column-gap: 0.55rem;
+  row-gap: 0.32rem;
   align-items: center;
+  align-content: center;
   justify-content: start;
 }
 
 .ms-step-value {
+  grid-column: 1;
+  grid-row: 1 / span 2;
   display: inline-block;
   padding: 0.1rem 0.1rem 0.1rem 0;
-  font-weight: 700;
+  min-width: 1.2em;
+  font-size: 1.25rem;
+  font-weight: 800;
   color: var(--md-sys-color-on-surface);
   line-height: 1.2;
 }
 
+#pitchStepUpBtn {
+  grid-column: 2;
+  grid-row: 1;
+}
+
+#pitchStepDownBtn {
+  grid-column: 2;
+  grid-row: 2;
+}
+
 .ms-step-btn {
-  min-width: 2.4rem;
-  padding: 0.5rem 0.6rem;
+  min-width: 6.3rem;
+  width: 6.3rem;
+  height: 6.3rem;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 3.42rem;
+  line-height: 1;
   font-weight: 700;
 }
 
 .ms-alter-row {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.4rem;
+  display: grid;
+  grid-template-columns: auto auto;
+  grid-template-rows: repeat(5, auto);
+  align-items: center;
+  justify-content: start;
+  gap: 0.35rem 0.35rem;
+  margin-top: 0.35rem;
 }
 
 .ms-alter-btn {
-  min-width: 2.6rem;
-  padding: 0.5rem 0.65rem;
+  min-width: 2.7rem;
+  width: 2.7rem;
+  height: 2.7rem;
+  padding: 0;
+  border-radius: 999px;
+  font-size: 1.1rem;
   font-weight: 700;
 }
+
+.ms-alter-btn[data-alter="none"] {
+  grid-column: 1;
+  grid-row: 3;
+  width: auto;
+  min-width: 3.7rem;
+  padding: 0 0.9rem;
+  border-radius: 999px;
+  font-size: 1rem;
+}
+
+.ms-alter-btn[data-alter="2"] { grid-column: 2; grid-row: 1; }
+.ms-alter-btn[data-alter="1"] { grid-column: 2; grid-row: 2; }
+.ms-alter-btn[data-alter="0"] { grid-column: 2; grid-row: 3; }
+.ms-alter-btn[data-alter="-1"] { grid-column: 2; grid-row: 4; }
+.ms-alter-btn[data-alter="-2"] { grid-column: 2; grid-row: 5; }
 
 .ms-alter-btn.is-active {
   background: rgba(98, 0, 238, 0.12);
@@ -1300,7 +1413,10 @@ body {
   }
 
   .ms-grid {
-    grid-template-columns: 1fr;
+    grid-template-columns: auto 1fr;
+    column-gap: 0.65rem;
+    row-gap: 0.45rem;
+    align-items: start;
   }
 
   .ms-top-tab {
@@ -1332,6 +1448,15 @@ body {
   .ms-top-tab::after {
     display: none;
   }
+
+  .ms-grid .ms-field:nth-of-type(2) .ms-alter-row {
+    justify-content: start;
+  }
+
+  .ms-grid .ms-field:nth-of-type(3) {
+    margin-top: 0.15rem;
+  }
+
 }
 
 </style>
@@ -1530,41 +1655,20 @@ body {
 
         <section class="md-section ms-flow-step ms-tab-panel" data-tab-panel="edit" hidden>
           <h2 class="md-section-title"><span class="ms-step-no">3</span>編集</h2>
-          <div id="uiMessage" class="ms-ui-message md-hidden" role="status" aria-live="polite"></div>
-          <p id="measurePartNameText" class="ms-track-label">トラック名: -</p>
-          <p id="measureSelectionText" class="ms-status">小節未選択（譜面から小節クリックして選択）</p>
+          <div id="measureEmptyState" class="ms-empty-state" role="status" aria-live="polite">
+            <div class="ms-empty-state-inner">
+              <div class="ms-empty-state-title">小節が未選択です</div>
+              <div class="ms-empty-state-body">譜面から小節クリックして選択してください</div>
+              <div class="ms-empty-state-actions">
+                <button id="measureSelectGuideBtn" type="button" class="md-button md-button--surface">
+                  譜面へ移動
+                </button>
+              </div>
+            </div>
+          </div>
           <div id="measureEditorWrap" class="ms-measure-editor md-hidden">
             <div id="measureEditorArea" class="ms-debug-score"></div>
           </div>
-
-          <div class="ms-grid">
-            <label class="ms-field">音名(step)
-              <div class="ms-step-row">
-                <input id="pitchStep" type="hidden" value="" />
-                <span id="pitchStepValue" class="ms-step-value" aria-live="polite">休符</span>
-                <button id="pitchStepDownBtn" type="button" class="md-button md-button--surface ms-step-btn" aria-label="音名を下げる">↓</button>
-                <button id="pitchStepUpBtn" type="button" class="md-button md-button--surface ms-step-btn" aria-label="音名を上げる">↑</button>
-              </div>
-            </label>
-            <label class="ms-field">変化記号(alter)
-              <div class="ms-alter-row" role="group" aria-label="変化記号">
-                <input id="pitchAlter" type="hidden" value="none" />
-                <button type="button" class="md-button md-button--surface ms-alter-btn" data-alter="none" aria-label="変化記号なし">なし</button>
-                <button type="button" class="md-button md-button--surface ms-alter-btn" data-alter="-2" aria-label="ダブルフラット">♭♭</button>
-                <button type="button" class="md-button md-button--surface ms-alter-btn" data-alter="-1" aria-label="フラット">♭</button>
-                <button type="button" class="md-button md-button--surface ms-alter-btn" data-alter="0" aria-label="ナチュラル">♮</button>
-                <button type="button" class="md-button md-button--surface ms-alter-btn" data-alter="1" aria-label="シャープ">♯</button>
-                <button type="button" class="md-button md-button--surface ms-alter-btn" data-alter="2" aria-label="ダブルシャープ">♯♯</button>
-              </div>
-            </label>
-            <input id="pitchOctave" type="hidden" value="4" />
-            <label class="ms-field">音価(duration)
-              <select id="durationPreset" class="md-select" aria-label="音価プリセット">
-                <option value="">（音価を選択）</option>
-              </select>
-            </label>
-          </div>
-
           <div class="ms-actions">
             <button id="convertRestBtn" type="button" class="md-button md-button--tonal ms-icon-button">
               <svg aria-hidden="true" viewBox="0 0 34 24" class="ms-btn-icon ms-btn-icon--wide" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round">
@@ -1602,6 +1706,40 @@ body {
               <span>音符削除</span>
             </button>
           </div>
+
+          <div class="ms-grid">
+            <label class="ms-field">
+              <span class="ms-field-label">音名(step)</span>
+              <div class="ms-step-row">
+                <input id="pitchStep" type="hidden" value="" />
+                <span id="pitchStepValue" class="ms-step-value" aria-live="polite">休符</span>
+                <button id="pitchStepDownBtn" type="button" class="md-button md-button--surface ms-step-btn" aria-label="音名を下げる">↓</button>
+                <button id="pitchStepUpBtn" type="button" class="md-button md-button--surface ms-step-btn" aria-label="音名を上げる">↑</button>
+              </div>
+            </label>
+            <label class="ms-field">
+              <span class="ms-field-label">変化記号(alter)</span>
+              <div class="ms-alter-row" role="group" aria-label="変化記号">
+                <input id="pitchAlter" type="hidden" value="none" />
+                <button type="button" class="md-button md-button--surface ms-alter-btn" data-alter="none" aria-label="変化記号なし">なし</button>
+                <button type="button" class="md-button md-button--surface ms-alter-btn" data-alter="-2" aria-label="ダブルフラット">♭♭</button>
+                <button type="button" class="md-button md-button--surface ms-alter-btn" data-alter="-1" aria-label="フラット">♭</button>
+                <button type="button" class="md-button md-button--surface ms-alter-btn" data-alter="0" aria-label="ナチュラル">♮</button>
+                <button type="button" class="md-button md-button--surface ms-alter-btn" data-alter="1" aria-label="シャープ">♯</button>
+                <button type="button" class="md-button md-button--surface ms-alter-btn" data-alter="2" aria-label="ダブルシャープ">♯♯</button>
+              </div>
+            </label>
+            <input id="pitchOctave" type="hidden" value="4" />
+            <label class="ms-field">
+              <span class="ms-field-label">音価(duration)</span>
+              <select id="durationPreset" class="md-select" aria-label="音価プリセット">
+                <option value="">（音価を選択）</option>
+              </select>
+              <div id="uiMessage" class="ms-ui-message ms-ui-message--inline md-hidden" role="status" aria-live="polite"></div>
+            </label>
+          </div>
+
+          <p id="measurePartNameText" class="ms-track-label md-hidden">トラック名: -</p>
           <div class="ms-actions">
             <button id="measureApplyBtn" type="button" class="md-button md-button--primary ms-icon-button" disabled>
               <svg aria-hidden="true" viewBox="0 0 24 24" class="ms-btn-icon" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round">
@@ -1740,7 +1878,8 @@ const debugScoreMeta = qo("#debugScoreMeta");
 const debugScoreArea = q("#debugScoreArea");
 const uiMessage = q("#uiMessage");
 const measurePartNameText = q("#measurePartNameText");
-const measureSelectionText = q("#measureSelectionText");
+const measureEmptyState = q("#measureEmptyState");
+const measureSelectGuideBtn = q("#measureSelectGuideBtn");
 const measureEditorWrap = q("#measureEditorWrap");
 const measureEditorArea = q("#measureEditorArea");
 const measureApplyBtn = q("#measureApplyBtn");
@@ -2248,9 +2387,9 @@ const syncStepFromSelectedDraftNote = () => {
 const renderMeasureEditorState = () => {
     var _a;
     if (!selectedMeasure || !draftCore) {
-        measurePartNameText.textContent = "小節未選択（譜面から小節クリックして選択）";
-        measureSelectionText.textContent = "小節未選択（譜面から小節クリックして選択）";
-        measureSelectionText.classList.add("md-hidden");
+        measurePartNameText.textContent = "トラック名: -";
+        measurePartNameText.classList.add("md-hidden");
+        measureEmptyState.classList.remove("md-hidden");
         measureEditorWrap.classList.add("md-hidden");
         measureApplyBtn.disabled = true;
         measureDiscardBtn.disabled = true;
@@ -2259,8 +2398,8 @@ const renderMeasureEditorState = () => {
     const partName = (_a = partIdToName.get(selectedMeasure.partId)) !== null && _a !== void 0 ? _a : selectedMeasure.partId;
     measurePartNameText.textContent =
         `トラック名: ${partName} / 選択中: トラック=${selectedMeasure.partId} / 小節=${selectedMeasure.measureNumber}`;
-    measureSelectionText.textContent = "";
-    measureSelectionText.classList.add("md-hidden");
+    measurePartNameText.classList.remove("md-hidden");
+    measureEmptyState.classList.add("md-hidden");
     measureEditorWrap.classList.remove("md-hidden");
     measureDiscardBtn.disabled = false;
     measureApplyBtn.disabled = !draftCore.isDirty();
@@ -3366,6 +3505,9 @@ if (topTabButtons.length > 0 && topTabPanels.length > 0) {
     }
     activateTopTab(((_a = topTabButtons.find((button) => button.classList.contains("is-active"))) === null || _a === void 0 ? void 0 : _a.dataset.tab) || "input");
 }
+measureSelectGuideBtn.addEventListener("click", () => {
+    activateTopTab("score");
+});
 inputTypeXml.addEventListener("change", renderInputMode);
 inputTypeAbc.addEventListener("change", renderInputMode);
 inputTypeNew.addEventListener("change", renderInputMode);

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -263,11 +263,48 @@ body {
   color: var(--md-sys-color-on-surface-variant);
 }
 
-.ms-track-label {
-  margin: 0.15rem 0;
-  color: var(--md-sys-color-on-surface-variant);
+.ms-empty-state {
+  border: 1px solid #dfd9e9;
+  border-radius: 12px;
+  background: #f4f1f7;
+  min-height: 140px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  margin-bottom: 0.6rem;
+}
+
+.ms-empty-state.md-hidden {
+  display: none !important;
+}
+
+.ms-empty-state-inner {
+  text-align: center;
+}
+
+.ms-empty-state-title {
+  font-size: 1rem;
+  font-weight: 700;
+  color: #3d3947;
+}
+
+.ms-empty-state-body {
+  margin-top: 0.35rem;
   font-size: 0.9rem;
-  font-weight: 600;
+  color: #6a6675;
+}
+
+.ms-empty-state-actions {
+  margin-top: 0.7rem;
+}
+
+.ms-track-label {
+  margin: 0.05rem 0 0.35rem;
+  color: #7a7587;
+  font-size: 0.72rem;
+  font-weight: 400;
+  letter-spacing: 0.005em;
 }
 
 .ms-ui-message {
@@ -277,6 +314,11 @@ body {
   border: 1px solid transparent;
   font-size: 0.88rem;
   line-height: 1.4;
+}
+
+.ms-ui-message--inline {
+  margin-top: 0.35rem;
+  margin-bottom: 0;
 }
 
 .ms-ui-message--error {
@@ -304,39 +346,110 @@ body {
   color: var(--md-sys-color-on-surface-variant);
 }
 
+.ms-field-label {
+  display: none;
+}
+
+/* Keep duration selector on its own row for compact editing flow */
+.ms-grid .ms-field:nth-of-type(3) {
+  grid-column: 1 / -1;
+}
+
+.ms-grid .ms-field:nth-of-type(3) .md-select {
+  width: min(26rem, 100%);
+}
+
+.ms-grid .ms-field:nth-of-type(1) {
+  align-self: stretch;
+  display: flex;
+  align-items: center;
+}
+
+.ms-grid .ms-field:nth-of-type(2) {
+  align-self: start;
+}
+
 .ms-step-row {
   display: grid;
-  grid-template-columns: auto auto auto;
-  gap: 0.4rem;
+  grid-template-columns: auto auto;
+  grid-template-rows: auto auto;
+  column-gap: 0.55rem;
+  row-gap: 0.32rem;
   align-items: center;
+  align-content: center;
   justify-content: start;
 }
 
 .ms-step-value {
+  grid-column: 1;
+  grid-row: 1 / span 2;
   display: inline-block;
   padding: 0.1rem 0.1rem 0.1rem 0;
-  font-weight: 700;
+  min-width: 1.2em;
+  font-size: 1.25rem;
+  font-weight: 800;
   color: var(--md-sys-color-on-surface);
   line-height: 1.2;
 }
 
+#pitchStepUpBtn {
+  grid-column: 2;
+  grid-row: 1;
+}
+
+#pitchStepDownBtn {
+  grid-column: 2;
+  grid-row: 2;
+}
+
 .ms-step-btn {
-  min-width: 2.4rem;
-  padding: 0.5rem 0.6rem;
+  min-width: 6.3rem;
+  width: 6.3rem;
+  height: 6.3rem;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 3.42rem;
+  line-height: 1;
   font-weight: 700;
 }
 
 .ms-alter-row {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.4rem;
+  display: grid;
+  grid-template-columns: auto auto;
+  grid-template-rows: repeat(5, auto);
+  align-items: center;
+  justify-content: start;
+  gap: 0.35rem 0.35rem;
+  margin-top: 0.35rem;
 }
 
 .ms-alter-btn {
-  min-width: 2.6rem;
-  padding: 0.5rem 0.65rem;
+  min-width: 2.7rem;
+  width: 2.7rem;
+  height: 2.7rem;
+  padding: 0;
+  border-radius: 999px;
+  font-size: 1.1rem;
   font-weight: 700;
 }
+
+.ms-alter-btn[data-alter="none"] {
+  grid-column: 1;
+  grid-row: 3;
+  width: auto;
+  min-width: 3.7rem;
+  padding: 0 0.9rem;
+  border-radius: 999px;
+  font-size: 1rem;
+}
+
+.ms-alter-btn[data-alter="2"] { grid-column: 2; grid-row: 1; }
+.ms-alter-btn[data-alter="1"] { grid-column: 2; grid-row: 2; }
+.ms-alter-btn[data-alter="0"] { grid-column: 2; grid-row: 3; }
+.ms-alter-btn[data-alter="-1"] { grid-column: 2; grid-row: 4; }
+.ms-alter-btn[data-alter="-2"] { grid-column: 2; grid-row: 5; }
 
 .ms-alter-btn.is-active {
   background: rgba(98, 0, 238, 0.12);
@@ -471,7 +584,10 @@ body {
   }
 
   .ms-grid {
-    grid-template-columns: 1fr;
+    grid-template-columns: auto 1fr;
+    column-gap: 0.65rem;
+    row-gap: 0.45rem;
+    align-items: start;
   }
 
   .ms-top-tab {
@@ -503,4 +619,13 @@ body {
   .ms-top-tab::after {
     display: none;
   }
+
+  .ms-grid .ms-field:nth-of-type(2) .ms-alter-row {
+    justify-content: start;
+  }
+
+  .ms-grid .ms-field:nth-of-type(3) {
+    margin-top: 0.15rem;
+  }
+
 }

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -69,7 +69,8 @@ const debugScoreMeta = qo("#debugScoreMeta");
 const debugScoreArea = q("#debugScoreArea");
 const uiMessage = q("#uiMessage");
 const measurePartNameText = q("#measurePartNameText");
-const measureSelectionText = q("#measureSelectionText");
+const measureEmptyState = q("#measureEmptyState");
+const measureSelectGuideBtn = q("#measureSelectGuideBtn");
 const measureEditorWrap = q("#measureEditorWrap");
 const measureEditorArea = q("#measureEditorArea");
 const measureApplyBtn = q("#measureApplyBtn");
@@ -577,9 +578,9 @@ const syncStepFromSelectedDraftNote = () => {
 const renderMeasureEditorState = () => {
     var _a;
     if (!selectedMeasure || !draftCore) {
-        measurePartNameText.textContent = "小節未選択（譜面から小節クリックして選択）";
-        measureSelectionText.textContent = "小節未選択（譜面から小節クリックして選択）";
-        measureSelectionText.classList.add("md-hidden");
+        measurePartNameText.textContent = "トラック名: -";
+        measurePartNameText.classList.add("md-hidden");
+        measureEmptyState.classList.remove("md-hidden");
         measureEditorWrap.classList.add("md-hidden");
         measureApplyBtn.disabled = true;
         measureDiscardBtn.disabled = true;
@@ -588,8 +589,8 @@ const renderMeasureEditorState = () => {
     const partName = (_a = partIdToName.get(selectedMeasure.partId)) !== null && _a !== void 0 ? _a : selectedMeasure.partId;
     measurePartNameText.textContent =
         `トラック名: ${partName} / 選択中: トラック=${selectedMeasure.partId} / 小節=${selectedMeasure.measureNumber}`;
-    measureSelectionText.textContent = "";
-    measureSelectionText.classList.add("md-hidden");
+    measurePartNameText.classList.remove("md-hidden");
+    measureEmptyState.classList.add("md-hidden");
     measureEditorWrap.classList.remove("md-hidden");
     measureDiscardBtn.disabled = false;
     measureApplyBtn.disabled = !draftCore.isDirty();
@@ -1695,6 +1696,9 @@ if (topTabButtons.length > 0 && topTabPanels.length > 0) {
     }
     activateTopTab(((_a = topTabButtons.find((button) => button.classList.contains("is-active"))) === null || _a === void 0 ? void 0 : _a.dataset.tab) || "input");
 }
+measureSelectGuideBtn.addEventListener("click", () => {
+    activateTopTab("score");
+});
 inputTypeXml.addEventListener("change", renderInputMode);
 inputTypeAbc.addEventListener("change", renderInputMode);
 inputTypeNew.addEventListener("change", renderInputMode);

--- a/src/ts/main.ts
+++ b/src/ts/main.ts
@@ -110,7 +110,8 @@ const debugScoreMeta = qo<HTMLParagraphElement>("#debugScoreMeta");
 const debugScoreArea = q<HTMLDivElement>("#debugScoreArea");
 const uiMessage = q<HTMLDivElement>("#uiMessage");
 const measurePartNameText = q<HTMLParagraphElement>("#measurePartNameText");
-const measureSelectionText = q<HTMLParagraphElement>("#measureSelectionText");
+const measureEmptyState = q<HTMLDivElement>("#measureEmptyState");
+const measureSelectGuideBtn = q<HTMLButtonElement>("#measureSelectGuideBtn");
 const measureEditorWrap = q<HTMLDivElement>("#measureEditorWrap");
 const measureEditorArea = q<HTMLDivElement>("#measureEditorArea");
 const measureApplyBtn = q<HTMLButtonElement>("#measureApplyBtn");
@@ -646,9 +647,9 @@ const syncStepFromSelectedDraftNote = (): void => {
 
 const renderMeasureEditorState = (): void => {
   if (!selectedMeasure || !draftCore) {
-    measurePartNameText.textContent = "小節未選択（譜面から小節クリックして選択）";
-    measureSelectionText.textContent = "小節未選択（譜面から小節クリックして選択）";
-    measureSelectionText.classList.add("md-hidden");
+    measurePartNameText.textContent = "トラック名: -";
+    measurePartNameText.classList.add("md-hidden");
+    measureEmptyState.classList.remove("md-hidden");
     measureEditorWrap.classList.add("md-hidden");
     measureApplyBtn.disabled = true;
     measureDiscardBtn.disabled = true;
@@ -658,8 +659,8 @@ const renderMeasureEditorState = (): void => {
   const partName = partIdToName.get(selectedMeasure.partId) ?? selectedMeasure.partId;
   measurePartNameText.textContent =
     `トラック名: ${partName} / 選択中: トラック=${selectedMeasure.partId} / 小節=${selectedMeasure.measureNumber}`;
-  measureSelectionText.textContent = "";
-  measureSelectionText.classList.add("md-hidden");
+  measurePartNameText.classList.remove("md-hidden");
+  measureEmptyState.classList.add("md-hidden");
   measureEditorWrap.classList.remove("md-hidden");
   measureDiscardBtn.disabled = false;
   measureApplyBtn.disabled = !draftCore.isDirty();
@@ -1807,6 +1808,9 @@ if (topTabButtons.length > 0 && topTabPanels.length > 0) {
     topTabButtons.find((button) => button.classList.contains("is-active"))?.dataset.tab || "input"
   );
 }
+measureSelectGuideBtn.addEventListener("click", () => {
+  activateTopTab("score");
+});
 
 inputTypeXml.addEventListener("change", renderInputMode);
 inputTypeAbc.addEventListener("change", renderInputMode);


### PR DESCRIPTION
### 概要
編集セクションの「小節未選択」状態をMD3らしい空状態カードに置き換え、編集コントロール（音名・変化記号・音価）の配置と視認性を改善しました。 あわせて、譜面タブへ戻る導線とエラーメッセージ表示位置を見直しています。

### 主な変更点
- 編集セクションに空状態カード `#measureEmptyState` を追加
  - 文言: 「小節が未選択です」
  - 補助文: 「譜面から小節クリックして選択してください」
  - アクション: 「譜面へ移動」ボタン（クリックで譜面タブへ遷移）
- 旧 `measureSelectionText` を廃止し、未選択状態表示を空状態カードへ一本化
- トラック情報表示 `#measurePartNameText` の表示制御を見直し
  - 未選択時は非表示
  - 選択時のみ表示
  - 視覚ノイズを抑えるためスタイルを軽量化
- エラーメッセージ `#uiMessage` を音価セレクト配下へ移動（inline表示）
- 編集UIのレイアウト再編
  - 音価セレクトを独立行へ
  - 音名上下ボタンを大型化し、上下2段配置へ
  - 変化記号ボタン群を縦寄りグリッド構成へ（`なし` を中央系に配置）
  - ラベル表示を抑制してコンパクト化（`ms-field-label` 非表示）
- `main.ts` 側の状態制御を空状態カード仕様に追従
  - 未選択時: 空状態カード表示 / 編集エリア非表示
  - 選択時: 空状態カード非表示 / 編集エリア表示
  - 「譜面へ移動」ボタンイベントを追加

### 変更ファイル
- `mikuscore-src.html`
- `src/css/app.css`
- `src/ts/main.ts`
- `mikuscore.html`（生成物更新）
- `src/js/main.js`（生成物更新）

### 期待効果
- 未選択時の状態が直感的にわかる
- 編集導線（譜面へ戻る）が明確になる
- 音高/変化記号/音価操作の視認性と操作性が向上する