### PR TITLE
時間解像度の既定値を 480 に統一（Playback / MIDI Export / 新規譜面 divisions）

### DIFF
--- a/docs/spec/MIDI_IO.md
+++ b/docs/spec/MIDI_IO.md
@@ -209,8 +209,10 @@ For same-tick same-pitch situations, event ordering is configurable:
 #### Current usage policy
 
 - `safe` export profile:
+  - TPQ defaults to `480`
   - default writer path (`midi-writer.js`)
 - `musescore_parity` profile:
+  - TPQ is fixed to `480`
   - raw writer path enabled
   - retrigger policy defaults to `off_before_on`
 

--- a/docs/spec/PLAYBACK.md
+++ b/docs/spec/PLAYBACK.md
@@ -36,7 +36,7 @@ This file MUST remain side-effect free.
 
 ## Core constants and types
 
-- `PLAYBACK_TICKS_PER_QUARTER = 128`
+- `PLAYBACK_TICKS_PER_QUARTER = 480`
 - `SynthSchedule`
   - `tempo`
   - optional `tempoEvents`

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -1843,7 +1843,7 @@ const createNewMusicXml = () => {
     const fifths = Number.isFinite(parsedFifths) ? Math.max(-7, Math.min(7, Math.round(parsedFifths))) : 0;
     const beats = normalizeNewTimeBeats();
     const beatType = normalizeNewTimeBeatType();
-    const divisions = 960;
+    const divisions = 480;
     const measureCount = 8;
     const measureDuration = Math.max(1, Math.round(divisions * beats * (4 / beatType)));
     const clefs = usePianoGrandStaffTemplate ? ["treble"] : listCurrentNewPartClefs();
@@ -3128,7 +3128,7 @@ const getMidiWriterRuntime = () => {
 };
 const normalizeTicksPerQuarter = (ticksPerQuarter) => {
     if (!Number.isFinite(ticksPerQuarter))
-        return 128;
+        return 480;
     return Math.max(1, Math.round(ticksPerQuarter));
 };
 const setMidiWriterHeaderTicksPerQuarter = (midiWriter, ticksPerQuarter) => {
@@ -5363,7 +5363,7 @@ const buildMidiBytesForPlayback = (events, tempo, programPreset = "electric_pian
     if (!rawWriter && !midiWriter) {
         throw new Error("midi-writer.js is not loaded.");
     }
-    const writerTicksPerQuarter = normalizeTicksPerQuarter((_a = options.ticksPerQuarter) !== null && _a !== void 0 ? _a : 128);
+    const writerTicksPerQuarter = normalizeTicksPerQuarter((_a = options.ticksPerQuarter) !== null && _a !== void 0 ? _a : 480);
     if (midiWriter) {
         setMidiWriterHeaderTicksPerQuarter(midiWriter, writerTicksPerQuarter);
     }
@@ -6858,7 +6858,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.startMeasurePlayback = exports.startPlayback = exports.stopPlayback = exports.createBasicWaveSynthEngine = exports.PLAYBACK_TICKS_PER_QUARTER = void 0;
 const midi_io_1 = require("./midi-io");
 const musicxml_io_1 = require("./musicxml-io");
-exports.PLAYBACK_TICKS_PER_QUARTER = 128;
+exports.PLAYBACK_TICKS_PER_QUARTER = 480;
 const summarizeDiagnostics = (diagnostics) => {
     if (!diagnostics.length)
         return "unknown reason";
@@ -6887,7 +6887,7 @@ const normalizeWaveform = (value) => {
 const createBasicWaveSynthEngine = (options) => {
     const ticksPerQuarter = Number.isFinite(options.ticksPerQuarter)
         ? Math.max(1, Math.round(options.ticksPerQuarter))
-        : 128;
+        : 480;
     let audioContext = null;
     let activeSynthNodes = [];
     let synthStopTimer = null;
@@ -7816,7 +7816,7 @@ const resolveMidiExportRuntimeOptions = (profileValue, baseTicksPerQuarter) => {
     const profile = (0, exports.normalizeMidiExportProfile)(profileValue);
     const normalizedBaseTicks = Number.isFinite(baseTicksPerQuarter) && Math.round(baseTicksPerQuarter) > 0
         ? Math.round(baseTicksPerQuarter)
-        : 128;
+        : 480;
     if (profile === "musescore_parity") {
         return {
             profile,

--- a/src/ts/main.ts
+++ b/src/ts/main.ts
@@ -1993,7 +1993,7 @@ const createNewMusicXml = (): string => {
   const fifths = Number.isFinite(parsedFifths) ? Math.max(-7, Math.min(7, Math.round(parsedFifths))) : 0;
   const beats = normalizeNewTimeBeats();
   const beatType = normalizeNewTimeBeatType();
-  const divisions = 960;
+  const divisions = 480;
   const measureCount = 8;
   const measureDuration = Math.max(1, Math.round(divisions * beats * (4 / beatType)));
   const clefs = usePianoGrandStaffTemplate ? ["treble"] : listCurrentNewPartClefs();

--- a/src/ts/midi-io.ts
+++ b/src/ts/midi-io.ts
@@ -683,7 +683,7 @@ const getMidiWriterRuntime = (): MidiWriterRuntime | null => {
 };
 
 const normalizeTicksPerQuarter = (ticksPerQuarter: number): number => {
-  if (!Number.isFinite(ticksPerQuarter)) return 128;
+  if (!Number.isFinite(ticksPerQuarter)) return 480;
   return Math.max(1, Math.round(ticksPerQuarter));
 };
 
@@ -3214,7 +3214,7 @@ export const buildMidiBytesForPlayback = (
   if (!rawWriter && !midiWriter) {
     throw new Error("midi-writer.js is not loaded.");
   }
-  const writerTicksPerQuarter = normalizeTicksPerQuarter(options.ticksPerQuarter ?? 128);
+  const writerTicksPerQuarter = normalizeTicksPerQuarter(options.ticksPerQuarter ?? 480);
   if (midiWriter) {
     setMidiWriterHeaderTicksPerQuarter(midiWriter, writerTicksPerQuarter);
   }

--- a/src/ts/midi-musescore-io.ts
+++ b/src/ts/midi-musescore-io.ts
@@ -27,7 +27,7 @@ export const resolveMidiExportRuntimeOptions = (
   const normalizedBaseTicks =
     Number.isFinite(baseTicksPerQuarter) && Math.round(baseTicksPerQuarter) > 0
       ? Math.round(baseTicksPerQuarter)
-      : 128;
+      : 480;
   if (profile === "musescore_parity") {
     return {
       profile,

--- a/src/ts/playback-flow.ts
+++ b/src/ts/playback-flow.ts
@@ -34,7 +34,7 @@ export type BasicWaveSynthEngine = {
   stop: () => void;
 };
 
-export const PLAYBACK_TICKS_PER_QUARTER = 128;
+export const PLAYBACK_TICKS_PER_QUARTER = 480;
 
 const summarizeDiagnostics = (diagnostics: Diagnostic[]): string => {
   if (!diagnostics.length) return "unknown reason";
@@ -65,7 +65,7 @@ const normalizeWaveform = (value: string): OscillatorType => {
 export const createBasicWaveSynthEngine = (options: { ticksPerQuarter: number }): BasicWaveSynthEngine => {
   const ticksPerQuarter = Number.isFinite(options.ticksPerQuarter)
     ? Math.max(1, Math.round(options.ticksPerQuarter))
-    : 128;
+    : 480;
   let audioContext: AudioContext | null = null;
   let activeSynthNodes: Array<{ oscillator: OscillatorNode; gainNode: GainNode }> = [];
   let synthStopTimer: number | null = null;


### PR DESCRIPTION
## 概要
時間解像度の既定値が `128` と `480` で混在していたため、関連箇所を `480` に統一しました。 合わせて仕様ドキュメントも更新しています。

## 変更内容
- `PLAYBACK_TICKS_PER_QUARTER` を `128 -> 480` に変更
- Playback エンジン内の `ticksPerQuarter` フォールバックを `128 -> 480` に変更
- MIDI Export runtime の base TPQ フォールバックを `128 -> 480` に変更
- MIDI writer 側の TPQ フォールバック（`normalizeTicksPerQuarter` / `options.ticksPerQuarter ?? ...`）を `128 -> 480` に変更
- 新規譜面生成時の `divisions` を `960 -> 480` に変更
- 生成物更新（`src/js/main.js`, `mikuscore.html`）
- 仕様書更新
  - `docs/spec/PLAYBACK.md`
  - `docs/spec/MIDI_IO.md`

## 目的
- Playback / MIDI / 新規譜面作成で時間解像度の基準を揃える
- 設定値の読み解きやデバッグ時の混乱を減らす
- 今後の仕様説明を簡潔にする

## 影響範囲
- Playback スケジューリングの tick 基準
- `safe` / `musescore_parity` プロファイルの TPQ 既定挙動
- 新規作成 MusicXML の `<divisions>` 既定値
- ビルド生成物

## 確認
- `npm run check:all` 実行済み
- typecheck / test:all / build すべて成功