### PR TITLE
English UI migration and bilingual spec docs update (EN/JA split)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,64 +1,107 @@
 # mikuscore
 
-ブラウザ上で完結する MusicXML スコアエディタのプロジェクトです。  
-このアプリの主眼は「多機能化」ではなく、**既存 MusicXML を壊さずに編集する信頼性**です。  
-MVP段階で機能を絞っているのは意図的で、まず「壊さない編集」を確実に成立させることを最優先にしています。
+## English
+mikuscore is a browser-only MusicXML score editor.
 
-## このアプリの特徴
+Its primary goal is reliability, not feature volume: preserve existing MusicXML and apply only safe, minimal edits.
 
-- 既存 MusicXML の保全を最優先
-- 最小パッチ編集（必要なノードだけ変更）
-- ラウンドトリップ安全性（`load -> edit -> save` の意味的同一性）
-- unknown / unsupported 要素の保持
-- `<backup>` / `<forward>` / 既存 `<beam>` の保持
-- 失敗時は原子的にロールバック（DOM 不変）
-- 将来 UI を差し替え可能な Core / UI 分離設計
+### Core Principles
+- Preserve existing MusicXML as much as possible.
+- Apply minimal patches (change only required nodes).
+- Keep round-trip safety (`load -> edit -> save`).
+- Preserve unknown/unsupported elements.
+- Preserve `<backup>`, `<forward>`, and existing `<beam>` nodes.
+- Roll back atomically on failure.
+- Keep Core/UI separated so UI can be replaced later.
 
-## 主要な仕様ハイライト（MVP）
+### MVP Highlights
+- If `dirty === false`, save returns original XML text (`original_noop`).
+- Overfull measures are rejected with `MEASURE_OVERFULL`.
+- Non-editable voices are rejected with `MVP_UNSUPPORTED_NON_EDITABLE_VOICE`.
+- MVP commands: `change_to_pitch`, `change_duration`, `insert_note_after`, `delete_note`, `split_note`.
+- Rests are not a normal edit target, but rest-to-note via `change_to_pitch` is allowed.
+- Serialization is compact (no pretty-print).
 
-- `dirty === false` の保存は入力 XML 文字列をそのまま返す（`original_noop`）
-- 小節 overfull は `MEASURE_OVERFULL` で拒否
-- 非編集対象 voice は `MVP_UNSUPPORTED_NON_EDITABLE_VOICE` で拒否
-- `change_to_pitch` / `change_duration` / `insert_note_after` / `delete_note` / `split_note` をMVPコマンドとして扱う
-- 休符は通常の編集対象外だが、`change_to_pitch` による休符音符化は許可
-- pretty-print なしでシリアライズ
+### Supported MusicXML Version
+- **MusicXML 4.0**
 
-## 対応する MusicXML バージョン
+### Distribution and Development
+- Distribution: **single-file web app** (`mikuscore.html`).
+- Runtime: offline, no external network dependency.
+- Source: split TypeScript files.
+- Build: `mikuscore-src.html` + `src/` -> `mikuscore.html`.
 
-- 対象: **MusicXML 4.0**
+### Development Commands
+- `npm run build`
+- `npm run clean`
+- `npm run typecheck`
+- `npm run test:unit`
+- `npm run test:property`
+- `npm run test:all`
 
-## 配布と開発方針
+### Documents
+- `docs/spec/SPEC.md`
+- `docs/spec/TERMS.md`
+- `docs/spec/COMMANDS.md`
+- `docs/spec/COMMAND_CATALOG.md`
+- `docs/spec/DIAGNOSTICS.md`
+- `docs/spec/TEST_MATRIX.md`
+- `docs/spec/BUILD_PROCESS.md`
+- `docs/spec/ARCHITECTURE.md`
+- `docs/spec/UI_SPEC.md`
+- `docs/spec/SCREEN_SPEC.md`
+- `TODO.md`
 
-- 配布形態: **Single-file Web App**（単一 HTML）
-- 実行条件: オフライン動作、外部依存なし
-- 開発形態: 分割 TypeScript ソース
-- ビルド方針: `mikuscore-src.html` + `src/` から `mikuscore.html` を生成
+---
 
-## 開発コマンド
+## 日本語
+ブラウザ上で完結する MusicXML スコアエディタのプロジェクトです。
 
-- `npm run build`: `mikuscore-src.html` と `src/` から `mikuscore.html`（配布物）を生成
-- `npm run clean`: 生成物（`mikuscore.html`, `src/js/main.js`）を削除
-- `npm run typecheck`: 型チェック
-- `npm run test:unit`: ユニットテスト
-- `npm run test:property`: propertyテスト
-- `npm run test:all`: 全テスト
+このアプリの主眼は「多機能化」ではなく、既存 MusicXML を壊さずに編集する信頼性です。
 
-## ドキュメント
+### 基本方針
+- 既存 MusicXML の保全を最優先。
+- 最小パッチ編集（必要なノードだけ変更）。
+- ラウンドトリップ安全性（`load -> edit -> save`）。
+- unknown / unsupported 要素を保持。
+- `<backup>` / `<forward>` / 既存 `<beam>` を保持。
+- 失敗時は原子的にロールバック。
+- 将来の UI 置換を考慮した Core / UI 分離設計。
 
-- `docs/spec/SPEC.md`: MVP コア仕様
-- `docs/spec/TERMS.md`: 用語とスコープ
-- `docs/spec/COMMANDS.md`: dispatch/save 契約
-- `docs/spec/COMMAND_CATALOG.md`: コマンド境界（payload/失敗条件）
-- `docs/spec/DIAGNOSTICS.md`: 診断コード定義
-- `docs/spec/TEST_MATRIX.md`: 必須テスト観点
-- `docs/spec/BUILD_PROCESS.md`: 単一 HTML 配布向けビルド方針
-- `docs/spec/ARCHITECTURE.md`: Core/UI分離とバージョン前提を含むアーキテクチャ方針
-- `docs/spec/UI_SPEC.md`: UI動作仕様
-- `docs/spec/SCREEN_SPEC.md`: 画面仕様（レイアウト/文言/導線）
-- `TODO.md`: 仕様・実装・テストのタスク管理
+### MVP 仕様ハイライト
+- `dirty === false` の保存は入力 XML をそのまま返す（`original_noop`）。
+- 小節 overfull は `MEASURE_OVERFULL` で拒否。
+- 非編集対象 voice は `MVP_UNSUPPORTED_NON_EDITABLE_VOICE` で拒否。
+- `change_to_pitch` / `change_duration` / `insert_note_after` / `delete_note` / `split_note` をMVPコマンドとして扱う。
+- 休符は通常の編集対象外だが、`change_to_pitch` による休符音符化は許可。
+- pretty-print なしでシリアライズ。
 
-## 現在のステータス
+### 対応 MusicXML バージョン
+- **MusicXML 4.0**
 
-仕様策定フェーズは完了し、Core 実装（TypeScript）とテスト基盤は稼働中です。  
-UI 側では 4ステップ（入力/譜面/編集/出力）のタブ式フローを採用し、MusicXML入力/ABC入力/新規作成に対応しています。  
-譜面クリック選択、休符音符化、音符分割、3形式（MusicXML/ABC/MIDI）の出力まで実装済みです。
+### 配布と開発方針
+- 配布形態: 単一 HTML（`mikuscore.html`）。
+- 実行条件: オフライン動作、外部依存なし。
+- 開発形態: 分割 TypeScript ソース。
+- ビルド方針: `mikuscore-src.html` + `src/` から `mikuscore.html` を生成。
+
+### 開発コマンド
+- `npm run build`
+- `npm run clean`
+- `npm run typecheck`
+- `npm run test:unit`
+- `npm run test:property`
+- `npm run test:all`
+
+### ドキュメント
+- `docs/spec/SPEC.md`
+- `docs/spec/TERMS.md`
+- `docs/spec/COMMANDS.md`
+- `docs/spec/COMMAND_CATALOG.md`
+- `docs/spec/DIAGNOSTICS.md`
+- `docs/spec/TEST_MATRIX.md`
+- `docs/spec/BUILD_PROCESS.md`
+- `docs/spec/ARCHITECTURE.md`
+- `docs/spec/UI_SPEC.md`
+- `docs/spec/SCREEN_SPEC.md`
+- `TODO.md`

--- a/TODO.md
+++ b/TODO.md
@@ -1,48 +1,86 @@
 # TODO
 
-## 現在地（2026-02 時点）
+## English
+### Current Status (2026-02)
 
-### 完了済み
+#### Done
+- [x] Implemented core `ScoreCore` load/dispatch/save and key validations.
+- [x] Prepared unit and property test baseline.
+- [x] Reorganized UI flow for edit/check/export.
+- [x] Promoted Verovio rendering to official path.
+- [x] Implemented note click selection.
+- [x] Improved SVG click -> `nodeId` resolution (`elementsFromPoint` fallback).
+- [x] Implemented `change_to_pitch`.
+- [x] Implemented `split_note`.
+- [x] Implemented rest-to-note conversion.
+- [x] Added playback path with `midi-writer.js`.
+- [x] Fixed transpose behavior including Clarinet in A.
 
+#### Known Issues
+- [ ] Verovio warning `slur ... could not be ended` may appear from input MusicXML; loading currently continues.
+- [ ] Click mapping expects note-head/real note area click; staff/empty click can return `MVP_TARGET_NOT_FOUND`.
+- [ ] Tuplet-like duration presets are currently restricted to measures/voices where compatible tuplet context already exists.
+- [ ] Some accidental rendering in `ABC export` is still incorrect (key/accidental precedence needs review).
+
+### Next Priorities
+#### P1: Editing stability
+- [ ] Improve selected-note highlight visibility.
+- [ ] Unify failure message policy (UI + console wording).
+- [ ] Add at least one E2E click-mapping test.
+
+#### P2: Spec and tests sync
+- [ ] Add save-XML/re-render consistency checks in `docs/spec`.
+- [ ] Document and test selection retention rules across re-render.
+
+#### P3: Feature expansion
+- [ ] Decide whether to reintroduce `insert_note_after` in UI.
+- [ ] Reconfirm in-session `xml:id` strategy and operation rules.
+
+### Resume Checklist
+1. `npm run build`
+2. Hard reload `mikuscore.html`
+3. Confirm note click selection on score panel
+4. Run `change_to_pitch` / `change_duration` / `split_note` -> save -> confirm re-render
+
+---
+
+## 日本語
+### 現在地（2026-02 時点）
+
+#### 完了済み
 - [x] Core（`ScoreCore`）の load / dispatch / save と主要バリデーションを実装済み。
 - [x] 単体テスト + property test の基盤を整備済み。
-- [x] UI を日本語中心に整理し、編集・確認・出力の導線を再配置済み。
-- [x] Verovio レンダリングを正式採用（デバッグ用途から昇格）。
-- [x] Verovio クリック選択（ノート 1 つ選択）を実装済み。
-- [x] SVG 上クリック -> `nodeId` 解決の改善（`elementsFromPoint` フォールバック）を実装済み。
-- [x] `change_to_pitch` 先行導入（選択ノート対象）を実装済み。
+- [x] UI の編集・確認・出力導線を再配置済み。
+- [x] Verovio レンダリングを正式採用済み。
+- [x] ノートクリック選択を実装済み。
+- [x] SVG 上クリック -> `nodeId` 解決を改善済み（`elementsFromPoint` フォールバック）。
+- [x] `change_to_pitch` を実装済み。
 - [x] `split_note` を実装済み。
 - [x] 休符の音符化（rest -> pitched note）を実装済み。
 - [x] `midi-writer.js` を使った再生経路を導入済み。
 - [x] Clarinet in A 含む `transpose` 反映を修正済み。
 
-### 既知事項（把握中）
+#### 既知事項
+- [ ] Verovio 警告 `slur ... could not be ended` は入力 MusicXML 由来で表示されることがある。現状は読み込み継続。
+- [ ] クリック選択は音符クリック前提。五線や空白クリックは `MVP_TARGET_NOT_FOUND` になりうる。
+- [ ] 音価ドロップダウンの 3 連系は、現状「同小節/同 voice に既存 tuplet がある場合のみ許可」の暫定制約。
+- [ ] `ABC出力` で一部臨時記号（alter/accidental）の表現が崩れる問題が残っている。
 
-- [ ] Verovio 警告 `slur ... could not be ended` は入力 MusicXML 由来で表示される。現状は読み込み継続。
-- [ ] クリック選択は「音符そのもの」クリック前提。五線や空白クリックは `MVP_TARGET_NOT_FOUND` になる（想定動作）。
-- [ ] 音価ドロップダウンの 3 連系は、現状「同小節/同 voice に既存 tuplet がある場合のみ許可」の暫定制約。将来は連符生成を含む自然な編集体験へ改善する。
-- [ ] `ABC出力` で一部臨時記号（alter/accidental）の表現が崩れる問題を修正（調号・臨時記号・小節内事故記号の優先順を見直し）。
+### 次にやること
+#### P1: 編集体験の安定化
+- [ ] 選択ノートの視覚ハイライトを強化。
+- [ ] 失敗時メッセージを統一（UI表示と console 文面）。
+- [ ] クリックマッピングの E2E テストを追加（最低 1 ケース）。
 
-## 次にやること（優先順）
-
-### P1: 編集体験の安定化
-
-- [ ] 選択ノートの視覚ハイライトを強化（現在選択が一目で分かる状態）。
-- [ ] 失敗時メッセージを統一（UI表示と `console` ログの文面ポリシー確定）。
-- [ ] クリックマッピングの E2E テスト追加（最低 1 ケース）。
-
-### P2: 仕様とテストの同期
-
+#### P2: 仕様とテストの同期
 - [ ] 保存 XML と再レンダリング結果の整合チェック手順を `docs/spec` に追記。
-- [ ] Verovio レンダリング更新時の選択維持ルールを明文化しテスト化。
+- [ ] レンダリング更新時の選択維持ルールを明文化しテスト化。
 
-### P3: 仕様拡張
-
+#### P3: 仕様拡張
 - [ ] `insert_note_after` の UI 再導入可否を仕様確定。
 - [ ] セッション内 `xml:id` 付与戦略を再確認（永続化しない方針の運用ルール化）。
 
-## 次回の再開手順
-
+### 次回の再開手順
 1. `npm run build`
 2. `mikuscore.html` をハードリロードして動作確認
 3. 譜面でノートクリック -> 選択状態更新を確認

--- a/core/ScoreCore.ts
+++ b/core/ScoreCore.ts
@@ -115,7 +115,7 @@ export class ScoreCore {
         ) {
           return this.fail(
             "MVP_INVALID_COMMAND_PAYLOAD",
-            "この小節/voice には3連コンテキストがないため、3連音価は適用できません。"
+            "Tuplet durations are not allowed because this measure/voice has no tuplet context."
           );
         }
         const oldDuration = getDurationValue(target) ?? 0;

--- a/docs/spec/SCREEN_SPEC.md
+++ b/docs/spec/SCREEN_SPEC.md
@@ -1,43 +1,149 @@
 # SCREEN_SPEC
 
+## English
 ## Purpose
-
-`mikuscore` の画面仕様（現行実装ベース）を定義する。
+Define the current screen specification for `mikuscore`.
 
 ## Global Layout
+- Single-page application layout.
+- Top brand header (`mikuscore` title, info `(i)`, GitHub link).
+- 4-step tab stepper below header.
 
-- 画面は単一ページ構成。
+## Stepper / Tabs
+- Step 1: `Input`
+- Step 2: `Score`
+- Step 3: `Edit`
+- Step 4: `Export`
+
+### Interaction
+- Clicking a step opens the corresponding panel.
+- `is-active` indicates current tab.
+- `is-complete` indicates completion state.
+
+## Panel: Input
+### Input format radio
+- `MusicXML input`
+- `ABC input`
+- `Create new`
+
+### Input source radio
+- `File load`
+- `Source input`
+
+### Blocks
+- `fileInputBlock`
+  - file picker button
+  - selected file name
+- `sourceXmlInputBlock`
+  - MusicXML textarea
+- `abcInputBlock`
+  - ABC textarea
+- `newInputBlock`
+  - track/part count
+  - time signature (beats / beat-unit)
+  - key signature
+  - clef settings per part
+
+### Action
+- `Load` button
+- Imported data is unified into MusicXML DOM for all downstream flow.
+
+## Panel: Score
+### Header
+- Title: `Score`
+- `(i)` tooltip explains note-click selection.
+
+### Controls
+- `Play`
+- `Stop`
+
+### Preview
+- Verovio SVG rendering.
+- Note click -> SVG id -> `nodeId` mapping.
+
+## Panel: Edit
+### Empty state
+- Card with:
+  - title: `No measure selected`
+  - text: `Click a measure in the score to select it`
+  - action: `Go to Score`
+
+### Selected state
+- Measure preview
+- Status row (track label / selected part and measure)
+
+### Edit controls
+- Action buttons:
+  - `Convert Rest to Note`
+  - `Split Note`
+  - `Delete Note`
+- Pitch:
+  - current step text
+  - `↑` / `↓`
+- Alter:
+  - `None`, `♭♭`, `♭`, `♮`, `♯`, `♯♯`
+- Duration:
+  - preset dropdown
+  - inline diagnostics below dropdown
+- Measure actions:
+  - `Apply`
+  - `Discard`
+  - `Play`
+
+## Panel: Export
+### Buttons
+- `MusicXML Export` (primary)
+- `ABC Export`
+- `MIDI Export`
+
+### File naming policy
+Use timestamp suffix to reduce conflicts:
+- `mikuscore-YYYYMMDDhhmm.musicxml`
+- `mikuscore-YYYYMMDDhhmm.abc`
+- `mikuscore-YYYYMMDDhhmm.mid`
+
+## Diagnostics placement
+- Edit errors/warnings are shown below the duration dropdown.
+- Preserve Core diagnostic code/message in UI output.
+
+## Non-goals
+- Complex score-authoring workflows
+- Multi-layer modal workflows
+- In-screen advanced history management (`undo`/`redo`)
+
+---
+
+## 日本語
+## 目的
+`mikuscore` の現行画面仕様を定義する。
+
+## 全体レイアウト
+- 単一ページ構成。
 - 上部にブランドヘッダ（`mikuscore` タイトル、説明 `(i)`、GitHubリンク）。
 - その下に 4 ステップのタブ式ステッパー。
 
-## Stepper / Tab Definition
-
+## ステッパー / タブ
 - Step 1: `入力`
 - Step 2: `譜面`
 - Step 3: `編集`
 - Step 4: `出力`
 
-### Interaction
-
-- ステッパー項目を押すと対応パネルに遷移。
+### 操作
+- ステッパー選択で対応パネルへ遷移。
 - `is-active` が現在タブ。
-- `is-complete` は完了ステータス表示用途。
+- `is-complete` は完了状態の表示。
 
-## Panel: 入力
-
-### Input Format Radio
-
+## パネル: 入力
+### 入力形式ラジオ
 - `MusicXML入力`
 - `ABC入力`
 - `新規作成`
 
-### Input Source Radio
-
+### 入力ソースラジオ
 - `ファイル読み込み`
 - `ソース入力`
 
-### Blocks
-
+### ブロック
 - `fileInputBlock`
   - ファイル選択ボタン
   - 選択ファイル名表示
@@ -46,89 +152,74 @@
 - `abcInputBlock`
   - ABC textarea
 - `newInputBlock`
-  - トラック数
+  - トラック/パート数
   - 拍子（拍数/拍の単位）
   - 調号
   - 各パートの記号設定
 
-### Action
-
+### アクション
 - `読み込み` ボタン
 - 取り込んだ内容は MusicXML DOM に統一して後続処理へ渡す。
 
-## Panel: 譜面
-
-### Header
-
+## パネル: 譜面
+### ヘッダ
 - タイトル: `譜面`
-- `(i)` ツールチップ: 音符クリックで編集対象選択する説明
+- `(i)` ツールチップ: 音符クリック選択の説明。
 
-### Controls
-
+### コントロール
 - `再生`
 - `停止`
 
-### Preview
-
+### プレビュー
 - Verovio SVG を表示。
-- ノートクリック -> SVG id -> nodeId マッピング。
+- ノートクリック -> SVG id -> `nodeId` マッピング。
 
-## Panel: 編集
-
-### Empty State (未選択時)
-
-- カード表示
+## パネル: 編集
+### 未選択状態
+- カード表示:
   - タイトル: `小節が未選択です`
   - 説明: `譜面から小節クリックして選択してください`
   - ボタン: `譜面へ移動`
 
-### Selected State (選択時)
+### 選択状態
+- 小節プレビュー表示。
+- ステータス行表示（トラック名 / 選択中 part と measure）。
 
-- 小節プレビュー表示
-- ステータス行表示（トラック名 / 選択中 part, measure）
-
-### Edit Controls
-
-- 行動ボタン:
+### 編集コントロール
+- 操作ボタン:
   - `休符を音符化`
   - `音符分割`
   - `音符削除`
-- Pitch:
+- 音名:
   - 現在 step 表示
-  - `↑` / `↓` ボタン
-- Alter:
+  - `↑` / `↓`
+- 変化記号:
   - `なし`, `♭♭`, `♭`, `♮`, `♯`, `♯♯`
-- Duration:
+- 音価:
   - プリセットドロップダウン
-  - 直下に inline 診断メッセージ
-- Measure action:
+  - ドロップダウン下に inline 診断表示
+- 小節操作:
   - `確定`
   - `破棄`
   - `再生`
 
-## Panel: 出力
-
-### Buttons
-
+## パネル: 出力
+### ボタン
 - `MusicXML出力`（primary）
 - `ABC出力`
 - `MIDI出力`
 
-### File Name Policy
-
-タイムスタンプ付与で衝突緩和:
-
+### ファイル名ポリシー
+衝突緩和のためタイムスタンプを付与:
 - `mikuscore-YYYYMMDDhhmm.musicxml`
 - `mikuscore-YYYYMMDDhhmm.abc`
 - `mikuscore-YYYYMMDDhhmm.mid`
 
-## Diagnostics Placement
+## 診断表示配置
+- 編集時のエラー/警告は音価ドロップダウン直下に表示。
+- Core 診断コード/メッセージを保持して表示。
 
-- 編集時のエラー/警告は duration ドロップダウン直下に表示。
-- Core diagnostics code/message を保持したまま表示。
-
-## Non-goals (Screen)
-
+## 非対象
 - 複雑な作譜ワークフロー
 - 多段モーダル UI
-- 画面内での高度な履歴管理（undo/redo）
+- 画面内での高度な履歴管理（`undo`/`redo`）

--- a/docs/spec/UI_SPEC.md
+++ b/docs/spec/UI_SPEC.md
@@ -1,81 +1,145 @@
 # UI Specification (MVP)
 
+## English
 ## Purpose
-
 This document defines current MVP UI behavior for `mikuscore`.
 
-UI is an interaction layer only. Core remains the single source of truth for score mutation.
+The UI is only an interaction layer; Core remains the single source of truth for score mutation.
 
 ## Non-Negotiable Rule
-
 - UI MUST NOT mutate XML DOM directly.
 - UI MUST call core APIs only: `load(xml)`, `dispatch(command)`, `save()`.
 
 ## Current Screen Structure
-
 Top-level flow is a 4-step tabbed stepper:
-
-1. 入力 (`data-tab="input"`)
-2. 譜面 (`data-tab="score"`)
-3. 編集 (`data-tab="edit"`)
-4. 出力 (`data-tab="save"`)
+1. Input (`data-tab="input"`)
+2. Score (`data-tab="score"`)
+3. Edit (`data-tab="edit"`)
+4. Export (`data-tab="save"`)
 
 ## Input Behavior
-
 - Input type radio:
