### PR TITLE
ABC I/O仕様ドキュメントを実装に同期（%@mksメタ・連符・臨時記号・TODO更新）

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -16,12 +16,14 @@
 - [x] Added playback path with `midi-writer.js`.
 - [x] Fixed transpose behavior including Clarinet in A.
 - [x] Improved iPhone Safari audio start stability (`pointerdown`/`touchstart` unlock, `AudioContext` resume flow, `webkitAudioContext` fallback).
+- [x] Fixed ABC tuplet timing drift in playback-related roundtrip paths.
+- [x] Added `%@mks` roundtrip support for measure metadata (`number` / `implicit` / `repeat` / `times`) and `transpose` (`chromatic` / `diatonic`).
+- [x] Improved ABC accidental export rules (suppress redundant naturals, preserve required naturals per key/measure context).
 
 #### Known Issues
 - [ ] Verovio warning `slur ... could not be ended` may appear from input MusicXML; loading currently continues.
 - [ ] Click mapping expects note-head/real note area click; staff/empty click can return `MVP_TARGET_NOT_FOUND`.
 - [ ] Tuplet-like duration presets are currently restricted to measures/voices where compatible tuplet context already exists.
-- [ ] Some accidental rendering in `ABC export` is still incorrect (key/accidental precedence needs review).
 
 ### Next Priorities
 #### P1: Editing stability
@@ -34,6 +36,9 @@
 - [ ] Document and test selection retention rules across re-render.
 - [ ] Add ABC roundtrip golden tests (`MusicXML -> ABC -> MusicXML`) for representative orchestral/piano scores.
 - [ ] Define acceptable roundtrip delta policy for ABC path (what may change vs must be preserved).
+- [ ] Add optional `%@mks ...` metadata compaction:
+  - On `MusicXML -> ABC`, suppress consecutive `%@mks` comment lines when values are unchanged from the previous measure.
+  - On `ABC -> MusicXML`, if `%@mks` metadata is omitted, inherit the previous measure's metadata for reconstruction.
 
 #### P3: Feature expansion
 - [ ] Decide whether to reintroduce `insert_note_after` in UI.
@@ -70,12 +75,14 @@
 - [x] `midi-writer.js` を使った再生経路を導入済み。
 - [x] Clarinet in A 含む `transpose` 反映を修正済み。
 - [x] iPhone Safari での音出し安定性を改善済み（`pointerdown`/`touchstart` 先行アンロック、`AudioContext` resume 経路、`webkitAudioContext` フォールバック）。
+- [x] ABC の連符（tuplet）往復時に発生していた再生タイミングずれを修正済み。
+- [x] `%@mks` の小節メタ（`number` / `implicit` / `repeat` / `times`）と `transpose`（`chromatic` / `diatonic`）の往復保持を実装済み。
+- [x] ABC 出力の臨時記号ルールを改善済み（不要なナチュラル抑制、必要なナチュラルは保持）。
 
 #### 既知事項
 - [ ] Verovio 警告 `slur ... could not be ended` は入力 MusicXML 由来で表示されることがある。現状は読み込み継続。
 - [ ] クリック選択は音符クリック前提。五線や空白クリックは `MVP_TARGET_NOT_FOUND` になりうる。
 - [ ] 音価ドロップダウンの 3 連系は、現状「同小節/同 voice に既存 tuplet がある場合のみ許可」の暫定制約。
-- [ ] `ABC出力` で一部臨時記号（alter/accidental）の表現が崩れる問題が残っている。
 
 ### 次にやること
 #### P1: 編集体験の安定化
@@ -88,6 +95,9 @@
 - [ ] レンダリング更新時の選択維持ルールを明文化しテスト化。
 - [ ] 代表的なオーケストラ譜/ピアノ譜で `MusicXML -> ABC -> MusicXML` のゴールデン往復テストを追加。
 - [ ] ABC経由での往復差分ポリシー（許容差分/非許容差分）を明文化。
