### PR TITLE
クロスフォーマット回帰テスト強化と小節メタ保持の拡張（MuseScore / MIDI / ABC / LilyPond / MEI）

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "node scripts/build.mjs",
+    "build:all": "npm run test:all && npm run build",
     "check:all": "npm run typecheck && npm run test:all && npm run build",
     "build:vendor:utaformatix3": "bash scripts/sync-utaformatix3-vendor.sh",
     "clean": "rm -f mikuscore.html src/js/main.js",

--- a/tests/unit/abc-io.spec.ts
+++ b/tests/unit/abc-io.spec.ts
@@ -596,6 +596,52 @@ V:1
     expect(outDoc.querySelector('note > notations > slur[type="stop"]')).not.toBeNull();
   });
 
+  it("MusicXML->ABC exports tie notation and roundtrips it", () => {
+    const xmlWithTie = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>1920</duration>
+        <voice>1</voice><type>half</type>
+        <tie type="start"/><notations><tied type="start"/></notations>
+      </note>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>1920</duration>
+        <voice>1</voice><type>half</type>
+        <tie type="stop"/><notations><tied type="stop"/></notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithTie);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("-");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector('note > tie[type="start"]')).not.toBeNull();
+    expect(outDoc.querySelector('note > tie[type="stop"]')).not.toBeNull();
+    expect(outDoc.querySelector('note > notations > tied[type="start"]')).not.toBeNull();
+    expect(outDoc.querySelector('note > notations > tied[type="stop"]')).not.toBeNull();
+  });
+
   it("MusicXML->ABC keeps explicit accidental when lane key is unknown", () => {
     const xmlWithoutKeyButWithSharp = `<?xml version="1.0" encoding="UTF-8"?>
 <score-partwise version="3.1">

--- a/tests/unit/musescore-io.spec.ts
+++ b/tests/unit/musescore-io.spec.ts
@@ -555,6 +555,308 @@ describe("musescore-io", () => {
     expect(stop).not.toBeNull();
   });
 
+  it("roundtrip keeps octave-shift (8va/8vb) exported as chord-local Ottava spanner", () => {
+    const musicXml = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>P1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>480</divisions><time><beats>2</beats><beat-type>4</beat-type></time></attributes>
+      <direction><direction-type><octave-shift type="down" size="8" number="1"/></direction-type></direction>
+      <note><pitch><step>A</step><octave>6</octave></pitch><duration>960</duration><voice>1</voice><type>half</type></note>
+    </measure>
+    <measure number="2">
+      <direction><direction-type><octave-shift type="stop" size="8" number="1"/></direction-type></direction>
+      <note><pitch><step>A</step><octave>5</octave></pitch><duration>960</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(musicXml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+    const mscx = exportMusicXmlDomToMuseScore(srcDoc);
+    const dstXml = convertMuseScoreToMusicXml(mscx, { sourceMetadata: false, debugMetadata: false });
+    const dstDoc = parseMusicXmlDocument(dstXml);
+    expect(dstDoc).not.toBeNull();
+    if (!dstDoc) return;
+    const start = dstDoc.querySelector('part > measure:nth-of-type(1) > direction > direction-type > octave-shift[type="start"]');
+    const stop = dstDoc.querySelector('part > measure:nth-of-type(2) > direction > direction-type > octave-shift[type="stop"]');
+    expect(start).not.toBeNull();
+    expect(stop).not.toBeNull();
+  });
+
+  it("roundtrip keeps trill ornaments exported as chord-local Trill spanner", () => {
+    const musicXml = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>P1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>480</divisions><time><beats>2</beats><beat-type>4</beat-type></time></attributes>
+      <note>
+        <pitch><step>A</step><octave>3</octave></pitch>
+        <duration>960</duration><voice>1</voice><type>half</type>
+        <notations><ornaments><trill-mark/><wavy-line type="start" number="1"/></ornaments></notations>
+      </note>
+    </measure>
+    <measure number="2">
+      <note>
+        <pitch><step>A</step><octave>3</octave></pitch>
+        <duration>960</duration><voice>1</voice><type>half</type>
+        <notations><ornaments><wavy-line type="stop" number="1"/></ornaments></notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(musicXml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+    const mscx = exportMusicXmlDomToMuseScore(srcDoc);
+    const dstXml = convertMuseScoreToMusicXml(mscx, { sourceMetadata: false, debugMetadata: false });
+    const dstDoc = parseMusicXmlDocument(dstXml);
+    expect(dstDoc).not.toBeNull();
+    if (!dstDoc) return;
+    const start = dstDoc.querySelector('part > measure:nth-of-type(1) note > notations > ornaments > wavy-line[type="start"]');
+    const stop = dstDoc.querySelector('part > measure:nth-of-type(2) note > notations > ornaments > wavy-line[type="stop"]');
+    const trillMark = dstDoc.querySelector("part > measure:nth-of-type(1) note > notations > ornaments > trill-mark");
+    expect(start).not.toBeNull();
+    expect(stop).not.toBeNull();
+    expect(trillMark).not.toBeNull();
+  });
+
+  it("roundtrip keeps staccato articulation on a single-measure note", () => {
+    const musicXml = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>P1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>480</divisions><time><beats>2</beats><beat-type>4</beat-type></time></attributes>
+      <note>
+        <pitch><step>C</step><octave>5</octave></pitch>
+        <duration>480</duration><voice>1</voice><type>quarter</type>
+        <notations><articulations><staccato/></articulations></notations>
+      </note>
+      <note><rest/><duration>480</duration><voice>1</voice><type>quarter</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(musicXml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+    const mscx = exportMusicXmlDomToMuseScore(srcDoc);
+    const dstXml = convertMuseScoreToMusicXml(mscx, { sourceMetadata: false, debugMetadata: false });
+    const dstDoc = parseMusicXmlDocument(dstXml);
+    expect(dstDoc).not.toBeNull();
+    if (!dstDoc) return;
+    const first = dstDoc.querySelector("part > measure > note:nth-of-type(1)");
+    expect(first?.querySelector(":scope > notations > articulations > staccato")).not.toBeNull();
+  });
+
+  it("roundtrip keeps accent articulation on a single-measure note", () => {
+    const musicXml = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>P1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>480</divisions><time><beats>2</beats><beat-type>4</beat-type></time></attributes>
+      <note>
+        <pitch><step>B</step><octave>3</octave></pitch>
+        <duration>480</duration><voice>1</voice><type>quarter</type>
+        <notations><articulations><accent/></articulations></notations>
+      </note>
+      <note><rest/><duration>480</duration><voice>1</voice><type>quarter</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(musicXml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+    const mscx = exportMusicXmlDomToMuseScore(srcDoc);
+    const dstXml = convertMuseScoreToMusicXml(mscx, { sourceMetadata: false, debugMetadata: false });
+    const dstDoc = parseMusicXmlDocument(dstXml);
+    expect(dstDoc).not.toBeNull();
+    if (!dstDoc) return;
+    const first = dstDoc.querySelector("part > measure > note:nth-of-type(1)");
+    expect(first?.querySelector(":scope > notations > articulations > accent")).not.toBeNull();
+  });
+
+  it("roundtrip keeps implicit short pickup measure length", () => {
+    const musicXml = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>P1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="X1" implicit="yes">
+      <attributes><divisions>480</divisions><time><beats>4</beats><beat-type>4</beat-type></time></attributes>
+      <note><pitch><step>E</step><octave>4</octave></pitch><duration>480</duration><voice>1</voice><type>quarter</type></note>
+    </measure>
+    <measure number="1">
+      <note><rest/><duration>1920</duration><voice>1</voice><type>whole</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(musicXml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+    const mscx = exportMusicXmlDomToMuseScore(srcDoc);
+    const dstXml = convertMuseScoreToMusicXml(mscx, { sourceMetadata: false, debugMetadata: false });
+    const dstDoc = parseMusicXmlDocument(dstXml);
+    expect(dstDoc).not.toBeNull();
+    if (!dstDoc) return;
+    const pickup = dstDoc.querySelector("part > measure:nth-of-type(1)");
+    expect(pickup?.getAttribute("implicit")).toBe("yes");
+    const pickupDur = Array.from(pickup?.querySelectorAll(":scope > note > duration") ?? [])
+      .reduce((sum, node) => sum + Math.round(Number(node.textContent?.trim() ?? "0")), 0);
+    expect(pickupDur).toBe(480);
+  });
+
+  it("roundtrip keeps grace note marker and principal duration", () => {
+    const musicXml = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>P1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>480</divisions><time><beats>2</beats><beat-type>4</beat-type></time></attributes>
+      <note><grace slash="yes"/><pitch><step>C</step><octave>5</octave></pitch><voice>1</voice><type>eighth</type></note>
+      <note><pitch><step>D</step><octave>5</octave></pitch><duration>480</duration><voice>1</voice><type>quarter</type></note>
+      <note><rest/><duration>480</duration><voice>1</voice><type>quarter</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(musicXml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+    const mscx = exportMusicXmlDomToMuseScore(srcDoc);
+    const dstXml = convertMuseScoreToMusicXml(mscx, { sourceMetadata: false, debugMetadata: false });
+    const dstDoc = parseMusicXmlDocument(dstXml);
+    expect(dstDoc).not.toBeNull();
+    if (!dstDoc) return;
+    const first = dstDoc.querySelector("part > measure > note:nth-of-type(1)");
+    const second = dstDoc.querySelector("part > measure > note:nth-of-type(2)");
+    expect(first?.querySelector(":scope > grace")).not.toBeNull();
+    expect(second?.querySelector(":scope > duration")?.textContent?.trim()).toBe("480");
+  });
+
+  it("roundtrip keeps unpitched notes as timed note events", () => {
+    const musicXml = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list>
+    <score-part id="P1">
+      <part-name>Drums</part-name>
+      <score-instrument id="P1-I1"><instrument-name>Drum Set</instrument-name></score-instrument>
+    </score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>480</divisions><time><beats>2</beats><beat-type>4</beat-type></time></attributes>
+      <note>
+        <unpitched><display-step>C</display-step><display-octave>5</display-octave></unpitched>
+        <duration>480</duration><voice>1</voice><type>quarter</type><instrument id="P1-I1"/>
+      </note>
+      <note>
+        <unpitched><display-step>D</display-step><display-octave>5</display-octave></unpitched>
+        <duration>480</duration><voice>1</voice><type>quarter</type><instrument id="P1-I1"/>
+      </note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(musicXml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+    const mscx = exportMusicXmlDomToMuseScore(srcDoc);
+    const dstXml = convertMuseScoreToMusicXml(mscx, { sourceMetadata: false, debugMetadata: false });
+    const dstDoc = parseMusicXmlDocument(dstXml);
+    expect(dstDoc).not.toBeNull();
+    if (!dstDoc) return;
+    const timedNotes = Array.from(dstDoc.querySelectorAll("part > measure > note"))
+      .filter((n) => n.querySelector(":scope > rest") === null);
+    expect(timedNotes.length).toBe(2);
+    const durations = timedNotes.map((n) => n.querySelector(":scope > duration")?.textContent?.trim() ?? "");
+    expect(durations).toEqual(["480", "480"]);
+  });
+
+  it("roundtrip keeps section-boundary double bar + explicit same-meter time (m24/m25 minimal)", () => {
+    const musicXml = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>P1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="24">
+      <attributes><divisions>480</divisions><time><beats>2</beats><beat-type>4</beat-type></time></attributes>
+      <note><pitch><step>A</step><octave>4</octave></pitch><duration>480</duration><voice>1</voice><type>quarter</type></note>
+      <note><rest/><duration>480</duration><voice>1</voice><type>quarter</type></note>
+      <barline location="right"><bar-style>light-light</bar-style></barline>
+    </measure>
+    <measure number="25">
+      <attributes><time><beats>2</beats><beat-type>4</beat-type></time></attributes>
+      <note><pitch><step>B</step><octave>4</octave></pitch><duration>480</duration><voice>1</voice><type>quarter</type></note>
+      <note><rest/><duration>480</duration><voice>1</voice><type>quarter</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(musicXml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+    const mscx = exportMusicXmlDomToMuseScore(srcDoc);
+    const dstXml = convertMuseScoreToMusicXml(mscx, { sourceMetadata: false, debugMetadata: false });
+    const dstDoc = parseMusicXmlDocument(dstXml);
+    expect(dstDoc).not.toBeNull();
+    if (!dstDoc) return;
+
+    const m25 = dstDoc.querySelector("part > measure:nth-of-type(2)");
+    expect(m25).not.toBeNull();
+    expect(m25?.querySelector(":scope > attributes > time > beats")?.textContent?.trim()).toBe("2");
+    expect(m25?.querySelector(":scope > attributes > time > beat-type")?.textContent?.trim()).toBe("4");
+
+    const m24RightDouble = dstDoc.querySelector('part > measure:nth-of-type(1) > barline[location="right"] > bar-style');
+    const m25LeftDouble = dstDoc.querySelector('part > measure:nth-of-type(2) > barline[location="left"] > bar-style');
+    const hasBoundaryDouble =
+      m24RightDouble?.textContent?.trim() === "light-light"
+      || m25LeftDouble?.textContent?.trim() === "light-light";
+    expect(hasBoundaryDouble).toBe(true);
+  });
+
+  it("keeps written type for MusicXML triplet eighths on MusicXML->MuseScore->MusicXML", () => {
+    const musicXml = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>P1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>480</divisions><time><beats>2</beats><beat-type>4</beat-type></time></attributes>
+      <note>
+        <pitch><step>C</step><octave>5</octave></pitch>
+        <duration>160</duration><voice>1</voice><type>eighth</type>
+        <time-modification><actual-notes>3</actual-notes><normal-notes>2</normal-notes></time-modification>
+        <notations><tuplet type="start" number="1"/></notations>
+      </note>
+      <note>
+        <pitch><step>D</step><octave>5</octave></pitch>
+        <duration>160</duration><voice>1</voice><type>eighth</type>
+        <time-modification><actual-notes>3</actual-notes><normal-notes>2</normal-notes></time-modification>
+      </note>
+      <note>
+        <pitch><step>E</step><octave>5</octave></pitch>
+        <duration>160</duration><voice>1</voice><type>eighth</type>
+        <time-modification><actual-notes>3</actual-notes><normal-notes>2</normal-notes></time-modification>
+        <notations><tuplet type="stop" number="1"/></notations>
+      </note>
+      <note><rest/><duration>480</duration><voice>1</voice><type>quarter</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(musicXml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+    const mscx = exportMusicXmlDomToMuseScore(srcDoc);
+    const dstXml = convertMuseScoreToMusicXml(mscx, { sourceMetadata: false, debugMetadata: false });
+    const dstDoc = parseMusicXmlDocument(dstXml);
+    expect(dstDoc).not.toBeNull();
+    if (!dstDoc) return;
+    const first = dstDoc.querySelector("part > measure > note:nth-of-type(1)");
+    const third = dstDoc.querySelector("part > measure > note:nth-of-type(3)");
+    expect(first?.querySelector(":scope > type")?.textContent?.trim()).toBe("eighth");
+    expect(first?.querySelector(":scope > duration")?.textContent?.trim()).toBe("160");
+    expect(first?.querySelector(":scope > notations > tuplet[type=\"start\"]")).not.toBeNull();
+    expect(third?.querySelector(":scope > notations > tuplet[type=\"stop\"]")).not.toBeNull();
+  });
+
   it("exports MusicXML cut-time symbol into MuseScore TimeSig subtype", () => {
     const musicXml = `<?xml version="1.0" encoding="UTF-8"?>
 <score-partwise version="4.0">


### PR DESCRIPTION
### 概要
MusicXML 周辺の回帰耐性を上げるために、以下を実施しました。

- MuseScore 変換の保持ロジックを強化
- MIDI/ABC/LilyPond/MEI へ同等テストを展開
- LilyPond/MEI で小節メタ（明示拍子・ダブルバー等）の保持を拡張
- `build:all`（`test:all` + `build`）を追加
- 生成物（`mikuscore.html`, `src/js/main.js`）を再ビルド

### 主な変更点

#### 1. MuseScore I/O 強化
- `src/ts/musescore-io.ts`
- 明示拍子再宣言の保持（`explicitTimeSig`）
- 境界ダブルバー保持（`leftDoubleBarline`）
- chord ローカル Spanner（Ottava/Trill）解釈強化
- `implicit` pickup 復元のため `Measure len` 変換を追加
- `unpitched`（display-step/display-octave）入力の欠落防止

#### 2. LilyPond I/O 強化
- `src/ts/lilypond-io.ts`
- `%@mks measure` に以下メタを追加・復元:
  - `explicitTime`, `beats`, `beatType`, `doubleBar`
- 同拍子の明示再宣言と `light-light` ダブルバーを roundtrip で保持

#### 3. MEI I/O 強化
- `src/ts/mei-io.ts`
- `annot type="musicxml-measure-meta"` で measure メタを保存
- 復元対象:
  - `number`, `implicit`, `repeat`, `times`
  - `explicitTime`, `beats`, `beatType`, `doubleBar`
- 同拍子再明示・ダブルバーを roundtrip で復元可能に

#### 4. テスト拡充
- `tests/unit/musescore-io.spec.ts`
- `tests/unit/midi-io.spec.ts`
- `tests/unit/abc-io.spec.ts`
- `tests/unit/lilypond-io.spec.ts`
- `tests/unit/mei-io.spec.ts`

追加した代表ケース:
- implicit short pickup
- grace / tuplet / tie / slur / articulation の保持
- section boundary の double bar + explicit same-meter time
- MIDI 側の同等タイミング検証（triplet・underfull+implicit 境界など）

#### 5. ビルド運用
- `package.json`
- `build:all` スクリプト追加:
  - `npm run test:all && npm run build`

### 変更ファイル
- `package.json`
- `src/ts/musescore-io.ts`
- `src/ts/lilypond-io.ts`
- `src/ts/mei-io.ts`
- `tests/unit/musescore-io.spec.ts`
- `tests/unit/midi-io.spec.ts`
- `tests/unit/abc-io.spec.ts`
- `tests/unit/lilypond-io.spec.ts`
- `tests/unit/mei-io.spec.ts`
- `mikuscore.html`
- `src/js/main.js`

### 検証
- `npm run build:all` 実行済み
- `test:all` 全通過
- `mikuscore.html` / `src/js/main.js` 生成確認済み