### PR TITLE
LilyPond装飾復元強化（slur/trill）と index キャッシュバスト改善、関連ドキュメント更新

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -95,7 +95,7 @@
 - [ ] Implement measure copy/paste in core first (validation/compatibility), then connect UI and optional system clipboard API.
 - [ ] Expand ABC compatibility for ornaments (`trill`, `turn`, grace variants) with explicit preserve/degrade rules.
 - [ ] Add ABC import compatibility mode for overfull legacy exports and surface warning summary in UI.
-- [ ] Add LilyPond (`.ly`) import/export support.
+- [x] Add LilyPond (`.ly`) import/export support.
 - [ ] Add MEI (Music Encoding Initiative) import/export support.
 - [ ] Add MuseScore (`.mscz` / `.mscx`) import/export support.
 - [ ] Add VSQX import/export support.
@@ -214,7 +214,7 @@
 - [ ] 実装順を「core先行（整合チェック含む） -> UI接続 -> 必要ならシステム Clipboard API 連携」に固定。
 - [ ] ABCの装飾記号（`trill`/`turn`/前打音バリエーション）の互換対応を拡張し、保持/劣化ルールを規定。
 - [ ] 旧ABC由来の小節過充填に対する互換モードを整備し、UIに警告サマリを表示。
-- [ ] LilyPond（`.ly`）の入出力対応を追加。
+- [x] LilyPond（`.ly`）の入出力対応を追加。
 - [ ] MEI（Music Encoding Initiative）の入出力対応を追加。
 - [ ] MuseScore形式（`.mscz` / `.mscx`）の入出力対応を追加。
 - [ ] VSQX 形式の入出力対応を追加。

--- a/docs/spec/FORMAT_IO_CHECKLIST.md
+++ b/docs/spec/FORMAT_IO_CHECKLIST.md
@@ -37,6 +37,7 @@ When adding a new format (e.g. ABC / MEI / future formats), use this checklist t
   - [ ] tempo
   - [ ] key/time/transpose
   - [ ] `miscellaneous-field` equivalent (if representable in source format)
+  - [ ] format-specific roundtrip hints (if used) are explicitly documented (key format, scope, restore rule)
 - [ ] Unsupported feature handling is explicit:
   - [ ] either diagnostic + skip
   - [ ] or hard error + fail import
@@ -57,6 +58,7 @@ When adding a new format (e.g. ABC / MEI / future formats), use this checklist t
   - [ ] tempo
   - [ ] transpose
   - [ ] `miscellaneous-field` equivalent
+  - [ ] comment-level metadata/hints (if any) are versioned and parseable (e.g. `%@mks ...`)
 - [ ] If loss is unavoidable, degradation behavior is documented
 
 ---
@@ -116,7 +118,19 @@ When adding a new format (e.g. ABC / MEI / future formats), use this checklist t
 - [ ] For each format, document retention policy for both categories:
   - preserve as-is / transform / drop
   - roundtrip expectations (`MusicXML -> Format -> MusicXML`, `Format -> MusicXML -> Format`)
+- [ ] If using out-of-band comment hints (non-XML metadata), define:
+  - token schema and allowed keys
+  - event addressing key (`voice + measure + event`)
+  - fallback when hint is absent or invalid
+  - safety against conflicts with existing source comments
 - [ ] Keep namespace separation strict (`src:*` vs `mks:*` vs `diag:*` vs optional `dbg:*`) to avoid mixing source data, functional extension metadata, diagnostics, and debug traces.
+
+### LilyPond Note (Current `mks` usage)
+
+- `%@mks lanes ...`:
+  - stores per-measure multi-lane token streams to restore same-staff multi-voice structure (`backup`) on import.
+- `%@mks slur ...`:
+  - stores slur start/stop metadata (`type`, optional `number`, optional `placement`) by event key for roundtrip restoration.
 
 ---
 

--- a/docs/spec/PLAYBACK.md
+++ b/docs/spec/PLAYBACK.md
@@ -89,15 +89,24 @@ This file MUST remain side-effect free.
 
 1. Save current score.
 2. Parse saved MusicXML.
+3. Resolve optional start location:
+   - if `startFromMeasure` is provided (`partId`, `measureNumber`),
+     playback MUST seek to that measure start tick within the target part.
 3. Resolve playback mode:
    - `playback`
    - `midi` (when MIDI-like playback is enabled)
 4. Build events via `buildPlaybackEventsFromMusicXmlDoc`.
 5. Build optional tempo/control streams for MIDI-like mode.
+6. If a start measure was resolved:
+   - trim note events to `startTicks >= startTick` and rebase by `-startTick`
+   - trim/rebase tempo events and inject a tick-0 tempo from the latest pre-start tempo
+   - trim/rebase control events (`CC`) to the new origin
 6. Build MIDI bytes (diagnostic parity and validation path).
 7. Convert to synth schedule and start playback.
 
 On failure, status text MUST be updated and playback MUST not start.