+- [ ] `%@mks ...` メタコメントの省略最適化を追加。
+  - `MusicXML -> ABC` では、前小節と同一内容が連続する場合、後続の `%@mks` コメント行を省略可能にする。
+  - `ABC -> MusicXML` では、省略により不足した `%@mks` 情報を前小節の値で継承して復元する。
 
 #### P3: 仕様拡張
 - [ ] `insert_note_after` の UI 再導入可否を仕様確定。

--- a/docs/spec/ABC_IO.md
+++ b/docs/spec/ABC_IO.md
@@ -51,6 +51,7 @@ Parser reads:
 - headers (`X:`, `T:`, `C:`, `M:`, `L:`, `K:`)
 - voice directives (`V:` with optional `name`, `clef`, `transpose`)
 - optional `%%score` voice ordering directive
+- optional mikuscore metadata comments (`%@mks key ...`, `%@mks measure ...`, `%@mks transpose ...`)
 - body note/rest/chord tokens
 
 ## Compatibility behavior
@@ -78,6 +79,8 @@ Returned structure includes:
 
 - `meta` (title/composer/meter/unit/key)
 - `parts[]` with `partId`, `partName`, `clef`, optional `transpose`, `measures`
+- per-measure metadata hints (measure number / implicit / repeat / repeat times)
+- tuplet timing metadata (`timeModification`, tuplet start/stop markers)
 - voice ordering based on `%%score` + declared fallback order
 - `warnings[]` for non-fatal issues
 
@@ -115,8 +118,15 @@ Exports:
 ## Note export policy
 
 - supports rests, pitch notes, chords, durations, ties
+- supports tuplet roundtrip export (`(n:q:r` style) from MusicXML time-modification/tuplet notations
 - emits accidentals based on key signature + measure accidental memory
+  - suppresses redundant naturals in-context
+  - emits required naturals where key/measure context differs
 - serializes each part as ABC measure stream (`|` separated)
+- emits mikuscore metadata lines for lossless roundtrip:
+  - `%@mks key voice=... measure=... fifths=...`
+  - `%@mks measure voice=... measure=... number=... implicit=... [repeat=...] [times=...]`
+  - `%@mks transpose voice=... chromatic=... [diatonic=...]`
 
 ---
 
@@ -134,6 +144,9 @@ Generation policy:
 - writes part list + default midi-instrument tags
 - writes first-measure attributes (key/time/clef and optional transpose)
 - preserves tie semantics using both `<tie>` and `<notations><tied>`
+- restores tuplet semantics using both `<time-modification>` and `<notations><tuplet>`
+- restores measure metadata (`number`, `implicit`) and repeat barlines from `%@mks measure`
+- restores transpose (`chromatic`, `diatonic`) from `%@mks transpose`
 - inserts a fallback whole-rest note for empty measures
 
 ---
@@ -162,4 +175,3 @@ Supported mappings:
 - This module is compatibility-oriented and intentionally pragmatic.
 - It does not aim to be a complete strict ABC standard implementation.
 - Behavior prioritizes stable import/export for mikuscore workflows.
-

--- a/docs/spec/abc-compat-parser-ebnf.md
+++ b/docs/spec/abc-compat-parser-ebnf.md
@@ -8,7 +8,7 @@ It is based on ABC 2.1 and includes currently supported compatibility behavior o
 ## Scope
 - Header: `X,T,C,M,L,K,V` and `%%score`
 - Body: note/rest (`z/x`), accidentals, length, tie (`-`), broken rhythm (`>` `<`), barlines, chords, tuplets
-- Compatibility extensions: `M:C`, `M:C|`, inline text skip (`"..."`), standalone octave marker tolerance (`,` / `'`)
+- Compatibility extensions: `M:C`, `M:C|`, inline text skip (`"..."`), standalone octave marker tolerance (`,` / `'`), mikuscore `%@mks ...` metadata comments
 
 ## EBNF
 
