### PR TITLE
MVPのvoice編集制約を「voice=1固定」から「コマンド/対象voice一致」に変更し、Local Draft UIとEdit操作…

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Its primary goal is reliability, not feature volume: edit while preserving exist
 ### MVP Highlights
 - If `dirty === false`, save returns original XML text (`original_noop`).
 - Overfull measures are rejected with `MEASURE_OVERFULL`.
-- Non-editable voices are rejected with `MVP_UNSUPPORTED_NON_EDITABLE_VOICE`.
+- Commands must target the same voice as the selected note; mismatches are rejected with `MVP_UNSUPPORTED_NON_EDITABLE_VOICE`.
 - MVP commands: `change_to_pitch`, `change_duration`, `insert_note_after`, `delete_note`, `split_note`.
 - Rests are not a normal edit target, but rest-to-note via `change_to_pitch` is allowed.
 - Serialization is compact (no pretty-print).
@@ -75,7 +75,7 @@ Its primary goal is reliability, not feature volume: edit while preserving exist
 ### MVP 仕様ハイライト
 - `dirty === false` の保存は入力 XML をそのまま返す（`original_noop`）。
 - 小節 overfull は `MEASURE_OVERFULL` で拒否。
-- 非編集対象 voice は `MVP_UNSUPPORTED_NON_EDITABLE_VOICE` で拒否。
+- コマンド voice と対象ノート voice が不一致の場合は `MVP_UNSUPPORTED_NON_EDITABLE_VOICE` で拒否。
 - `change_to_pitch` / `change_duration` / `insert_note_after` / `delete_note` / `split_note` をMVPコマンドとして扱う。
 - 休符は通常の編集対象外だが、`change_to_pitch` による休符音符化は許可。
 - pretty-print なしでシリアライズ。

--- a/core/interfaces.ts
+++ b/core/interfaces.ts
@@ -100,5 +100,5 @@ export type CoreCommand =
   | UiNoopCommand;
 
 export type ScoreCoreOptions = {
-  editableVoice?: VoiceId;
+  editableVoice?: VoiceId | null;
 };

