### PR TITLE
LilyPondラウンドトリップの欠落音修正（m97/m138）と VSQX/MSCX の2スペース整形、選択小節から再生対応

### DIFF
--- a/src/ts/main.ts
+++ b/src/ts/main.ts
@@ -1818,7 +1818,11 @@ const unlockAudioForPlayback = async (): Promise<boolean> => {
 const startPlayback = async (): Promise<void> => {
   const ok = await unlockAudioForPlayback();
   if (!ok) return;
-  await startPlaybackFlow(playbackFlowOptions, { isLoaded: state.loaded, core });
+  await startPlaybackFlow(playbackFlowOptions, {
+    isLoaded: state.loaded,
+    core,
+    startFromMeasure: selectedMeasure,
+  });
 };
 
 const startMeasurePlayback = async (): Promise<void> => {

--- a/src/ts/playback-flow.ts
+++ b/src/ts/playback-flow.ts
@@ -4,6 +4,8 @@ import {
   buildPlaybackEventsFromMusicXmlDoc,
   collectMidiControlEventsFromMusicXmlDoc,
   collectMidiKeySignatureEventsFromMusicXmlDoc,
+  type MidiControlEvent,
+  type MidiTempoEvent,
   collectMidiProgramOverridesFromMusicXmlDoc,
   collectMidiTimeSignatureEventsFromMusicXmlDoc,
   collectMidiTempoEventsFromMusicXmlDoc,
@@ -364,6 +366,95 @@ type SaveCapableCore = {
   debugSerializeCurrentXml: () => string | null;
 };
 
+type PlaybackStartLocation = {
+  partId: string;
+  measureNumber: string;
+};
+
+const parsePositiveInt = (text: string | null | undefined): number | null => {
+  const value = Number.parseInt(String(text ?? "").trim(), 10);
+  return Number.isFinite(value) && value > 0 ? value : null;
+};
+
+const resolveMeasureStartTickInPart = (
+  doc: Document,
+  startFromMeasure: PlaybackStartLocation,
+  fallbackDivisions: number
+): number | null => {
+  const part = Array.from(doc.querySelectorAll("score-partwise > part")).find(
+    (p) => (p.getAttribute("id") ?? "").trim() === String(startFromMeasure.partId || "").trim()
+  );
+  if (!part) return null;
+  let divisions = Math.max(1, Math.round(fallbackDivisions));
+  let beats = 4;
+  let beatType = 4;
+  let tick = 0;
+  const measures = Array.from(part.querySelectorAll(":scope > measure"));
+  for (const measure of measures) {
+    const attrs = measure.querySelector(":scope > attributes");
+    const nextDivisions = parsePositiveInt(attrs?.querySelector(":scope > divisions")?.textContent);
+    if (nextDivisions) divisions = nextDivisions;
+    const nextBeats = parsePositiveInt(attrs?.querySelector(":scope > time > beats")?.textContent);
+    if (nextBeats) beats = nextBeats;
+    const nextBeatType = parsePositiveInt(attrs?.querySelector(":scope > time > beat-type")?.textContent);
+    if (nextBeatType) beatType = nextBeatType;
+    const measureNo = (measure.getAttribute("number") ?? "").trim();
+    if (measureNo === String(startFromMeasure.measureNumber ?? "").trim()) {
+      return tick;
+    }
+    const measureTicks = Math.max(1, Math.round((divisions * beats * 4) / Math.max(1, beatType)));
+    tick += measureTicks;
+  }
+  return null;
+};
+
+const trimPlaybackFromTick = (
+  parsedPlayback: ReturnType<typeof buildPlaybackEventsFromMusicXmlDoc>,
+  tempoEvents: MidiTempoEvent[],
+  controlEvents: MidiControlEvent[],
+  startTick: number
+): {
+  parsedPlayback: ReturnType<typeof buildPlaybackEventsFromMusicXmlDoc>;
+  tempoEvents: MidiTempoEvent[];
+  controlEvents: MidiControlEvent[];
+} => {
+  if (!Number.isFinite(startTick) || startTick <= 0) {
+    return { parsedPlayback, tempoEvents, controlEvents };
+  }
+  const safeStartTick = Math.max(0, Math.round(startTick));
+  const trimmedEvents = parsedPlayback.events
+    .filter((event) => event.startTicks >= safeStartTick)
+    .map((event) => ({ ...event, startTicks: event.startTicks - safeStartTick }));
+
+  const sortedTempo = (tempoEvents ?? [])
+    .slice()
+    .map((event) => ({
+      startTicks: Math.max(0, Math.round(event.startTicks)),
+      bpm: Math.max(1, Math.round(event.bpm || parsedPlayback.tempo || 120)),
+    }))
+    .sort((a, b) => a.startTicks - b.startTicks);
+  const lastTempoBeforeOrAtStart = sortedTempo
+    .slice()
+    .reverse()
+    .find((event) => event.startTicks <= safeStartTick);
+  const trimmedTempoEvents = sortedTempo
+    .filter((event) => event.startTicks > safeStartTick)
+    .map((event) => ({ ...event, startTicks: event.startTicks - safeStartTick }));
+  if (lastTempoBeforeOrAtStart) {
+    trimmedTempoEvents.unshift({ startTicks: 0, bpm: lastTempoBeforeOrAtStart.bpm });
+  }
+
+  const trimmedControlEvents = (controlEvents ?? [])
+    .filter((event) => event.startTicks >= safeStartTick)
+    .map((event) => ({ ...event, startTicks: event.startTicks - safeStartTick }));
+
+  return {
+    parsedPlayback: { ...parsedPlayback, events: trimmedEvents },
+    tempoEvents: trimmedTempoEvents,
+    controlEvents: trimmedControlEvents,
+  };
+};
+
 export const stopPlayback = (options: PlaybackFlowOptions): void => {
   options.engine.stop();
   options.setIsPlaying(false);
@@ -373,7 +464,7 @@ export const stopPlayback = (options: PlaybackFlowOptions): void => {
 
 export const startPlayback = async (
   options: PlaybackFlowOptions,
-  params: { isLoaded: boolean; core: SaveCapableCore }
+  params: { isLoaded: boolean; core: SaveCapableCore; startFromMeasure?: PlaybackStartLocation | null }
 ): Promise<void> => {
   if (!params.isLoaded || options.getIsPlaying()) return;
 
@@ -410,18 +501,33 @@ export const startPlayback = async (
     metricAccentEnabled: options.getMetricAccentEnabled(),
     metricAccentProfile: options.getMetricAccentProfile(),
   });
-  const events = parsedPlayback.events;
+  let effectiveParsedPlayback = parsedPlayback;
+  let effectiveTempoEvents = useMidiLikePlayback
+    ? collectMidiTempoEventsFromMusicXmlDoc(playbackDoc, options.ticksPerQuarter)
+    : [];
+  let effectiveControlEvents = useMidiLikePlayback
+    ? collectMidiControlEventsFromMusicXmlDoc(playbackDoc, options.ticksPerQuarter)
+    : [];
+  if (params.startFromMeasure) {
+    const startTick = resolveMeasureStartTickInPart(playbackDoc, params.startFromMeasure, options.ticksPerQuarter);
+    if (startTick !== null && startTick > 0) {
+      const trimmed = trimPlaybackFromTick(
+        effectiveParsedPlayback,
+        effectiveTempoEvents,
+        effectiveControlEvents,
+        startTick
+      );
+      effectiveParsedPlayback = trimmed.parsedPlayback;
+      effectiveTempoEvents = trimmed.tempoEvents;
+      effectiveControlEvents = trimmed.controlEvents;
+    }
+  }
+  const events = effectiveParsedPlayback.events;
   if (events.length === 0) {
     options.setPlaybackText("Playback: no playable notes");
     options.renderControlState();
     return;
   }
-  const tempoEvents = useMidiLikePlayback
-    ? collectMidiTempoEventsFromMusicXmlDoc(playbackDoc, options.ticksPerQuarter)
-    : [];
-  const controlEvents = useMidiLikePlayback
-    ? collectMidiControlEventsFromMusicXmlDoc(playbackDoc, options.ticksPerQuarter)
-    : [];
   const timeSignatureEvents = useMidiLikePlayback
     ? collectMidiTimeSignatureEventsFromMusicXmlDoc(playbackDoc, options.ticksPerQuarter)
     : [];
@@ -435,11 +541,11 @@ export const startPlayback = async (
   try {
     midiBytes = buildMidiBytesForPlayback(
       events,
-      parsedPlayback.tempo,
+      effectiveParsedPlayback.tempo,
       "electric_piano_2",
       collectMidiProgramOverridesFromMusicXmlDoc(playbackDoc),
-      controlEvents,
-      tempoEvents,
+      effectiveControlEvents,
+      effectiveTempoEvents,
       timeSignatureEvents,
       keySignatureEvents
     );
@@ -453,7 +559,7 @@ export const startPlayback = async (
 
   try {
     await options.engine.playSchedule(
-      toSynthSchedule(parsedPlayback.tempo, events, tempoEvents, controlEvents),
+      toSynthSchedule(effectiveParsedPlayback.tempo, events, effectiveTempoEvents, effectiveControlEvents),
       waveform,
       () => {
         options.setIsPlaying(false);
@@ -470,8 +576,11 @@ export const startPlayback = async (
   }
 
   options.setIsPlaying(true);
+  const fromMeasureLabel = params.startFromMeasure
+    ? ` / from measure ${params.startFromMeasure.measureNumber}`
+    : "";
   options.setPlaybackText(
-    `Playing: ${events.length} notes / mode ${playbackMode} / MIDI ${midiBytes.length} bytes / waveform ${waveform}`
+    `Playing: ${events.length} notes / mode ${playbackMode}${fromMeasureLabel} / MIDI ${midiBytes.length} bytes / waveform ${waveform}`
   );
   options.renderControlState();
   options.renderAll();


### PR DESCRIPTION
## 概要

以下をまとめて対応しました。

1. LilyPond ラウンドトリップ時の欠落音問題を修正
- 同一スタッフ内の複数レーン（backup区切り）で音が落ちるケース（Paganini m97相当）
- 連符+短音列で丸め誤差により末尾音が落ちるケース（m138相当）

2. VSQX / MSCX 出力XMLの整形を 2スペース字下げに統一
- `.vsqx` / `.mscx` / `.mscz(内包 score.mscx)` に適用

3. Score画面で選択小節からの再生を実装
- 小節選択後に再生すると、その小節開始Tickから再生

---

## 主な変更

### LilyPond I/O (`src/ts/lilypond-io.ts`)
- `LilyDirectEvent` に `backup` イベントを追加
- `%@mks lanes ...` メタデータを新設・パース実装
  - 出力時: 同一スタッフ内の複数レーンを保持
  - 入力時: レーンを復元し、`<backup>` を再構築
- アーティキュレーション適用時に `backup` をスキップ
- 入出力双方で「微小 overfill（丸め誤差）」を許容（許容量あり）
  - m138相当の末尾16分音符欠落を防止

### ダウンロード整形 (`src/ts/download-flow.ts`)
- 2スペース整形関数を追加
- `createVsqxDownloadPayload` で整形済み VSQX を出力
- `createMuseScoreDownloadPayload` で整形済み MSCX を出力
  - 圧縮時（MSCZ）の `score.mscx` にも同整形を適用

### 再生開始位置 (`src/ts/main.ts`, `src/ts/playback-flow.ts`)
- `startPlayback` 呼び出しに `startFromMeasure` を追加
- 指定小節の開始Tick算出ロジックを追加
- 再生イベント / テンポ / コントロールイベントを開始Tick基準でトリム
- 再生ステータス表示に `from measure X` を反映

### テスト
- `tests/unit/lilypond-io.spec.ts`
  - 同一スタッフ複数レーン復元（m97相当）
  - 7:8連符 + 16分列末尾保持（m138相当）
- `tests/unit/download-flow.spec.ts`
  - VSQX/MSCX の2スペース整形確認

---

## 変更ファイル

- `src/ts/lilypond-io.ts`
- `src/ts/download-flow.ts`
- `src/ts/main.ts`
- `src/ts/playback-flow.ts`
- `tests/unit/lilypond-io.spec.ts`
- `tests/unit/download-flow.spec.ts`
- `src/js/main.js`（ビルド成果物）
- `mikuscore.html`（ビルド成果物）

---

## 検証

- `npm run test:unit -- tests/unit/lilypond-io.spec.ts` ✅
- `npm run test:unit -- tests/unit/download-flow.spec.ts` ✅
- `npm run build:all` ✅（`test:all` + `build`）

---

## 期待される効果

- LilyPond roundtrip での欠落音回帰を防止
- VSQX/MSCX の可読性向上（整形統一）
- 編集中の小節からの即時再生が可能になり作業効率が向上