@@ -81,6 +81,7 @@ digit            = "0".."9" ;
 - Treat `x` rest as `z` rest.
 - Support chords (`[CEG]`, `[A,,CE]`).
 - Support tuplets (`(3abc`, `(5:4:5abcde`) with duration scaling.
+- Accept `%@mks` metadata comments (`key`, `measure`, `transpose`) and feed roundtrip metadata when present.
 - Ignore `:` in barline variants (`:|`, `|:`, `||`) without parse failure.
 - Ignore standalone `,` / `'` for compatibility.
 
@@ -99,7 +100,7 @@ ABC 2.1 を土台とし、`abcjs` / `abcm2ps` 系の実データ差を現行実�
 ## Scope
 - ヘッダ: `X,T,C,M,L,K,V` と `%%score`
 - ボディ: 音符、休符(`z/x`)、臨時記号、長さ、タイ(`-`)、broken rhythm(`>` `<`)、小節線、和音、連符
-- 許容拡張: `M:C`, `M:C|`, インライン文字列(`"..."`)のスキップ、単独オクターブ記号(`,`/`'`)の許容
+- 許容拡張: `M:C`, `M:C|`, インライン文字列(`"..."`)のスキップ、単独オクターブ記号(`,`/`'`)の許容、mikuscore の `%@mks ...` メタコメント
 
 ## EBNF
 上記 English セクションの EBNF を正本とする。
@@ -110,6 +111,7 @@ ABC 2.1 を土台とし、`abcjs` / `abcm2ps` 系の実データ差を現行実�
 - `x` 休符を `z` と同様に扱う。
 - chord (`[CEG]`, `[A,,CE]` など) を同時発音として扱う。
 - tuplet (`(3abc`, `(5:4:5abcde` など) を音価スケーリングで扱う。
+- `%@mks` メタコメント（`key` / `measure` / `transpose`）を受理し、存在時は往復メタ情報として利用する。
 - `:|`, `|:`, `||` などの `:` は小節補助記号として無視（構文エラー化しない）。
 - 単独の `,` / `'` は互換目的で無視して継続する。
 


### PR DESCRIPTION
### 概要
実装済みの ABC/MusicXML 変換挙動に合わせて、仕様書と TODO を更新するドキュメント同期PRです。

### 変更内容
1. `TODO.md` の更新
- 完了済みに以下を追加
  - ABC連符（tuplet）往復時のタイミングずれ修正
  - `%@mks` の小節メタ/transpose 往復対応
  - ABC出力時の臨時記号ルール改善（冗長ナチュラル抑制・必要ナチュラル保持）
- 既知事項から「ABC出力の臨時記号崩れ」を削除
- 次優先（P2）に `%@mks` コメント省略最適化タスクを追加
  - MusicXML→ABC: 前小節と同一なら連続 `%@mks` 行を省略
  - ABC→MusicXML: 省略で欠けたメタを前小節継承で復元

2. `docs/spec/ABC_IO.md` の更新
- パーサ入力として `%@mks key/measure/transpose` コメントを明記
- 解析結果に以下を追記
  - 小節メタ（number/implicit/repeat/times）
  - tuplet 時間情報（`timeModification`、start/stop）
- MusicXML→ABC の方針に以下を追記
  - tuplet 往復表現
  - 臨時記号の出力方針（不要natural抑制、必要natural出力）
  - `%@mks` メタ行出力
- ABC→MusicXML の方針に以下を追記
  - `<time-modification>` / `<tuplet>` 復元
  - measure/repeat/transpose メタ復元

3. `docs/spec/abc-compat-parser-ebnf.md` の更新
- Scope / Compatibility Notes（英日）に `%@mks` メタコメント対応を追記

### 影響範囲
- ドキュメントのみ（実装コード変更なし）
- 仕様と実装の齟齬を縮小し、今後の保守・テスト基準を明確化