-  - `MusicXML入力`
-  - `ABC入力`
-  - `新規作成`
+  - `MusicXML input`
+  - `ABC input`
+  - `Create new`
 - Input mode radio:
-  - `ファイル読み込み`
-  - `ソース入力`
-- `ABC入力` で読み込んだ場合:
-  - ABC -> MusicXML に変換
-  - 後続処理は MusicXML DOM を正本として進行
+  - `File load`
+  - `Source input`
+- When loading from `ABC input`:
+  - Convert ABC -> MusicXML
+  - Continue all downstream flow using MusicXML DOM as source of truth
 
-## Score (譜面) Behavior
-
+## Score Behavior
 - Verovio SVG preview is the interaction target.
-- Click on note in SVG resolves to core `nodeId` via mapping layer.
-- Mapping uses:
+- Clicking a note resolves to core `nodeId` through mapping layer.
+- Mapping strategy:
   - target/ancestor id traversal
   - `elementsFromPoint` fallback
-- Playback controls (`再生`, `停止`) are provided in this panel.
+- Playback controls are provided (`Play`, `Stop`).
 
-## Edit (編集) Behavior
-
-- If no measure selected, show empty state card (`小節が未選択です`) with `譜面へ移動` action.
+## Edit Behavior
+- If no measure selected, show empty-state card with `Go to Score` action.
 - If selected:
   - show measure preview
   - show edit controls
-- Command controls include:
-  - `休符を音符化`
-  - `音符分割`
-  - `音符削除`
+- Command controls:
+  - `Convert Rest to Note`
+  - `Split Note`
+  - `Delete Note`
   - pitch up/down
-  - alter buttons (`なし`, `♭♭`, `♭`, `♮`, `♯`, `♯♯`)
+  - alter buttons (`None`, `♭♭`, `♭`, `♮`, `♯`, `♯♯`)
   - duration dropdown
-- Command diagnostic messages are shown inline under duration selector (`#uiMessage`).
+- Command diagnostics are shown inline under duration selector (`#uiMessage`).
 
-## Output (出力) Behavior
-
+## Output Behavior
 - Download buttons:
-  - `MusicXML出力`
-  - `ABC出力`
-  - `MIDI出力`
-- Download file names include timestamp suffix to reduce collisions:
+  - `MusicXML Export`
+  - `ABC Export`
+  - `MIDI Export`
+- Download names include timestamp suffix:
   - `mikuscore-YYYYMMDDhhmm.musicxml`
   - `mikuscore-YYYYMMDDhhmm.abc`
   - `mikuscore-YYYYMMDDhhmm.mid`
 
 ## Selection / Command Rules
-
 - Selection key is `nodeId`.
-- If selected node disappears after command, UI clears selection.
+- If selected node disappears after command, selection is cleared.
 - Core diagnostics are authoritative.
 
 ## Accessibility / UX Notes
-
 - Buttons have explicit labels.
-- Empty/disabled states are visibly distinct.
-- Editing actions are explicit (no hidden auto-apply beyond defined control events).
+- Empty/disabled states are visually distinct.
+- Editing actions stay explicit (no hidden auto-apply beyond defined control events).
+
+---
+
+## 日本語
+## 目的
+本ドキュメントは `mikuscore` の MVP UI 振る舞いを定義する。
+
+UI は操作レイヤのみで、譜面変更の正本は Core とする。
+
+## 非交渉ルール
+- UI は XML DOM を直接変更しない。
+- UI は Core API（`load(xml)`, `dispatch(command)`, `save()`）のみ呼ぶ。
+
+## 画面構成
+4ステップのタブ式ステッパー:
+1. 入力 (`data-tab="input"`)
+2. 譜面 (`data-tab="score"`)
+3. 編集 (`data-tab="edit"`)
+4. 出力 (`data-tab="save"`)
+
+## 入力仕様
+- 入力種別ラジオ:
+  - `MusicXML入力`
+  - `ABC入力`
+  - `新規作成`
+- 入力モードラジオ:
+  - `ファイル読み込み`
+  - `ソース入力`
+- `ABC入力` の読み込み時:
+  - ABC -> MusicXML へ変換
+  - 後続処理は MusicXML DOM を正本として継続
+
+## 譜面仕様
+- Verovio SVG プレビューを操作対象とする。
+- 音符クリックで `nodeId` を解決する。
+- マッピングは以下の順で解決:
+  - target/ancestor id 走査
+  - `elementsFromPoint` フォールバック
+- 再生コントロール（`再生`, `停止`）を提供。
+
+## 編集仕様
+- 小節未選択時は empty-state カードを表示し、`譜面へ移動` を提供。
+- 小節選択時:
+  - 小節プレビュー表示
+  - 編集コントロール表示
+- コマンド群:
+  - `休符を音符化`
+  - `音符分割`
+  - `音符削除`
+  - 音名 up/down
+  - 臨時記号（`なし`, `♭♭`, `♭`, `♮`, `♯`, `♯♯`）
+  - 音価ドロップダウン
+- 診断メッセージは音価ドロップダウン直下（`#uiMessage`）に表示。
+
+## 出力仕様
+- 出力ボタン:
+  - `MusicXML出力`
+  - `ABC出力`
+  - `MIDI出力`
+- ファイル名は衝突緩和のためタイムスタンプを付与:
+  - `mikuscore-YYYYMMDDhhmm.musicxml`
+  - `mikuscore-YYYYMMDDhhmm.abc`
+  - `mikuscore-YYYYMMDDhhmm.mid`
+
+## 選択・コマンド規則
+- 選択キーは `nodeId`。
+- コマンド後に選択ノードが消えた場合は選択解除。
+- 診断情報は Core の結果を正とする。
+
+## アクセシビリティ / UX
+- ボタンラベルを明示する。
+- empty/disabled 状態を視認可能にする。
+- 編集操作は明示的に実行し、隠れた自動適用は行わない。

--- a/docs/spec/abc-compat-parser-ebnf.md
+++ b/docs/spec/abc-compat-parser-ebnf.md
@@ -1,12 +1,14 @@
 # ABC Compat Parser EBNF (draft)
 
-ABC 2.1 を土台にしつつ、`abcjs` / `abcm2ps` でよく見かける記法差のうち、現状実装で吸収している部分を含みます。
+## English
+This document defines the grammar baseline for the project ABC parser.
+
+It is based on ABC 2.1 and includes currently supported compatibility behavior observed in real-world `abcjs` / `abcm2ps` style inputs.
 
 ## Scope
-
-- ヘッダ: `X,T,C,M,L,K,V` と `%%score`
-- ボディ: 音符、休符(`z/x`)、臨時記号、長さ、タイ(`-`)、broken rhythm(`>` `<`)、小節線、和音、連符
-- 許容拡張: `M:C`, `M:C|`, インライン文字列(`"..."`)のスキップ、単独オクターブ記号(`,`/`'`)の許容
+- Header: `X,T,C,M,L,K,V` and `%%score`
+- Body: note/rest (`z/x`), accidentals, length, tie (`-`), broken rhythm (`>` `<`), barlines, chords, tuplets
+- Compatibility extensions: `M:C`, `M:C|`, inline text skip (`"..."`), standalone octave marker tolerance (`,` / `'`)
 
 ## EBNF
 
@@ -74,7 +76,35 @@ digit            = "0".."9" ;
 ```
 
 ## Compatibility Notes
+- Allow broken rhythm with spaces (`A > B`).
+- Skip inline chord symbols/annotations like `"D"A` for MusicXML generation (warn only).
+- Treat `x` rest as `z` rest.
+- Support chords (`[CEG]`, `[A,,CE]`).
+- Support tuplets (`(3abc`, `(5:4:5abcde`) with duration scaling.
+- Ignore `:` in barline variants (`:|`, `|:`, `||`) without parse failure.
+- Ignore standalone `,` / `'` for compatibility.
 
+## Growth Policy
+- Parsing robustness first (warning-first policy).
+- Add regression tests when extending duration/pitch semantics.
+- Update this document’s compatibility notes whenever absorbing new real-world variance.
+
+---
+
+## 日本語
+この文書は、プロジェクトの ABC パーサーにおける文法基準を定義する。
+
+ABC 2.1 を土台とし、`abcjs` / `abcm2ps` 系の実データ差を現行実装で吸収している範囲を含む。
+
+## Scope
+- ヘッダ: `X,T,C,M,L,K,V` と `%%score`
+- ボディ: 音符、休符(`z/x`)、臨時記号、長さ、タイ(`-`)、broken rhythm(`>` `<`)、小節線、和音、連符
+- 許容拡張: `M:C`, `M:C|`, インライン文字列(`"..."`)のスキップ、単独オクターブ記号(`,`/`'`)の許容
+
+## EBNF
+上記 English セクションの EBNF を正本とする。
+
+## Compatibility Notes
 - `A > B` のような空白入り broken rhythm を許容。
 - `"D"A` のような和音名/注釈は MusicXML 生成対象外としてスキップ（警告のみ）。
 - `x` 休符を `z` と同様に扱う。
@@ -84,7 +114,6 @@ digit            = "0".."9" ;
 - 単独の `,` / `'` は互換目的で無視して継続する。
 
 ## Growth Policy
-
-- まず parse を落とさない（warning first）
-- 音価・音高の意味解釈を追加する時は回帰テストを同時追加
-- 実データ差分を吸収したら、この文書の `Compatibility Notes` へ追記
+- まず parse を落とさない（warning first）。
+- 音価・音高の意味解釈を追加する時は回帰テストを同時追加。
+- 実データ差分を吸収したら `Compatibility Notes` を更新する。

--- a/mikuscore-src.html
+++ b/mikuscore-src.html
@@ -27,7 +27,7 @@
           </span>
           <span>mikuscore</span>
           <span class="md-tooltip-group">
-            <span class="md-info-chip" aria-label="mikuscore の詳細説明">
+            <span class="md-info-chip" aria-label="About mikuscore">
               <svg aria-hidden="true" viewBox="0 0 24 24" class="md-info-icon" fill="none">
                 <circle cx="12" cy="12" r="9" fill="#cbbcf0"></circle>
                 <rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"></rect>
@@ -35,11 +35,11 @@
               </svg>
             </span>
             <span class="md-tooltip-content md-tooltip md-tooltip--rich md-tooltip--wide">
-              mikuscore は、MusicXML の既存構造をできるだけ保持しながら編集することを重視したローカル完結型エディタです。
-              入力（ファイル/ソース）から譜面プレビュー、ノート編集、再生確認、保存/ダウンロードまでを一画面で行えます。
-              操作手順: 1) 入力を選んで読み込み 2) 譜面プレビューで選択 3) ノートを編集 4) 再生で確認して保存 / ダウンロード。
-              まず読み込み後に譜面をクリックして対象ノートを選び、音高・音価を調整してください。
-              複雑な作業は MuseScore など別のソフトで実施してください。mikuscore はスマホで利用可能なソフトを目指します。
+              mikuscore is a local editor focused on preserving existing MusicXML structure while editing.
+              From input (file/source), score preview, note editing, playback, and export/download are handled in one screen.
+              Workflow: 1) Choose input and load 2) Select from score preview 3) Edit notes 4) Verify by playback and export/download.
+              After loading, click notes in the score to select targets, then adjust pitch and duration.
+              Use tools like MuseScore for complex work. mikuscore aims to be practical on mobile devices.
             </span>
           </span>
           <a
@@ -47,7 +47,7 @@
             class="ms-hero-link"
             target="_blank"
             rel="noopener noreferrer"
-            aria-label="mikuscore の GitHub リポジトリを開く"
+            aria-label="Open mikuscore GitHub repository"
           >
             <svg aria-hidden="true" viewBox="0 0 16 16" class="ms-btn-icon" fill="currentColor">
               <use href="#md-icon-github" xlink:href="#md-icon-github"></use>
@@ -57,45 +57,45 @@
         </h1>
       </header>
 
-      <div class="ms-top-tabs" role="tablist" aria-label="mikuscore セクション">
+      <div class="ms-top-tabs" role="tablist" aria-label="mikuscore sections">
         <button type="button" class="ms-top-tab is-active" data-tab="input">
           <span class="ms-top-tab-no">1</span>
-          <span class="ms-top-tab-label">入力</span>
+          <span class="ms-top-tab-label">Input</span>
         </button>
         <button type="button" class="ms-top-tab" data-tab="score">
           <span class="ms-top-tab-no">2</span>
-          <span class="ms-top-tab-label">譜面</span>
+          <span class="ms-top-tab-label">Score</span>
         </button>
         <button type="button" class="ms-top-tab" data-tab="edit">
           <span class="ms-top-tab-no">3</span>
-          <span class="ms-top-tab-label">編集</span>
+          <span class="ms-top-tab-label">Edit</span>
         </button>
         <button type="button" class="ms-top-tab" data-tab="save">
           <span class="ms-top-tab-no">4</span>
-          <span class="ms-top-tab-label">出力</span>
+          <span class="ms-top-tab-label">Export</span>
         </button>
       </div>
 
       <div class="ms-flow">
         <section class="md-section ms-flow-step ms-tab-panel" data-tab-panel="input">
-          <h2 class="md-section-title"><span class="ms-step-no">1</span>入力</h2>
-          <div class="ms-radio-group" role="radiogroup" aria-label="入力フォーマット">
-            <label class="md-radio"><input id="inputTypeXml" type="radio" name="inputType" value="xml" checked /> MusicXML入力</label>
-            <label class="md-radio"><input id="inputTypeAbc" type="radio" name="inputType" value="abc" /> ABC入力</label>
-            <label class="md-radio"><input id="inputTypeNew" type="radio" name="inputType" value="new" /> 新規作成</label>
+          <h2 class="md-section-title"><span class="ms-step-no">1</span>Input</h2>
+          <div class="ms-radio-group" role="radiogroup" aria-label="Input format">
+            <label class="md-radio"><input id="inputTypeXml" type="radio" name="inputType" value="xml" checked /> MusicXML Input</label>
+            <label class="md-radio"><input id="inputTypeAbc" type="radio" name="inputType" value="abc" /> ABC Input</label>
+            <label class="md-radio"><input id="inputTypeNew" type="radio" name="inputType" value="new" /> New Score</label>
           </div>
 
-          <div class="ms-radio-group" role="radiogroup" aria-label="取込方法">
-            <label class="md-radio"><input id="inputModeFile" type="radio" name="inputMode" value="file" checked /> ファイル読み込み</label>
-            <label class="md-radio"><input id="inputModeSource" type="radio" name="inputMode" value="source" /> ソース入力</label>
+          <div class="ms-radio-group" role="radiogroup" aria-label="Import mode">
+            <label class="md-radio"><input id="inputModeFile" type="radio" name="inputMode" value="file" checked /> File input</label>
+            <label class="md-radio"><input id="inputModeSource" type="radio" name="inputMode" value="source" /> Source input</label>
           </div>
 
           <div id="newInputBlock" class="ms-block md-hidden">
             <div class="ms-stack-sm">
-              <label class="ms-field">トラック数（パート数）
+              <label class="ms-field">Track count (parts)
                 <input id="newPartCount" type="number" min="1" max="16" step="1" value="1" class="md-input" />
               </label>
-              <label class="ms-field">拍子
+              <label class="ms-field">Time signature
                 <div class="ms-form-row">
                   <input id="newTimeBeats" type="number" min="1" max="16" step="1" value="4" class="md-input" style="max-width: 8rem;" />
                   <span>/</span>
@@ -107,7 +107,7 @@
                   </select>
                 </div>
               </label>
-              <label class="ms-field">調号
+              <label class="ms-field">Key signature
                 <select id="newKeyFifths" class="md-select">
                   <option value="1">♯1 (G)</option>
                   <option value="2">♯2 (D)</option>
@@ -116,7 +116,7 @@
                   <option value="5">♯5 (B)</option>
                   <option value="6">♯6 (F#)</option>
                   <option value="7">♯7 (C#)</option>
-                  <option value="0" selected>なし (C)</option>
+                  <option value="0" selected>None (C)</option>
                   <option value="-1">♭1 (F)</option>
                   <option value="-2">♭2 (Bb)</option>
                   <option value="-3">♭3 (Eb)</option>
@@ -137,9 +137,9 @@
                 <path d="M12 10v6"></path>
                 <path d="M9 13l3 3 3-3"></path>
               </svg>
-              <span>ファイルを選択</span>
+              <span>Choose file</span>
             </button>
-            <span id="fileNameText" class="ms-file-name">未選択</span>
+            <span id="fileNameText" class="ms-file-name">No file selected</span>
             <input id="fileInput" type="file" accept=".musicxml,.xml,.abc,text/plain,text/xml,application/xml" hidden />
           </div>
 
@@ -160,16 +160,16 @@
                 <path d="M12.2 13.4V9.8"></path>
                 <path d="M10 11.9l2.2 2.2 2.2-2.2"></path>
               </svg>
-              <span>読み込み</span>
+              <span>Load</span>
             </button>
           </div>
         </section>
 
         <section class="md-section ms-flow-step ms-tab-panel" data-tab-panel="score" hidden>
           <h2 class="md-section-title">
-            <span class="ms-step-no">2</span>譜面
+            <span class="ms-step-no">2</span>Score
             <span class="md-tooltip-group">
-              <span class="md-info-chip" aria-label="譜面プレビューの説明">
+              <span class="md-info-chip" aria-label="Score preview help">
                 <svg aria-hidden="true" viewBox="0 0 24 24" class="md-info-icon" fill="none">
                   <circle cx="12" cy="12" r="9" fill="#cbbcf0"></circle>
                   <rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"></rect>
@@ -177,7 +177,7 @@
                 </svg>
               </span>
               <span class="md-tooltip-content md-tooltip md-tooltip--rich md-tooltip--wide">
-                音符をクリックすると、編集対象として選択します。
+                Click a note to select it for editing.
               </span>
             </span>
           </h2>
@@ -186,13 +186,13 @@
               <svg aria-hidden="true" viewBox="0 0 24 24" class="ms-btn-icon" fill="currentColor">
                 <path d="M8 6.5v11l9-5.5z"></path>
               </svg>
-              <span>再生</span>
+              <span>Play</span>
             </button>
             <button id="stopBtn" type="button" class="md-button md-button--surface ms-icon-button" disabled>
               <svg aria-hidden="true" viewBox="0 0 24 24" class="ms-btn-icon" fill="currentColor">
                 <rect x="7" y="7" width="10" height="10" rx="1.5"></rect>
               </svg>
-              <span>停止</span>
+              <span>Stop</span>
             </button>
           </div>
           <div id="debugScoreWrap" class="ms-debug-wrap">
@@ -201,14 +201,14 @@
         </section>
 
         <section class="md-section ms-flow-step ms-tab-panel" data-tab-panel="edit" hidden>
-          <h2 class="md-section-title"><span class="ms-step-no">3</span>編集</h2>
+          <h2 class="md-section-title"><span class="ms-step-no">3</span>Edit</h2>
           <div id="measureEmptyState" class="ms-empty-state" role="status" aria-live="polite">
             <div class="ms-empty-state-inner">
-              <div class="ms-empty-state-title">小節が未選択です</div>
-              <div class="ms-empty-state-body">譜面から小節クリックして選択してください</div>
+              <div class="ms-empty-state-title">No measure selected</div>
+              <div class="ms-empty-state-body">Click a measure in the score to select it</div>
               <div class="ms-empty-state-actions">
                 <button id="measureSelectGuideBtn" type="button" class="md-button md-button--surface">
-                  譜面へ移動
+                  Go to Score
                 </button>
               </div>
             </div>
@@ -230,7 +230,7 @@
                 <circle cx="27.3" cy="15.9" r="2.2" fill="currentColor" stroke="none"></circle>
                 <path d="M29.3 15.9V7.1"></path>
               </svg>
-              <span>休符を音符化</span>
+              <span>Convert Rest to Note</span>
             </button>
             <button id="splitNoteBtn" type="button" class="md-button md-button--tonal ms-icon-button">
               <svg aria-hidden="true" viewBox="0 0 24 24" class="ms-btn-icon" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round">
@@ -240,7 +240,7 @@
                 <circle cx="16.5" cy="15.5" r="2.5" fill="currentColor" stroke="none"></circle>
                 <path d="M19 15.5V8"></path>
               </svg>
-              <span>音符分割</span>
+              <span>Split Note</span>
             </button>
             <button id="deleteBtn" type="button" class="md-button md-button--surface ms-icon-button">
               <svg aria-hidden="true" viewBox="0 0 24 24" class="ms-btn-icon" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round">
@@ -250,68 +250,68 @@
                 <path d="M10 10v7"></path>
                 <path d="M14 10v7"></path>
               </svg>
-              <span>音符削除</span>
+              <span>Delete Note</span>
             </button>
           </div>
 
           <div class="ms-grid">
             <label class="ms-field">
-              <span class="ms-field-label">音名(step)</span>
+              <span class="ms-field-label">Pitch step</span>
               <div class="ms-step-row">
                 <input id="pitchStep" type="hidden" value="" />
-                <span id="pitchStepValue" class="ms-step-value" aria-live="polite">休符</span>
-                <button id="pitchStepDownBtn" type="button" class="md-button md-button--surface ms-step-btn" aria-label="音名を下げる">↓</button>
-                <button id="pitchStepUpBtn" type="button" class="md-button md-button--surface ms-step-btn" aria-label="音名を上げる">↑</button>
+                <span id="pitchStepValue" class="ms-step-value" aria-live="polite">Rest</span>
+                <button id="pitchStepDownBtn" type="button" class="md-button md-button--surface ms-step-btn" aria-label="Lower pitch step">↓</button>
+                <button id="pitchStepUpBtn" type="button" class="md-button md-button--surface ms-step-btn" aria-label="Raise pitch step">↑</button>
               </div>
             </label>
             <label class="ms-field">
-              <span class="ms-field-label">変化記号(alter)</span>
-              <div class="ms-alter-row" role="group" aria-label="変化記号">
+              <span class="ms-field-label">Accidental</span>
+              <div class="ms-alter-row" role="group" aria-label="Accidental">
                 <input id="pitchAlter" type="hidden" value="none" />
-                <button type="button" class="md-button md-button--surface ms-alter-btn" data-alter="none" aria-label="変化記号なし">なし</button>
-                <button type="button" class="md-button md-button--surface ms-alter-btn" data-alter="-2" aria-label="ダブルフラット">♭♭</button>
-                <button type="button" class="md-button md-button--surface ms-alter-btn" data-alter="-1" aria-label="フラット">♭</button>
-                <button type="button" class="md-button md-button--surface ms-alter-btn" data-alter="0" aria-label="ナチュラル">♮</button>
-                <button type="button" class="md-button md-button--surface ms-alter-btn" data-alter="1" aria-label="シャープ">♯</button>
-                <button type="button" class="md-button md-button--surface ms-alter-btn" data-alter="2" aria-label="ダブルシャープ">♯♯</button>
+                <button type="button" class="md-button md-button--surface ms-alter-btn" data-alter="none" aria-label="No accidental">None</button>
+                <button type="button" class="md-button md-button--surface ms-alter-btn" data-alter="-2" aria-label="Double flat">♭♭</button>
+                <button type="button" class="md-button md-button--surface ms-alter-btn" data-alter="-1" aria-label="Flat">♭</button>
+                <button type="button" class="md-button md-button--surface ms-alter-btn" data-alter="0" aria-label="Natural">♮</button>
+                <button type="button" class="md-button md-button--surface ms-alter-btn" data-alter="1" aria-label="Sharp">♯</button>
+                <button type="button" class="md-button md-button--surface ms-alter-btn" data-alter="2" aria-label="Double sharp">♯♯</button>
               </div>
             </label>
             <input id="pitchOctave" type="hidden" value="4" />
             <label class="ms-field">
-              <span class="ms-field-label">音価(duration)</span>
-              <select id="durationPreset" class="md-select" aria-label="音価プリセット">
-                <option value="">（音価を選択）</option>
+              <span class="ms-field-label">Duration</span>
+              <select id="durationPreset" class="md-select" aria-label="Duration preset">
+                <option value="">(Select duration)</option>
               </select>
               <div id="uiMessage" class="ms-ui-message ms-ui-message--inline md-hidden" role="status" aria-live="polite"></div>
             </label>
           </div>
 
-          <p id="measurePartNameText" class="ms-track-label md-hidden">トラック名: -</p>
+          <p id="measurePartNameText" class="ms-track-label md-hidden">Track: -</p>
           <div class="ms-actions">
             <button id="measureApplyBtn" type="button" class="md-button md-button--primary ms-icon-button" disabled>
               <svg aria-hidden="true" viewBox="0 0 24 24" class="ms-btn-icon" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round">
                 <path d="M20 7L9 18l-5-5"></path>
               </svg>
-              <span>確定</span>
+              <span>Apply</span>
             </button>
             <button id="measureDiscardBtn" type="button" class="md-button md-button--surface ms-icon-button" disabled>
               <svg aria-hidden="true" viewBox="0 0 24 24" class="ms-btn-icon" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round">
                 <path d="M18 6L6 18"></path>
                 <path d="M6 6l12 12"></path>
               </svg>
-              <span>破棄</span>
+              <span>Discard</span>
             </button>
             <button id="playMeasureBtn" type="button" class="md-button md-button--tonal ms-icon-button" disabled>
               <svg aria-hidden="true" viewBox="0 0 24 24" class="ms-btn-icon" fill="currentColor">
                 <path d="M8 6.5v11l9-5.5z"></path>
               </svg>
-              <span>再生</span>
+              <span>Play</span>
             </button>
           </div>
         </section>
 
         <section class="md-section ms-flow-step ms-tab-panel" data-tab-panel="save" hidden>
-          <h2 class="md-section-title"><span class="ms-step-no">4</span>出力</h2>
+          <h2 class="md-section-title"><span class="ms-step-no">4</span>Export</h2>
           <div class="ms-actions">
             <button id="downloadBtn" type="button" class="md-button md-button--primary ms-icon-button" disabled>
               <svg aria-hidden="true" viewBox="0 0 24 24" class="ms-btn-icon" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round">
@@ -319,7 +319,7 @@
                 <path d="M8 11l4 4 4-4"></path>
                 <path d="M4 19h16"></path>
               </svg>
-              <span>MusicXML出力</span>
+              <span>Export MusicXML</span>
             </button>
             <button id="downloadAbcBtn" type="button" class="md-button md-button--tonal ms-icon-button" disabled>
               <svg aria-hidden="true" viewBox="0 0 24 24" class="ms-btn-icon" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round">
@@ -330,7 +330,7 @@
                 <path d="M12.2 12.4h2.5a1.7 1.7 0 0 1 0 3.4h-2.5z"></path>
                 <path d="M18.2 10.2a2.3 2.3 0 1 0 0 4.6"></path>
               </svg>
-              <span>ABC出力</span>
+              <span>Export ABC</span>
             </button>
             <button id="downloadMidiBtn" type="button" class="md-button md-button--tonal ms-icon-button" disabled>
               <svg aria-hidden="true" viewBox="0 0 24 24" class="ms-btn-icon" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round">
@@ -342,7 +342,7 @@
                 <circle cx="14.8" cy="12.6" r="0.6" fill="currentColor" stroke="none"></circle>
                 <circle cx="12" cy="11.8" r="0.6" fill="currentColor" stroke="none"></circle>
               </svg>
-              <span>MIDI出力</span>
+              <span>Export MIDI</span>
             </button>
           </div>
         </section>

--- a/mikuscore.html
+++ b/mikuscore.html
@@ -1480,7 +1480,7 @@ body {
           </span>
           <span>mikuscore</span>
           <span class="md-tooltip-group">
-            <span class="md-info-chip" aria-label="mikuscore の詳細説明">
+            <span class="md-info-chip" aria-label="About mikuscore">
               <svg aria-hidden="true" viewBox="0 0 24 24" class="md-info-icon" fill="none">
                 <circle cx="12" cy="12" r="9" fill="#cbbcf0"></circle>
                 <rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"></rect>
@@ -1488,11 +1488,11 @@ body {
               </svg>
             </span>
             <span class="md-tooltip-content md-tooltip md-tooltip--rich md-tooltip--wide">
-              mikuscore は、MusicXML の既存構造をできるだけ保持しながら編集することを重視したローカル完結型エディタです。
-              入力（ファイル/ソース）から譜面プレビュー、ノート編集、再生確認、保存/ダウンロードまでを一画面で行えます。
-              操作手順: 1) 入力を選んで読み込み 2) 譜面プレビューで選択 3) ノートを編集 4) 再生で確認して保存 / ダウンロード。
-              まず読み込み後に譜面をクリックして対象ノートを選び、音高・音価を調整してください。
-              複雑な作業は MuseScore など別のソフトで実施してください。mikuscore はスマホで利用可能なソフトを目指します。
+              mikuscore is a local editor focused on preserving existing MusicXML structure while editing.
+              From input (file/source), score preview, note editing, playback, and export/download are handled in one screen.
+              Workflow: 1) Choose input and load 2) Select from score preview 3) Edit notes 4) Verify by playback and export/download.
+              After loading, click notes in the score to select targets, then adjust pitch and duration.
+              Use tools like MuseScore for complex work. mikuscore aims to be practical on mobile devices.
             </span>
           </span>
           <a