+
+Status text SHOULD include start context when provided (e.g. `from measure X`).
 
 ## startMeasurePlayback
 

--- a/index.html
+++ b/index.html
@@ -3,6 +3,9 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Cache-Control" content="no-store, no-cache, must-revalidate, max-age=0" />
+  <meta http-equiv="Pragma" content="no-cache" />
+  <meta http-equiv="Expires" content="0" />
   <title>mikuscore</title>
   <style>
     :root {
@@ -135,7 +138,7 @@
         <li>ABC, MEI, and LilyPond support is currently experimental.</li>
       </ul>
       <div class="link-row">
-        <a class="link-btn" href="./mikuscore.html">Open mikuscore</a>
+        <a class="link-btn" href="./mikuscore.html?v=202602270655">Open mikuscore</a>
         <a class="link-btn-secondary" href="https://github.com/igapyon/mikuscore" target="_blank" rel="noopener noreferrer">GitHub</a>
       </div>
     </section>
@@ -163,10 +166,42 @@
         <li>ABC、MEI、LilyPond 対応は現在 Experimental（試験対応）です。</li>
       </ul>
       <div class="link-row">
-        <a class="link-btn" href="./mikuscore.html">mikuscore を開く</a>
+        <a class="link-btn" href="./mikuscore.html?v=202602270655">mikuscore を開く</a>
         <a class="link-btn-secondary" href="https://github.com/igapyon/mikuscore" target="_blank" rel="noopener noreferrer">GitHub</a>
       </div>
     </section>
   </main>
+  <script>
+    (() => {
+      // Cache-busting: append a timestamp query right before opening mikuscore.html.
+      const selector = 'a[href^="./mikuscore.html"]';
+      const buildVersionStamp = () => {
+        const d = new Date();
+        return (
+          d.getFullYear().toString() +
+          String(d.getMonth() + 1).padStart(2, "0") +
+          String(d.getDate()).padStart(2, "0") +
+          String(d.getHours()).padStart(2, "0") +
+          String(d.getMinutes()).padStart(2, "0")
+        );
+      };
+      const stampAndGo = (anchor) => {
+        const u = new URL(anchor.getAttribute("href"), location.href);
+        u.searchParams.set("v", buildVersionStamp());
+        anchor.setAttribute("href", u.pathname + u.search);
+      };
+      document.addEventListener("click", (ev) => {
+        const a = ev.target.closest(selector);
+        if (!a) return;
+        stampAndGo(a);
+      }, true);
+      document.addEventListener("auxclick", (ev) => {
+        if (ev.button !== 1) return;
+        const a = ev.target.closest(selector);
+        if (!a) return;
+        stampAndGo(a);
+      }, true);
+    })();
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## 概要

このPRでは、LilyPond roundtrip の記譜見栄え劣化を改善しつつ、配布導線のキャッシュ問題対策と仕様ドキュメントの同期を行いました。

主な対象:

- LilyPond I/O (`src/ts/lilypond-io.ts`)
- LilyPondユニットテスト (`tests/unit/lilypond-io.spec.ts`)
- 配布入口ページ (`index.html`)
- 仕様/タスクドキュメント (`TODO.md`, `docs/spec/PLAYBACK.md`, `docs/spec/FORMAT_IO_CHECKLIST.md`)
- ビルド成果物 (`src/js/main.js`, `mikuscore.html`)

---

## 変更内容

### 1) LilyPond roundtrip の復元強化

`%@mks` メタコメントを拡張し、以下を roundtrip 復元対象に追加:

- `slur`（start/stop, number, placement）
- `trill`（`trill-mark`, `wavy-line` start/stop/number）

加えて、連符由来の表記音価劣化を抑えるため:

- tupletヒント（actual/normal）を使った `type` 推定補正を追加

結果として、`m85` 相当の triplet-16th 見栄え（type/slur）と、`m156-157` 相当の trill 記号が保持されるようになりました。

---

### 2) `index.html` のキャッシュ回避強化

- `meta http-equiv` による no-cache/no-store 系ヘッダを追加
- `mikuscore.html` へのリンクに `?v=...` を付与
- クリック直前に `v` を更新するスクリプトを追加
  - `v` は `YYYYMMDDHHmm` 形式
  - コメントでキャッシュバスト目的を明記

---

### 3) ドキュメント同期

- `TODO.md`
  - LilyPond 入出力対応を完了 (`[x]`) に更新（英日）
- `docs/spec/PLAYBACK.md`
  - `startFromMeasure` と開始tick起点の event/tempo/CC トリム仕様を追記
- `docs/spec/FORMAT_IO_CHECKLIST.md`
  - out-of-band コメントヒントの定義項目を追記
  - LilyPondの `%@mks lanes` / `%@mks slur` の現行利用を明文化

---

## テスト

- `tests/unit/lilypond-io.spec.ts` に以下を追加/更新
  - `keeps triplet-16th visual semantics (type/slur) on m85-like roundtrip`
  - `exports and imports trill ornaments via %@mks trill metadata`
- 対象ユニットテスト実行: OK