--- a/core/validators.ts
+++ b/core/validators.ts
@@ -8,9 +8,10 @@ import {
 
 export const validateVoice = (
   command: CoreCommand,
-  editableVoice: VoiceId
+  editableVoice?: VoiceId | null
 ): Diagnostic | null => {
   if (command.type === "ui_noop") return null;
+  if (!editableVoice) return null;
   if (command.voice === editableVoice) return null;
   return {
     code: "MVP_UNSUPPORTED_NON_EDITABLE_VOICE",

--- a/docs/spec/COMMANDS.md
+++ b/docs/spec/COMMANDS.md
@@ -27,7 +27,7 @@ type SaveResult = {
 ## Required Behavior
 
 1. `dispatch(command)`
-- MUST reject non-editable voice with `MVP_UNSUPPORTED_NON_EDITABLE_VOICE`.
+- MUST reject command/target voice mismatch with `MVP_UNSUPPORTED_NON_EDITABLE_VOICE`.
 - MUST reject malformed payload with `MVP_INVALID_COMMAND_PAYLOAD`.
 - MUST reject overfull with `MEASURE_OVERFULL`.
 - MUST be atomic on failure (DOM unchanged, dirty unchanged).

--- a/docs/spec/COMMAND_CATALOG.md
+++ b/docs/spec/COMMAND_CATALOG.md
@@ -50,7 +50,7 @@ Rules:
 
 - MUST patch only the target note pitch-related fields.
 - MUST validate payload before mutation.
-- MUST reject non-editable voice (`MVP_UNSUPPORTED_NON_EDITABLE_VOICE`).
+- MUST reject command/target voice mismatch (`MVP_UNSUPPORTED_NON_EDITABLE_VOICE`).
 - MUST reject `grace` / `cue` / `chord` targets (`MVP_UNSUPPORTED_NOTE_KIND`).
 - Rest target is allowed in MVP for rest-to-note conversion.
 
@@ -69,7 +69,7 @@ Rules:
 
 - MUST patch only the target `<duration>` and required notation hints.
 - MUST validate duration payload before mutation.
-- MUST reject non-editable voice (`MVP_UNSUPPORTED_NON_EDITABLE_VOICE`).
+- MUST reject command/target voice mismatch (`MVP_UNSUPPORTED_NON_EDITABLE_VOICE`).
 - MUST reject `grace` / `cue` / `chord` / `rest` targets (`MVP_UNSUPPORTED_NOTE_KIND`).
 - MUST reject overfull (`MEASURE_OVERFULL`).
 - If underfull, MAY succeed and MAY return `MEASURE_UNDERFULL` warning.
@@ -112,7 +112,7 @@ type DeleteNoteCommand = {
 Rules:
 
 - MUST delete only target note.
-- MUST reject non-editable voice (`MVP_UNSUPPORTED_NON_EDITABLE_VOICE`).
+- MUST reject command/target voice mismatch (`MVP_UNSUPPORTED_NON_EDITABLE_VOICE`).
 - MUST reject `grace` / `cue` / `chord` / `rest` targets (`MVP_UNSUPPORTED_NOTE_KIND`).
 - MUST reject structural delete at backup/forward boundary.
 - For non-chord delete, implementation MAY replace target note with same-duration rest.

--- a/docs/spec/DIAGNOSTICS.md
+++ b/docs/spec/DIAGNOSTICS.md
@@ -8,7 +8,7 @@ Single source of truth for diagnostics emitted by core.
 
 1. `MEASURE_OVERFULL`
 - Severity: error
-- Trigger: command would cause `occupiedTime > measureCapacity` in editable voice.
+- Trigger: command would cause `occupiedTime > measureCapacity` in the command voice lane.
 - Required behavior:
   - command result `ok=false`
   - DOM unchanged
@@ -17,7 +17,7 @@ Single source of truth for diagnostics emitted by core.
 
 2. `MVP_UNSUPPORTED_NON_EDITABLE_VOICE`
 - Severity: error
-- Trigger: command targets non-editable voice, or would require backup/forward restructuring to realize edit.
+- Trigger: command voice mismatches target voice, or edit would require unsupported lane/boundary restructuring.
 - Required behavior:
   - command result `ok=false`
   - DOM unchanged

--- a/docs/spec/SPEC.md
+++ b/docs/spec/SPEC.md
@@ -166,9 +166,9 @@ Core supports the following command family:
 - `split_note`
 - `ui_noop`
 
-## 7.1 Voice Restriction
+## 7.1 Voice Match Restriction
 
-- Editing non-editable voice MUST fail with `MVP_UNSUPPORTED_NON_EDITABLE_VOICE`.
+- Command voice MUST match target note voice; mismatch MUST fail with `MVP_UNSUPPORTED_NON_EDITABLE_VOICE`.
 
 ## 7.2 Note-kind Restriction
 
@@ -227,7 +227,7 @@ Automated tests MUST cover:
 - dirty save (`serialized_dirty`)
 - overfull rejection
 - underfull behavior
-- non-editable voice rejection
+- voice mismatch rejection
 - unsupported note-kind rejection rules
 - split-note behavior
 - rest-to-note conversion path

--- a/docs/spec/TERMS.md
+++ b/docs/spec/TERMS.md
@@ -14,14 +14,14 @@ Normative terms and MVP scope boundaries.
 
 - `Core`: non-UI engine for MusicXML load/edit/save guarantees.
 - `UI`: interaction/render layer; MUST NOT mutate score DOM directly.
-- `Editable voice`: editable voice ID (default `1`).
+- `Command voice`: voice ID carried by each edit command; MUST match target note voice.
 - `Dirty`: successful content-changing edit has occurred.
 - `No-op save`: `dirty === false`, returns original XML text unchanged.
 
 ## MVP In Scope
 
 - DOM-preserving load/edit/save.
-- Commands on editable voice.
+- Commands whose voice matches the target note voice.
 - Overfull rejection / underfull warning model.
 - Verovio click-to-select mapping.
 - Split-note command (`split_note`).

--- a/docs/spec/TEST_MATRIX.md
+++ b/docs/spec/TEST_MATRIX.md
@@ -35,8 +35,8 @@ Executable test planning mapped from MVP requirements.
   - warning MAY include `MEASURE_UNDERFULL`
   - implementation-dependent rest compensation behavior stays consistent
 
-5. `BF-1 Non-editable voice rejected`
-- Given: command targeting non-editable voice
+5. `BF-1 Voice mismatch rejected`
+- Given: command voice does not match target note voice
 - Then:
   - `ok=false`
   - `MVP_UNSUPPORTED_NON_EDITABLE_VOICE`

--- a/mikuscore-src.html
+++ b/mikuscore-src.html
@@ -80,9 +80,6 @@
         <section class="md-section ms-flow-step ms-tab-panel" data-tab-panel="input">
           <h2 class="md-section-title"><span class="ms-step-no">1</span>Input</h2>
 
-          <div id="localDraftNotice" class="ms-local-draft md-hidden" role="status" aria-live="polite">
-            <div id="localDraftText" class="ms-local-draft-text"></div>
-          </div>
           <div class="ms-radio-group-wrap">
             <div class="ms-radio-group" role="radiogroup" aria-label="Input format">
               <label class="md-radio"><input id="inputTypeXml" type="radio" name="inputType" value="xml" checked /> MusicXML Input</label>
@@ -171,6 +168,9 @@
               <span>Load</span>
             </button>
             <button id="loadSampleBtn" type="button" class="md-button md-button--tonal">Load sample</button>
+          </div>
+          <div id="localDraftNotice" class="ms-local-draft md-hidden" role="status" aria-live="polite">
+            <div id="localDraftText" class="ms-local-draft-text"></div>
           </div>
         </section>
 
@@ -261,6 +261,12 @@
               </svg>
               <span>Delete Note</span>
             </button>
+            <button id="playMeasureBtn" type="button" class="md-button md-button--tonal ms-icon-button" disabled>
+              <svg aria-hidden="true" viewBox="0 0 24 24" class="ms-btn-icon" fill="currentColor">
+                <path d="M8 6.5v11l9-5.5z"></path>
+              </svg>
+              <span>Play</span>
+            </button>
           </div>
 
           <div class="ms-grid">
@@ -309,12 +315,6 @@
                 <path d="M6 6l12 12"></path>
               </svg>
               <span>Discard</span>
-            </button>
-            <button id="playMeasureBtn" type="button" class="md-button md-button--tonal ms-icon-button" disabled>
-              <svg aria-hidden="true" viewBox="0 0 24 24" class="ms-btn-icon" fill="currentColor">
-                <path d="M8 6.5v11l9-5.5z"></path>
-              </svg>
-              <span>Play</span>
             </button>
           </div>
         </section>

--- a/mikuscore.html
+++ b/mikuscore.html
@@ -1069,6 +1069,7 @@ body {
 }
 
 .ms-local-draft {
+  margin-top: 0.45rem;
   margin-bottom: 0.75rem;
   border: 1px solid #b7dde4;
   border-radius: 12px;
@@ -1594,9 +1595,6 @@ body {
         <section class="md-section ms-flow-step ms-tab-panel" data-tab-panel="input">
           <h2 class="md-section-title"><span class="ms-step-no">1</span>Input</h2>
 
-          <div id="localDraftNotice" class="ms-local-draft md-hidden" role="status" aria-live="polite">
-            <div id="localDraftText" class="ms-local-draft-text"></div>
-          </div>
           <div class="ms-radio-group-wrap">
             <div class="ms-radio-group" role="radiogroup" aria-label="Input format">
               <label class="md-radio"><input id="inputTypeXml" type="radio" name="inputType" value="xml" checked /> MusicXML Input</label>
@@ -1685,6 +1683,9 @@ body {
               <span>Load</span>
             </button>
             <button id="loadSampleBtn" type="button" class="md-button md-button--tonal">Load sample</button>
+          </div>
+          <div id="localDraftNotice" class="ms-local-draft md-hidden" role="status" aria-live="polite">
+            <div id="localDraftText" class="ms-local-draft-text"></div>
           </div>
         </section>
 
@@ -1775,6 +1776,12 @@ body {
               </svg>
               <span>Delete Note</span>
             </button>
+            <button id="playMeasureBtn" type="button" class="md-button md-button--tonal ms-icon-button" disabled>
+              <svg aria-hidden="true" viewBox="0 0 24 24" class="ms-btn-icon" fill="currentColor">
+                <path d="M8 6.5v11l9-5.5z"></path>
+              </svg>
+              <span>Play</span>
+            </button>
           </div>
 
           <div class="ms-grid">
@@ -1823,12 +1830,6 @@ body {
                 <path d="M6 6l12 12"></path>
               </svg>
               <span>Discard</span>
-            </button>
-            <button id="playMeasureBtn" type="button" class="md-button md-button--tonal ms-icon-button" disabled>
-              <svg aria-hidden="true" viewBox="0 0 24 24" class="ms-btn-icon" fill="currentColor">
-                <path d="M8 6.5v11l9-5.5z"></path>
-              </svg>
-              <span>Play</span>
             </button>
           </div>
         </section>
@@ -1904,7 +1905,7 @@ const load_flow_1 = require("./load-flow");
 const playback_flow_1 = require("./playback-flow");
 const preview_flow_1 = require("./preview-flow");
 const sampleXml_1 = require("./sampleXml");
-const EDITABLE_VOICE = "1";
+const DEFAULT_VOICE = "1";
 const q = (selector) => {
     const el = document.querySelector(selector);
     if (!el)
@@ -1973,7 +1974,7 @@ const measureDiscardBtn = q("#measureDiscardBtn");
 const playMeasureBtn = q("#playMeasureBtn");
 const topTabButtons = Array.from(document.querySelectorAll(".ms-top-tab"));
 const topTabPanels = Array.from(document.querySelectorAll(".ms-tab-panel"));
-const core = new ScoreCore_1.ScoreCore({ editableVoice: EDITABLE_VOICE });
+const core = new ScoreCore_1.ScoreCore();
 const state = {
     loaded: false,
     selectedNodeId: null,
@@ -1992,7 +1993,7 @@ let selectedMeasure = null;
 let draftCore = null;
 let draftNoteNodeIds = [];
 let draftSvgIdToNodeId = new Map();
-let selectedDraftVoice = EDITABLE_VOICE;
+let selectedDraftVoice = DEFAULT_VOICE;
 let selectedDraftNoteIsRest = false;
 let suppressDurationPresetEvent = false;
 let selectedDraftDurationValue = null;
@@ -2136,12 +2137,16 @@ const formatLocalDraftTime = (timestamp) => {
 const renderLocalDraftUi = () => {
     const draft = readLocalDraft();
     const hasDraft = Boolean(draft);
-    const draftLoadedInInput = hasDraft && draft ? draft.xml.trim() === String(xmlInput.value || "").trim() : false;
-    localDraftNotice.classList.toggle("md-hidden", !draftLoadedInInput);
-    discardDraftExportBtn.classList.toggle("md-hidden", !hasDraft);
-    if (!draftLoadedInInput || !draft)
+    const inputPanelVisible = topTabPanels.some((panel) => panel.dataset.tabPanel === "input" && !panel.hidden);
+    const showNotice = hasDraft && inputPanelVisible;
+    localDraftNotice.classList.toggle("md-hidden", !showNotice);
+    discardDraftExportBtn.classList.remove("md-hidden");
+    discardDraftExportBtn.disabled = !hasDraft;
+    if (!showNotice || !draft) {
+        localDraftText.textContent = "";
         return;
-    localDraftText.textContent = `Local draft loaded (saved at ${formatLocalDraftTime(draft.updatedAt)}).`;
+    }
+    localDraftText.textContent = `Local draft exists (saved at ${formatLocalDraftTime(draft.updatedAt)}).`;
 };
 const applyInitialXmlInputValue = () => {
     const draft = readLocalDraft();
@@ -2423,7 +2428,7 @@ const renderAlterButtons = () => {
 };
 const syncStepFromSelectedDraftNote = () => {
     var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p, _q, _r, _s;
-    selectedDraftVoice = EDITABLE_VOICE;
+    selectedDraftVoice = DEFAULT_VOICE;
     selectedDraftNoteIsRest = false;
     pitchStep.disabled = false;
     pitchStep.title = "";
@@ -2433,7 +2438,7 @@ const syncStepFromSelectedDraftNote = () => {
         btn.title = "";
     }
     if (!draftCore || !state.selectedNodeId) {
-        selectedDraftVoice = EDITABLE_VOICE;
+        selectedDraftVoice = DEFAULT_VOICE;
         selectedDraftDurationValue = null;
         rebuildDurationPresetOptions(DEFAULT_DIVISIONS);
         setDurationPresetFromValue(null);
@@ -2445,7 +2450,7 @@ const syncStepFromSelectedDraftNote = () => {
     }
     const xml = draftCore.debugSerializeCurrentXml();
     if (!xml) {
-        selectedDraftVoice = EDITABLE_VOICE;
+        selectedDraftVoice = DEFAULT_VOICE;
         selectedDraftDurationValue = null;
         rebuildDurationPresetOptions(DEFAULT_DIVISIONS);
         setDurationPresetFromValue(null);
@@ -2457,7 +2462,7 @@ const syncStepFromSelectedDraftNote = () => {
     }
     const doc = (0, musicxml_io_1.parseMusicXmlDocument)(xml);
     if (!doc) {
-        selectedDraftVoice = EDITABLE_VOICE;
+        selectedDraftVoice = DEFAULT_VOICE;
         selectedDraftDurationValue = null;
         rebuildDurationPresetOptions(DEFAULT_DIVISIONS);
         setDurationPresetFromValue(null);
@@ -2472,7 +2477,7 @@ const syncStepFromSelectedDraftNote = () => {
     for (let i = 0; i < count; i += 1) {
         if (draftNoteNodeIds[i] !== state.selectedNodeId)
             continue;
-        selectedDraftVoice = ((_b = (_a = notes[i].querySelector(":scope > voice")) === null || _a === void 0 ? void 0 : _a.textContent) === null || _b === void 0 ? void 0 : _b.trim()) || EDITABLE_VOICE;
+        selectedDraftVoice = ((_b = (_a = notes[i].querySelector(":scope > voice")) === null || _a === void 0 ? void 0 : _a.textContent) === null || _b === void 0 ? void 0 : _b.trim()) || DEFAULT_VOICE;
         const measure = notes[i].closest("measure");
         const divisions = resolveEffectiveDivisionsForMeasure(doc, measure);
         rebuildDurationPresetOptions(divisions);
@@ -2543,7 +2548,7 @@ const syncStepFromSelectedDraftNote = () => {
         renderAlterButtons();
         return;
     }
-    selectedDraftVoice = EDITABLE_VOICE;
+    selectedDraftVoice = DEFAULT_VOICE;
     selectedDraftDurationValue = null;
     rebuildDurationPresetOptions(DEFAULT_DIVISIONS);
     setDurationPresetFromValue(null);
@@ -2962,7 +2967,7 @@ const initializeMeasureEditor = (location) => {
         setUiMappingDiagnostic("Failed to extract selected measure.");
         return;
     }
-    const nextDraft = new ScoreCore_1.ScoreCore({ editableVoice: EDITABLE_VOICE });
+    const nextDraft = new ScoreCore_1.ScoreCore();
     try {
         nextDraft.load(extracted);
     }
@@ -3099,7 +3104,7 @@ const synthEngine = (0, playback_flow_1.createBasicWaveSynthEngine)({ ticksPerQu
 const playbackFlowOptions = {
     engine: synthEngine,
     ticksPerQuarter: playback_flow_1.PLAYBACK_TICKS_PER_QUARTER,
-    editableVoice: EDITABLE_VOICE,
+    editableVoice: DEFAULT_VOICE,
     debugLog: DEBUG_LOG,
     getIsPlaying: () => isPlaying,
     setIsPlaying: (playing) => {
@@ -3167,7 +3172,7 @@ const readDuration = () => {
 };
 const commandVoiceForSelection = () => {
     const voice = String(selectedDraftVoice || "").trim();
-    return voice || EDITABLE_VOICE;
+    return voice || DEFAULT_VOICE;
 };
 const onDurationPresetChange = () => {
     if (suppressDurationPresetEvent)
@@ -3231,7 +3236,7 @@ const autoSaveCurrentXml = (persistLocalDraft = false) => {
         if (result.diagnostics.some((d) => d.code === "MEASURE_OVERFULL")) {
             const debugXml = core.debugSerializeCurrentXml();
             if (debugXml) {
-                dumpOverfullContext(debugXml, EDITABLE_VOICE);
+                dumpOverfullContext(debugXml, DEFAULT_VOICE);
             }
             else if (DEBUG_LOG) {
                 console.warn("[mikuscore][debug] no in-memory XML to dump.");
@@ -3315,6 +3320,8 @@ const onLoadClick = async () => {
     if (result.nextXmlInputText !== undefined) {
         xmlInput.value = result.nextXmlInputText;
     }
+    // Persist immediately on explicit load actions (Load / Load sample).
+    writeLocalDraft(result.xmlToLoad);
     loadFromText(result.xmlToLoad);
 };
 const onDiscardLocalDraft = () => {
@@ -3675,6 +3682,10 @@ const activateTopTab = (tabName) => {
     for (const panel of topTabPanels) {
         panel.hidden = panel.dataset.tabPanel !== tabName;
     }
+    if (tabName !== "input") {
+        localDraftNotice.classList.add("md-hidden");
+    }
+    renderLocalDraftUi();
 };
 if (topTabButtons.length > 0 && topTabPanels.length > 0) {
     for (const button of topTabButtons) {
@@ -20825,7 +20836,6 @@ const commands_1 = require("./commands");
 const timeIndex_1 = require("./timeIndex");
 const xmlUtils_1 = require("./xmlUtils");
 const validators_1 = require("./validators");
-const DEFAULT_EDITABLE_VOICE = "1";
 class ScoreCore {
     constructor(options = {}) {
         var _a;
@@ -20836,7 +20846,8 @@ class ScoreCore {
         this.nodeToId = new WeakMap();
         this.idToNode = new Map();
         this.nodeCounter = 0;
-        this.editableVoice = (_a = options.editableVoice) !== null && _a !== void 0 ? _a : DEFAULT_EDITABLE_VOICE;
+        const rawEditableVoice = String((_a = options.editableVoice) !== null && _a !== void 0 ? _a : "").trim();
+        this.editableVoice = rawEditableVoice || null;
     }
     load(xml) {
         this.originalXml = xml;
@@ -21077,14 +21088,21 @@ class ScoreCore {
             const note = measure.querySelector("note");
             if (!note)
                 continue;
-            const timing = (0, timeIndex_1.getMeasureTimingForVoice)(note, this.editableVoice);
-            if (!timing)
-                continue;
-            if (timing.occupied > timing.capacity) {
-                return {
-                    code: "MEASURE_OVERFULL",
-                    message: `Occupied time ${timing.occupied} exceeds capacity ${timing.capacity}.`,
-                };
+            const voices = this.editableVoice
+                ? [this.editableVoice]
+                : Array.from(new Set(Array.from(measure.querySelectorAll("note"))
+                    .map((measureNote) => (0, xmlUtils_1.getVoiceText)(measureNote))
+                    .filter((voice) => Boolean(voice))));
+            for (const voice of voices) {
+                const timing = (0, timeIndex_1.getMeasureTimingForVoice)(note, voice);
+                if (!timing)
+                    continue;
+                if (timing.occupied > timing.capacity) {
+                    return {
+                        code: "MEASURE_OVERFULL",
+                        message: `Occupied time ${timing.occupied} exceeds capacity ${timing.capacity}.`,
+                    };
+                }
             }
         }
         return null;
@@ -21346,6 +21364,8 @@ const timeIndex_1 = require("./timeIndex");
 const xmlUtils_1 = require("./xmlUtils");
 const validateVoice = (command, editableVoice) => {
     if (command.type === "ui_noop")
+        return null;
+    if (!editableVoice)
         return null;
     if (command.voice === editableVoice)
         return null;

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -240,6 +240,7 @@ body {
 }
 
 .ms-local-draft {
+  margin-top: 0.45rem;
   margin-bottom: 0.75rem;
   border: 1px solid #b7dde4;
   border-radius: 12px;


### PR DESCRIPTION
…UIを整理

### 概要
MVPのvoice制約を見直し、`voice=1` 固定編集を廃止しました。
編集可否は「コマンドの `voice` が対象ノート `voice` と一致するか」で判定します。
あわせて、Local Draft表示まわりとEdit画面のボタン配置を改善しました。

### 変更内容

#### 1. Core: voice制約の緩和（固定voice廃止）
- `ScoreCore` の `editableVoice` を `string | null` とし、未指定時は全voice対象に。
- `validateVoice` は `editableVoice` 未指定時に制限しない挙動へ変更。
- `save()` 時の overfull 検査を、固定voiceではなく対象measure内voiceで評価する形に更新。
- `ScoreCoreOptions` の型を `editableVoice?: VoiceId | null` に変更。

対象ファイル:
- `core/ScoreCore.ts`
- `core/validators.ts`
- `core/interfaces.ts`

#### 2. UI: Core初期化のvoice固定を解除
- `new ScoreCore({ editableVoice: "1" })` を `new ScoreCore()` に変更（メイン/measure editor）。
- `EDITABLE_VOICE` 定数名を `DEFAULT_VOICE` に整理（UIのfallback用途）。

対象ファイル:
- `src/ts/main.ts`

#### 3. テスト強化（他voiceの不意な更新防止）
- 既存BF-1を「non-editable voice rejected」から「voice mismatch rejected」に明確化。
- `voice=2` 編集成功ケースを追加。
- `voice=2` 編集時に `voice=1` が不変であることを検証するテストを追加。

対象ファイル:
- `tests/unit/core.spec.ts`

#### 4. 仕様・README更新
- 「non-editable voice」表現を、実装準拠の「command/target voice mismatch」へ置換。
- TERMS/DIAGNOSTICS/SPEC/COMMANDS/COMMAND_CATALOG/TEST_MATRIX を整合更新。

対象ファイル:
- `README.md`
- `docs/spec/TERMS.md`
- `docs/spec/DIAGNOSTICS.md`
- `docs/spec/SPEC.md`
- `docs/spec/COMMANDS.md`
- `docs/spec/COMMAND_CATALOG.md`
- `docs/spec/TEST_MATRIX.md`

#### 5. Edit/UI改善
- Edit画面の `Play` ボタンを `Delete Note` の右へ移動。
- Local Draft通知を Loadボタン群の下へ移動。
- Local Draft通知の上マージン追加。
- 通知文言を `Local draft loaded ...` から `Local draft exists ...` に変更。
- `Discard Draft` は常時表示し、draft未存在時は `disabled`。
- Local Draft通知表示は localStorageを真実源として単純化（存在時のみ表示）。

対象ファイル:
- `mikuscore-src.html`
- `src/css/app.css`
- `src/ts/main.ts`

#### 6. Load操作時のDraft更新
- `Load` / `Load sample` 成功時に即 `writeLocalDraft()` を実行し、Draft時刻を即時更新。

対象ファイル:
- `src/ts/main.ts`

### 生成物更新
- `mikuscore.html`
- `src/js/main.js`

### 動作確認
- `npm run test:unit`（全件成功）
- `npm run typecheck`（成功）
- `npm run build`（成功）