@@ -1500,7 +1500,7 @@ body {
             class="ms-hero-link"
             target="_blank"
             rel="noopener noreferrer"
-            aria-label="mikuscore の GitHub リポジトリを開く"
+            aria-label="Open mikuscore GitHub repository"
           >
             <svg aria-hidden="true" viewBox="0 0 16 16" class="ms-btn-icon" fill="currentColor">
               <use href="#md-icon-github" xlink:href="#md-icon-github"></use>
@@ -1510,45 +1510,45 @@ body {
         </h1>
       </header>
 
-      <div class="ms-top-tabs" role="tablist" aria-label="mikuscore セクション">
+      <div class="ms-top-tabs" role="tablist" aria-label="mikuscore sections">
         <button type="button" class="ms-top-tab is-active" data-tab="input">
           <span class="ms-top-tab-no">1</span>
-          <span class="ms-top-tab-label">入力</span>
+          <span class="ms-top-tab-label">Input</span>
         </button>
         <button type="button" class="ms-top-tab" data-tab="score">
           <span class="ms-top-tab-no">2</span>
-          <span class="ms-top-tab-label">譜面</span>
+          <span class="ms-top-tab-label">Score</span>
         </button>
         <button type="button" class="ms-top-tab" data-tab="edit">
           <span class="ms-top-tab-no">3</span>
-          <span class="ms-top-tab-label">編集</span>
+          <span class="ms-top-tab-label">Edit</span>
         </button>
         <button type="button" class="ms-top-tab" data-tab="save">
           <span class="ms-top-tab-no">4</span>
-          <span class="ms-top-tab-label">出力</span>
+          <span class="ms-top-tab-label">Export</span>
         </button>
       </div>
 
       <div class="ms-flow">
         <section class="md-section ms-flow-step ms-tab-panel" data-tab-panel="input">
-          <h2 class="md-section-title"><span class="ms-step-no">1</span>入力</h2>
-          <div class="ms-radio-group" role="radiogroup" aria-label="入力フォーマット">
-            <label class="md-radio"><input id="inputTypeXml" type="radio" name="inputType" value="xml" checked /> MusicXML入力</label>
-            <label class="md-radio"><input id="inputTypeAbc" type="radio" name="inputType" value="abc" /> ABC入力</label>
-            <label class="md-radio"><input id="inputTypeNew" type="radio" name="inputType" value="new" /> 新規作成</label>
+          <h2 class="md-section-title"><span class="ms-step-no">1</span>Input</h2>
+          <div class="ms-radio-group" role="radiogroup" aria-label="Input format">
+            <label class="md-radio"><input id="inputTypeXml" type="radio" name="inputType" value="xml" checked /> MusicXML Input</label>
+            <label class="md-radio"><input id="inputTypeAbc" type="radio" name="inputType" value="abc" /> ABC Input</label>
+            <label class="md-radio"><input id="inputTypeNew" type="radio" name="inputType" value="new" /> New Score</label>
           </div>
 
-          <div class="ms-radio-group" role="radiogroup" aria-label="取込方法">
-            <label class="md-radio"><input id="inputModeFile" type="radio" name="inputMode" value="file" checked /> ファイル読み込み</label>
-            <label class="md-radio"><input id="inputModeSource" type="radio" name="inputMode" value="source" /> ソース入力</label>
+          <div class="ms-radio-group" role="radiogroup" aria-label="Import mode">
+            <label class="md-radio"><input id="inputModeFile" type="radio" name="inputMode" value="file" checked /> File input</label>
+            <label class="md-radio"><input id="inputModeSource" type="radio" name="inputMode" value="source" /> Source input</label>
           </div>
 
           <div id="newInputBlock" class="ms-block md-hidden">
             <div class="ms-stack-sm">
-              <label class="ms-field">トラック数（パート数）
+              <label class="ms-field">Track count (parts)
                 <input id="newPartCount" type="number" min="1" max="16" step="1" value="1" class="md-input" />
               </label>
-              <label class="ms-field">拍子
+              <label class="ms-field">Time signature
                 <div class="ms-form-row">
                   <input id="newTimeBeats" type="number" min="1" max="16" step="1" value="4" class="md-input" style="max-width: 8rem;" />
                   <span>/</span>
@@ -1560,7 +1560,7 @@ body {
                   </select>
                 </div>
               </label>
-              <label class="ms-field">調号
+              <label class="ms-field">Key signature
                 <select id="newKeyFifths" class="md-select">
                   <option value="1">♯1 (G)</option>
                   <option value="2">♯2 (D)</option>
@@ -1569,7 +1569,7 @@ body {
                   <option value="5">♯5 (B)</option>
                   <option value="6">♯6 (F#)</option>
                   <option value="7">♯7 (C#)</option>
-                  <option value="0" selected>なし (C)</option>
+                  <option value="0" selected>None (C)</option>
                   <option value="-1">♭1 (F)</option>
                   <option value="-2">♭2 (Bb)</option>
                   <option value="-3">♭3 (Eb)</option>
@@ -1590,9 +1590,9 @@ body {
                 <path d="M12 10v6"></path>
                 <path d="M9 13l3 3 3-3"></path>
               </svg>
-              <span>ファイルを選択</span>
+              <span>Choose file</span>
             </button>
-            <span id="fileNameText" class="ms-file-name">未選択</span>
+            <span id="fileNameText" class="ms-file-name">No file selected</span>
             <input id="fileInput" type="file" accept=".musicxml,.xml,.abc,text/plain,text/xml,application/xml" hidden />
           </div>
 
@@ -1613,16 +1613,16 @@ body {
                 <path d="M12.2 13.4V9.8"></path>
                 <path d="M10 11.9l2.2 2.2 2.2-2.2"></path>
               </svg>
-              <span>読み込み</span>
+              <span>Load</span>
             </button>
           </div>
         </section>
 
         <section class="md-section ms-flow-step ms-tab-panel" data-tab-panel="score" hidden>
           <h2 class="md-section-title">
-            <span class="ms-step-no">2</span>譜面
+            <span class="ms-step-no">2</span>Score
             <span class="md-tooltip-group">
-              <span class="md-info-chip" aria-label="譜面プレビューの説明">
+              <span class="md-info-chip" aria-label="Score preview help">
                 <svg aria-hidden="true" viewBox="0 0 24 24" class="md-info-icon" fill="none">
                   <circle cx="12" cy="12" r="9" fill="#cbbcf0"></circle>
                   <rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"></rect>
@@ -1630,7 +1630,7 @@ body {
                 </svg>
               </span>
               <span class="md-tooltip-content md-tooltip md-tooltip--rich md-tooltip--wide">
-                音符をクリックすると、編集対象として選択します。
+                Click a note to select it for editing.
               </span>
             </span>
           </h2>
@@ -1639,13 +1639,13 @@ body {
               <svg aria-hidden="true" viewBox="0 0 24 24" class="ms-btn-icon" fill="currentColor">
                 <path d="M8 6.5v11l9-5.5z"></path>
               </svg>
-              <span>再生</span>
+              <span>Play</span>
             </button>
             <button id="stopBtn" type="button" class="md-button md-button--surface ms-icon-button" disabled>
               <svg aria-hidden="true" viewBox="0 0 24 24" class="ms-btn-icon" fill="currentColor">
                 <rect x="7" y="7" width="10" height="10" rx="1.5"></rect>
               </svg>
-              <span>停止</span>
+              <span>Stop</span>
             </button>
           </div>
           <div id="debugScoreWrap" class="ms-debug-wrap">
@@ -1654,14 +1654,14 @@ body {
         </section>
 
         <section class="md-section ms-flow-step ms-tab-panel" data-tab-panel="edit" hidden>
-          <h2 class="md-section-title"><span class="ms-step-no">3</span>編集</h2>
+          <h2 class="md-section-title"><span class="ms-step-no">3</span>Edit</h2>
           <div id="measureEmptyState" class="ms-empty-state" role="status" aria-live="polite">
             <div class="ms-empty-state-inner">
-              <div class="ms-empty-state-title">小節が未選択です</div>
-              <div class="ms-empty-state-body">譜面から小節クリックして選択してください</div>
+              <div class="ms-empty-state-title">No measure selected</div>
+              <div class="ms-empty-state-body">Click a measure in the score to select it</div>
               <div class="ms-empty-state-actions">
                 <button id="measureSelectGuideBtn" type="button" class="md-button md-button--surface">
-                  譜面へ移動
+                  Go to Score
                 </button>
               </div>
             </div>
@@ -1683,7 +1683,7 @@ body {
                 <circle cx="27.3" cy="15.9" r="2.2" fill="currentColor" stroke="none"></circle>
                 <path d="M29.3 15.9V7.1"></path>
               </svg>
-              <span>休符を音符化</span>
+              <span>Convert Rest to Note</span>
             </button>
             <button id="splitNoteBtn" type="button" class="md-button md-button--tonal ms-icon-button">
               <svg aria-hidden="true" viewBox="0 0 24 24" class="ms-btn-icon" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round">
@@ -1693,7 +1693,7 @@ body {
                 <circle cx="16.5" cy="15.5" r="2.5" fill="currentColor" stroke="none"></circle>
                 <path d="M19 15.5V8"></path>
               </svg>
-              <span>音符分割</span>
+              <span>Split Note</span>
             </button>
             <button id="deleteBtn" type="button" class="md-button md-button--surface ms-icon-button">
               <svg aria-hidden="true" viewBox="0 0 24 24" class="ms-btn-icon" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round">
@@ -1703,68 +1703,68 @@ body {
                 <path d="M10 10v7"></path>
                 <path d="M14 10v7"></path>
               </svg>
-              <span>音符削除</span>
+              <span>Delete Note</span>
             </button>
           </div>
 
           <div class="ms-grid">
             <label class="ms-field">
-              <span class="ms-field-label">音名(step)</span>
+              <span class="ms-field-label">Pitch step</span>
               <div class="ms-step-row">
                 <input id="pitchStep" type="hidden" value="" />
-                <span id="pitchStepValue" class="ms-step-value" aria-live="polite">休符</span>
-                <button id="pitchStepDownBtn" type="button" class="md-button md-button--surface ms-step-btn" aria-label="音名を下げる">↓</button>
-                <button id="pitchStepUpBtn" type="button" class="md-button md-button--surface ms-step-btn" aria-label="音名を上げる">↑</button>
+                <span id="pitchStepValue" class="ms-step-value" aria-live="polite">Rest</span>
+                <button id="pitchStepDownBtn" type="button" class="md-button md-button--surface ms-step-btn" aria-label="Lower pitch step">↓</button>
+                <button id="pitchStepUpBtn" type="button" class="md-button md-button--surface ms-step-btn" aria-label="Raise pitch step">↑</button>
               </div>
             </label>
             <label class="ms-field">
-              <span class="ms-field-label">変化記号(alter)</span>
-              <div class="ms-alter-row" role="group" aria-label="変化記号">
+              <span class="ms-field-label">Accidental</span>
+              <div class="ms-alter-row" role="group" aria-label="Accidental">
                 <input id="pitchAlter" type="hidden" value="none" />
-                <button type="button" class="md-button md-button--surface ms-alter-btn" data-alter="none" aria-label="変化記号なし">なし</button>
-                <button type="button" class="md-button md-button--surface ms-alter-btn" data-alter="-2" aria-label="ダブルフラット">♭♭</button>
-                <button type="button" class="md-button md-button--surface ms-alter-btn" data-alter="-1" aria-label="フラット">♭</button>
-                <button type="button" class="md-button md-button--surface ms-alter-btn" data-alter="0" aria-label="ナチュラル">♮</button>
-                <button type="button" class="md-button md-button--surface ms-alter-btn" data-alter="1" aria-label="シャープ">♯</button>
-                <button type="button" class="md-button md-button--surface ms-alter-btn" data-alter="2" aria-label="ダブルシャープ">♯♯</button>
+                <button type="button" class="md-button md-button--surface ms-alter-btn" data-alter="none" aria-label="No accidental">None</button>
+                <button type="button" class="md-button md-button--surface ms-alter-btn" data-alter="-2" aria-label="Double flat">♭♭</button>
+                <button type="button" class="md-button md-button--surface ms-alter-btn" data-alter="-1" aria-label="Flat">♭</button>
+                <button type="button" class="md-button md-button--surface ms-alter-btn" data-alter="0" aria-label="Natural">♮</button>
+                <button type="button" class="md-button md-button--surface ms-alter-btn" data-alter="1" aria-label="Sharp">♯</button>
+                <button type="button" class="md-button md-button--surface ms-alter-btn" data-alter="2" aria-label="Double sharp">♯♯</button>
               </div>
             </label>
             <input id="pitchOctave" type="hidden" value="4" />
             <label class="ms-field">
-              <span class="ms-field-label">音価(duration)</span>
-              <select id="durationPreset" class="md-select" aria-label="音価プリセット">
-                <option value="">（音価を選択）</option>
+              <span class="ms-field-label">Duration</span>
+              <select id="durationPreset" class="md-select" aria-label="Duration preset">
+                <option value="">(Select duration)</option>
               </select>
               <div id="uiMessage" class="ms-ui-message ms-ui-message--inline md-hidden" role="status" aria-live="polite"></div>
             </label>
           </div>
 
-          <p id="measurePartNameText" class="ms-track-label md-hidden">トラック名: -</p>
+          <p id="measurePartNameText" class="ms-track-label md-hidden">Track: -</p>
           <div class="ms-actions">
             <button id="measureApplyBtn" type="button" class="md-button md-button--primary ms-icon-button" disabled>
               <svg aria-hidden="true" viewBox="0 0 24 24" class="ms-btn-icon" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round">
                 <path d="M20 7L9 18l-5-5"></path>
               </svg>
-              <span>確定</span>
+              <span>Apply</span>
             </button>
             <button id="measureDiscardBtn" type="button" class="md-button md-button--surface ms-icon-button" disabled>
               <svg aria-hidden="true" viewBox="0 0 24 24" class="ms-btn-icon" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round">
                 <path d="M18 6L6 18"></path>
                 <path d="M6 6l12 12"></path>
               </svg>
-              <span>破棄</span>
+              <span>Discard</span>
             </button>
             <button id="playMeasureBtn" type="button" class="md-button md-button--tonal ms-icon-button" disabled>
               <svg aria-hidden="true" viewBox="0 0 24 24" class="ms-btn-icon" fill="currentColor">
                 <path d="M8 6.5v11l9-5.5z"></path>
               </svg>
-              <span>再生</span>
+              <span>Play</span>
             </button>
           </div>
         </section>
 
         <section class="md-section ms-flow-step ms-tab-panel" data-tab-panel="save" hidden>
-          <h2 class="md-section-title"><span class="ms-step-no">4</span>出力</h2>
+          <h2 class="md-section-title"><span class="ms-step-no">4</span>Export</h2>
           <div class="ms-actions">
             <button id="downloadBtn" type="button" class="md-button md-button--primary ms-icon-button" disabled>
               <svg aria-hidden="true" viewBox="0 0 24 24" class="ms-btn-icon" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round">
@@ -1772,7 +1772,7 @@ body {
                 <path d="M8 11l4 4 4-4"></path>
                 <path d="M4 19h16"></path>
               </svg>
-              <span>MusicXML出力</span>
+              <span>Export MusicXML</span>
             </button>
             <button id="downloadAbcBtn" type="button" class="md-button md-button--tonal ms-icon-button" disabled>
               <svg aria-hidden="true" viewBox="0 0 24 24" class="ms-btn-icon" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round">
@@ -1783,7 +1783,7 @@ body {
                 <path d="M12.2 12.4h2.5a1.7 1.7 0 0 1 0 3.4h-2.5z"></path>
                 <path d="M18.2 10.2a2.3 2.3 0 1 0 0 4.6"></path>
               </svg>
-              <span>ABC出力</span>
+              <span>Export ABC</span>
             </button>
             <button id="downloadMidiBtn" type="button" class="md-button md-button--tonal ms-icon-button" disabled>
               <svg aria-hidden="true" viewBox="0 0 24 24" class="ms-btn-icon" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round">
@@ -1795,7 +1795,7 @@ body {
                 <circle cx="14.8" cy="12.6" r="0.6" fill="currentColor" stroke="none"></circle>
                 <circle cx="12" cy="11.8" r="0.6" fill="currentColor" stroke="none"></circle>
               </svg>
-              <span>MIDI出力</span>
+              <span>Export MIDI</span>
             </button>
           </div>
         </section>
@@ -1997,7 +1997,7 @@ const renderInputMode = () => {
     inputModeSource.disabled = isNewType;
     const loadLabel = loadBtn.querySelector("span");
     if (loadLabel) {
-        loadLabel.textContent = isNewType ? "新規作成" : "読み込み";
+        loadLabel.textContent = isNewType ? "Create" : "Load";
     }
     fileInput.accept = isAbcType
         ? ".abc,text/plain"
@@ -2041,14 +2041,14 @@ const renderNewPartClefControls = () => {
         row.className = "ms-form-row";
         const label = document.createElement("label");
         label.className = "ms-field";
-        label.textContent = `パート${i + 1} 記号`;
+        label.textContent = `Part ${i + 1} clef`;
         const select = document.createElement("select");
         select.className = "md-select";
         select.setAttribute("data-part-clef", "true");
         const options = [
-            { value: "treble", label: "ト音記号" },
-            { value: "alto", label: "ハ音記号" },
-            { value: "bass", label: "ヘ音記号" },
+            { value: "treble", label: "Treble clef" },
+            { value: "alto", label: "Alto clef" },
+            { value: "bass", label: "Bass clef" },
         ];
         for (const optionDef of options) {
             const option = document.createElement("option");
@@ -2067,8 +2067,8 @@ const renderStatus = () => {
         return;
     const dirty = core.isDirty();
     statusText.textContent = state.loaded
-        ? `ロード済み / 変更あり=${dirty} / ノート数=${state.noteNodeIds.length}`
-        : "未ロード（まず読み込みしてください）";
+        ? `Loaded / dirty=${dirty}  / notes=${state.noteNodeIds.length}`
+        : "Not loaded (please load first)";
 };
 const renderNotes = () => {
     const selectedNodeId = state.selectedNodeId && draftNoteNodeIds.includes(state.selectedNodeId)
@@ -2080,7 +2080,7 @@ const renderNotes = () => {
     noteSelect.innerHTML = "";
     const placeholder = document.createElement("option");
     placeholder.value = "";
-    placeholder.textContent = draftNoteNodeIds.length === 0 ? "(ノートなし)" : "(選択してください)";
+    placeholder.textContent = draftNoteNodeIds.length === 0 ? "(No notes)" : "(Select one)";
     noteSelect.appendChild(placeholder);
     for (const nodeId of draftNoteNodeIds) {
         const option = document.createElement("option");
@@ -2104,7 +2104,7 @@ const renderPitchStepValue = () => {
         pitchStepValue.textContent = step;
     }
     else {
-        pitchStepValue.textContent = "休符";
+        pitchStepValue.textContent = "Rest";
     }
 };
 const normalizeAlterValue = (value) => {
@@ -2139,26 +2139,26 @@ const resolveEffectiveDivisionsForMeasure = (doc, targetMeasure) => {
 const rebuildDurationPresetOptions = (divisions) => {
     const safeDivisions = Number.isInteger(divisions) && divisions > 0 ? divisions : DEFAULT_DIVISIONS;
     const defs = [
-        { label: "全音符", num: 4, den: 1 },
-        { label: "付点2分音符", num: 3, den: 1 },
-        { label: "2分音符", num: 2, den: 1 },
-        { label: "2分3連(1音)", num: 4, den: 3 },
-        { label: "付点4分音符", num: 3, den: 2 },
-        { label: "4分音符", num: 1, den: 1 },
-        { label: "4分3連(1音)", num: 2, den: 3 },
-        { label: "付点8分音符", num: 3, den: 4 },
-        { label: "8分音符", num: 1, den: 2 },
-        { label: "8分3連(1音)", num: 1, den: 3 },
-        { label: "付点16分音符", num: 3, den: 8 },
-        { label: "16分音符", num: 1, den: 4 },
-        { label: "16分3連(1音)", num: 1, den: 6 },
-        { label: "32分音符", num: 1, den: 8 },
-        { label: "64分音符", num: 1, den: 16 },
+        { label: "Whole note", num: 4, den: 1 },
+        { label: "Dotted half note", num: 3, den: 1 },
+        { label: "Half note", num: 2, den: 1 },
+        { label: "Half-note triplet (1 note)", num: 4, den: 3 },
+        { label: "Dotted quarter note", num: 3, den: 2 },
+        { label: "Quarter note", num: 1, den: 1 },
+        { label: "Quarter-note triplet (1 note)", num: 2, den: 3 },
+        { label: "Dotted eighth note", num: 3, den: 4 },
+        { label: "Eighth note", num: 1, den: 2 },
+        { label: "Eighth-note triplet (1 note)", num: 1, den: 3 },
+        { label: "Dotted sixteenth note", num: 3, den: 8 },
+        { label: "Sixteenth note", num: 1, den: 4 },
+        { label: "Sixteenth-note triplet (1 note)", num: 1, den: 6 },
+        { label: "3Half note", num: 1, den: 8 },
+        { label: "6Quarter note", num: 1, den: 16 },
     ];
     durationPreset.innerHTML = "";
     const placeholder = document.createElement("option");
     placeholder.value = "";
-    placeholder.textContent = "（音価を選択）";
+    placeholder.textContent = "(Select duration)";
     durationPreset.appendChild(placeholder);
     const used = new Set();
     for (const def of defs) {
@@ -2192,7 +2192,7 @@ const setDurationPresetFromValue = (duration) => {
     }
     const custom = document.createElement("option");
     custom.value = String(duration);
-    custom.textContent = `カスタム(${duration})`;
+    custom.textContent = `Custom(${duration})`;
     custom.className = "ms-duration-custom";
     durationPreset.appendChild(custom);
     durationPreset.value = custom.value;
@@ -2240,8 +2240,8 @@ const applyDurationPresetAvailability = (selectedNote, divisions) => {
         const isTriplet = durationValueIsTriplet(value, divisions);
         const unavailable = isTriplet && !hasTupletContext;
         option.disabled = unavailable;
-        const baseLabel = (_b = (_a = option.textContent) === null || _a === void 0 ? void 0 : _a.replace("（この小節では不可）", "").trim()) !== null && _b !== void 0 ? _b : "";
-        option.textContent = unavailable ? `${baseLabel}（この小節では不可）` : baseLabel;
+        const baseLabel = (_b = (_a = option.textContent) === null || _a === void 0 ? void 0 : _a.replace(" (not allowed in this measure)", "").trim()) !== null && _b !== void 0 ? _b : "";
+        option.textContent = unavailable ? `${baseLabel} (not allowed in this measure)` : baseLabel;
     }
 };
 const renderAlterButtons = () => {
@@ -2261,7 +2261,7 @@ const syncStepFromSelectedDraftNote = () => {
     selectedDraftNoteIsRest = false;
     pitchStep.disabled = false;
     pitchStep.title = "";
-    pitchOctave.title = "音名 ↑/↓ に連動して自動調整されます。";
+    pitchOctave.title = "Automatically adjusted with pitch step up/down.";
     for (const btn of pitchAlterBtns) {
         btn.disabled = false;
         btn.title = "";
@@ -2354,12 +2354,12 @@ const syncStepFromSelectedDraftNote = () => {
             selectedDraftNoteIsRest = true;
             pitchStep.value = "";
             pitchStep.disabled = true;
-            pitchStep.title = "休符は音高を持たないため、音高変更はできません。";
+            pitchStep.title = "Rests do not have pitch. Pitch changes are disabled.";
             for (const btn of pitchAlterBtns) {
                 btn.disabled = true;
-                btn.title = "休符は音高を持たないため、音高変更はできません。";
+                btn.title = "Rests do not have pitch. Pitch changes are disabled.";
             }
-            pitchOctave.title = "音名 ↑/↓ に連動して自動調整されます。";
+            pitchOctave.title = "Automatically adjusted with pitch step up/down.";
             renderPitchStepValue();
             renderAlterButtons();
             return;
@@ -2387,7 +2387,7 @@ const syncStepFromSelectedDraftNote = () => {
 const renderMeasureEditorState = () => {
     var _a;
     if (!selectedMeasure || !draftCore) {
-        measurePartNameText.textContent = "トラック名: -";
+        measurePartNameText.textContent = "Track: -";
         measurePartNameText.classList.add("md-hidden");
         measureEmptyState.classList.remove("md-hidden");
         measureEditorWrap.classList.add("md-hidden");
@@ -2397,7 +2397,7 @@ const renderMeasureEditorState = () => {
     }
     const partName = (_a = partIdToName.get(selectedMeasure.partId)) !== null && _a !== void 0 ? _a : selectedMeasure.partId;
     measurePartNameText.textContent =
-        `トラック名: ${partName} / 選択中: トラック=${selectedMeasure.partId} / 小節=${selectedMeasure.measureNumber}`;
+        `Track: ${partName} / Selected: track=${selectedMeasure.partId}  / measure=${selectedMeasure.measureNumber}`;
     measurePartNameText.classList.remove("md-hidden");
     measureEmptyState.classList.add("md-hidden");
     measureEditorWrap.classList.remove("md-hidden");
@@ -2453,7 +2453,7 @@ const renderDiagnostics = () => {
     const dispatch = state.lastDispatchResult;
     const save = state.lastSaveResult;
     if (!dispatch && !save) {
-        diagArea.textContent = "診断なし";
+        diagArea.textContent = "No diagnostics";
         return;
     }
     if (dispatch) {
@@ -2479,7 +2479,7 @@ const renderDiagnostics = () => {
         }
     }
     if (!diagArea.firstChild) {
-        diagArea.textContent = "診断なし";
+        diagArea.textContent = "No diagnostics";
     }
 };
 const renderUiMessage = () => {
@@ -2489,14 +2489,14 @@ const renderUiMessage = () => {
     if (dispatch) {
         if (!dispatch.ok && dispatch.diagnostics.length > 0) {
             const d = dispatch.diagnostics[0];
-            uiMessage.textContent = `エラー: ${d.message} (${d.code})`;
+            uiMessage.textContent = `Error: ${d.message} (${d.code})`;
             uiMessage.classList.add("ms-ui-message--error");
             uiMessage.classList.remove("md-hidden");
             return;
         }
         if (dispatch.warnings.length > 0) {
             const w = dispatch.warnings[0];
-            uiMessage.textContent = `警告: ${w.message} (${w.code})`;
+            uiMessage.textContent = `Warning: ${w.message} (${w.code})`;
             uiMessage.classList.add("ms-ui-message--warning");
             uiMessage.classList.remove("md-hidden");
             return;
@@ -2505,7 +2505,7 @@ const renderUiMessage = () => {
     const save = state.lastSaveResult;
     if (save && !save.ok && save.diagnostics.length > 0) {
         const d = save.diagnostics[0];
-        uiMessage.textContent = `エラー: ${d.message} (${d.code})`;
+        uiMessage.textContent = `Error: ${d.message} (${d.code})`;
         uiMessage.classList.add("ms-ui-message--error");
         uiMessage.classList.remove("md-hidden");
         return;
@@ -2792,7 +2792,7 @@ const initializeMeasureEditor = (location) => {
         return;
     const extracted = extractMeasureEditorXml(xml, location.partId, location.measureNumber);
     if (!extracted) {
-        setUiMappingDiagnostic("選択小節の抽出に失敗しました。");
+        setUiMappingDiagnostic("Failed to extract selected measure.");
         return;
     }
     const nextDraft = new ScoreCore_1.ScoreCore({ editableVoice: EDITABLE_VOICE });
@@ -2800,7 +2800,7 @@ const initializeMeasureEditor = (location) => {
         nextDraft.load(extracted);
     }
     catch (error) {
-        setUiMappingDiagnostic(`選択小節の読み込みに失敗しました: ${error instanceof Error ? error.message : String(error)}`);
+        setUiMappingDiagnostic(`Failed to load the selected measure: ${error instanceof Error ? error.message : String(error)}`);
         return;
     }
     draftCore = nextDraft;
@@ -2826,16 +2826,16 @@ const onVerovioScoreClick = (event) => {
         });
     }
     if (!nodeId) {
-        setUiMappingDiagnostic("クリック位置からノートを特定できませんでした。");
+        setUiMappingDiagnostic("Could not resolve a note from the clicked position.");
         return;
     }
     if (!state.noteNodeIds.includes(nodeId)) {
-        setUiMappingDiagnostic(`クリック要素に対応する nodeId が見つかりませんでした: ${nodeId}`);
+        setUiMappingDiagnostic(`No nodeId matched the clicked element: ${nodeId}`);
         return;
     }
     const location = nodeIdToLocation.get(nodeId);
     if (!location) {
-        setUiMappingDiagnostic(`nodeId からトラック/小節を特定できませんでした: ${nodeId}`);
+        setUiMappingDiagnostic(`Could not resolve track/measure from nodeId: ${nodeId}`);
         return;
     }
     initializeMeasureEditor(location);
@@ -3029,7 +3029,7 @@ const onDurationPresetChange = () => {
             diagnostics: [
                 {
                     code: first.code,
-                    message: "この音価には変更できません。小節内の長さ上限を超えます。",
+                    message: "This duration is not allowed. It exceeds the measure capacity.",
                 },
             ],
         };
@@ -3092,7 +3092,7 @@ const loadFromText = (xml) => {
             diagnostics: [
                 {
                     code: "MVP_COMMAND_EXECUTION_FAILED",
-                    message: err instanceof Error ? err.message : "読み込みに失敗しました。",
+                    message: err instanceof Error ? err.message : "Load failed.",
                 },
             ],
             warnings: [],
@@ -3220,7 +3220,7 @@ const requireSelectedNode = () => {
             dirtyChanged: false,
             changedNodeIds: [],
             affectedMeasureNumbers: [],
-            diagnostics: [{ code: "MVP_COMMAND_TARGET_MISSING", message: "先に小節を選択してください。" }],
+            diagnostics: [{ code: "MVP_COMMAND_TARGET_MISSING", message: "Select a measure first." }],
             warnings: [],
         };
         renderAll();
@@ -3234,7 +3234,7 @@ const requireSelectedNode = () => {
         dirtyChanged: false,
         changedNodeIds: [],
         affectedMeasureNumbers: [],
-        diagnostics: [{ code: "MVP_COMMAND_TARGET_MISSING", message: "ノートを選択してください。" }],
+        diagnostics: [{ code: "MVP_COMMAND_TARGET_MISSING", message: "Select a note." }],
         warnings: [],
     };
     renderAll();
@@ -3251,7 +3251,7 @@ const onChangePitch = () => {
             dirtyChanged: false,
             changedNodeIds: [],
             affectedMeasureNumbers: [],
-            diagnostics: [{ code: "MVP_INVALID_COMMAND_PAYLOAD", message: "pitch 入力が不正です。" }],
+            diagnostics: [{ code: "MVP_INVALID_COMMAND_PAYLOAD", message: "Invalid pitch input." }],
             warnings: [],
         };
         renderAll();
@@ -3348,14 +3348,14 @@ const onMeasureApply = () => {
         return;
     const merged = replaceMeasureInMainXml(mainXml, selectedMeasure.partId, selectedMeasure.measureNumber, draftSave.xml);
     if (!merged) {
-        setUiMappingDiagnostic("小節確定に失敗しました。");
+        setUiMappingDiagnostic("Failed to apply measure changes.");
         return;
     }
     try {
         core.load(merged);
     }
     catch (error) {
-        setUiMappingDiagnostic(`小節確定後の再読込に失敗しました: ${error instanceof Error ? error.message : String(error)}`);
+        setUiMappingDiagnostic(`Failed to reload after applying measure changes: ${error instanceof Error ? error.message : String(error)}`);
         return;
     }
     state.loaded = true;
@@ -3382,7 +3382,7 @@ const onChangeDuration = () => {
             dirtyChanged: false,
             changedNodeIds: [],
             affectedMeasureNumbers: [],
-            diagnostics: [{ code: "MVP_INVALID_COMMAND_PAYLOAD", message: "duration 入力が不正です。" }],
+            diagnostics: [{ code: "MVP_INVALID_COMMAND_PAYLOAD", message: "Invalid duration input." }],
             warnings: [],
         };
         renderAll();
@@ -3408,7 +3408,7 @@ const onInsertAfter = () => {
             dirtyChanged: false,
             changedNodeIds: [],
             affectedMeasureNumbers: [],
-            diagnostics: [{ code: "MVP_INVALID_COMMAND_PAYLOAD", message: "挿入ノート入力が不正です。" }],
+            diagnostics: [{ code: "MVP_INVALID_COMMAND_PAYLOAD", message: "Invalid inserted note input." }],
             warnings: [],
         };
         renderAll();
@@ -3519,7 +3519,7 @@ fileSelectBtn.addEventListener("click", () => fileInput.click());
 fileInput.addEventListener("change", () => {
     var _a;
     const f = (_a = fileInput.files) === null || _a === void 0 ? void 0 : _a[0];
-    fileNameText.textContent = f ? f.name : "未選択";
+    fileNameText.textContent = f ? f.name : "No file selected";
 });
 loadBtn.addEventListener("click", () => {
     void onLoadClick();
@@ -17886,7 +17886,7 @@ exports.renderMeasureEditorPreview = exports.renderScorePreview = void 0;
 const verovio_out_1 = require("./verovio-out");
 const renderScorePreview = async (params) => {
     if (!params.xml) {
-        params.setMetaText("描画対象XMLがありません");
+        params.setMetaText("No XML to render.");
         params.setSvgHtml("");
         params.setSvgIdMap(new Map());
         return;
@@ -17894,12 +17894,12 @@ const renderScorePreview = async (params) => {
     const renderBundle = params.buildRenderXmlForVerovio(params.xml);
     const renderDoc = renderBundle.renderDoc;
     if (!renderDoc) {
-        params.setMetaText("描画失敗: MusicXML解析失敗");
+        params.setMetaText("Render failed: invalid MusicXML.");
         params.setSvgHtml("");
         params.setSvgIdMap(new Map());
         return;
     }
-    params.setMetaText("verovio 描画中...");
+    params.setMetaText("Rendering with verovio...");
     try {
         const { svg, pageCount } = await (0, verovio_out_1.renderMusicXmlDomToSvg)(renderDoc, {
             pageWidth: 20000,
@@ -17944,7 +17944,7 @@ const renderScorePreview = async (params) => {
         if (!params.isRenderSeqCurrent(params.renderSeq))
             return;
         const message = error instanceof Error ? error.message : String(error);
-        params.setMetaText("描画失敗: " + message);
+        params.setMetaText("Render failed: " + message);
         params.setSvgHtml("");
         params.setSvgIdMap(new Map());
     }
@@ -17958,18 +17958,18 @@ const renderMeasureEditorPreview = async (params) => {
     }
     const sourceDoc = params.parseMusicXmlDocument(params.xml);
     if (!sourceDoc) {
-        params.setHtml("描画失敗: MusicXML解析失敗");
+        params.setHtml("Render failed: invalid MusicXML.");
         params.setSvgIdMap(new Map());
         return;
     }
     const renderBundle = params.buildRenderDocWithNodeIds(sourceDoc, params.draftNoteNodeIds.slice(), "mks-draft");
     const renderDoc = renderBundle.renderDoc;
     if (!renderDoc) {
-        params.setHtml("描画失敗: MusicXML解析失敗");
+        params.setHtml("Render failed: invalid MusicXML.");
         params.setSvgIdMap(new Map());
         return;
     }
-    params.setHtml("描画中...");
+    params.setHtml("Rendering...");
     try {
         const { svg } = await (0, verovio_out_1.renderMusicXmlDomToSvg)(renderDoc, {
             pageWidth: 6000,
@@ -17990,7 +17990,7 @@ const renderMeasureEditorPreview = async (params) => {
         params.onRendered();
     }
     catch (error) {
-        params.setHtml(`描画失敗: ${error instanceof Error ? error.message : String(error)}`);
+        params.setHtml(`Render failed: ${error instanceof Error ? error.message : String(error)}`);
         params.setSvgIdMap(new Map());
     }
 };
@@ -18083,11 +18083,11 @@ const ensureVerovioToolkit = async () => {
     verovioInitPromise = (async () => {
         const runtime = getVerovioRuntime();
         if (!runtime || typeof runtime.toolkit !== "function") {
-            throw new Error("verovio.js が読み込まれていません。");
+            throw new Error("verovio.js is not loaded.");
         }
         const moduleObj = runtime.module;
         if (!moduleObj) {
-            throw new Error("verovio module が見つかりません。");
+            throw new Error("verovio module was not found.");
         }
         if (!moduleObj.calledRun || typeof moduleObj.cwrap !== "function") {
             await new Promise((resolve, reject) => {
@@ -18096,7 +18096,7 @@ const ensureVerovioToolkit = async () => {
                     if (settled)
                         return;
                     settled = true;
-                    reject(new Error("verovio 初期化待機がタイムアウトしました。"));
+                    reject(new Error("Timed out while waiting for verovio initialization."));
                 }, 8000);
                 const complete = () => {
                     if (settled)
@@ -18129,7 +18129,7 @@ const ensureVerovioToolkit = async () => {
 const renderMusicXmlDomToSvg = async (doc, options) => {
     const toolkit = await ensureVerovioToolkit();
     if (!toolkit) {
-        throw new Error("verovio toolkit の初期化に失敗しました。");
+        throw new Error("Failed to initialize verovio toolkit.");
     }
     // Keep source DOM intact and only sanitize slur mismatch on render copy.
     const renderDoc = cloneXmlDocument(doc);
@@ -18138,15 +18138,15 @@ const renderMusicXmlDomToSvg = async (doc, options) => {
     toolkit.setOptions(options);
     const loaded = toolkit.loadData(xml);
     if (!loaded) {
-        throw new Error("verovio loadData が失敗しました。");
+        throw new Error("verovio loadData failed.");
     }
     const pageCount = toolkit.getPageCount();
     if (!Number.isFinite(pageCount) || pageCount < 1) {
-        throw new Error("verovio pageCount が不正です。");
+        throw new Error("verovio returned an invalid pageCount.");
     }
     const svg = toolkit.renderToSVG(1, {});
     if (!svg) {
-        throw new Error("verovio SVG 生成に失敗しました。");
+        throw new Error("Failed to generate SVG with verovio.");
     }
     return { svg, pageCount };
 };
@@ -18436,7 +18436,7 @@ const createBasicWaveSynthEngine = (options) => {
     };
     const playSchedule = async (schedule, waveform, onEnded) => {
         if (!schedule || !Array.isArray(schedule.events) || schedule.events.length === 0) {
-            throw new Error("先に変換してください。");
+            throw new Error("Please convert first.");
         }
         if (!audioContext) {
             audioContext = new AudioContext();
@@ -18480,7 +18480,7 @@ const toSynthSchedule = (tempo, events) => {
 const stopPlayback = (options) => {
     options.engine.stop();
     options.setIsPlaying(false);
-    options.setPlaybackText("再生: 停止中");
+    options.setPlaybackText("Playback: stopped");
     options.renderControlState();
 };
 exports.stopPlayback = stopPlayback;
@@ -18501,19 +18501,19 @@ const startPlayback = async (options, params) => {
             }
         }
         options.renderAll();
-        options.setPlaybackText("再生: 保存失敗");
+        options.setPlaybackText("Playback: save failed");
         return;
     }
     const playbackDoc = (0, musicxml_io_1.parseMusicXmlDocument)(saveResult.xml);
     if (!playbackDoc) {
-        options.setPlaybackText("再生: MusicXML解析失敗");
+        options.setPlaybackText("Playback: invalid MusicXML");
         options.renderControlState();
         return;
     }
     const parsedPlayback = (0, midi_io_1.buildPlaybackEventsFromMusicXmlDoc)(playbackDoc, options.ticksPerQuarter);
     const events = parsedPlayback.events;
     if (events.length === 0) {
-        options.setPlaybackText("再生: 再生可能ノートなし");
+        options.setPlaybackText("Playback: no playable notes");
         options.renderControlState();
         return;
     }
@@ -18522,24 +18522,24 @@ const startPlayback = async (options, params) => {
         midiBytes = (0, midi_io_1.buildMidiBytesForPlayback)(events, parsedPlayback.tempo);
     }
     catch (error) {
-        options.setPlaybackText("再生: MIDI生成失敗 (" + (error instanceof Error ? error.message : String(error)) + ")");
+        options.setPlaybackText("Playback: MIDI generation failed (" + (error instanceof Error ? error.message : String(error)) + ")");
         options.renderControlState();
         return;
     }
     try {
         await options.engine.playSchedule(toSynthSchedule(parsedPlayback.tempo, events), FIXED_PLAYBACK_WAVEFORM, () => {
             options.setIsPlaying(false);
-            options.setPlaybackText("再生: 停止中");
+            options.setPlaybackText("Playback: stopped");
             options.renderControlState();
         });
     }
     catch (error) {
-        options.setPlaybackText("再生: シンセ再生失敗 (" + (error instanceof Error ? error.message : String(error)) + ")");
+        options.setPlaybackText("Playback: synth playback failed (" + (error instanceof Error ? error.message : String(error)) + ")");
         options.renderControlState();
         return;
     }
     options.setIsPlaying(true);
-    options.setPlaybackText(`再生中: ノート${events.length}件 / MIDI ${midiBytes.length} bytes / 波形 sine`);
+    options.setPlaybackText(`Playing: ${events.length} notes / MIDI ${midiBytes.length} bytes / waveform sine`);
     options.renderControlState();
     options.renderAll();
 };
@@ -18551,37 +18551,37 @@ const startMeasurePlayback = async (options, params) => {
     if (!saveResult.ok) {
         options.onMeasureSaveDiagnostics(saveResult.diagnostics);
         options.logDiagnostics("playback", saveResult.diagnostics);
-        options.setPlaybackText("再生: 小節保存失敗");
+        options.setPlaybackText("Playback: measure save failed");
         options.renderAll();
         return;
     }
     const playbackDoc = (0, musicxml_io_1.parseMusicXmlDocument)(saveResult.xml);
     if (!playbackDoc) {
-        options.setPlaybackText("再生: MusicXML解析失敗");
+        options.setPlaybackText("Playback: invalid MusicXML");
         options.renderControlState();
         return;
     }
     const parsedPlayback = (0, midi_io_1.buildPlaybackEventsFromMusicXmlDoc)(playbackDoc, options.ticksPerQuarter);
     const events = parsedPlayback.events;
     if (events.length === 0) {
-        options.setPlaybackText("再生: この小節に再生可能ノートなし");
+        options.setPlaybackText("Playback: no playable notes in this measure");
         options.renderControlState();
         return;
     }
     try {
         await options.engine.playSchedule(toSynthSchedule(parsedPlayback.tempo, events), FIXED_PLAYBACK_WAVEFORM, () => {
             options.setIsPlaying(false);
-            options.setPlaybackText("再生: 停止中");
+            options.setPlaybackText("Playback: stopped");
             options.renderControlState();
         });
     }
     catch (error) {
-        options.setPlaybackText("再生: 小節再生失敗 (" + (error instanceof Error ? error.message : String(error)) + ")");
+        options.setPlaybackText("Playback: measure playback failed (" + (error instanceof Error ? error.message : String(error)) + ")");
         options.renderControlState();
         return;
     }
     options.setIsPlaying(true);
-    options.setPlaybackText(`再生中: 選択小節 ノート${events.length}件 / 波形 sine`);
+    options.setPlaybackText(`Playing: selected measure / ${events.length} notes / waveform sine`);
     options.renderControlState();
 };
 exports.startMeasurePlayback = startMeasurePlayback;
@@ -18669,7 +18669,7 @@ const buildMidiBytesForPlayback = (events, tempo) => {
     var _a;
     const midiWriter = getMidiWriterRuntime();
     if (!midiWriter) {
-        throw new Error("midi-writer.js が読み込まれていません。");
+        throw new Error("midi-writer.js is not loaded.");
     }
     const tracksById = new Map();
     for (const event of events) {
@@ -18716,7 +18716,7 @@ const buildMidiBytesForPlayback = (events, tempo) => {
         midiTracks.push(track);
     });
     if (!midiTracks.length) {
-        throw new Error("MIDI化するノートがありません。");
+        throw new Error("No notes available for MIDI conversion.");
     }
     const writer = new midiWriter.Writer(midiTracks);
     const built = writer.buildFile();
@@ -18906,7 +18906,7 @@ const resolveLoadFlow = async (params) => {
             return {
                 ok: false,
                 diagnosticCode: "MVP_INVALID_COMMAND_PAYLOAD",
-                diagnosticMessage: "ファイルを選択してください。",
+                diagnosticMessage: "Please select a file.",
             };
         }
         sourceText = await selected.text();
@@ -18932,7 +18932,7 @@ const resolveLoadFlow = async (params) => {
             return {
                 ok: false,
                 diagnosticCode: "MVP_INVALID_COMMAND_PAYLOAD",
-                diagnosticMessage: `ABCの解析に失敗しました: ${error instanceof Error ? error.message : String(error)}`,
+                diagnosticMessage: `Failed to parse ABC: ${error instanceof Error ? error.message : String(error)}`,
             };
         }
     }
@@ -18957,7 +18957,7 @@ const resolveLoadFlow = async (params) => {
         return {
             ok: false,
             diagnosticCode: "MVP_INVALID_COMMAND_PAYLOAD",
-            diagnosticMessage: `ABCの解析に失敗しました: ${error instanceof Error ? error.message : String(error)}`,
+            diagnosticMessage: `Failed to parse ABC: ${error instanceof Error ? error.message : String(error)}`,
         };
     }
 };
@@ -19102,7 +19102,7 @@ const parseAbcLengthToken = (token, lineNo) => {
         const p = token.split("/");
         return reduceFraction(Number(p[0]), Number(p[1]), { num: 1, den: 1 });
     }
-    throw new Error(`line ${lineNo}: 長さ指定を解釈できません: ${token}`);
+    throw new Error(`line ${lineNo}: Could not parse length token: ${token}`);
 };
 const abcLengthTokenFromFraction = (ratio) => {
     const reduced = reduceFraction(ratio.num, ratio.den, { num: 1, den: 1 });
@@ -19264,7 +19264,7 @@ function parseForMusicXml(source, settings) {
         bodyEntries.push({ text: noComment, lineNo, voiceId: currentVoiceId });
     }
     if (bodyEntries.length === 0) {
-        throw new Error("本文が見つかりません。ABCのノート列を入力してください。 (line 1)");
+        throw new Error("Body not found. Please provide ABC note content. (line 1)");
     }
     const meter = parseMeter(headers.M || "4/4", warnings);
     const unitLength = parseFraction(headers.L || "1/8", "L", warnings);
@@ -19316,7 +19316,7 @@ function parseForMusicXml(source, settings) {
             }
             if (ch === ">" || ch === "<") {
                 if (!lastEventNotes || lastEventNotes.length === 0 || lastEventNotes.some((n) => n.isRest)) {
-                    warnings.push("line " + entry.lineNo + ": broken rhythm(" + ch + ") の前にノートがないためスキップしました。");
+                    warnings.push("line " + entry.lineNo + ": broken rhythm(" + ch + ")  has no preceding note; skipped.");
                     idx += 1;
                     continue;
                 }
@@ -19339,12 +19339,12 @@ function parseForMusicXml(source, settings) {
                         tupletRemaining = r;
                     }
                     else {
-                        warnings.push("line " + entry.lineNo + ": 連符記法の解釈に失敗しました: " + tupletMatch[0]);
+                        warnings.push("line " + entry.lineNo + ": Failed to parse tuplet notation: " + tupletMatch[0]);
                     }
                     idx += tupletMatch[0].length;
                     continue;
                 }
-                warnings.push("line " + entry.lineNo + ": 非対応の連符記法をスキップしました: (");
+                warnings.push("line " + entry.lineNo + ": Skipped unsupported tuplet notation: (");
                 idx += 1;
                 continue;
             }
@@ -19354,7 +19354,7 @@ function parseForMusicXml(source, settings) {
                     pendingTieToNext = true;
                 }
                 else {
-                    warnings.push("line " + entry.lineNo + ": tie(-) の前にノートがないためスキップしました。");
+                    warnings.push("line " + entry.lineNo + ": tie(-)  has no preceding note; skipped.");
                 }
                 idx += 1;
                 continue;
@@ -19367,7 +19367,7 @@ function parseForMusicXml(source, settings) {
                 else {
                     idx = text.length;
                 }
-                warnings.push("line " + entry.lineNo + ': インライン文字列("...")はスキップしました。');
+                warnings.push("line " + entry.lineNo + ': Skipped inline string ("...").');
                 continue;
             }
             if (ch === "!" || ch === "+") {
@@ -19378,13 +19378,13 @@ function parseForMusicXml(source, settings) {
                 else {
                     idx += 1;
                 }
-                warnings.push("line " + entry.lineNo + ": 装飾記法をスキップしました: " + ch + "..." + ch);
+                warnings.push("line " + entry.lineNo + ": Skipped decoration: " + ch + "..." + ch);
                 continue;
             }
             if (ch === "[") {
                 const chordResult = parseChordAt(text, idx, entry.lineNo);
                 if (!chordResult) {
-                    warnings.push("line " + entry.lineNo + ": 和音記法の解釈に失敗したためスキップしました。");
+                    warnings.push("line " + entry.lineNo + ": Failed to parse chord notation; skipped.");
                     idx += 1;
                     continue;
                 }
@@ -19419,7 +19419,7 @@ function parseForMusicXml(source, settings) {
                 }
                 const dur = durationInDivisions(absoluteLength, 960);
                 if (dur <= 0) {
-                    throw new Error("line " + entry.lineNo + ": 長さが不正です");
+                    throw new Error("line " + entry.lineNo + ": Invalid length");
                 }
                 const chordNotes = [];
                 for (let chordIndex = 0; chordIndex < chordResult.notes.length; chordIndex += 1) {
@@ -19444,7 +19444,7 @@ function parseForMusicXml(source, settings) {
                 continue;
             }
             if (ch === "]" || ch === ")" || ch === "{" || ch === "}") {
-                warnings.push("line " + entry.lineNo + ": 非対応記法をスキップしました: " + ch);
+                warnings.push("line " + entry.lineNo + ": Skipped unsupported notation: " + ch);
                 idx += 1;
                 continue;
             }
@@ -19464,7 +19464,7 @@ function parseForMusicXml(source, settings) {
             }
             const pitchChar = text[idx];
             if (!pitchChar || !/[A-Ga-gzZxX]/.test(pitchChar)) {
-                throw new Error("line " + entry.lineNo + ": ノート/休符の解釈に失敗しました: " + text.slice(idx, idx + 12));
+                throw new Error("line " + entry.lineNo + ": Failed to parse note/rest: " + text.slice(idx, idx + 12));
             }
             idx += 1;
             let octaveShift = "";
@@ -19505,7 +19505,7 @@ function parseForMusicXml(source, settings) {
             }
             const dur = durationInDivisions(absoluteLength, 960);
             if (dur <= 0) {
-                throw new Error("line " + entry.lineNo + ": 長さが不正です");
+                throw new Error("line " + entry.lineNo + ": Invalid length");
             }
             const note = buildNoteData(pitchChar, accidentalText, octaveShift, absoluteLength, dur, entry.lineNo, keySignatureAccidentals, measureAccidentals);
             if (pendingTieToNext && !note.isRest) {
@@ -19513,7 +19513,7 @@ function parseForMusicXml(source, settings) {
                 pendingTieToNext = false;
             }
             else if (note.isRest && pendingTieToNext) {
-                warnings.push("line " + entry.lineNo + ": tie(-) の後ろが休符のため tie を解除しました。");
+                warnings.push("line " + entry.lineNo + ": tie(-) was followed by a rest; tie removed.");
                 pendingTieToNext = false;
             }
             note.voice = entry.voiceId;
@@ -19530,7 +19530,7 @@ function parseForMusicXml(source, settings) {
         }
     }
     if (noteCount === 0) {
-        throw new Error("ノートまたは休符が見つかりませんでした。 (line 1)");
+        throw new Error("No notes or rests were found. (line 1)");
     }
     const orderedVoiceIds = parseScoreVoiceOrder(scoreDirective, declaredVoiceIds);
     const parts = orderedVoiceIds.map((voiceId, index) => {
@@ -19679,7 +19679,7 @@ function parseMeter(raw, warnings) {
     }
     const m = normalized.match(/^(\d+)\/(\d+)$/);
     if (!m) {
-        warnings.push("拍子 M: の形式が不正なため 4/4 を使用しました: " + raw);
+        warnings.push("Invalid meter M: format; defaulted to 4/4: " + raw);
         return { beats: 4, beatType: 4 };
     }
     return { beats: Number(m[1]), beatType: Number(m[2]) };
@@ -19687,12 +19687,12 @@ function parseMeter(raw, warnings) {
 function parseFraction(raw, fieldName, warnings) {
     const parsed = abcCommon.parseFractionText(raw, { num: 1, den: 8 });
     if (parsed.num === 1 && parsed.den === 8 && !/^\s*\d+\/\d+\s*$/.test(String(raw || ""))) {
-        warnings.push(fieldName + " の形式が不正なため 1/8 を使用しました: " + raw);
+        warnings.push(fieldName + " has invalid format; defaulted to 1/8: " + raw);
         return parsed;
     }
     const m = String(raw || "").match(/^\s*(\d+)\/(\d+)\s*$/);
     if (!m || !Number(m[1]) || !Number(m[2])) {
-        warnings.push(fieldName + " の値が不正なため 1/8 を使用しました: " + raw);
+        warnings.push(fieldName + " has invalid value; defaulted to 1/8: " + raw);
         return { num: 1, den: 8 };
     }
     return parsed;
@@ -19703,7 +19703,7 @@ function parseKey(raw, warnings) {
     if (fifths !== null) {
         return { fifths };
     }
-    warnings.push("K: 非対応キーのため C を使用しました: " + key);
+    warnings.push("K: unsupported key; defaulted to C: " + key);
     return { fifths: 0 };
 }
 function parseLengthToken(token, lineNo) {
@@ -19787,7 +19787,7 @@ function buildNoteData(pitchChar, accidental, octaveShift, absoluteLength, durat
         }
     }
     if (octave < 0 || octave > 9) {
-        throw new Error("line " + lineNo + ": オクターブが範囲外です");
+        throw new Error("line " + lineNo + ": Octave out of range");
     }
     let alter = null;
     let accidentalText = null;
@@ -20687,7 +20687,7 @@ class ScoreCore {
                 const durationNotation = (0, xmlUtils_1.getDurationNotationHint)(target, command.duration);
                 if ((durationNotation === null || durationNotation === void 0 ? void 0 : durationNotation.triplet) &&
                     !measureVoiceHasTupletContext(target, command.voice)) {
-                    return this.fail("MVP_INVALID_COMMAND_PAYLOAD", "この小節/voice には3連コンテキストがないため、3連音価は適用できません。");
+                    return this.fail("MVP_INVALID_COMMAND_PAYLOAD", "Tuplet durations are not allowed because this measure/voice has no tuplet context.");
                 }
                 const oldDuration = (_a = (0, xmlUtils_1.getDurationValue)(target)) !== null && _a !== void 0 ? _a : 0;
                 const timing = (0, timeIndex_1.getMeasureTimingForVoice)(target, command.voice);

--- a/src/css/md3/VERSION.md
+++ b/src/css/md3/VERSION.md
@@ -1,23 +1,45 @@
 # MD3 Spec Versions
 
+## English
 - local-html-tools MD3 Token Spec: `v1.0.0`
 - local-html-tools MD3 Core Spec: `v1.0.2`
 - local-html-tools MD3 Icon Spec: `v1.0.0`
 
 ## Policy
-
-- `token-spec.css` は `local-html-tools MD3 Token Spec`（`:root` / `--md-sys-*` の標準トークン定義）。
-- `core-spec.css` は `local-html-tools MD3 Core Spec`（共通コンポーネントの標準スタイル定義）。
-- `icon-spec.svg` は `local-html-tools MD3 Icon Spec`（menu/copy/refresh の標準SVG定義）。
-- `docs/*.html` には、未使用定義を含む標準セットを貼り付けてよい（仕様準拠を優先）。
+- `token-spec.css` defines standard design tokens (`:root` / `--md-sys-*`).
+- `core-spec.css` defines standard shared component styles.
+- `icon-spec.svg` defines standard SVG symbols (menu/copy/refresh).
+- `docs/*.html` may include full standard sets, including currently unused definitions, to preserve spec compliance.
 
 ## Change Log
+- `v1.0.0` (2026-02-08)
+  - Initial extraction of Token/Core from `md3/index.html`.
+- `v1.0.1` (2026-02-08)
+  - Changed checked switch knob color to white (`md-switch-input:checked + .md-switch::after`).
+- `v1.0.2` (2026-02-08)
+  - Removed `font-weight` from `md-switch-label` to prioritize page typography.
+- `v1.0.0` (2026-02-08, Icon Spec)
+  - Added standard SVG symbols for menu/copy/refresh (`href` + `xlink:href`).
 
+---
+
+## 日本語
+- local-html-tools MD3 Token Spec: `v1.0.0`
+- local-html-tools MD3 Core Spec: `v1.0.2`
+- local-html-tools MD3 Icon Spec: `v1.0.0`
+
+## 方針
+- `token-spec.css` は標準トークン定義（`:root` / `--md-sys-*`）。
+- `core-spec.css` は共通コンポーネントの標準スタイル定義。
+- `icon-spec.svg` は標準 SVG シンボル定義（menu/copy/refresh）。
+- `docs/*.html` には未使用定義を含む標準セットを貼り付けてよい（仕様準拠優先）。
+
+## 変更履歴
 - `v1.0.0` (2026-02-08)
   - `md3/index.html` 掲載の Token/Core を初回切り出し。
 - `v1.0.1` (2026-02-08)
   - `md-switch` の checked ノブ色を白に変更（`md-switch-input:checked + .md-switch::after`）。
 - `v1.0.2` (2026-02-08)
-  - `md-switch-label` の `font-weight` を削除し、ページ側タイポグラフィを優先する。
+  - `md-switch-label` の `font-weight` を削除し、ページ側タイポグラフィを優先。
 - `v1.0.0` (2026-02-08, Icon Spec)
-  - menu / copy / refresh の標準SVGシンボルを追加（`href` + `xlink:href` 併記運用）。
+  - menu / copy / refresh の標準 SVG シンボルを追加（`href` + `xlink:href` 併記）。

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -188,7 +188,7 @@ const renderInputMode = () => {
     inputModeSource.disabled = isNewType;
     const loadLabel = loadBtn.querySelector("span");
     if (loadLabel) {
-        loadLabel.textContent = isNewType ? "新規作成" : "読み込み";
+        loadLabel.textContent = isNewType ? "Create" : "Load";
     }
     fileInput.accept = isAbcType
         ? ".abc,text/plain"
@@ -232,14 +232,14 @@ const renderNewPartClefControls = () => {
         row.className = "ms-form-row";
         const label = document.createElement("label");
         label.className = "ms-field";
-        label.textContent = `パート${i + 1} 記号`;
+        label.textContent = `Part ${i + 1} clef`;
         const select = document.createElement("select");
         select.className = "md-select";
         select.setAttribute("data-part-clef", "true");
         const options = [
-            { value: "treble", label: "ト音記号" },
-            { value: "alto", label: "ハ音記号" },
-            { value: "bass", label: "ヘ音記号" },
+            { value: "treble", label: "Treble clef" },
+            { value: "alto", label: "Alto clef" },
+            { value: "bass", label: "Bass clef" },
         ];
         for (const optionDef of options) {
             const option = document.createElement("option");
@@ -258,8 +258,8 @@ const renderStatus = () => {
         return;
     const dirty = core.isDirty();
     statusText.textContent = state.loaded
-        ? `ロード済み / 変更あり=${dirty} / ノート数=${state.noteNodeIds.length}`
-        : "未ロード（まず読み込みしてください）";
+        ? `Loaded / dirty=${dirty}  / notes=${state.noteNodeIds.length}`
+        : "Not loaded (please load first)";
 };
 const renderNotes = () => {
     const selectedNodeId = state.selectedNodeId && draftNoteNodeIds.includes(state.selectedNodeId)
@@ -271,7 +271,7 @@ const renderNotes = () => {
     noteSelect.innerHTML = "";
     const placeholder = document.createElement("option");
     placeholder.value = "";
-    placeholder.textContent = draftNoteNodeIds.length === 0 ? "(ノートなし)" : "(選択してください)";
+    placeholder.textContent = draftNoteNodeIds.length === 0 ? "(No notes)" : "(Select one)";
     noteSelect.appendChild(placeholder);
     for (const nodeId of draftNoteNodeIds) {
         const option = document.createElement("option");
@@ -295,7 +295,7 @@ const renderPitchStepValue = () => {
         pitchStepValue.textContent = step;
     }
     else {
-        pitchStepValue.textContent = "休符";
+        pitchStepValue.textContent = "Rest";
     }
 };
 const normalizeAlterValue = (value) => {
@@ -330,26 +330,26 @@ const resolveEffectiveDivisionsForMeasure = (doc, targetMeasure) => {
 const rebuildDurationPresetOptions = (divisions) => {
     const safeDivisions = Number.isInteger(divisions) && divisions > 0 ? divisions : DEFAULT_DIVISIONS;
     const defs = [
-        { label: "全音符", num: 4, den: 1 },
-        { label: "付点2分音符", num: 3, den: 1 },
-        { label: "2分音符", num: 2, den: 1 },
-        { label: "2分3連(1音)", num: 4, den: 3 },
-        { label: "付点4分音符", num: 3, den: 2 },
-        { label: "4分音符", num: 1, den: 1 },
-        { label: "4分3連(1音)", num: 2, den: 3 },
-        { label: "付点8分音符", num: 3, den: 4 },
-        { label: "8分音符", num: 1, den: 2 },
-        { label: "8分3連(1音)", num: 1, den: 3 },
-        { label: "付点16分音符", num: 3, den: 8 },
-        { label: "16分音符", num: 1, den: 4 },
-        { label: "16分3連(1音)", num: 1, den: 6 },
-        { label: "32分音符", num: 1, den: 8 },
-        { label: "64分音符", num: 1, den: 16 },
+        { label: "Whole note", num: 4, den: 1 },
+        { label: "Dotted half note", num: 3, den: 1 },
+        { label: "Half note", num: 2, den: 1 },
+        { label: "Half-note triplet (1 note)", num: 4, den: 3 },
+        { label: "Dotted quarter note", num: 3, den: 2 },
+        { label: "Quarter note", num: 1, den: 1 },
+        { label: "Quarter-note triplet (1 note)", num: 2, den: 3 },
+        { label: "Dotted eighth note", num: 3, den: 4 },
+        { label: "Eighth note", num: 1, den: 2 },
+        { label: "Eighth-note triplet (1 note)", num: 1, den: 3 },
+        { label: "Dotted sixteenth note", num: 3, den: 8 },
+        { label: "Sixteenth note", num: 1, den: 4 },
+        { label: "Sixteenth-note triplet (1 note)", num: 1, den: 6 },
+        { label: "3Half note", num: 1, den: 8 },
+        { label: "6Quarter note", num: 1, den: 16 },
     ];
     durationPreset.innerHTML = "";
     const placeholder = document.createElement("option");
     placeholder.value = "";
-    placeholder.textContent = "（音価を選択）";
+    placeholder.textContent = "(Select duration)";
     durationPreset.appendChild(placeholder);
     const used = new Set();
     for (const def of defs) {
@@ -383,7 +383,7 @@ const setDurationPresetFromValue = (duration) => {
     }
     const custom = document.createElement("option");
     custom.value = String(duration);
-    custom.textContent = `カスタム(${duration})`;
+    custom.textContent = `Custom(${duration})`;
     custom.className = "ms-duration-custom";
     durationPreset.appendChild(custom);
     durationPreset.value = custom.value;
@@ -431,8 +431,8 @@ const applyDurationPresetAvailability = (selectedNote, divisions) => {
         const isTriplet = durationValueIsTriplet(value, divisions);
         const unavailable = isTriplet && !hasTupletContext;
         option.disabled = unavailable;
-        const baseLabel = (_b = (_a = option.textContent) === null || _a === void 0 ? void 0 : _a.replace("（この小節では不可）", "").trim()) !== null && _b !== void 0 ? _b : "";
-        option.textContent = unavailable ? `${baseLabel}（この小節では不可）` : baseLabel;
+        const baseLabel = (_b = (_a = option.textContent) === null || _a === void 0 ? void 0 : _a.replace(" (not allowed in this measure)", "").trim()) !== null && _b !== void 0 ? _b : "";
+        option.textContent = unavailable ? `${baseLabel} (not allowed in this measure)` : baseLabel;
     }
 };
 const renderAlterButtons = () => {
@@ -452,7 +452,7 @@ const syncStepFromSelectedDraftNote = () => {
     selectedDraftNoteIsRest = false;
     pitchStep.disabled = false;
     pitchStep.title = "";
-    pitchOctave.title = "音名 ↑/↓ に連動して自動調整されます。";
+    pitchOctave.title = "Automatically adjusted with pitch step up/down.";
     for (const btn of pitchAlterBtns) {
         btn.disabled = false;
         btn.title = "";
@@ -545,12 +545,12 @@ const syncStepFromSelectedDraftNote = () => {
             selectedDraftNoteIsRest = true;
             pitchStep.value = "";
             pitchStep.disabled = true;
-            pitchStep.title = "休符は音高を持たないため、音高変更はできません。";
+            pitchStep.title = "Rests do not have pitch. Pitch changes are disabled.";
             for (const btn of pitchAlterBtns) {
                 btn.disabled = true;
-                btn.title = "休符は音高を持たないため、音高変更はできません。";
+                btn.title = "Rests do not have pitch. Pitch changes are disabled.";
             }
-            pitchOctave.title = "音名 ↑/↓ に連動して自動調整されます。";
+            pitchOctave.title = "Automatically adjusted with pitch step up/down.";
             renderPitchStepValue();
             renderAlterButtons();
             return;
@@ -578,7 +578,7 @@ const syncStepFromSelectedDraftNote = () => {
 const renderMeasureEditorState = () => {
     var _a;
     if (!selectedMeasure || !draftCore) {
-        measurePartNameText.textContent = "トラック名: -";
+        measurePartNameText.textContent = "Track: -";
         measurePartNameText.classList.add("md-hidden");
         measureEmptyState.classList.remove("md-hidden");
         measureEditorWrap.classList.add("md-hidden");
@@ -588,7 +588,7 @@ const renderMeasureEditorState = () => {
     }
     const partName = (_a = partIdToName.get(selectedMeasure.partId)) !== null && _a !== void 0 ? _a : selectedMeasure.partId;
     measurePartNameText.textContent =
-        `トラック名: ${partName} / 選択中: トラック=${selectedMeasure.partId} / 小節=${selectedMeasure.measureNumber}`;
+        `Track: ${partName} / Selected: track=${selectedMeasure.partId}  / measure=${selectedMeasure.measureNumber}`;
     measurePartNameText.classList.remove("md-hidden");
     measureEmptyState.classList.add("md-hidden");
     measureEditorWrap.classList.remove("md-hidden");
@@ -644,7 +644,7 @@ const renderDiagnostics = () => {
     const dispatch = state.lastDispatchResult;
     const save = state.lastSaveResult;
     if (!dispatch && !save) {
-        diagArea.textContent = "診断なし";
+        diagArea.textContent = "No diagnostics";
         return;
     }
     if (dispatch) {
@@ -670,7 +670,7 @@ const renderDiagnostics = () => {
         }
     }
     if (!diagArea.firstChild) {
-        diagArea.textContent = "診断なし";
+        diagArea.textContent = "No diagnostics";
     }
 };
 const renderUiMessage = () => {
@@ -680,14 +680,14 @@ const renderUiMessage = () => {
     if (dispatch) {
         if (!dispatch.ok && dispatch.diagnostics.length > 0) {
             const d = dispatch.diagnostics[0];
-            uiMessage.textContent = `エラー: ${d.message} (${d.code})`;
+            uiMessage.textContent = `Error: ${d.message} (${d.code})`;
             uiMessage.classList.add("ms-ui-message--error");
             uiMessage.classList.remove("md-hidden");
             return;
         }
         if (dispatch.warnings.length > 0) {
             const w = dispatch.warnings[0];
-            uiMessage.textContent = `警告: ${w.message} (${w.code})`;
+            uiMessage.textContent = `Warning: ${w.message} (${w.code})`;
             uiMessage.classList.add("ms-ui-message--warning");
             uiMessage.classList.remove("md-hidden");
             return;
@@ -696,7 +696,7 @@ const renderUiMessage = () => {
     const save = state.lastSaveResult;
     if (save && !save.ok && save.diagnostics.length > 0) {
         const d = save.diagnostics[0];
-        uiMessage.textContent = `エラー: ${d.message} (${d.code})`;
+        uiMessage.textContent = `Error: ${d.message} (${d.code})`;
         uiMessage.classList.add("ms-ui-message--error");
         uiMessage.classList.remove("md-hidden");
         return;
@@ -983,7 +983,7 @@ const initializeMeasureEditor = (location) => {
         return;
     const extracted = extractMeasureEditorXml(xml, location.partId, location.measureNumber);
     if (!extracted) {
-        setUiMappingDiagnostic("選択小節の抽出に失敗しました。");
+        setUiMappingDiagnostic("Failed to extract selected measure.");
         return;
     }
     const nextDraft = new ScoreCore_1.ScoreCore({ editableVoice: EDITABLE_VOICE });
@@ -991,7 +991,7 @@ const initializeMeasureEditor = (location) => {
         nextDraft.load(extracted);
     }
     catch (error) {
-        setUiMappingDiagnostic(`選択小節の読み込みに失敗しました: ${error instanceof Error ? error.message : String(error)}`);
+        setUiMappingDiagnostic(`Failed to load the selected measure: ${error instanceof Error ? error.message : String(error)}`);
         return;
     }
     draftCore = nextDraft;
@@ -1017,16 +1017,16 @@ const onVerovioScoreClick = (event) => {
         });
     }
     if (!nodeId) {
-        setUiMappingDiagnostic("クリック位置からノートを特定できませんでした。");
+        setUiMappingDiagnostic("Could not resolve a note from the clicked position.");
         return;
     }
     if (!state.noteNodeIds.includes(nodeId)) {
-        setUiMappingDiagnostic(`クリック要素に対応する nodeId が見つかりませんでした: ${nodeId}`);
+        setUiMappingDiagnostic(`No nodeId matched the clicked element: ${nodeId}`);
         return;
     }
     const location = nodeIdToLocation.get(nodeId);
     if (!location) {
-        setUiMappingDiagnostic(`nodeId からトラック/小節を特定できませんでした: ${nodeId}`);
+        setUiMappingDiagnostic(`Could not resolve track/measure from nodeId: ${nodeId}`);
         return;
     }
     initializeMeasureEditor(location);
@@ -1220,7 +1220,7 @@ const onDurationPresetChange = () => {
             diagnostics: [
                 {
                     code: first.code,
-                    message: "この音価には変更できません。小節内の長さ上限を超えます。",
+                    message: "This duration is not allowed. It exceeds the measure capacity.",
                 },
             ],
         };
@@ -1283,7 +1283,7 @@ const loadFromText = (xml) => {
             diagnostics: [
                 {
                     code: "MVP_COMMAND_EXECUTION_FAILED",
-                    message: err instanceof Error ? err.message : "読み込みに失敗しました。",
+                    message: err instanceof Error ? err.message : "Load failed.",
                 },
             ],
             warnings: [],
@@ -1411,7 +1411,7 @@ const requireSelectedNode = () => {
             dirtyChanged: false,
             changedNodeIds: [],
             affectedMeasureNumbers: [],
-            diagnostics: [{ code: "MVP_COMMAND_TARGET_MISSING", message: "先に小節を選択してください。" }],
+            diagnostics: [{ code: "MVP_COMMAND_TARGET_MISSING", message: "Select a measure first." }],
             warnings: [],
         };
         renderAll();
@@ -1425,7 +1425,7 @@ const requireSelectedNode = () => {
         dirtyChanged: false,
         changedNodeIds: [],
         affectedMeasureNumbers: [],
-        diagnostics: [{ code: "MVP_COMMAND_TARGET_MISSING", message: "ノートを選択してください。" }],
+        diagnostics: [{ code: "MVP_COMMAND_TARGET_MISSING", message: "Select a note." }],
         warnings: [],
     };
     renderAll();
@@ -1442,7 +1442,7 @@ const onChangePitch = () => {
             dirtyChanged: false,
             changedNodeIds: [],
             affectedMeasureNumbers: [],
-            diagnostics: [{ code: "MVP_INVALID_COMMAND_PAYLOAD", message: "pitch 入力が不正です。" }],
+            diagnostics: [{ code: "MVP_INVALID_COMMAND_PAYLOAD", message: "Invalid pitch input." }],
             warnings: [],
         };
         renderAll();
@@ -1539,14 +1539,14 @@ const onMeasureApply = () => {
         return;
     const merged = replaceMeasureInMainXml(mainXml, selectedMeasure.partId, selectedMeasure.measureNumber, draftSave.xml);
     if (!merged) {
-        setUiMappingDiagnostic("小節確定に失敗しました。");
+        setUiMappingDiagnostic("Failed to apply measure changes.");
         return;
     }
     try {
         core.load(merged);
     }
     catch (error) {
-        setUiMappingDiagnostic(`小節確定後の再読込に失敗しました: ${error instanceof Error ? error.message : String(error)}`);
+        setUiMappingDiagnostic(`Failed to reload after applying measure changes: ${error instanceof Error ? error.message : String(error)}`);
         return;
     }
     state.loaded = true;
@@ -1573,7 +1573,7 @@ const onChangeDuration = () => {
             dirtyChanged: false,
             changedNodeIds: [],
             affectedMeasureNumbers: [],
-            diagnostics: [{ code: "MVP_INVALID_COMMAND_PAYLOAD", message: "duration 入力が不正です。" }],
+            diagnostics: [{ code: "MVP_INVALID_COMMAND_PAYLOAD", message: "Invalid duration input." }],
             warnings: [],
         };
         renderAll();
@@ -1599,7 +1599,7 @@ const onInsertAfter = () => {
             dirtyChanged: false,
             changedNodeIds: [],
             affectedMeasureNumbers: [],
-            diagnostics: [{ code: "MVP_INVALID_COMMAND_PAYLOAD", message: "挿入ノート入力が不正です。" }],
+            diagnostics: [{ code: "MVP_INVALID_COMMAND_PAYLOAD", message: "Invalid inserted note input." }],
             warnings: [],
         };
         renderAll();
@@ -1710,7 +1710,7 @@ fileSelectBtn.addEventListener("click", () => fileInput.click());
 fileInput.addEventListener("change", () => {
     var _a;
     const f = (_a = fileInput.files) === null || _a === void 0 ? void 0 : _a[0];
-    fileNameText.textContent = f ? f.name : "未選択";
+    fileNameText.textContent = f ? f.name : "No file selected";
 });
 loadBtn.addEventListener("click", () => {
     void onLoadClick();
@@ -16077,7 +16077,7 @@ exports.renderMeasureEditorPreview = exports.renderScorePreview = void 0;
 const verovio_out_1 = require("./verovio-out");
 const renderScorePreview = async (params) => {
     if (!params.xml) {
-        params.setMetaText("描画対象XMLがありません");
+        params.setMetaText("No XML to render.");
         params.setSvgHtml("");
         params.setSvgIdMap(new Map());
         return;
@@ -16085,12 +16085,12 @@ const renderScorePreview = async (params) => {
     const renderBundle = params.buildRenderXmlForVerovio(params.xml);
     const renderDoc = renderBundle.renderDoc;
     if (!renderDoc) {
-        params.setMetaText("描画失敗: MusicXML解析失敗");
+        params.setMetaText("Render failed: invalid MusicXML.");
         params.setSvgHtml("");
         params.setSvgIdMap(new Map());
         return;
     }
-    params.setMetaText("verovio 描画中...");
+    params.setMetaText("Rendering with verovio...");
     try {
         const { svg, pageCount } = await (0, verovio_out_1.renderMusicXmlDomToSvg)(renderDoc, {
             pageWidth: 20000,
@@ -16135,7 +16135,7 @@ const renderScorePreview = async (params) => {
         if (!params.isRenderSeqCurrent(params.renderSeq))
             return;
         const message = error instanceof Error ? error.message : String(error);
-        params.setMetaText("描画失敗: " + message);
+        params.setMetaText("Render failed: " + message);
         params.setSvgHtml("");
         params.setSvgIdMap(new Map());
     }
@@ -16149,18 +16149,18 @@ const renderMeasureEditorPreview = async (params) => {
     }
     const sourceDoc = params.parseMusicXmlDocument(params.xml);
     if (!sourceDoc) {
-        params.setHtml("描画失敗: MusicXML解析失敗");
+        params.setHtml("Render failed: invalid MusicXML.");
         params.setSvgIdMap(new Map());
         return;
     }
     const renderBundle = params.buildRenderDocWithNodeIds(sourceDoc, params.draftNoteNodeIds.slice(), "mks-draft");
     const renderDoc = renderBundle.renderDoc;
     if (!renderDoc) {
-        params.setHtml("描画失敗: MusicXML解析失敗");
+        params.setHtml("Render failed: invalid MusicXML.");
         params.setSvgIdMap(new Map());
         return;
     }
-    params.setHtml("描画中...");
+    params.setHtml("Rendering...");
     try {
         const { svg } = await (0, verovio_out_1.renderMusicXmlDomToSvg)(renderDoc, {
             pageWidth: 6000,
@@ -16181,7 +16181,7 @@ const renderMeasureEditorPreview = async (params) => {
         params.onRendered();
     }
     catch (error) {
-        params.setHtml(`描画失敗: ${error instanceof Error ? error.message : String(error)}`);
+        params.setHtml(`Render failed: ${error instanceof Error ? error.message : String(error)}`);
         params.setSvgIdMap(new Map());
     }
 };
@@ -16274,11 +16274,11 @@ const ensureVerovioToolkit = async () => {
     verovioInitPromise = (async () => {
         const runtime = getVerovioRuntime();
         if (!runtime || typeof runtime.toolkit !== "function") {
-            throw new Error("verovio.js が読み込まれていません。");
+            throw new Error("verovio.js is not loaded.");
         }
         const moduleObj = runtime.module;
         if (!moduleObj) {
-            throw new Error("verovio module が見つかりません。");
+            throw new Error("verovio module was not found.");
         }
         if (!moduleObj.calledRun || typeof moduleObj.cwrap !== "function") {
             await new Promise((resolve, reject) => {
@@ -16287,7 +16287,7 @@ const ensureVerovioToolkit = async () => {
                     if (settled)
                         return;
                     settled = true;
-                    reject(new Error("verovio 初期化待機がタイムアウトしました。"));
+                    reject(new Error("Timed out while waiting for verovio initialization."));
                 }, 8000);
                 const complete = () => {
                     if (settled)
@@ -16320,7 +16320,7 @@ const ensureVerovioToolkit = async () => {
 const renderMusicXmlDomToSvg = async (doc, options) => {
     const toolkit = await ensureVerovioToolkit();
     if (!toolkit) {
-        throw new Error("verovio toolkit の初期化に失敗しました。");
+        throw new Error("Failed to initialize verovio toolkit.");
     }
     // Keep source DOM intact and only sanitize slur mismatch on render copy.
     const renderDoc = cloneXmlDocument(doc);
@@ -16329,15 +16329,15 @@ const renderMusicXmlDomToSvg = async (doc, options) => {
     toolkit.setOptions(options);
     const loaded = toolkit.loadData(xml);
     if (!loaded) {
-        throw new Error("verovio loadData が失敗しました。");
+        throw new Error("verovio loadData failed.");
     }
     const pageCount = toolkit.getPageCount();
     if (!Number.isFinite(pageCount) || pageCount < 1) {
-        throw new Error("verovio pageCount が不正です。");
+        throw new Error("verovio returned an invalid pageCount.");
     }
     const svg = toolkit.renderToSVG(1, {});
     if (!svg) {
-        throw new Error("verovio SVG 生成に失敗しました。");
+        throw new Error("Failed to generate SVG with verovio.");
     }
     return { svg, pageCount };
 };
@@ -16627,7 +16627,7 @@ const createBasicWaveSynthEngine = (options) => {
     };
     const playSchedule = async (schedule, waveform, onEnded) => {
         if (!schedule || !Array.isArray(schedule.events) || schedule.events.length === 0) {
-            throw new Error("先に変換してください。");
+            throw new Error("Please convert first.");
         }
         if (!audioContext) {
             audioContext = new AudioContext();
@@ -16671,7 +16671,7 @@ const toSynthSchedule = (tempo, events) => {
 const stopPlayback = (options) => {
     options.engine.stop();
     options.setIsPlaying(false);
-    options.setPlaybackText("再生: 停止中");
+    options.setPlaybackText("Playback: stopped");
     options.renderControlState();
 };
 exports.stopPlayback = stopPlayback;
@@ -16692,19 +16692,19 @@ const startPlayback = async (options, params) => {
             }
         }
         options.renderAll();
-        options.setPlaybackText("再生: 保存失敗");
+        options.setPlaybackText("Playback: save failed");
         return;
     }
     const playbackDoc = (0, musicxml_io_1.parseMusicXmlDocument)(saveResult.xml);
     if (!playbackDoc) {
-        options.setPlaybackText("再生: MusicXML解析失敗");
+        options.setPlaybackText("Playback: invalid MusicXML");
         options.renderControlState();
         return;
     }
     const parsedPlayback = (0, midi_io_1.buildPlaybackEventsFromMusicXmlDoc)(playbackDoc, options.ticksPerQuarter);
     const events = parsedPlayback.events;
     if (events.length === 0) {
-        options.setPlaybackText("再生: 再生可能ノートなし");
+        options.setPlaybackText("Playback: no playable notes");
         options.renderControlState();
         return;
     }
@@ -16713,24 +16713,24 @@ const startPlayback = async (options, params) => {
         midiBytes = (0, midi_io_1.buildMidiBytesForPlayback)(events, parsedPlayback.tempo);
     }
     catch (error) {
-        options.setPlaybackText("再生: MIDI生成失敗 (" + (error instanceof Error ? error.message : String(error)) + ")");
+        options.setPlaybackText("Playback: MIDI generation failed (" + (error instanceof Error ? error.message : String(error)) + ")");
         options.renderControlState();
         return;
     }
     try {
         await options.engine.playSchedule(toSynthSchedule(parsedPlayback.tempo, events), FIXED_PLAYBACK_WAVEFORM, () => {
             options.setIsPlaying(false);
-            options.setPlaybackText("再生: 停止中");
+            options.setPlaybackText("Playback: stopped");
             options.renderControlState();
         });
     }
     catch (error) {
-        options.setPlaybackText("再生: シンセ再生失敗 (" + (error instanceof Error ? error.message : String(error)) + ")");
+        options.setPlaybackText("Playback: synth playback failed (" + (error instanceof Error ? error.message : String(error)) + ")");
         options.renderControlState();
         return;
     }
     options.setIsPlaying(true);
-    options.setPlaybackText(`再生中: ノート${events.length}件 / MIDI ${midiBytes.length} bytes / 波形 sine`);
+    options.setPlaybackText(`Playing: ${events.length} notes / MIDI ${midiBytes.length} bytes / waveform sine`);
     options.renderControlState();
     options.renderAll();
 };
@@ -16742,37 +16742,37 @@ const startMeasurePlayback = async (options, params) => {
     if (!saveResult.ok) {
         options.onMeasureSaveDiagnostics(saveResult.diagnostics);
         options.logDiagnostics("playback", saveResult.diagnostics);
-        options.setPlaybackText("再生: 小節保存失敗");
+        options.setPlaybackText("Playback: measure save failed");
         options.renderAll();
         return;
     }
     const playbackDoc = (0, musicxml_io_1.parseMusicXmlDocument)(saveResult.xml);
     if (!playbackDoc) {
-        options.setPlaybackText("再生: MusicXML解析失敗");
+        options.setPlaybackText("Playback: invalid MusicXML");
         options.renderControlState();
         return;
     }
     const parsedPlayback = (0, midi_io_1.buildPlaybackEventsFromMusicXmlDoc)(playbackDoc, options.ticksPerQuarter);
     const events = parsedPlayback.events;
     if (events.length === 0) {
-        options.setPlaybackText("再生: この小節に再生可能ノートなし");
+        options.setPlaybackText("Playback: no playable notes in this measure");
         options.renderControlState();
         return;
     }
     try {
         await options.engine.playSchedule(toSynthSchedule(parsedPlayback.tempo, events), FIXED_PLAYBACK_WAVEFORM, () => {
             options.setIsPlaying(false);
-            options.setPlaybackText("再生: 停止中");
+            options.setPlaybackText("Playback: stopped");
             options.renderControlState();
         });
     }
     catch (error) {
-        options.setPlaybackText("再生: 小節再生失敗 (" + (error instanceof Error ? error.message : String(error)) + ")");
+        options.setPlaybackText("Playback: measure playback failed (" + (error instanceof Error ? error.message : String(error)) + ")");
         options.renderControlState();
         return;
     }
     options.setIsPlaying(true);
-    options.setPlaybackText(`再生中: 選択小節 ノート${events.length}件 / 波形 sine`);
+    options.setPlaybackText(`Playing: selected measure / ${events.length} notes / waveform sine`);
     options.renderControlState();
 };
 exports.startMeasurePlayback = startMeasurePlayback;
@@ -16860,7 +16860,7 @@ const buildMidiBytesForPlayback = (events, tempo) => {
     var _a;
     const midiWriter = getMidiWriterRuntime();
     if (!midiWriter) {
-        throw new Error("midi-writer.js が読み込まれていません。");
+        throw new Error("midi-writer.js is not loaded.");
     }
     const tracksById = new Map();
     for (const event of events) {
@@ -16907,7 +16907,7 @@ const buildMidiBytesForPlayback = (events, tempo) => {
         midiTracks.push(track);
     });
     if (!midiTracks.length) {
-        throw new Error("MIDI化するノートがありません。");
+        throw new Error("No notes available for MIDI conversion.");
     }
     const writer = new midiWriter.Writer(midiTracks);
     const built = writer.buildFile();
@@ -17097,7 +17097,7 @@ const resolveLoadFlow = async (params) => {
             return {
                 ok: false,
                 diagnosticCode: "MVP_INVALID_COMMAND_PAYLOAD",
-                diagnosticMessage: "ファイルを選択してください。",
+                diagnosticMessage: "Please select a file.",
             };
         }
         sourceText = await selected.text();
@@ -17123,7 +17123,7 @@ const resolveLoadFlow = async (params) => {
             return {
                 ok: false,
                 diagnosticCode: "MVP_INVALID_COMMAND_PAYLOAD",
-                diagnosticMessage: `ABCの解析に失敗しました: ${error instanceof Error ? error.message : String(error)}`,
+                diagnosticMessage: `Failed to parse ABC: ${error instanceof Error ? error.message : String(error)}`,
             };
         }
     }
@@ -17148,7 +17148,7 @@ const resolveLoadFlow = async (params) => {
         return {
             ok: false,
             diagnosticCode: "MVP_INVALID_COMMAND_PAYLOAD",
-            diagnosticMessage: `ABCの解析に失敗しました: ${error instanceof Error ? error.message : String(error)}`,
+            diagnosticMessage: `Failed to parse ABC: ${error instanceof Error ? error.message : String(error)}`,
         };
     }
 };
@@ -17293,7 +17293,7 @@ const parseAbcLengthToken = (token, lineNo) => {
         const p = token.split("/");
         return reduceFraction(Number(p[0]), Number(p[1]), { num: 1, den: 1 });
     }
-    throw new Error(`line ${lineNo}: 長さ指定を解釈できません: ${token}`);
+    throw new Error(`line ${lineNo}: Could not parse length token: ${token}`);
 };
 const abcLengthTokenFromFraction = (ratio) => {
     const reduced = reduceFraction(ratio.num, ratio.den, { num: 1, den: 1 });
@@ -17455,7 +17455,7 @@ function parseForMusicXml(source, settings) {
         bodyEntries.push({ text: noComment, lineNo, voiceId: currentVoiceId });
     }
     if (bodyEntries.length === 0) {
-        throw new Error("本文が見つかりません。ABCのノート列を入力してください。 (line 1)");
+        throw new Error("Body not found. Please provide ABC note content. (line 1)");
     }
     const meter = parseMeter(headers.M || "4/4", warnings);
     const unitLength = parseFraction(headers.L || "1/8", "L", warnings);
@@ -17507,7 +17507,7 @@ function parseForMusicXml(source, settings) {
             }
             if (ch === ">" || ch === "<") {
                 if (!lastEventNotes || lastEventNotes.length === 0 || lastEventNotes.some((n) => n.isRest)) {
-                    warnings.push("line " + entry.lineNo + ": broken rhythm(" + ch + ") の前にノートがないためスキップしました。");
+                    warnings.push("line " + entry.lineNo + ": broken rhythm(" + ch + ")  has no preceding note; skipped.");
                     idx += 1;
                     continue;
                 }
@@ -17530,12 +17530,12 @@ function parseForMusicXml(source, settings) {
                         tupletRemaining = r;
                     }
                     else {
-                        warnings.push("line " + entry.lineNo + ": 連符記法の解釈に失敗しました: " + tupletMatch[0]);
+                        warnings.push("line " + entry.lineNo + ": Failed to parse tuplet notation: " + tupletMatch[0]);
                     }
                     idx += tupletMatch[0].length;
                     continue;
                 }
-                warnings.push("line " + entry.lineNo + ": 非対応の連符記法をスキップしました: (");
+                warnings.push("line " + entry.lineNo + ": Skipped unsupported tuplet notation: (");
                 idx += 1;
                 continue;
             }
@@ -17545,7 +17545,7 @@ function parseForMusicXml(source, settings) {
                     pendingTieToNext = true;
                 }
                 else {
-                    warnings.push("line " + entry.lineNo + ": tie(-) の前にノートがないためスキップしました。");
+                    warnings.push("line " + entry.lineNo + ": tie(-)  has no preceding note; skipped.");
                 }
                 idx += 1;
                 continue;
@@ -17558,7 +17558,7 @@ function parseForMusicXml(source, settings) {
                 else {
                     idx = text.length;
                 }
-                warnings.push("line " + entry.lineNo + ': インライン文字列("...")はスキップしました。');
+                warnings.push("line " + entry.lineNo + ': Skipped inline string ("...").');
                 continue;
             }
             if (ch === "!" || ch === "+") {
@@ -17569,13 +17569,13 @@ function parseForMusicXml(source, settings) {
                 else {
                     idx += 1;
                 }
-                warnings.push("line " + entry.lineNo + ": 装飾記法をスキップしました: " + ch + "..." + ch);
+                warnings.push("line " + entry.lineNo + ": Skipped decoration: " + ch + "..." + ch);
                 continue;
             }
             if (ch === "[") {
                 const chordResult = parseChordAt(text, idx, entry.lineNo);
                 if (!chordResult) {
-                    warnings.push("line " + entry.lineNo + ": 和音記法の解釈に失敗したためスキップしました。");
+                    warnings.push("line " + entry.lineNo + ": Failed to parse chord notation; skipped.");
                     idx += 1;
                     continue;
                 }
@@ -17610,7 +17610,7 @@ function parseForMusicXml(source, settings) {
                 }
                 const dur = durationInDivisions(absoluteLength, 960);
                 if (dur <= 0) {
-                    throw new Error("line " + entry.lineNo + ": 長さが不正です");
+                    throw new Error("line " + entry.lineNo + ": Invalid length");
                 }
                 const chordNotes = [];
                 for (let chordIndex = 0; chordIndex < chordResult.notes.length; chordIndex += 1) {
@@ -17635,7 +17635,7 @@ function parseForMusicXml(source, settings) {
                 continue;
             }
             if (ch === "]" || ch === ")" || ch === "{" || ch === "}") {
-                warnings.push("line " + entry.lineNo + ": 非対応記法をスキップしました: " + ch);
+                warnings.push("line " + entry.lineNo + ": Skipped unsupported notation: " + ch);
                 idx += 1;
                 continue;
             }
@@ -17655,7 +17655,7 @@ function parseForMusicXml(source, settings) {
             }
             const pitchChar = text[idx];
             if (!pitchChar || !/[A-Ga-gzZxX]/.test(pitchChar)) {
-                throw new Error("line " + entry.lineNo + ": ノート/休符の解釈に失敗しました: " + text.slice(idx, idx + 12));
+                throw new Error("line " + entry.lineNo + ": Failed to parse note/rest: " + text.slice(idx, idx + 12));
             }
             idx += 1;
             let octaveShift = "";
@@ -17696,7 +17696,7 @@ function parseForMusicXml(source, settings) {
             }
             const dur = durationInDivisions(absoluteLength, 960);
             if (dur <= 0) {
-                throw new Error("line " + entry.lineNo + ": 長さが不正です");
+                throw new Error("line " + entry.lineNo + ": Invalid length");
             }
             const note = buildNoteData(pitchChar, accidentalText, octaveShift, absoluteLength, dur, entry.lineNo, keySignatureAccidentals, measureAccidentals);
             if (pendingTieToNext && !note.isRest) {
@@ -17704,7 +17704,7 @@ function parseForMusicXml(source, settings) {
                 pendingTieToNext = false;
             }
             else if (note.isRest && pendingTieToNext) {
-                warnings.push("line " + entry.lineNo + ": tie(-) の後ろが休符のため tie を解除しました。");
+                warnings.push("line " + entry.lineNo + ": tie(-) was followed by a rest; tie removed.");
                 pendingTieToNext = false;
             }
             note.voice = entry.voiceId;
@@ -17721,7 +17721,7 @@ function parseForMusicXml(source, settings) {
         }
     }
     if (noteCount === 0) {
-        throw new Error("ノートまたは休符が見つかりませんでした。 (line 1)");
+        throw new Error("No notes or rests were found. (line 1)");
     }
     const orderedVoiceIds = parseScoreVoiceOrder(scoreDirective, declaredVoiceIds);
     const parts = orderedVoiceIds.map((voiceId, index) => {
@@ -17870,7 +17870,7 @@ function parseMeter(raw, warnings) {
     }
     const m = normalized.match(/^(\d+)\/(\d+)$/);
     if (!m) {
-        warnings.push("拍子 M: の形式が不正なため 4/4 を使用しました: " + raw);
+        warnings.push("Invalid meter M: format; defaulted to 4/4: " + raw);
         return { beats: 4, beatType: 4 };
     }
     return { beats: Number(m[1]), beatType: Number(m[2]) };
@@ -17878,12 +17878,12 @@ function parseMeter(raw, warnings) {
 function parseFraction(raw, fieldName, warnings) {
     const parsed = abcCommon.parseFractionText(raw, { num: 1, den: 8 });
     if (parsed.num === 1 && parsed.den === 8 && !/^\s*\d+\/\d+\s*$/.test(String(raw || ""))) {
-        warnings.push(fieldName + " の形式が不正なため 1/8 を使用しました: " + raw);
+        warnings.push(fieldName + " has invalid format; defaulted to 1/8: " + raw);
         return parsed;
     }
     const m = String(raw || "").match(/^\s*(\d+)\/(\d+)\s*$/);
     if (!m || !Number(m[1]) || !Number(m[2])) {
-        warnings.push(fieldName + " の値が不正なため 1/8 を使用しました: " + raw);
+        warnings.push(fieldName + " has invalid value; defaulted to 1/8: " + raw);
         return { num: 1, den: 8 };
     }
     return parsed;
@@ -17894,7 +17894,7 @@ function parseKey(raw, warnings) {
     if (fifths !== null) {
         return { fifths };
     }
-    warnings.push("K: 非対応キーのため C を使用しました: " + key);
+    warnings.push("K: unsupported key; defaulted to C: " + key);
     return { fifths: 0 };
 }
 function parseLengthToken(token, lineNo) {
@@ -17978,7 +17978,7 @@ function buildNoteData(pitchChar, accidental, octaveShift, absoluteLength, durat
         }
     }
     if (octave < 0 || octave > 9) {
-        throw new Error("line " + lineNo + ": オクターブが範囲外です");
+        throw new Error("line " + lineNo + ": Octave out of range");
     }
     let alter = null;
     let accidentalText = null;
@@ -18878,7 +18878,7 @@ class ScoreCore {
                 const durationNotation = (0, xmlUtils_1.getDurationNotationHint)(target, command.duration);
                 if ((durationNotation === null || durationNotation === void 0 ? void 0 : durationNotation.triplet) &&
                     !measureVoiceHasTupletContext(target, command.voice)) {
-                    return this.fail("MVP_INVALID_COMMAND_PAYLOAD", "この小節/voice には3連コンテキストがないため、3連音価は適用できません。");
+                    return this.fail("MVP_INVALID_COMMAND_PAYLOAD", "Tuplet durations are not allowed because this measure/voice has no tuplet context.");
                 }
                 const oldDuration = (_a = (0, xmlUtils_1.getDurationValue)(target)) !== null && _a !== void 0 ? _a : 0;
                 const timing = (0, timeIndex_1.getMeasureTimingForVoice)(target, command.voice);

--- a/src/ts/abc-io.ts
+++ b/src/ts/abc-io.ts
@@ -64,7 +64,7 @@ const parseAbcLengthToken = (token: string, lineNo: number): Fraction => {
     const p = token.split("/");
     return reduceFraction(Number(p[0]), Number(p[1]), { num: 1, den: 1 });
   }
-  throw new Error(`line ${lineNo}: 長さ指定を解釈できません: ${token}`);
+  throw new Error(`line ${lineNo}: Could not parse length token: ${token}`);
 };
 
 const abcLengthTokenFromFraction = (ratio: Fraction): string => {
@@ -242,7 +242,7 @@ const abcCommon = AbcCommon;
     }
 
     if (bodyEntries.length === 0) {
-      throw new Error("本文が見つかりません。ABCのノート列を入力してください。 (line 1)");
+      throw new Error("Body not found. Please provide ABC note content. (line 1)");
     }
 
     const meter = parseMeter(headers.M || "4/4", warnings);
@@ -302,7 +302,7 @@ const abcCommon = AbcCommon;
 
         if (ch === ">" || ch === "<") {
           if (!lastEventNotes || lastEventNotes.length === 0 || lastEventNotes.some((n) => n.isRest)) {
-            warnings.push("line " + entry.lineNo + ": broken rhythm(" + ch + ") の前にノートがないためスキップしました。");
+            warnings.push("line " + entry.lineNo + ": broken rhythm(" + ch + ")  has no preceding note; skipped.");
             idx += 1;
             continue;
           }
@@ -325,12 +325,12 @@ const abcCommon = AbcCommon;
               tupletScale = { num: q, den: n };
               tupletRemaining = r;
             } else {
-              warnings.push("line " + entry.lineNo + ": 連符記法の解釈に失敗しました: " + tupletMatch[0]);
+              warnings.push("line " + entry.lineNo + ": Failed to parse tuplet notation: " + tupletMatch[0]);
             }
             idx += tupletMatch[0].length;
             continue;
           }
-          warnings.push("line " + entry.lineNo + ": 非対応の連符記法をスキップしました: (");
+          warnings.push("line " + entry.lineNo + ": Skipped unsupported tuplet notation: (");
           idx += 1;
           continue;
         }
@@ -340,7 +340,7 @@ const abcCommon = AbcCommon;
             lastNote.tieStart = true;
             pendingTieToNext = true;
           } else {
-            warnings.push("line " + entry.lineNo + ": tie(-) の前にノートがないためスキップしました。");
+            warnings.push("line " + entry.lineNo + ": tie(-)  has no preceding note; skipped.");
           }
           idx += 1;
           continue;
@@ -353,7 +353,7 @@ const abcCommon = AbcCommon;
           } else {
             idx = text.length;
           }
-          warnings.push("line " + entry.lineNo + ': インライン文字列("...")はスキップしました。');
+          warnings.push("line " + entry.lineNo + ': Skipped inline string ("...").');
           continue;
         }
 
@@ -364,14 +364,14 @@ const abcCommon = AbcCommon;
           } else {
             idx += 1;
           }
-          warnings.push("line " + entry.lineNo + ": 装飾記法をスキップしました: " + ch + "..." + ch);
+          warnings.push("line " + entry.lineNo + ": Skipped decoration: " + ch + "..." + ch);
           continue;
         }
 
         if (ch === "[") {
           const chordResult = parseChordAt(text, idx, entry.lineNo);
           if (!chordResult) {
-            warnings.push("line " + entry.lineNo + ": 和音記法の解釈に失敗したためスキップしました。");
+            warnings.push("line " + entry.lineNo + ": Failed to parse chord notation; skipped.");
             idx += 1;
             continue;
           }
@@ -405,7 +405,7 @@ const abcCommon = AbcCommon;
           }
           const dur = durationInDivisions(absoluteLength, 960);
           if (dur <= 0) {
-            throw new Error("line " + entry.lineNo + ": 長さが不正です");
+            throw new Error("line " + entry.lineNo + ": Invalid length");
           }
           const chordNotes = [];
           for (let chordIndex = 0; chordIndex < chordResult.notes.length; chordIndex += 1) {
@@ -440,7 +440,7 @@ const abcCommon = AbcCommon;
         }
 
         if (ch === "]" || ch === ")" || ch === "{" || ch === "}") {
-          warnings.push("line " + entry.lineNo + ": 非対応記法をスキップしました: " + ch);
+          warnings.push("line " + entry.lineNo + ": Skipped unsupported notation: " + ch);
           idx += 1;
           continue;
         }
@@ -462,7 +462,7 @@ const abcCommon = AbcCommon;
 
         const pitchChar = text[idx];
         if (!pitchChar || !/[A-Ga-gzZxX]/.test(pitchChar)) {
-          throw new Error("line " + entry.lineNo + ": ノート/休符の解釈に失敗しました: " + text.slice(idx, idx + 12));
+          throw new Error("line " + entry.lineNo + ": Failed to parse note/rest: " + text.slice(idx, idx + 12));
         }
         idx += 1;
 
@@ -507,7 +507,7 @@ const abcCommon = AbcCommon;
 
         const dur = durationInDivisions(absoluteLength, 960);
         if (dur <= 0) {
-          throw new Error("line " + entry.lineNo + ": 長さが不正です");
+          throw new Error("line " + entry.lineNo + ": Invalid length");
         }
 
         const note = buildNoteData(
@@ -524,7 +524,7 @@ const abcCommon = AbcCommon;
           note.tieStop = true;
           pendingTieToNext = false;
         } else if (note.isRest && pendingTieToNext) {
-          warnings.push("line " + entry.lineNo + ": tie(-) の後ろが休符のため tie を解除しました。");
+          warnings.push("line " + entry.lineNo + ": tie(-) was followed by a rest; tie removed.");
           pendingTieToNext = false;
         }
         note.voice = entry.voiceId;
@@ -543,7 +543,7 @@ const abcCommon = AbcCommon;
     }
 
     if (noteCount === 0) {
-      throw new Error("ノートまたは休符が見つかりませんでした。 (line 1)");
+      throw new Error("No notes or rests were found. (line 1)");
     }
 
     const orderedVoiceIds = parseScoreVoiceOrder(scoreDirective, declaredVoiceIds);
@@ -699,7 +699,7 @@ const abcCommon = AbcCommon;
     }
     const m = normalized.match(/^(\d+)\/(\d+)$/);
     if (!m) {
-      warnings.push("拍子 M: の形式が不正なため 4/4 を使用しました: " + raw);
+      warnings.push("Invalid meter M: format; defaulted to 4/4: " + raw);
       return { beats: 4, beatType: 4 };
     }
     return { beats: Number(m[1]), beatType: Number(m[2]) };
@@ -708,12 +708,12 @@ const abcCommon = AbcCommon;
   function parseFraction(raw, fieldName, warnings) {
     const parsed = abcCommon.parseFractionText(raw, { num: 1, den: 8 });
     if (parsed.num === 1 && parsed.den === 8 && !/^\s*\d+\/\d+\s*$/.test(String(raw || ""))) {
-      warnings.push(fieldName + " の形式が不正なため 1/8 を使用しました: " + raw);
+      warnings.push(fieldName + " has invalid format; defaulted to 1/8: " + raw);
       return parsed;
     }
     const m = String(raw || "").match(/^\s*(\d+)\/(\d+)\s*$/);
     if (!m || !Number(m[1]) || !Number(m[2])) {
-      warnings.push(fieldName + " の値が不正なため 1/8 を使用しました: " + raw);
+      warnings.push(fieldName + " has invalid value; defaulted to 1/8: " + raw);
       return { num: 1, den: 8 };
     }
     return parsed;
@@ -726,7 +726,7 @@ const abcCommon = AbcCommon;
       return { fifths };
     }
 
-    warnings.push("K: 非対応キーのため C を使用しました: " + key);
+    warnings.push("K: unsupported key; defaulted to C: " + key);
     return { fifths: 0 };
   }
 
@@ -826,7 +826,7 @@ const abcCommon = AbcCommon;
     }
 
     if (octave < 0 || octave > 9) {
-      throw new Error("line " + lineNo + ": オクターブが範囲外です");
+      throw new Error("line " + lineNo + ": Octave out of range");
     }
 
     let alter = null;

--- a/src/ts/load-flow.ts
+++ b/src/ts/load-flow.ts
@@ -45,7 +45,7 @@ export const resolveLoadFlow = async (params: LoadFlowParams): Promise<LoadFlowR
       return {
         ok: false,
         diagnosticCode: "MVP_INVALID_COMMAND_PAYLOAD",
-        diagnosticMessage: "ファイルを選択してください。",
+        diagnosticMessage: "Please select a file.",
       };
     }
     sourceText = await selected.text();
@@ -70,7 +70,7 @@ export const resolveLoadFlow = async (params: LoadFlowParams): Promise<LoadFlowR
       return {
         ok: false,
         diagnosticCode: "MVP_INVALID_COMMAND_PAYLOAD",
-        diagnosticMessage: `ABCの解析に失敗しました: ${
+        diagnosticMessage: `Failed to parse ABC: ${
           error instanceof Error ? error.message : String(error)
         }`,
       };
@@ -98,10 +98,9 @@ export const resolveLoadFlow = async (params: LoadFlowParams): Promise<LoadFlowR
     return {
       ok: false,
       diagnosticCode: "MVP_INVALID_COMMAND_PAYLOAD",
-      diagnosticMessage: `ABCの解析に失敗しました: ${
+      diagnosticMessage: `Failed to parse ABC: ${
         error instanceof Error ? error.message : String(error)
       }`,
     };
   }
 };
-

--- a/src/ts/main.ts
+++ b/src/ts/main.ts
@@ -247,7 +247,7 @@ const renderInputMode = (): void => {
   inputModeSource.disabled = isNewType;
   const loadLabel = loadBtn.querySelector("span");
   if (loadLabel) {
-    loadLabel.textContent = isNewType ? "新規作成" : "読み込み";
+    loadLabel.textContent = isNewType ? "Create" : "Load";
   }
 
   fileInput.accept = isAbcType
@@ -300,16 +300,16 @@ const renderNewPartClefControls = (): void => {
 
     const label = document.createElement("label");
     label.className = "ms-field";
-    label.textContent = `パート${i + 1} 記号`;
+    label.textContent = `Part ${i + 1} clef`;
 
     const select = document.createElement("select");
     select.className = "md-select";
     select.setAttribute("data-part-clef", "true");
 
     const options: Array<{ value: string; label: string }> = [
-      { value: "treble", label: "ト音記号" },
-      { value: "alto", label: "ハ音記号" },
-      { value: "bass", label: "ヘ音記号" },
+      { value: "treble", label: "Treble clef" },
+      { value: "alto", label: "Alto clef" },
+      { value: "bass", label: "Bass clef" },
     ];
     for (const optionDef of options) {
       const option = document.createElement("option");
@@ -329,8 +329,8 @@ const renderStatus = (): void => {
   if (!statusText) return;
   const dirty = core.isDirty();
   statusText.textContent = state.loaded
-    ? `ロード済み / 変更あり=${dirty} / ノート数=${state.noteNodeIds.length}`
-    : "未ロード（まず読み込みしてください）";
+    ? `Loaded / dirty=${dirty}  / notes=${state.noteNodeIds.length}`
+    : "Not loaded (please load first)";
 };
 
 const renderNotes = (): void => {
@@ -344,7 +344,7 @@ const renderNotes = (): void => {
   noteSelect.innerHTML = "";
   const placeholder = document.createElement("option");
   placeholder.value = "";
-  placeholder.textContent = draftNoteNodeIds.length === 0 ? "(ノートなし)" : "(選択してください)";
+  placeholder.textContent = draftNoteNodeIds.length === 0 ? "(No notes)" : "(Select one)";
   noteSelect.appendChild(placeholder);
 
   for (const nodeId of draftNoteNodeIds) {
@@ -370,7 +370,7 @@ const renderPitchStepValue = (): void => {
   if (isPitchStepValue(step)) {
     pitchStepValue.textContent = step;
   } else {
-    pitchStepValue.textContent = "休符";
+    pitchStepValue.textContent = "Rest";
   }
 };
 
@@ -405,27 +405,27 @@ const resolveEffectiveDivisionsForMeasure = (
 const rebuildDurationPresetOptions = (divisions: number): void => {
   const safeDivisions = Number.isInteger(divisions) && divisions > 0 ? divisions : DEFAULT_DIVISIONS;
   const defs: Array<{ label: string; num: number; den: number }> = [
-    { label: "全音符", num: 4, den: 1 },
-    { label: "付点2分音符", num: 3, den: 1 },
-    { label: "2分音符", num: 2, den: 1 },
-    { label: "2分3連(1音)", num: 4, den: 3 },
-    { label: "付点4分音符", num: 3, den: 2 },
-    { label: "4分音符", num: 1, den: 1 },
-    { label: "4分3連(1音)", num: 2, den: 3 },
-    { label: "付点8分音符", num: 3, den: 4 },
-    { label: "8分音符", num: 1, den: 2 },
-    { label: "8分3連(1音)", num: 1, den: 3 },
-    { label: "付点16分音符", num: 3, den: 8 },
-    { label: "16分音符", num: 1, den: 4 },
-    { label: "16分3連(1音)", num: 1, den: 6 },
-    { label: "32分音符", num: 1, den: 8 },
-    { label: "64分音符", num: 1, den: 16 },
+    { label: "Whole note", num: 4, den: 1 },
+    { label: "Dotted half note", num: 3, den: 1 },
+    { label: "Half note", num: 2, den: 1 },
+    { label: "Half-note triplet (1 note)", num: 4, den: 3 },
+    { label: "Dotted quarter note", num: 3, den: 2 },
+    { label: "Quarter note", num: 1, den: 1 },
+    { label: "Quarter-note triplet (1 note)", num: 2, den: 3 },
+    { label: "Dotted eighth note", num: 3, den: 4 },
+    { label: "Eighth note", num: 1, den: 2 },
+    { label: "Eighth-note triplet (1 note)", num: 1, den: 3 },
+    { label: "Dotted sixteenth note", num: 3, den: 8 },
+    { label: "Sixteenth note", num: 1, den: 4 },
+    { label: "Sixteenth-note triplet (1 note)", num: 1, den: 6 },
+    { label: "3Half note", num: 1, den: 8 },
+    { label: "6Quarter note", num: 1, den: 16 },
   ];
 
   durationPreset.innerHTML = "";
   const placeholder = document.createElement("option");
   placeholder.value = "";
-  placeholder.textContent = "（音価を選択）";
+  placeholder.textContent = "(Select duration)";
   durationPreset.appendChild(placeholder);
 
   const used = new Set<number>();
@@ -460,7 +460,7 @@ const setDurationPresetFromValue = (duration: number | null): void => {
   }
   const custom = document.createElement("option");
   custom.value = String(duration);
-  custom.textContent = `カスタム(${duration})`;
+  custom.textContent = `Custom(${duration})`;
   custom.className = "ms-duration-custom";
   durationPreset.appendChild(custom);
   durationPreset.value = custom.value;
@@ -504,8 +504,8 @@ const applyDurationPresetAvailability = (selectedNote: Element, divisions: numbe
     const isTriplet = durationValueIsTriplet(value, divisions);
     const unavailable = isTriplet && !hasTupletContext;
     option.disabled = unavailable;
-    const baseLabel = option.textContent?.replace("（この小節では不可）", "").trim() ?? "";
-    option.textContent = unavailable ? `${baseLabel}（この小節では不可）` : baseLabel;
+    const baseLabel = option.textContent?.replace(" (not allowed in this measure)", "").trim() ?? "";
+    option.textContent = unavailable ? `${baseLabel} (not allowed in this measure)` : baseLabel;
   }
 };
 
@@ -525,7 +525,7 @@ const syncStepFromSelectedDraftNote = (): void => {
   selectedDraftNoteIsRest = false;
   pitchStep.disabled = false;
   pitchStep.title = "";
-  pitchOctave.title = "音名 ↑/↓ に連動して自動調整されます。";
+  pitchOctave.title = "Automatically adjusted with pitch step up/down.";
   for (const btn of pitchAlterBtns) {
     btn.disabled = false;
     btn.title = "";
@@ -614,12 +614,12 @@ const syncStepFromSelectedDraftNote = (): void => {
       selectedDraftNoteIsRest = true;
       pitchStep.value = "";
       pitchStep.disabled = true;
-      pitchStep.title = "休符は音高を持たないため、音高変更はできません。";
+      pitchStep.title = "Rests do not have pitch. Pitch changes are disabled.";
       for (const btn of pitchAlterBtns) {
         btn.disabled = true;
-        btn.title = "休符は音高を持たないため、音高変更はできません。";
+        btn.title = "Rests do not have pitch. Pitch changes are disabled.";
       }
-      pitchOctave.title = "音名 ↑/↓ に連動して自動調整されます。";
+      pitchOctave.title = "Automatically adjusted with pitch step up/down.";
       renderPitchStepValue();
       renderAlterButtons();
       return;
@@ -647,7 +647,7 @@ const syncStepFromSelectedDraftNote = (): void => {
 
 const renderMeasureEditorState = (): void => {
   if (!selectedMeasure || !draftCore) {
-    measurePartNameText.textContent = "トラック名: -";
+    measurePartNameText.textContent = "Track: -";
     measurePartNameText.classList.add("md-hidden");
     measureEmptyState.classList.remove("md-hidden");
     measureEditorWrap.classList.add("md-hidden");
@@ -658,7 +658,7 @@ const renderMeasureEditorState = (): void => {
 
   const partName = partIdToName.get(selectedMeasure.partId) ?? selectedMeasure.partId;
   measurePartNameText.textContent =
-    `トラック名: ${partName} / 選択中: トラック=${selectedMeasure.partId} / 小節=${selectedMeasure.measureNumber}`;
+    `Track: ${partName} / Selected: track=${selectedMeasure.partId}  / measure=${selectedMeasure.measureNumber}`;
   measurePartNameText.classList.remove("md-hidden");
   measureEmptyState.classList.add("md-hidden");
   measureEditorWrap.classList.remove("md-hidden");
@@ -716,7 +716,7 @@ const renderDiagnostics = (): void => {
   const save = state.lastSaveResult;
 
   if (!dispatch && !save) {
-    diagArea.textContent = "診断なし";
+    diagArea.textContent = "No diagnostics";
     return;
   }
 
@@ -745,7 +745,7 @@ const renderDiagnostics = (): void => {
   }
 
   if (!diagArea.firstChild) {
-    diagArea.textContent = "診断なし";
+    diagArea.textContent = "No diagnostics";
   }
 };
 
@@ -757,14 +757,14 @@ const renderUiMessage = (): void => {
   if (dispatch) {
     if (!dispatch.ok && dispatch.diagnostics.length > 0) {
       const d = dispatch.diagnostics[0];
-      uiMessage.textContent = `エラー: ${d.message} (${d.code})`;
+      uiMessage.textContent = `Error: ${d.message} (${d.code})`;
       uiMessage.classList.add("ms-ui-message--error");
       uiMessage.classList.remove("md-hidden");
       return;
     }
     if (dispatch.warnings.length > 0) {
       const w = dispatch.warnings[0];
-      uiMessage.textContent = `警告: ${w.message} (${w.code})`;
+      uiMessage.textContent = `Warning: ${w.message} (${w.code})`;
       uiMessage.classList.add("ms-ui-message--warning");
       uiMessage.classList.remove("md-hidden");
       return;
@@ -774,7 +774,7 @@ const renderUiMessage = (): void => {
   const save = state.lastSaveResult;
   if (save && !save.ok && save.diagnostics.length > 0) {
     const d = save.diagnostics[0];
-    uiMessage.textContent = `エラー: ${d.message} (${d.code})`;
+    uiMessage.textContent = `Error: ${d.message} (${d.code})`;
     uiMessage.classList.add("ms-ui-message--error");
     uiMessage.classList.remove("md-hidden");
     return;
@@ -1079,14 +1079,14 @@ const initializeMeasureEditor = (location: NoteLocation): void => {
   if (!xml) return;
   const extracted = extractMeasureEditorXml(xml, location.partId, location.measureNumber);
   if (!extracted) {
-    setUiMappingDiagnostic("選択小節の抽出に失敗しました。");
+    setUiMappingDiagnostic("Failed to extract selected measure.");
     return;
   }
   const nextDraft = new ScoreCore({ editableVoice: EDITABLE_VOICE });
   try {
     nextDraft.load(extracted);
   } catch (error) {
-    setUiMappingDiagnostic(`選択小節の読み込みに失敗しました: ${error instanceof Error ? error.message : String(error)}`);
+    setUiMappingDiagnostic(`Failed to load the selected measure: ${error instanceof Error ? error.message : String(error)}`);
     return;
   }
 
@@ -1112,16 +1112,16 @@ const onVerovioScoreClick = (event: MouseEvent): void => {
     });
   }
   if (!nodeId) {
-    setUiMappingDiagnostic("クリック位置からノートを特定できませんでした。");
+    setUiMappingDiagnostic("Could not resolve a note from the clicked position.");
     return;
   }
   if (!state.noteNodeIds.includes(nodeId)) {
-    setUiMappingDiagnostic(`クリック要素に対応する nodeId が見つかりませんでした: ${nodeId}`);
+    setUiMappingDiagnostic(`No nodeId matched the clicked element: ${nodeId}`);
     return;
   }
   const location = nodeIdToLocation.get(nodeId);
   if (!location) {
-    setUiMappingDiagnostic(`nodeId からトラック/小節を特定できませんでした: ${nodeId}`);
+    setUiMappingDiagnostic(`Could not resolve track/measure from nodeId: ${nodeId}`);
     return;
   }
   initializeMeasureEditor(location);
@@ -1316,7 +1316,7 @@ const onDurationPresetChange = (): void => {
       diagnostics: [
         {
           code: first.code,
-          message: "この音価には変更できません。小節内の長さ上限を超えます。",
+          message: "This duration is not allowed. It exceeds the measure capacity.",
         },
       ],
     };
@@ -1382,7 +1382,7 @@ const loadFromText = (xml: string): void => {
       diagnostics: [
         {
           code: "MVP_COMMAND_EXECUTION_FAILED",
-          message: err instanceof Error ? err.message : "読み込みに失敗しました。",
+          message: err instanceof Error ? err.message : "Load failed.",
         },
       ],
       warnings: [],
@@ -1517,7 +1517,7 @@ const requireSelectedNode = (): string | null => {
       dirtyChanged: false,
       changedNodeIds: [],
       affectedMeasureNumbers: [],
-      diagnostics: [{ code: "MVP_COMMAND_TARGET_MISSING", message: "先に小節を選択してください。" }],
+      diagnostics: [{ code: "MVP_COMMAND_TARGET_MISSING", message: "Select a measure first." }],
       warnings: [],
     };
     renderAll();
@@ -1530,7 +1530,7 @@ const requireSelectedNode = (): string | null => {
     dirtyChanged: false,
     changedNodeIds: [],
     affectedMeasureNumbers: [],
-    diagnostics: [{ code: "MVP_COMMAND_TARGET_MISSING", message: "ノートを選択してください。" }],
+    diagnostics: [{ code: "MVP_COMMAND_TARGET_MISSING", message: "Select a note." }],
     warnings: [],
   };
   renderAll();
@@ -1547,7 +1547,7 @@ const onChangePitch = (): void => {
       dirtyChanged: false,
       changedNodeIds: [],
       affectedMeasureNumbers: [],
-      diagnostics: [{ code: "MVP_INVALID_COMMAND_PAYLOAD", message: "pitch 入力が不正です。" }],
+      diagnostics: [{ code: "MVP_INVALID_COMMAND_PAYLOAD", message: "Invalid pitch input." }],
       warnings: [],
     };
     renderAll();
@@ -1647,14 +1647,14 @@ const onMeasureApply = (): void => {
     draftSave.xml
   );
   if (!merged) {
-    setUiMappingDiagnostic("小節確定に失敗しました。");
+    setUiMappingDiagnostic("Failed to apply measure changes.");
     return;
   }
 
   try {
     core.load(merged);
   } catch (error) {
-    setUiMappingDiagnostic(`小節確定後の再読込に失敗しました: ${error instanceof Error ? error.message : String(error)}`);
+    setUiMappingDiagnostic(`Failed to reload after applying measure changes: ${error instanceof Error ? error.message : String(error)}`);
     return;
   }
 
@@ -1682,7 +1682,7 @@ const onChangeDuration = (): void => {
       dirtyChanged: false,
       changedNodeIds: [],
       affectedMeasureNumbers: [],
-      diagnostics: [{ code: "MVP_INVALID_COMMAND_PAYLOAD", message: "duration 入力が不正です。" }],
+      diagnostics: [{ code: "MVP_INVALID_COMMAND_PAYLOAD", message: "Invalid duration input." }],
       warnings: [],
     };
     renderAll();
@@ -1709,7 +1709,7 @@ const onInsertAfter = (): void => {
       dirtyChanged: false,
       changedNodeIds: [],
       affectedMeasureNumbers: [],
-      diagnostics: [{ code: "MVP_INVALID_COMMAND_PAYLOAD", message: "挿入ノート入力が不正です。" }],
+      diagnostics: [{ code: "MVP_INVALID_COMMAND_PAYLOAD", message: "Invalid inserted note input." }],
       warnings: [],
     };
     renderAll();
@@ -1822,7 +1822,7 @@ newPartCountInput.addEventListener("input", renderNewPartClefControls);
 fileSelectBtn.addEventListener("click", () => fileInput.click());
 fileInput.addEventListener("change", () => {
   const f = fileInput.files?.[0];
-  fileNameText.textContent = f ? f.name : "未選択";
+  fileNameText.textContent = f ? f.name : "No file selected";
 });
 loadBtn.addEventListener("click", () => {
   void onLoadClick();

--- a/src/ts/midi-io.ts
+++ b/src/ts/midi-io.ts
@@ -102,7 +102,7 @@ const normalizeTicksPerQuarter = (ticksPerQuarter: number): number => {
 export const buildMidiBytesForPlayback = (events: PlaybackEvent[], tempo: number): Uint8Array => {
   const midiWriter = getMidiWriterRuntime();
   if (!midiWriter) {
-    throw new Error("midi-writer.js が読み込まれていません。");
+    throw new Error("midi-writer.js is not loaded.");
   }
   const tracksById = new Map<string, PlaybackEvent[]>();
   for (const event of events) {
@@ -157,7 +157,7 @@ export const buildMidiBytesForPlayback = (events: PlaybackEvent[], tempo: number
   });
 
   if (!midiTracks.length) {
-    throw new Error("MIDI化するノートがありません。");
+    throw new Error("No notes available for MIDI conversion.");
   }
 
   const writer = new midiWriter.Writer(midiTracks);

--- a/src/ts/playback-flow.ts
+++ b/src/ts/playback-flow.ts
@@ -103,7 +103,7 @@ export const createBasicWaveSynthEngine = (options: { ticksPerQuarter: number })
     onEnded?: () => void
   ): Promise<void> => {
     if (!schedule || !Array.isArray(schedule.events) || schedule.events.length === 0) {
-      throw new Error("先に変換してください。");
+      throw new Error("Please convert first.");
     }
 
     if (!audioContext) {
@@ -182,7 +182,7 @@ type SaveCapableCore = {
 export const stopPlayback = (options: PlaybackFlowOptions): void => {
   options.engine.stop();
   options.setIsPlaying(false);
-  options.setPlaybackText("再生: 停止中");
+  options.setPlaybackText("Playback: stopped");
   options.renderControlState();
 };
 
@@ -205,13 +205,13 @@ export const startPlayback = async (
       }
     }
     options.renderAll();
-    options.setPlaybackText("再生: 保存失敗");
+    options.setPlaybackText("Playback: save failed");
     return;
   }
 
   const playbackDoc = parseMusicXmlDocument(saveResult.xml);
   if (!playbackDoc) {
-    options.setPlaybackText("再生: MusicXML解析失敗");
+    options.setPlaybackText("Playback: invalid MusicXML");
     options.renderControlState();
     return;
   }
@@ -219,7 +219,7 @@ export const startPlayback = async (
   const parsedPlayback = buildPlaybackEventsFromMusicXmlDoc(playbackDoc, options.ticksPerQuarter);
   const events = parsedPlayback.events;
   if (events.length === 0) {
-    options.setPlaybackText("再生: 再生可能ノートなし");
+    options.setPlaybackText("Playback: no playable notes");
     options.renderControlState();
     return;
   }
@@ -229,7 +229,7 @@ export const startPlayback = async (
     midiBytes = buildMidiBytesForPlayback(events, parsedPlayback.tempo);
   } catch (error) {
     options.setPlaybackText(
-      "再生: MIDI生成失敗 (" + (error instanceof Error ? error.message : String(error)) + ")"
+      "Playback: MIDI generation failed (" + (error instanceof Error ? error.message : String(error)) + ")"
     );
     options.renderControlState();
     return;
@@ -241,20 +241,20 @@ export const startPlayback = async (
       FIXED_PLAYBACK_WAVEFORM,
       () => {
         options.setIsPlaying(false);
-        options.setPlaybackText("再生: 停止中");
+        options.setPlaybackText("Playback: stopped");
         options.renderControlState();
       }
     );
   } catch (error) {
     options.setPlaybackText(
-      "再生: シンセ再生失敗 (" + (error instanceof Error ? error.message : String(error)) + ")"
+      "Playback: synth playback failed (" + (error instanceof Error ? error.message : String(error)) + ")"
     );
     options.renderControlState();
     return;
   }
 
   options.setIsPlaying(true);
-  options.setPlaybackText(`再生中: ノート${events.length}件 / MIDI ${midiBytes.length} bytes / 波形 sine`);
+  options.setPlaybackText(`Playing: ${events.length} notes / MIDI ${midiBytes.length} bytes / waveform sine`);
   options.renderControlState();
   options.renderAll();
 };
@@ -269,14 +269,14 @@ export const startMeasurePlayback = async (
   if (!saveResult.ok) {
     options.onMeasureSaveDiagnostics(saveResult.diagnostics);
     options.logDiagnostics("playback", saveResult.diagnostics);
-    options.setPlaybackText("再生: 小節保存失敗");
+    options.setPlaybackText("Playback: measure save failed");
     options.renderAll();
     return;
   }
 
   const playbackDoc = parseMusicXmlDocument(saveResult.xml);
   if (!playbackDoc) {
-    options.setPlaybackText("再生: MusicXML解析失敗");
+    options.setPlaybackText("Playback: invalid MusicXML");
     options.renderControlState();
     return;
   }
@@ -284,7 +284,7 @@ export const startMeasurePlayback = async (
   const parsedPlayback = buildPlaybackEventsFromMusicXmlDoc(playbackDoc, options.ticksPerQuarter);
   const events = parsedPlayback.events;
   if (events.length === 0) {
-    options.setPlaybackText("再生: この小節に再生可能ノートなし");
+    options.setPlaybackText("Playback: no playable notes in this measure");
     options.renderControlState();
     return;
   }
@@ -295,19 +295,19 @@ export const startMeasurePlayback = async (
       FIXED_PLAYBACK_WAVEFORM,
       () => {
         options.setIsPlaying(false);
-        options.setPlaybackText("再生: 停止中");
+        options.setPlaybackText("Playback: stopped");
         options.renderControlState();
       }
     );
   } catch (error) {
     options.setPlaybackText(
-      "再生: 小節再生失敗 (" + (error instanceof Error ? error.message : String(error)) + ")"
+      "Playback: measure playback failed (" + (error instanceof Error ? error.message : String(error)) + ")"
     );
     options.renderControlState();
     return;
   }
 
   options.setIsPlaying(true);
-  options.setPlaybackText(`再生中: 選択小節 ノート${events.length}件 / 波形 sine`);
+  options.setPlaybackText(`Playing: selected measure / ${events.length} notes / waveform sine`);
   options.renderControlState();
 };

--- a/src/ts/preview-flow.ts
+++ b/src/ts/preview-flow.ts
@@ -19,7 +19,7 @@ export type RenderScorePreviewParams = {
 
 export const renderScorePreview = async (params: RenderScorePreviewParams): Promise<void> => {
   if (!params.xml) {
-    params.setMetaText("描画対象XMLがありません");
+    params.setMetaText("No XML to render.");
     params.setSvgHtml("");
     params.setSvgIdMap(new Map<string, string>());
     return;
@@ -28,13 +28,13 @@ export const renderScorePreview = async (params: RenderScorePreviewParams): Prom
   const renderBundle = params.buildRenderXmlForVerovio(params.xml);
   const renderDoc = renderBundle.renderDoc;
   if (!renderDoc) {
-    params.setMetaText("描画失敗: MusicXML解析失敗");
+    params.setMetaText("Render failed: invalid MusicXML.");
     params.setSvgHtml("");
     params.setSvgIdMap(new Map<string, string>());
     return;
   }
 
-  params.setMetaText("verovio 描画中...");
+  params.setMetaText("Rendering with verovio...");
   try {
     const { svg, pageCount } = await renderMusicXmlDomToSvg(renderDoc, {
       pageWidth: 20000,
@@ -81,7 +81,7 @@ export const renderScorePreview = async (params: RenderScorePreviewParams): Prom
   } catch (error: unknown) {
     if (!params.isRenderSeqCurrent(params.renderSeq)) return;
     const message = error instanceof Error ? error.message : String(error);
-    params.setMetaText("描画失敗: " + message);
+    params.setMetaText("Render failed: " + message);
     params.setSvgHtml("");
     params.setSvgIdMap(new Map<string, string>());
   }
@@ -112,7 +112,7 @@ export const renderMeasureEditorPreview = async (
 
   const sourceDoc = params.parseMusicXmlDocument(params.xml);
   if (!sourceDoc) {
-    params.setHtml("描画失敗: MusicXML解析失敗");
+    params.setHtml("Render failed: invalid MusicXML.");
     params.setSvgIdMap(new Map<string, string>());
     return;
   }
@@ -124,12 +124,12 @@ export const renderMeasureEditorPreview = async (
   );
   const renderDoc = renderBundle.renderDoc;
   if (!renderDoc) {
-    params.setHtml("描画失敗: MusicXML解析失敗");
+    params.setHtml("Render failed: invalid MusicXML.");
     params.setSvgIdMap(new Map<string, string>());
     return;
   }
 
-  params.setHtml("描画中...");
+  params.setHtml("Rendering...");
   try {
     const { svg } = await renderMusicXmlDomToSvg(renderDoc, {
       pageWidth: 6000,
@@ -150,7 +150,7 @@ export const renderMeasureEditorPreview = async (
     params.setSvgIdMap(map);
     params.onRendered();
   } catch (error: unknown) {
-    params.setHtml(`描画失敗: ${error instanceof Error ? error.message : String(error)}`);
+    params.setHtml(`Render failed: ${error instanceof Error ? error.message : String(error)}`);
     params.setSvgIdMap(new Map<string, string>());
   }
 };

--- a/src/ts/verovio-out.ts
+++ b/src/ts/verovio-out.ts
@@ -102,11 +102,11 @@ const ensureVerovioToolkit = async (): Promise<VerovioToolkitApi | null> => {
   verovioInitPromise = (async () => {
     const runtime = getVerovioRuntime();
     if (!runtime || typeof runtime.toolkit !== "function") {
-      throw new Error("verovio.js が読み込まれていません。");
+      throw new Error("verovio.js is not loaded.");
     }
     const moduleObj = runtime.module;
     if (!moduleObj) {
-      throw new Error("verovio module が見つかりません。");
+      throw new Error("verovio module was not found.");
     }
 
     if (!moduleObj.calledRun || typeof moduleObj.cwrap !== "function") {
@@ -115,7 +115,7 @@ const ensureVerovioToolkit = async (): Promise<VerovioToolkitApi | null> => {
         const timeoutId = window.setTimeout(() => {
           if (settled) return;
           settled = true;
-          reject(new Error("verovio 初期化待機がタイムアウトしました。"));
+          reject(new Error("Timed out while waiting for verovio initialization."));
         }, 8000);
 
         const complete = () => {
@@ -156,7 +156,7 @@ export const renderMusicXmlDomToSvg = async (
 ): Promise<VerovioRenderResult> => {
   const toolkit = await ensureVerovioToolkit();
   if (!toolkit) {
-    throw new Error("verovio toolkit の初期化に失敗しました。");
+    throw new Error("Failed to initialize verovio toolkit.");
   }
   // Keep source DOM intact and only sanitize slur mismatch on render copy.
   const renderDoc = cloneXmlDocument(doc);
@@ -165,15 +165,15 @@ export const renderMusicXmlDomToSvg = async (
   toolkit.setOptions(options);
   const loaded = toolkit.loadData(xml);
   if (!loaded) {
-    throw new Error("verovio loadData が失敗しました。");
+    throw new Error("verovio loadData failed.");
   }
   const pageCount = toolkit.getPageCount();
   if (!Number.isFinite(pageCount) || pageCount < 1) {
-    throw new Error("verovio pageCount が不正です。");
+    throw new Error("verovio returned an invalid pageCount.");
   }
   const svg = toolkit.renderToSVG(1, {});
   if (!svg) {
-    throw new Error("verovio SVG 生成に失敗しました。");
+    throw new Error("Failed to generate SVG with verovio.");
   }
   return { svg, pageCount };
 };


### PR DESCRIPTION
1. アプリUIの英語化（日本語文言の整理）
2. 主要Markdownドキュメントを「英語セクション + 区切り線 + 日本語セクション」の2段構成に統一
3. ビルド生成物（`mikuscore.html`, `src/js/main.js`）への反映

---

- `src/ts/main.ts` の残存日本語文言を英語化
- 関連モジュールのメッセージ文言も英語化
  - `src/ts/preview-flow.ts`
  - `src/ts/load-flow.ts`
  - `src/ts/midi-io.ts`
  - `src/ts/verovio-out.ts`
  - `src/ts/playback-flow.ts`
  - `src/ts/abc-io.ts`
  - `core/ScoreCore.ts`（診断メッセージ含む）
- 目的: UI/診断/内部エラー表示の言語を英語で統一

以下を「English（上） / 区切り線 / 日本語（下）」構成へ更新:
- `README.md`
- `TODO.md`
- `docs/spec/UI_SPEC.md`
- `docs/spec/SCREEN_SPEC.md`
- `docs/spec/abc-compat-parser-ebnf.md`
- `src/css/md3/VERSION.md`

- `npm run build` を実行し、以下を更新
  - `mikuscore.html`
  - `src/js/main.js`

---

- 主に表示文言・仕様文書・生成物の更新
- コアロジックの振る舞い変更は最小限（診断メッセージ文言の英語化が中心）

---

- `npm run build` 成功
- 日本語文字列残存チェックを実施し、対象範囲内で解消済み
- UI表示およびエラーメッセージが英語で表示されることを確認

---

- 既存実装の機能方針は維持し、今回の主眼は「英語UI化」と「ドキュメント構成統一」
- 必要に応じて、未対応のドキュメント群にも同一フォーマットを横展開可能