### PR TITLE
feat(test): CFFPシリーズを導入し、形式横断ラウンドトリップ検証と仕様ドキュメントを拡充

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -93,8 +93,103 @@
 - [ ] Add band score workflow support (common band instrumentation templates, part handling, and layout defaults).
 - [ ] Define measure clipboard payload as MusicXML `<measure>...</measure>` fragment (app-internal clipboard first).
 - [ ] Implement measure copy/paste in core first (validation/compatibility), then connect UI and optional system clipboard API.
-- [ ] Expand ABC compatibility for ornaments (`trill`, `turn`, grace variants) with explicit preserve/degrade rules.
+- [x] Expand ABC compatibility for ornaments (`trill`, `turn`, grace variants) with explicit preserve/degrade rules.
+- [x] Start CFFP (Cross-Format Focus Parity) with a minimal `trill` fixture (`MusicXML -> all supported formats -> MusicXML`).
+- [x] Expand CFFP series with focused minimal fixtures:
+  - [x] `octave-shift (8va/8vb)` cross-format policy test.
+  - [x] `slur` cross-format policy test.
+  - [x] `tie` cross-format policy test.
+  - [x] `staccato` cross-format policy test.
+  - [x] `accent` cross-format policy test.
+  - [x] `grace` cross-format policy test.
+  - [x] `tuplet` cross-format policy test.
+  - [x] `accidental spelling` cross-format policy test.
+  - [x] `accidental reset rule` cross-format policy test (same-measure carry and next-measure reset).
+  - [x] `courtesy accidental` cross-format policy test (display-only accidental handling policy).
+  - [x] `key change mid-score` cross-format policy test.
+  - [x] `time signature change` cross-format policy test.
+  - [x] `double barline mid-score` cross-format policy test.
+  - [x] `repeat/ending barline metadata` cross-format policy test.
+  - [x] `beam continuity` cross-format policy test (across rest / split by beat policy).
+  - [x] `multi-voice + backup` cross-format policy test (same-staff lane reconstruction).
+  - [x] `grand-staff voice/staff mapping` cross-format policy test.
+  - [x] `pickup implicit measure` cross-format policy test (`implicit=yes` and measure numbering).
+  - [x] `trill variants` cross-format policy test (`trill-mark` + `wavy-line` start/stop + accidental-mark).
+  - [x] `turn` cross-format policy test.
+  - [x] `turn variants` cross-format policy test (`inverted-turn` + `delayed-turn`).
+  - [x] `mordent variants` cross-format policy test (`mordent` + `inverted-mordent`).
+  - [x] `ornament accidental-mark` cross-format policy test.
+  - [x] `schleifer` cross-format policy test.
+  - [x] `shake` cross-format policy test.
+  - [x] `dynamics basic (pp/ff)` cross-format policy test.
+  - [x] `dynamics accented (mf/sfz)` cross-format policy test.
+  - [x] `dynamics wedge (crescendo/diminuendo)` cross-format policy test.
+  - [x] `fermata` cross-format policy test.
+  - [x] `arpeggiate` cross-format policy test.
+  - [x] `breath-mark / caesura` cross-format policy test.
+  - [x] `glissando start/stop` cross-format policy test.
+  - [x] `transpose` cross-format policy test (per-part / per-measure hint behavior).
+  - [x] `tempo map` cross-format policy test (single tempo + change event).
+  - [x] Document CFFP preserve/degrade matrix per format (`musescore/midi/vsqx/abc/mei/lilypond`).
+  - [x] `slide start/stop` cross-format policy test.
+  - [x] `tremolo` cross-format policy test (`single` / `start-stop`).
+  - [x] `triplet bracket/placement` display-info cross-format policy test.
+  - [x] `CFFP-TECHNIQUE-TEXT` cross-format policy test (`direction-type/words`: `pizz.` / `arco` / `con sord.`).
+  - [x] `CFFP-ARTICULATION-EXT` cross-format policy test (`tenuto` / `staccatissimo` / `marcato`).
+  - [x] `CFFP-NOTEHEAD` cross-format policy test (`notehead`: `cross` / `diamond` ...).
+  - [x] `CFFP-STEM-BEAM-DIR` cross-format policy test (`stem` direction + beam direction info).
+  - [x] `CFFP-VOICE-STAFF-SWAP` cross-format policy test (voice crossing staves within a measure).
+  - [x] `CFFP-OTTAVA-NUMBERING` cross-format policy test (`octave-shift` with multiple `number` lines).
+  - [x] `CFFP-MEASURE-STYLE` cross-format policy test (`measure-style`: `slash` / `multiple-rest`).
+  - [x] `CFFP-PRINT-LAYOUT-MIN` cross-format policy test (`print` minimal layout: system/page break).
+  - [x] `CFFP-CLEF-MIDMEASURE` cross-format policy test (mid-measure clef change).
+  - [x] `CFFP-KEY-MODE` cross-format policy test (`key/mode`: major/minor).
+  - [x] `CFFP-MIDMEASURE-REPEAT` cross-format policy test (mid-measure repeat semantics/marking).
+  - [x] `CFFP-LYRIC-BASIC` cross-format policy test (1 syllable + melisma).
+  - [x] `CFFP-PERCUSSION-UNPITCHED` cross-format policy test (`unpitched` + `display-step` / `display-octave`).
+  - [x] `CFFP-PERCUSSION-NOTEHEAD` cross-format policy test (percussion noteheads: `x` / `triangle` / `diamond`).
+  - [x] `CFFP-PERCUSSION-INSTRUMENT-ID` cross-format policy test (`instrument id` mapping and retention).
+  - [x] `CFFP-PERCUSSION-VOICE-LAYER` cross-format policy test (drumset lane/voice separation in one staff).
+  - [x] `CFFP-PERCUSSION-STAFF-LINE` cross-format policy test (1-line vs 5-line percussion staff policy).
+  - [x] `CFFP-TRANSPOSING-INSTRUMENT` cross-format policy test (e.g., Clarinet in A `transpose` + concert/written pitch intent).
+  - [x] `CFFP-LEFT-HAND-PIZZICATO` cross-format policy test.
+  - [x] `CFFP-BOWING-DIRECTION` cross-format policy test (`up-bow` / `down-bow`).
+  - [x] `CFFP-HARMONIC-NATURAL-ARTIFICIAL` cross-format policy test (`harmonic` natural/artificial).
+  - [x] `CFFP-OPEN-STRING` cross-format policy test (`technical/open-string`).
+  - [x] `CFFP-STOPPED` cross-format policy test (`technical/stopped`).
+  - [x] `CFFP-SNAP-PIZZICATO` cross-format policy test (`technical/snap-pizzicato`, Bartok pizz.).
+  - [x] `CFFP-FINGERING` cross-format policy test (`technical/fingering`: 1-4 and substitution patterns).
+  - [x] `CFFP-STRING` cross-format policy test (`technical/string`: I/II/III/IV).
+  - [x] `CFFP-DOUBLE-TRIPLE-TONGUE` cross-format policy test (`double-tongue` / `triple-tongue`).
+  - [x] `CFFP-HEEL-TOE` cross-format policy test (`technical/heel` / `technical/toe`).
+  - [x] `CFFP-PLUCK-TEXT` cross-format policy test (pluck text: `p`, `i`, `m`, `a`).
+  - [x] `CFFP-BREATH-VARIANTS` cross-format policy test (breath-mark variants: comma/tick/upbow-like differences).
+  - [x] `CFFP-BREATH-PLACEMENT` cross-format policy test (`placement`/`default-x`/`default-y` retention on breath marks).
+  - [x] `CFFP-CAESURA-STYLE` cross-format policy test (caesura style variants retention).
+  - [x] `CFFP-TIMEWISE-BACKUP-FORWARD` cross-format policy test (`backup` / `forward` complex time progression).
+  - [x] `CFFP-CROSS-STAFF-BEAM` cross-format policy test (cross-staff beam).
+  - [x] `CFFP-CHORD-SYMBOL-ALTER` cross-format policy test (`harmony` tension/alter: `#11`, `b9`, ...).
+  - [x] `CFFP-NOTE-TIES-CROSS-MEASURE` cross-format policy test (cross-measure tie with same-pitch linkage).
+  - [x] `CFFP-MULTI-REST-COUNT` cross-format policy test (multiple-rest count retention).
+  - [x] `CFFP-REPEAT-JUMP-SOUND` cross-format policy test (`sound`: `fine` / `tocoda` / `coda` / `segno`).
+  - [x] `CFFP-CUE-GRACE-MIX` cross-format policy test (cue note + grace note mix).
+  - [x] `CFFP-ACCIDENTAL-COURTESY-MODE` cross-format policy test (courtesy accidental display-control variants).
+  - [x] `CFFP-LYRICS-MULTI-VERSE` cross-format policy test (multiple lyric verses: `number=1,2`).
+  - [x] `CFFP-TEXT-ENCODING` cross-format policy test (non-ASCII: Japanese lyrics / symbol-rich words).
+  - [x] `rehearsal mark` text-preservation cross-format policy test.
+  - [x] `segno/coda` symbol cross-format policy test.
+  - [x] `da capo / dal segno` jump words + sound-attributes cross-format policy test.
+  - [x] `pedal start/stop` cross-format policy test.
+  - [x] `harmony chord symbol` cross-format policy test (`root` / `bass` / `kind`).
+  - [x] `ending type` cross-format policy test (`start` / `stop` / `discontinue`).
+  - [x] CFFP practical priority queue:
+    - [x] `breath-mark / caesura`
+    - [x] `glissando`
+    - [x] `pedal`
+    - [x] `segno/coda`
+    - [x] `harmony chord symbol`
 - [ ] Add ABC import compatibility mode for overfull legacy exports and surface warning summary in UI.
+- [x] Add LilyPond octave-shift (`8va` / `8vb`) roundtrip preservation (currently degrade-policy).
 - [x] Add LilyPond (`.ly`) import/export support.
 - [ ] Add MEI (Music Encoding Initiative) import/export support.
 - [ ] Add MuseScore (`.mscz` / `.mscx`) import/export support.
@@ -212,8 +307,103 @@
 - [ ] バンド譜面への対応を追加（一般的な編成テンプレート、パート管理、レイアウト初期値を含む）。
 - [ ] 小節クリップボードのペイロードを MusicXML の `<measure>...</measure>` 断片として定義（まずはアプリ内クリップボード）。
 - [ ] 実装順を「core先行（整合チェック含む） -> UI接続 -> 必要ならシステム Clipboard API 連携」に固定。
-- [ ] ABCの装飾記号（`trill`/`turn`/前打音バリエーション）の互換対応を拡張し、保持/劣化ルールを規定。
+- [x] ABCの装飾記号（`trill`/`turn`/前打音バリエーション）の互換対応を拡張し、保持/劣化ルールを規定。
+- [x] CFFP（Cross-Format Focus Parity）を `trill` の最小断片で開始（`MusicXML -> 対応全形式 -> MusicXML`）。
+- [x] CFFP シリーズを最小断片で横展開する:
+  - [x] `octave-shift (8va/8vb)` の横断ポリシーテスト。
+  - [x] `slur` の横断ポリシーテスト。
+  - [x] `tie` の横断ポリシーテスト。
+  - [x] `staccato` の横断ポリシーテスト。
+  - [x] `accent` の横断ポリシーテスト。
+  - [x] `grace` の横断ポリシーテスト。
+  - [x] `tuplet` の横断ポリシーテスト。
+  - [x] `臨時記号スペリング` の横断ポリシーテスト。
+  - [x] `臨時記号の持ち越し/小節リセット規則` の横断ポリシーテスト。
+  - [x] `注意的臨時記号（courtesy accidental）` の横断ポリシーテスト（表示専用情報の扱い）。
+  - [x] `途中転調` の横断ポリシーテスト。
+  - [x] `途中拍子変更` の横断ポリシーテスト。
+  - [x] `曲途中の二重線` の横断ポリシーテスト。
+  - [x] `反復記号/エンディング線を伴う小節線メタ` の横断ポリシーテスト。
+  - [x] `ビーム連結` の横断ポリシーテスト（休符またぎ / 拍境界分割ポリシー）。
+  - [x] `複数voice + backup` の横断ポリシーテスト（同一五線レーン復元）。
+  - [x] `大譜表の staff/voice 対応` の横断ポリシーテスト。
+  - [x] `弱起（implicit小節）` の横断ポリシーテスト（`implicit=yes` と小節番号）。
+  - [x] `トリル派生` の横断ポリシーテスト（`trill-mark` + `wavy-line` start/stop + accidental-mark）。
+  - [x] `turn` の横断ポリシーテスト。
+  - [x] `turn派生` の横断ポリシーテスト（`inverted-turn` + `delayed-turn`）。
+  - [x] `mordent派生` の横断ポリシーテスト（`mordent` + `inverted-mordent`）。
+  - [x] `ornament accidental-mark` の横断ポリシーテスト。
+  - [x] `schleifer` の横断ポリシーテスト。
+  - [x] `shake` の横断ポリシーテスト。
+  - [x] `dynamics basic (pp/ff)` の横断ポリシーテスト。
+  - [x] `dynamics accented (mf/sfz)` の横断ポリシーテスト。
+  - [x] `dynamics wedge (crescendo/diminuendo)` の横断ポリシーテスト。
+  - [x] `fermata` の横断ポリシーテスト。
+  - [x] `arpeggiate` の横断ポリシーテスト。
+  - [x] `breath-mark / caesura` の横断ポリシーテスト。
+  - [x] `glissando start/stop` の横断ポリシーテスト。
+  - [x] `transpose` の横断ポリシーテスト（パート単位/小節単位ヒント）。
+  - [x] `テンポマップ` の横断ポリシーテスト（単一テンポ + 途中変更）。
+  - [x] 形式別（`musescore/midi/vsqx/abc/mei/lilypond`）の保持/劣化マトリクスを文書化。
+  - [x] `slide start/stop` の横断ポリシーテスト。
+  - [x] `tremolo` の横断ポリシーテスト（`single` / `start-stop`）。
+  - [x] `triplet bracket/placement` 表示情報の横断ポリシーテスト。
+  - [x] `CFFP-TECHNIQUE-TEXT` の横断ポリシーテスト（`direction-type/words`: `pizz.` / `arco` / `con sord.`）。
+  - [x] `CFFP-ARTICULATION-EXT` の横断ポリシーテスト（`tenuto` / `staccatissimo` / `marcato`）。
+  - [x] `CFFP-NOTEHEAD` の横断ポリシーテスト（`notehead`: `cross` / `diamond` など）。
+  - [x] `CFFP-STEM-BEAM-DIR` の横断ポリシーテスト（`stem` 方向 + beam 方向情報）。
+  - [x] `CFFP-VOICE-STAFF-SWAP` の横断ポリシーテスト（小節内で voice が staff をまたぐ）。
+  - [x] `CFFP-OTTAVA-NUMBERING` の横断ポリシーテスト（`octave-shift` の `number` 複数系）。
+  - [x] `CFFP-MEASURE-STYLE` の横断ポリシーテスト（`measure-style`: `slash` / `multiple-rest`）。
+  - [x] `CFFP-PRINT-LAYOUT-MIN` の横断ポリシーテスト（`print` の最小レイアウト: system/page break）。
+  - [x] `CFFP-CLEF-MIDMEASURE` の横断ポリシーテスト（小節途中 clef change）。
+  - [x] `CFFP-KEY-MODE` の横断ポリシーテスト（`key/mode`: major/minor）。
+  - [x] `CFFP-MIDMEASURE-REPEAT` の横断ポリシーテスト（小節途中の repeat セマンティクス/記号）。
+  - [x] `CFFP-LYRIC-BASIC` の横断ポリシーテスト（1音節 + melisma）。
+  - [x] `CFFP-PERCUSSION-UNPITCHED` の横断ポリシーテスト（`unpitched` + `display-step` / `display-octave`）。
+  - [x] `CFFP-PERCUSSION-NOTEHEAD` の横断ポリシーテスト（打楽器 notehead: `x` / `triangle` / `diamond`）。
+  - [x] `CFFP-PERCUSSION-INSTRUMENT-ID` の横断ポリシーテスト（`instrument id` の対応と保持）。
+  - [x] `CFFP-PERCUSSION-VOICE-LAYER` の横断ポリシーテスト（同一スタッフ内のドラムレーン/voice 分離）。
+  - [x] `CFFP-PERCUSSION-STAFF-LINE` の横断ポリシーテスト（1線/5線の打楽器五線ポリシー）。
+  - [x] `CFFP-TRANSPOSING-INSTRUMENT` の横断ポリシーテスト（例: Clarinet in A の `transpose` と実音/記譜音の意図）。
+  - [x] `CFFP-LEFT-HAND-PIZZICATO` の横断ポリシーテスト。
+  - [x] `CFFP-BOWING-DIRECTION` の横断ポリシーテスト（`up-bow` / `down-bow`）。
+  - [x] `CFFP-HARMONIC-NATURAL-ARTIFICIAL` の横断ポリシーテスト（`harmonic` の natural/artificial）。
+  - [x] `CFFP-OPEN-STRING` の横断ポリシーテスト（`technical/open-string`）。
+  - [x] `CFFP-STOPPED` の横断ポリシーテスト（`technical/stopped`）。
+  - [x] `CFFP-SNAP-PIZZICATO` の横断ポリシーテスト（`technical/snap-pizzicato`、バルトーク・ピチカート）。
+  - [x] `CFFP-FINGERING` の横断ポリシーテスト（`technical/fingering`: 1-4 と置換指）。
+  - [x] `CFFP-STRING` の横断ポリシーテスト（`technical/string`: I/II/III/IV）。
+  - [x] `CFFP-DOUBLE-TRIPLE-TONGUE` の横断ポリシーテスト（`double-tongue` / `triple-tongue`）。
+  - [x] `CFFP-HEEL-TOE` の横断ポリシーテスト（`technical/heel` / `technical/toe`）。
+  - [x] `CFFP-PLUCK-TEXT` の横断ポリシーテスト（プラック文字: `p` / `i` / `m` / `a`）。
+  - [x] `CFFP-BREATH-VARIANTS` の横断ポリシーテスト（comma/tick/upbow-like など breath-mark 変種）。
+  - [x] `CFFP-BREATH-PLACEMENT` の横断ポリシーテスト（breath-mark の `placement` / `default-x` / `default-y` 保持）。
+  - [x] `CFFP-CAESURA-STYLE` の横断ポリシーテスト（caesura の style 差保持）。
+  - [x] `CFFP-TIMEWISE-BACKUP-FORWARD` の横断ポリシーテスト（`backup` / `forward` を使う複雑時間進行）。
+  - [x] `CFFP-CROSS-STAFF-BEAM` の横断ポリシーテスト（cross-staff beam）。
+  - [x] `CFFP-CHORD-SYMBOL-ALTER` の横断ポリシーテスト（`harmony` のテンション/alter: `#11`, `b9` など）。
+  - [x] `CFFP-NOTE-TIES-CROSS-MEASURE` の横断ポリシーテスト（小節跨ぎ tie + 同音連結）。
+  - [x] `CFFP-MULTI-REST-COUNT` の横断ポリシーテスト（multiple rest の小節数保持）。
+  - [x] `CFFP-REPEAT-JUMP-SOUND` の横断ポリシーテスト（`sound` の `fine` / `tocoda` / `coda` / `segno`）。
+  - [x] `CFFP-CUE-GRACE-MIX` の横断ポリシーテスト（cue note と grace note の混在）。
+  - [x] `CFFP-ACCIDENTAL-COURTESY-MODE` の横断ポリシーテスト（courtesy accidental の表示制御差）。
+  - [x] `CFFP-LYRICS-MULTI-VERSE` の横断ポリシーテスト（複数 verse: `lyric number=1,2`）。
+  - [x] `CFFP-TEXT-ENCODING` の横断ポリシーテスト（非ASCII: 日本語歌詞・記号付き words）。
+  - [x] `rehearsal mark` 文字保持の横断ポリシーテスト。
+  - [x] `segno/coda` 記号の横断ポリシーテスト。
+  - [x] `da capo / dal segno`（jump words + sound属性）の横断ポリシーテスト。
+  - [x] `pedal start/stop` の横断ポリシーテスト。
+  - [x] `harmony chord symbol` の横断ポリシーテスト（`root` / `bass` / `kind`）。
+  - [x] `ending type` の横断ポリシーテスト（`start` / `stop` / `discontinue`）。
+  - [x] CFFP 実用優先キュー:
+    - [x] `breath-mark / caesura`
+    - [x] `glissando`
+    - [x] `pedal`
+    - [x] `segno/coda`
+    - [x] `harmony chord symbol`
 - [ ] 旧ABC由来の小節過充填に対する互換モードを整備し、UIに警告サマリを表示。
+- [x] LilyPond の octave-shift（`8va` / `8vb`）往復保持を実装する（現状は劣化ポリシー）。
 - [x] LilyPond（`.ly`）の入出力対応を追加。
 - [ ] MEI（Music Encoding Initiative）の入出力対応を追加。
 - [ ] MuseScore形式（`.mscz` / `.mscx`）の入出力対応を追加。

--- a/docs/spec/ABC_IO.md
+++ b/docs/spec/ABC_IO.md
@@ -72,6 +72,8 @@ Parser is intentionally lenient for real-world ABC:
 - tuplets (`(n[:q][:r]`)
 - broken rhythm (`>` / `<`)
 - barlines
+- decorations: `!trill!`, `!turn!`, `!invertedturn!`, `!staccato!`
+- grace groups `{...}` including slash grace variant (`{/g}`)
 
 ## Parse result characteristics
 
@@ -119,6 +121,12 @@ Exports:
 
 - supports rests, pitch notes, chords, durations, ties
 - supports tuplet roundtrip export (`(n:q:r` style) from MusicXML time-modification/tuplet notations
+- supports ornament export/import mapping:
+  - `trill-mark` / `wavy-line(start)` <-> `!trill!`
+  - `turn` <-> `!turn!`
+  - `inverted-turn` <-> `!invertedturn!`
+- supports grace slash mapping:
+  - MusicXML `<grace slash="yes"/>` <-> ABC grace token with leading slash (e.g. `{/g}`)
 - emits accidentals based on key signature + measure accidental memory
   - suppresses redundant naturals in-context
   - emits required naturals where key/measure context differs

--- a/docs/spec/FORMAT_IO_CHECKLIST.md
+++ b/docs/spec/FORMAT_IO_CHECKLIST.md
@@ -144,6 +144,19 @@ When adding a new format (e.g. ABC / MEI / future formats), use this checklist t
 - [ ] Roundtrip golden test for representative fixtures
 - [ ] Regression test for known tricky cases
 
+### CFFP Standard (Cross-Format Focus Parity)
+
+- [ ] For each focused notation topic, add one minimal fixture and run:
+  - `MusicXML -> format -> MusicXML` for all supported formats
+  - Target formats: `musescore / midi / vsqx / abc / mei / lilypond`
+- [ ] Define per-format policy for the topic:
+  - `must-preserve`: semantic element must remain after roundtrip
+  - `allowed-degrade`: degradation is accepted and documented
+- [ ] Keep assertion scope narrow for the topic:
+  - Example for trill: pitch/start timing baseline for all formats, trill-presence only where `must-preserve`
+- [ ] Store CFFP case IDs and policy matrix in `docs/spec/TEST_CFFP.md`
+- [ ] Add corresponding IDs to `docs/spec/TEST_MATRIX.md` for visibility in overall planning
+
 ---
 
 ## 8. Build and Release Hygiene

--- a/docs/spec/TEST_CFFP.md
+++ b/docs/spec/TEST_CFFP.md
@@ -1,0 +1,566 @@
+# TEST_CFFP
+
+## Purpose
+
+`CFFP` (Cross-Format Focus Parity) defines focused, minimal, cross-format roundtrip tests.
+
+One topic at a time:
+- prepare a minimal `MusicXML` fixture for that topic
+- run `MusicXML -> format -> MusicXML` for all supported formats
+- assert only topic-relevant invariants and policy
+
+Supported format targets:
+- `musescore`
+- `midi`
+- `vsqx`
+- `abc`
+- `mei`
+- `lilypond`
+
+---
+
+## Policy Model
+
+Each topic must define per-format policy:
+
+- `must-preserve`
+  - the semantic element must survive roundtrip
+- `allowed-degrade`
+  - degradation is accepted, but must be explicitly documented
+
+All topics should still keep baseline checks across all formats:
+- first pitched note pitch class / octave
+- first pitched note start timing baseline
+- no malformed MusicXML after roundtrip
+
+---
+
+## Case IDs and Status
+
+- `CFFP-TRILL`:
+  - Status: implemented
+  - Test: `tests/unit/cffp-series.spec.ts`
+  - Current policy:
+    - `must-preserve`: `abc`, `lilypond`, `musescore`
+    - `allowed-degrade`: `midi`, `vsqx`, `mei`
+
+- `CFFP-TRILL-VARIANTS`:
+  - Status: implemented
+  - Test: `tests/unit/cffp-series.spec.ts`
+  - Current policy:
+    - `must-preserve`: none
+    - `allowed-degrade`: `abc`, `mei`, `lilypond`, `musescore`, `midi`, `vsqx`
+
+- `CFFP-TURN`:
+  - Status: implemented
+  - Test: `tests/unit/cffp-series.spec.ts`
+  - Current policy:
+    - `must-preserve`: none
+    - `allowed-degrade`: `abc`, `mei`, `lilypond`, `musescore`, `midi`, `vsqx`
+  - Note:
+    - baseline first-note pitch is intentionally relaxed for this case because ornament handling can alter emitted leading-note representation by format.
+
+- `CFFP-TURN-VARIANTS`:
+  - Status: implemented
+  - Test: `tests/unit/cffp-series.spec.ts`
+  - Current policy:
+    - `must-preserve`: none
+    - `allowed-degrade`: `abc`, `mei`, `lilypond`, `musescore`, `midi`, `vsqx`
+  - Scope:
+    - `inverted-turn` + `delayed-turn`
+
+- `CFFP-MORDENT-VARIANTS`:
+  - Status: implemented
+  - Test: `tests/unit/cffp-series.spec.ts`
+  - Current policy:
+    - `must-preserve`: none
+    - `allowed-degrade`: `abc`, `mei`, `lilypond`, `musescore`, `midi`, `vsqx`
+  - Scope:
+    - `mordent` + `inverted-mordent`
+
+- `CFFP-ORNAMENT-ACCIDENTAL-MARK`:
+  - Status: implemented
+  - Test: `tests/unit/cffp-series.spec.ts`
+  - Current policy:
+    - `must-preserve`: none
+    - `allowed-degrade`: `abc`, `mei`, `lilypond`, `musescore`, `midi`, `vsqx`
+  - Scope:
+    - `ornaments/accidental-mark` (with ornament context)
+
+- `CFFP-SCHLEIFER`:
+  - Status: implemented
+  - Test: `tests/unit/cffp-series.spec.ts`
+  - Current policy:
+    - `must-preserve`: none
+    - `allowed-degrade`: `abc`, `mei`, `lilypond`, `musescore`, `midi`, `vsqx`
+
+- `CFFP-SHAKE`:
+  - Status: implemented
+  - Test: `tests/unit/cffp-series.spec.ts`
+  - Current policy:
+    - `must-preserve`: none
+    - `allowed-degrade`: `abc`, `mei`, `lilypond`, `musescore`, `midi`, `vsqx`
+
+- `CFFP-DYNAMICS-BASIC`:
+  - Status: implemented
+  - Test: `tests/unit/cffp-series.spec.ts`
+  - Current policy:
+    - `must-preserve`: `musescore`
+    - `allowed-degrade`: `abc`, `mei`, `lilypond`, `midi`, `vsqx`
+  - Scope:
+    - basic dynamics marks (`pp`, `ff`)
+
+- `CFFP-DYNAMICS-ACCENTED`:
+  - Status: implemented
+  - Test: `tests/unit/cffp-series.spec.ts`
+  - Current policy:
+    - `must-preserve`: `musescore`
+    - `allowed-degrade`: `abc`, `mei`, `lilypond`, `midi`, `vsqx`
+  - Scope:
+    - accented dynamics marks (`mf`, `sfz`)
+
+- `CFFP-DYNAMICS-WEDGE`:
+  - Status: implemented
+  - Test: `tests/unit/cffp-series.spec.ts`
+  - Current policy:
+    - `must-preserve`: none
+    - `allowed-degrade`: `abc`, `mei`, `lilypond`, `musescore`, `midi`, `vsqx`
+  - Scope:
+    - wedge crescendo/diminuendo lines
+
+- `CFFP-FERMATA`:
+  - Status: implemented
+  - Test: `tests/unit/cffp-series.spec.ts`
+  - Current policy:
+    - `must-preserve`: none
+    - `allowed-degrade`: `abc`, `mei`, `lilypond`, `musescore`, `midi`, `vsqx`
+
+- `CFFP-ARPEGGIATE`:
+  - Status: implemented
+  - Test: `tests/unit/cffp-series.spec.ts`
+  - Current policy:
+    - `must-preserve`: none
+    - `allowed-degrade`: `abc`, `mei`, `lilypond`, `musescore`, `midi`, `vsqx`
+
+- `CFFP-BREATH-CAESURA`:
+  - Status: implemented
+  - Test: `tests/unit/cffp-series.spec.ts`
+  - Current policy:
+    - `must-preserve`: none
+    - `allowed-degrade`: `abc`, `mei`, `lilypond`, `musescore`, `midi`, `vsqx`
+  - Scope:
+    - `articulations/breath-mark` + `articulations/caesura`
+
+- `CFFP-GLISSANDO`:
+  - Status: implemented
+  - Test: `tests/unit/cffp-series.spec.ts`
+  - Current policy:
+    - `must-preserve`: none
+    - `allowed-degrade`: `abc`, `mei`, `lilypond`, `musescore`, `midi`, `vsqx`
+  - Scope:
+    - `glissando` start/stop pair
+
+- `CFFP-PEDAL`:
+  - Status: implemented
+  - Test: `tests/unit/cffp-series.spec.ts`
+  - Current policy:
+    - `must-preserve`: none
+    - `allowed-degrade`: `abc`, `mei`, `lilypond`, `musescore`, `midi`, `vsqx`
+  - Scope:
+    - `direction-type/pedal` start/stop
+
+- `CFFP-SEGNO-CODA`:
+  - Status: implemented
+  - Test: `tests/unit/cffp-series.spec.ts`
+  - Current policy:
+    - `must-preserve`: none
+    - `allowed-degrade`: `abc`, `mei`, `lilypond`, `musescore`, `midi`, `vsqx`
+  - Scope:
+    - `direction-type/segno` + `direction-type/coda`
+
+- `CFFP-HARMONY-CHORDSYMBOL`:
+  - Status: implemented
+  - Test: `tests/unit/cffp-series.spec.ts`
+  - Current policy:
+    - `must-preserve`: none
+    - `allowed-degrade`: `abc`, `mei`, `lilypond`, `musescore`, `midi`, `vsqx`
+  - Scope:
+    - `harmony` (`root` / `root-alter` / `kind` / `bass`)
+
+- `CFFP-KEY-MODE`:
+  - Status: implemented
+  - Test: `tests/unit/cffp-series.spec.ts`
+  - Current policy:
+    - `must-preserve`: none
+    - `allowed-degrade`: `abc`, `mei`, `lilypond`, `musescore`, `midi`, `vsqx`
+  - Scope:
+    - `key/mode` transition (`major` -> `minor`)
+
+- `CFFP-TECHNIQUE-TEXT`:
+  - Status: implemented
+  - Test: `tests/unit/cffp-series.spec.ts`
+  - Current policy:
+    - `must-preserve`: none
+    - `allowed-degrade`: `abc`, `mei`, `lilypond`, `musescore`, `midi`, `vsqx`
+  - Scope:
+    - `direction-type/words` text marks (`pizz.` / `arco` / `con sord.`)
+
+- `CFFP-LEFT-HAND-PIZZICATO`:
+  - Status: implemented
+  - Test: `tests/unit/cffp-series.spec.ts`
+  - Current policy:
+    - `must-preserve`: none
+    - `allowed-degrade`: `abc`, `mei`, `lilypond`, `musescore`, `midi`, `vsqx`
+  - Scope:
+    - `technical/left-hand-pizzicato`
+
+- `CFFP-BOWING-DIRECTION`:
+  - Status: implemented
+  - Test: `tests/unit/cffp-series.spec.ts`
+  - Current policy:
+    - `must-preserve`: none
+    - `allowed-degrade`: `abc`, `mei`, `lilypond`, `musescore`, `midi`, `vsqx`
+  - Scope:
+    - bowing direction marks (`technical/up-bow` + `technical/down-bow`)
+
+- `CFFP-ARTICULATION-EXT`:
+  - Status: implemented
+  - Test: `tests/unit/cffp-series.spec.ts`
+  - Current policy:
+    - `must-preserve`: none
+    - `allowed-degrade`: `abc`, `mei`, `lilypond`, `musescore`, `midi`, `vsqx`
+  - Scope:
+    - extended articulations (`tenuto` / `staccatissimo` / `strong-accent`)
+
+- `CFFP-NOTEHEAD`:
+  - Status: implemented
+  - Test: `tests/unit/cffp-series.spec.ts`
+  - Current policy:
+    - `must-preserve`: none
+    - `allowed-degrade`: `abc`, `mei`, `lilypond`, `musescore`, `midi`, `vsqx`
+  - Scope:
+    - notehead variants (`cross` / `diamond`)
+
+- `CFFP-CLEF-MIDMEASURE`:
+  - Status: implemented
+  - Test: `tests/unit/cffp-series.spec.ts`
+  - Current policy:
+    - `must-preserve`: none
+    - `allowed-degrade`: `abc`, `mei`, `lilypond`, `musescore`, `midi`, `vsqx`
+  - Scope:
+    - mid-measure clef change
+
+- `CFFP-STEM-BEAM-DIR`:
+  - Status: implemented
+  - Test: `tests/unit/cffp-series.spec.ts`
+  - Current policy:
+    - `must-preserve`: none
+    - `allowed-degrade`: `abc`, `mei`, `lilypond`, `musescore`, `midi`, `vsqx`
+  - Scope:
+    - stem direction (`up`/`down`) + beam direction markers (`begin`/`end`)
+
+- `CFFP-VOICE-STAFF-SWAP`:
+  - Status: implemented
+  - Test: `tests/unit/cffp-series.spec.ts`
+  - Current policy:
+    - `must-preserve`: none
+    - `allowed-degrade`: `abc`, `mei`, `lilypond`, `musescore`, `midi`, `vsqx`
+  - Scope:
+    - same voice crossing staff 1/2 within one measure
+
+- `CFFP-MEASURE-STYLE`:
+  - Status: implemented
+  - Test: `tests/unit/cffp-series.spec.ts`
+  - Current policy:
+    - `must-preserve`: none
+    - `allowed-degrade`: `abc`, `mei`, `lilypond`, `musescore`, `midi`, `vsqx`
+  - Scope:
+    - `measure-style` (`slash` start/stop + `multiple-rest`)
+
+- `CFFP-PRINT-LAYOUT-MIN`:
+  - Status: implemented
+  - Test: `tests/unit/cffp-series.spec.ts`
+  - Current policy:
+    - `must-preserve`: none
+    - `allowed-degrade`: `abc`, `mei`, `lilypond`, `musescore`, `midi`, `vsqx`
+  - Scope:
+    - minimal `print` layout hints (`new-system` / `new-page`)
+
+- `CFFP-MIDMEASURE-REPEAT`:
+  - Status: implemented
+  - Test: `tests/unit/cffp-series.spec.ts`
+  - Current policy:
+    - `must-preserve`: none
+    - `allowed-degrade`: `abc`, `mei`, `lilypond`, `musescore`, `midi`, `vsqx`
+  - Scope:
+    - mid-measure repeat-like directives (`sound` forward/backward repeat with words marker)
+
+- `CFFP-OTTAVA-NUMBERING`:
+  - Status: implemented
+  - Test: `tests/unit/cffp-series.spec.ts`
+  - Current policy:
+    - `must-preserve`: none
+    - `allowed-degrade`: `abc`, `mei`, `lilypond`, `musescore`, `midi`, `vsqx`
+  - Scope:
+    - multiple `octave-shift` lanes using different `number` values
+
+- `CFFP-LYRIC-BASIC`:
+  - Status: implemented
+  - Test: `tests/unit/cffp-series.spec.ts`
+  - Current policy:
+    - `must-preserve`: none
+    - `allowed-degrade`: `abc`, `mei`, `lilypond`, `musescore`, `midi`, `vsqx`
+  - Scope:
+    - basic lyric text + melisma (`syllabic begin/end` + `extend`)
+
+- `CFFP-SLIDE`:
+  - Status: implemented
+  - Test: `tests/unit/cffp-series.spec.ts`
+  - Current policy:
+    - `must-preserve`: none
+    - `allowed-degrade`: `abc`, `mei`, `lilypond`, `musescore`, `midi`, `vsqx`
+  - Scope:
+    - `slide` start/stop pair
+
+- `CFFP-TREMOLO`:
+  - Status: implemented
+  - Test: `tests/unit/cffp-series.spec.ts`
+  - Current policy:
+    - `must-preserve`: none
+    - `allowed-degrade`: `abc`, `mei`, `lilypond`, `musescore`, `midi`, `vsqx`
+  - Scope:
+    - `tremolo` single + start/stop
+
+- `CFFP-REHEARSAL-MARK`:
+  - Status: implemented
+  - Test: `tests/unit/cffp-series.spec.ts`
+  - Current policy:
+    - `must-preserve`: none
+    - `allowed-degrade`: `abc`, `mei`, `lilypond`, `musescore`, `midi`, `vsqx`
+  - Scope:
+    - rehearsal text marker (`direction-type/rehearsal`)
+
+- `CFFP-DA-CAPO-DAL-SEGNO`:
+  - Status: implemented
+  - Test: `tests/unit/cffp-series.spec.ts`
+  - Current policy:
+    - `must-preserve`: none
+    - `allowed-degrade`: `abc`, `mei`, `lilypond`, `musescore`, `midi`, `vsqx`
+  - Scope:
+    - jump words + `sound` attributes (`dacapo` / `dalsegno`)
+
+- `CFFP-ENDING-TYPE`:
+  - Status: implemented
+  - Test: `tests/unit/cffp-series.spec.ts`
+  - Current policy:
+    - `must-preserve`: none
+    - `allowed-degrade`: `abc`, `mei`, `lilypond`, `musescore`, `midi`, `vsqx`
+  - Scope:
+    - `ending` type variants (`start` / `stop` / `discontinue`)
+
+- `CFFP-TRIPLET-BRACKET`:
+  - Status: implemented
+  - Test: `tests/unit/cffp-series.spec.ts`
+  - Current policy:
+    - `must-preserve`: none
+    - `allowed-degrade`: `abc`, `mei`, `lilypond`, `musescore`, `midi`, `vsqx`
+  - Scope:
+    - tuplet display attributes (`bracket` / `placement`)
+
+- `CFFP-OCTSHIFT`:
+  - Status: implemented
+  - Test: `tests/unit/cffp-series.spec.ts`
+  - Current policy:
+    - `must-preserve`: `lilypond`
+    - `allowed-degrade`: `musescore`, `midi`, `vsqx`, `abc`, `mei`
+
+- `CFFP-SLUR`:
+  - Status: implemented
+  - Test: `tests/unit/cffp-series.spec.ts`
+  - Current policy:
+    - `must-preserve`: `abc`, `lilypond`, `musescore`
+    - `allowed-degrade`: `midi`, `vsqx`, `mei`
+
+- `CFFP-TIE`:
+  - Status: implemented
+  - Test: `tests/unit/cffp-series.spec.ts`
+  - Current policy:
+    - `must-preserve`: `abc`, `musescore`
+    - `allowed-degrade`: `lilypond`, `midi`, `vsqx`, `mei`
+
+- `CFFP-STACCATO`:
+  - Status: implemented
+  - Test: `tests/unit/cffp-series.spec.ts`
+  - Current policy:
+    - `must-preserve`: `abc`, `mei`, `lilypond`, `musescore`
+    - `allowed-degrade`: `midi`, `vsqx`
+
+- `CFFP-ACCENT`:
+  - Status: implemented
+  - Test: `tests/unit/cffp-series.spec.ts`
+  - Current policy:
+    - `must-preserve`: `mei`, `lilypond`, `musescore`
+    - `allowed-degrade`: `abc`, `midi`, `vsqx`
+
+- `CFFP-GRACE`:
+  - Status: implemented
+  - Test: `tests/unit/cffp-series.spec.ts`
+  - Current policy:
+    - `must-preserve`: `abc`, `mei`, `lilypond`, `musescore`
+    - `allowed-degrade`: `midi`, `vsqx`
+
+- `CFFP-TUPLET`:
+  - Status: implemented
+  - Test: `tests/unit/cffp-series.spec.ts`
+  - Current policy:
+    - `must-preserve`: `abc`, `mei`, `lilypond`, `musescore`
+    - `allowed-degrade`: `midi`, `vsqx`
+
+- `CFFP-ACCIDENTAL`:
+  - Status: implemented
+  - Test: `tests/unit/cffp-series.spec.ts`
+  - Current policy:
+    - `must-preserve`: `abc`, `lilypond`, `musescore`
+    - `allowed-degrade`: `mei`, `midi`, `vsqx`
+
+- `CFFP-ACCIDENTAL-RESET`:
+  - Status: implemented
+  - Test: `tests/unit/cffp-series.spec.ts`
+  - Current policy:
+    - `must-preserve`: `abc`, `mei`, `lilypond`, `musescore`, `midi`
+    - `allowed-degrade`: `vsqx` (pitch baseline in this case)
+
+- `CFFP-COURTESY-ACCIDENTAL`:
+  - Status: implemented
+  - Test: `tests/unit/cffp-series.spec.ts`
+  - Current policy:
+    - `must-preserve`: none
+    - `allowed-degrade`: `abc`, `mei`, `lilypond`, `musescore`, `midi`, `vsqx`
+
+- `CFFP-BEAM-CONTINUITY`:
+  - Status: implemented
+  - Test: `tests/unit/cffp-series.spec.ts`
+  - Current policy:
+    - `must-preserve`: `musescore`
+    - `allowed-degrade`: `abc`, `mei`, `lilypond`, `midi`, `vsqx`
+
+- `CFFP-MULTIVOICE-BACKUP`:
+  - Status: implemented
+  - Test: `tests/unit/cffp-series.spec.ts`
+  - Current policy:
+    - `must-preserve`: `musescore`
+    - `allowed-degrade`: `abc`, `mei`, `lilypond`, `midi`, `vsqx`
+
+- `CFFP-PICKUP-IMPLICIT`:
+  - Status: implemented
+  - Test: `tests/unit/cffp-series.spec.ts`
+  - Current policy:
+    - `must-preserve`: `musescore`
+    - `allowed-degrade`: `abc`, `mei`, `lilypond`, `midi`, `vsqx`
+
+- `CFFP-TRANSPOSE`:
+  - Status: implemented
+  - Test: `tests/unit/cffp-series.spec.ts`
+  - Current policy:
+    - `must-preserve`: none
+    - `allowed-degrade`: `abc`, `mei`, `lilypond`, `musescore`, `midi`, `vsqx`
+  - Note:
+    - baseline first-note pitch is intentionally relaxed for this case because transposition semantics can shift written pitch representation by format.
+
+- `CFFP-GRANDSTAFF-MAPPING`:
+  - Status: implemented
+  - Test: `tests/unit/cffp-series.spec.ts`
+  - Current policy:
+    - `must-preserve`: `musescore`
+    - `allowed-degrade`: `abc`, `mei`, `lilypond`, `midi`, `vsqx`
+  - Note:
+    - baseline first-note pitch is intentionally relaxed for this case because first-note order can differ between staves by format.
+
+- `CFFP-KEY-CHANGE`:
+  - Status: implemented
+  - Test: `tests/unit/cffp-series.spec.ts`
+  - Current policy:
+    - `must-preserve`: `musescore`
+    - `allowed-degrade`: `abc`, `mei`, `lilypond`, `midi`, `vsqx`
+
+- `CFFP-TIME-CHANGE`:
+  - Status: implemented
+  - Test: `tests/unit/cffp-series.spec.ts`
+  - Current policy:
+    - `must-preserve`: `mei`, `lilypond`, `musescore`
+    - `allowed-degrade`: `abc`, `midi`, `vsqx`
+
+- `CFFP-DOUBLE-BARLINE`:
+  - Status: implemented
+  - Test: `tests/unit/cffp-series.spec.ts`
+  - Current policy:
+    - `must-preserve`: none
+    - `allowed-degrade`: `abc`, `mei`, `lilypond`, `musescore`, `midi`, `vsqx`
+
+- `CFFP-REPEAT-ENDING`:
+  - Status: implemented
+  - Test: `tests/unit/cffp-series.spec.ts`
+  - Current policy:
+    - `must-preserve`: `abc`, `lilypond`, `musescore`
+    - `allowed-degrade`: `mei`, `midi`, `vsqx`
+
+- `CFFP-TEMPO-MAP`:
+  - Status: implemented
+  - Test: `tests/unit/cffp-series.spec.ts`
+  - Current policy:
+    - `must-preserve`: `musescore`
+    - `allowed-degrade`: `abc`, `mei`, `lilypond`, `midi`, `vsqx`
+
+- Additional implemented cases (see `tests/unit/cffp-series.spec.ts`):
+  - `CFFP-ACCIDENTAL-COURTESY-MODE`
+  - `CFFP-PERCUSSION-UNPITCHED`
+  - `CFFP-PERCUSSION-NOTEHEAD`
+  - `CFFP-PERCUSSION-INSTRUMENT-ID`
+  - `CFFP-PERCUSSION-VOICE-LAYER`
+  - `CFFP-PERCUSSION-STAFF-LINE`
+  - `CFFP-TRANSPOSING-INSTRUMENT`
+  - `CFFP-TIMEWISE-BACKUP-FORWARD`
+  - `CFFP-CROSS-STAFF-BEAM`
+  - `CFFP-CHORD-SYMBOL-ALTER`
+  - `CFFP-NOTE-TIES-CROSS-MEASURE`
+  - `CFFP-MULTI-REST-COUNT`
+  - `CFFP-REPEAT-JUMP-SOUND`
+  - `CFFP-CUE-GRACE-MIX`
+  - `CFFP-LYRICS-MULTI-VERSE`
+  - `CFFP-TEXT-ENCODING`
+  - `CFFP-HARMONIC-NATURAL-ARTIFICIAL`
+  - `CFFP-OPEN-STRING`
+  - `CFFP-STOPPED`
+  - `CFFP-SNAP-PIZZICATO`
+  - `CFFP-FINGERING`
+  - `CFFP-STRING`
+  - `CFFP-DOUBLE-TRIPLE-TONGUE`
+  - `CFFP-HEEL-TOE`
+  - `CFFP-PLUCK-TEXT`
+  - `CFFP-BREATH-VARIANTS`
+  - `CFFP-BREATH-PLACEMENT`
+  - `CFFP-CAESURA-STYLE`
+
+---
+
+## Authoring Rules
+
+- Keep fixtures minimal (usually 1 measure).
+- Avoid mixing multiple semantics in one case.
+- Keep assertions deterministic and narrow.
+- If policy changes, update this file and `docs/spec/TEST_MATRIX.md` together.
+
+---
+
+## Current Matrix (Implemented Cases)
+
+- `must-preserve` focused:
+  - `musescore`: `CFFP-TRILL`, `CFFP-STACCATO`, `CFFP-ACCENT`, `CFFP-GRACE`, `CFFP-TUPLET`, `CFFP-ACCIDENTAL`, `CFFP-ACCIDENTAL-RESET`, `CFFP-BEAM-CONTINUITY`, `CFFP-MULTIVOICE-BACKUP`, `CFFP-PICKUP-IMPLICIT`, `CFFP-GRANDSTAFF-MAPPING`, `CFFP-TIME-CHANGE`, `CFFP-REPEAT-ENDING`, `CFFP-TEMPO-MAP`
+  - `abc`: `CFFP-TRILL`, `CFFP-SLUR`, `CFFP-TIE`, `CFFP-STACCATO`, `CFFP-GRACE`, `CFFP-TUPLET`, `CFFP-ACCIDENTAL`, `CFFP-ACCIDENTAL-RESET`, `CFFP-REPEAT-ENDING`
+  - `mei`: `CFFP-STACCATO`, `CFFP-ACCENT`, `CFFP-GRACE`, `CFFP-TUPLET`, `CFFP-ACCIDENTAL-RESET`, `CFFP-TIME-CHANGE`
+  - `lilypond`: `CFFP-TRILL`, `CFFP-OCTSHIFT`, `CFFP-STACCATO`, `CFFP-ACCENT`, `CFFP-GRACE`, `CFFP-TUPLET`, `CFFP-ACCIDENTAL`, `CFFP-ACCIDENTAL-RESET`, `CFFP-REPEAT-ENDING`, `CFFP-TIME-CHANGE`
+  - `midi`: `CFFP-ACCIDENTAL-RESET`
+  - `vsqx`: none
+
+- `allowed-degrade`:
+  - all other case/format combinations not listed above.

--- a/docs/spec/TEST_MATRIX.md
+++ b/docs/spec/TEST_MATRIX.md
@@ -99,3 +99,438 @@ Executable test planning mapped from MVP requirements.
 - Then:
   - `ok=false`
   - `MEASURE_OVERFULL`
+
+## CFFP Series (Cross-Format Focus Parity)
+
+15. `CFFP-TRILL Minimal trill cross-format roundtrip`
+- Input: minimal MusicXML with `trill-mark`
+- Route: `MusicXML -> (musescore|midi|vsqx|abc|mei|lilypond) -> MusicXML`
+- Then:
+  - baseline pitch/start timing assertions for all formats
+  - trill assertion per policy (`must-preserve` / `allowed-degrade`)
+
+16. `CFFP-OCTSHIFT Minimal octave-shift cross-format roundtrip`
+- Input: minimal MusicXML with `octave-shift`
+- Then:
+  - baseline pitch/timing assertions for all formats
+  - octave-shift assertion per policy
+
+17. `CFFP-SLUR Minimal slur cross-format roundtrip`
+- Input: minimal MusicXML with slur start/stop
+- Then:
+  - slur start/stop assertion per policy
+
+18. `CFFP-TIE Minimal tie cross-format roundtrip`
+- Input: minimal MusicXML with tie start/stop
+- Then:
+  - tie linkage assertion per policy
+
+19. `CFFP-STACCATO Minimal staccato cross-format roundtrip`
+- Input: minimal MusicXML with staccato
+- Then:
+  - articulation assertion per policy
+
+20. `CFFP-ACCENT Minimal accent cross-format roundtrip`
+- Input: minimal MusicXML with accent
+- Then:
+  - articulation assertion per policy
+
+21. `CFFP-GRACE Minimal grace cross-format roundtrip`
+- Input: minimal MusicXML with grace (and slash variant where applicable)
+- Then:
+  - grace semantics assertion per policy
+
+22. `CFFP-TUPLET Minimal tuplet cross-format roundtrip`
+- Input: minimal MusicXML with tuplet/time-modification
+- Then:
+  - tuplet semantics assertion per policy
+
+23. `CFFP-ACCIDENTAL Minimal accidental spelling/reset cross-format roundtrip`
+- Input: minimal MusicXML with explicit natural + key-context sharp
+- Then:
+  - accidental spelling/reset assertion per policy
+
+24. `CFFP-KEY-CHANGE Minimal mid-score key change cross-format roundtrip`
+- Input: minimal MusicXML with measure-level key change
+- Then:
+  - key change assertion per policy
+
+25. `CFFP-TIME-CHANGE Minimal mid-score time change cross-format roundtrip`
+- Input: minimal MusicXML with measure-level time change
+- Then:
+  - time signature change assertion per policy
+
+26. `CFFP-DOUBLE-BARLINE Minimal mid-score double barline cross-format roundtrip`
+- Input: minimal MusicXML with `light-light` barline at measure boundary
+- Then:
+  - double-barline preservation/degrade assertion per policy
+
+27. `CFFP-REPEAT-ENDING Minimal repeat/ending barline metadata cross-format roundtrip`
+- Input: minimal MusicXML with forward/backward repeat and ending metadata
+- Then:
+  - repeat/ending metadata assertion per policy
+
+28. `CFFP-TEMPO-MAP Minimal tempo change map cross-format roundtrip`
+- Input: minimal MusicXML with two tempo events (120 -> 90)
+- Then:
+  - tempo map preservation/degrade assertion per policy
+
+29. `CFFP-ACCIDENTAL-RESET Minimal accidental carry/reset cross-format roundtrip`
+- Input: minimal MusicXML with `F#` in measure 1 and `F` in measure 2
+- Then:
+  - same-measure accidental carry and next-measure reset semantics are preserved
+
+30. `CFFP-COURTESY-ACCIDENTAL Minimal courtesy accidental cross-format roundtrip`
+- Input: minimal MusicXML with explicit courtesy natural (`cautionary="yes"`)
+- Then:
+  - courtesy accidental display metadata assertion per policy
+
+31. `CFFP-BEAM-CONTINUITY Minimal beam continuity cross-format roundtrip`
+- Input: minimal MusicXML with eighth-note beams split by rest
+- Then:
+  - beam continuity preservation/degrade assertion per policy
+
+32. `CFFP-MULTIVOICE-BACKUP Minimal multi-voice backup cross-format roundtrip`
+- Input: minimal MusicXML with voice1 + backup + voice2 in one measure
+- Then:
+  - multi-voice lane reconstruction assertion per policy
+
+33. `CFFP-PICKUP-IMPLICIT Minimal pickup implicit-measure cross-format roundtrip`
+- Input: minimal MusicXML with first measure `number="0"` and `implicit="yes"`
+- Then:
+  - pickup/implicit measure metadata preservation/degrade assertion per policy
+
+34. `CFFP-TRILL-VARIANTS Minimal trill variants cross-format roundtrip`
+- Input: minimal MusicXML with `trill-mark` + `wavy-line start/stop` + `accidental-mark`
+- Then:
+  - trill variant metadata preservation/degrade assertion per policy
+
+35. `CFFP-TRANSPOSE Minimal transpose hint cross-format roundtrip`
+- Input: minimal MusicXML with measure-level transpose hints (`diatonic/chromatic`)
+- Then:
+  - transpose metadata preservation/degrade assertion per policy
+
+36. `CFFP-GRANDSTAFF-MAPPING Minimal grand-staff voice/staff mapping cross-format roundtrip`
+- Input: minimal MusicXML with two staves (`staves=2`) and explicit `staff=1/2` note mapping
+- Then:
+  - grand-staff staff/voice mapping preservation/degrade assertion per policy
+
+37. `CFFP-TURN Minimal turn ornament cross-format roundtrip`
+- Input: minimal MusicXML with `ornaments/turn`
+- Then:
+  - turn ornament preservation/degrade assertion per policy
+
+38. `CFFP-TURN-VARIANTS Minimal turn variants cross-format roundtrip`
+- Input: minimal MusicXML with `ornaments/inverted-turn` + `ornaments/delayed-turn`
+- Then:
+  - turn-variant ornament preservation/degrade assertion per policy
+
+39. `CFFP-MORDENT-VARIANTS Minimal mordent variants cross-format roundtrip`
+- Input: minimal MusicXML with `ornaments/mordent` + `ornaments/inverted-mordent`
+- Then:
+  - mordent-variant ornament preservation/degrade assertion per policy
+
+40. `CFFP-ORNAMENT-ACCIDENTAL-MARK Minimal ornament accidental-mark cross-format roundtrip`
+- Input: minimal MusicXML with `ornaments/accidental-mark` (ornament context)
+- Then:
+  - ornament accidental-mark preservation/degrade assertion per policy
+
+41. `CFFP-SCHLEIFER Minimal schleifer ornament cross-format roundtrip`
+- Input: minimal MusicXML with `ornaments/schleifer`
+- Then:
+  - schleifer ornament preservation/degrade assertion per policy
+
+42. `CFFP-SHAKE Minimal shake ornament cross-format roundtrip`
+- Input: minimal MusicXML with `ornaments/shake`
+- Then:
+  - shake ornament preservation/degrade assertion per policy
+
+43. `CFFP-DYNAMICS-BASIC Minimal dynamics marks cross-format roundtrip`
+- Input: minimal MusicXML with `dynamics/pp` and `dynamics/ff`
+- Then:
+  - dynamics marks preservation/degrade assertion per policy
+
+44. `CFFP-DYNAMICS-ACCENTED Minimal accented dynamics cross-format roundtrip`
+- Input: minimal MusicXML with `dynamics/mf` and `dynamics/sfz`
+- Then:
+  - accented dynamics preservation/degrade assertion per policy
+
+45. `CFFP-DYNAMICS-WEDGE Minimal wedge dynamics cross-format roundtrip`
+- Input: minimal MusicXML with wedge `crescendo/diminuendo` + `stop`
+- Then:
+  - wedge dynamics preservation/degrade assertion per policy
+
+46. `CFFP-FERMATA Minimal fermata cross-format roundtrip`
+- Input: minimal MusicXML with `notations/fermata`
+- Then:
+  - fermata preservation/degrade assertion per policy
+
+47. `CFFP-ARPEGGIATE Minimal arpeggiate cross-format roundtrip`
+- Input: minimal MusicXML with `notations/arpeggiate` on chord notes
+- Then:
+  - arpeggiate preservation/degrade assertion per policy
+
+48. `CFFP-BREATH-CAESURA Minimal breath/caesura cross-format roundtrip`
+- Input: minimal MusicXML with `articulations/breath-mark` + `articulations/caesura`
+- Then:
+  - breath/caesura preservation/degrade assertion per policy
+
+49. `CFFP-GLISSANDO Minimal glissando cross-format roundtrip`
+- Input: minimal MusicXML with `glissando` start/stop
+- Then:
+  - glissando preservation/degrade assertion per policy
+
+50. `CFFP-PEDAL Minimal pedal cross-format roundtrip`
+- Input: minimal MusicXML with `direction-type/pedal` start/stop
+- Then:
+  - pedal marking preservation/degrade assertion per policy
+
+51. `CFFP-SEGNO-CODA Minimal segno/coda cross-format roundtrip`
+- Input: minimal MusicXML with `direction-type/segno` and `direction-type/coda`
+- Then:
+  - segno/coda symbol preservation/degrade assertion per policy
+
+52. `CFFP-HARMONY-CHORDSYMBOL Minimal harmony chord-symbol cross-format roundtrip`
+- Input: minimal MusicXML with `<harmony>` (`root` / `kind` / `bass`)
+- Then:
+  - harmony chord-symbol preservation/degrade assertion per policy
+
+53. `CFFP-SLIDE Minimal slide cross-format roundtrip`
+- Input: minimal MusicXML with `slide` start/stop
+- Then:
+  - slide preservation/degrade assertion per policy
+
+54. `CFFP-TREMOLO Minimal tremolo cross-format roundtrip`
+- Input: minimal MusicXML with `tremolo` (`single` + `start/stop`)
+- Then:
+  - tremolo preservation/degrade assertion per policy
+
+55. `CFFP-REHEARSAL-MARK Minimal rehearsal-mark cross-format roundtrip`
+- Input: minimal MusicXML with `direction-type/rehearsal` text
+- Then:
+  - rehearsal-mark text preservation/degrade assertion per policy
+
+56. `CFFP-DA-CAPO-DAL-SEGNO Minimal jump-words/sound cross-format roundtrip`
+- Input: minimal MusicXML with `words` (`Da Capo` / `Dal Segno`) + `sound` (`dacapo` / `dalsegno`)
+- Then:
+  - jump words and sound-attribute preservation/degrade assertion per policy
+
+57. `CFFP-ENDING-TYPE Minimal ending-type cross-format roundtrip`
+- Input: minimal MusicXML with ending `type` (`start` / `stop` / `discontinue`)
+- Then:
+  - ending-type preservation/degrade assertion per policy
+
+58. `CFFP-TRIPLET-BRACKET Minimal triplet bracket/placement cross-format roundtrip`
+- Input: minimal MusicXML with tuplet `bracket="yes"` and `placement="above"`
+- Then:
+  - triplet bracket/placement preservation/degrade assertion per policy
+
+59. `CFFP-KEY-MODE Minimal key-mode cross-format roundtrip`
+- Input: minimal MusicXML with `key/mode` transition (`major` -> `minor`)
+- Then:
+  - key-mode preservation/degrade assertion per policy
+
+60. `CFFP-TECHNIQUE-TEXT Minimal technique-text cross-format roundtrip`
+- Input: minimal MusicXML with `direction-type/words` (`pizz.` / `arco` / `con sord.`)
+- Then:
+  - technique-text preservation/degrade assertion per policy
+
+61. `CFFP-ARTICULATION-EXT Minimal extended articulation cross-format roundtrip`
+- Input: minimal MusicXML with `tenuto` / `staccatissimo` / `strong-accent`
+- Then:
+  - extended articulation preservation/degrade assertion per policy
+
+62. `CFFP-NOTEHEAD Minimal notehead variants cross-format roundtrip`
+- Input: minimal MusicXML with `notehead` variants (`cross` / `diamond`)
+- Then:
+  - notehead preservation/degrade assertion per policy
+
+63. `CFFP-CLEF-MIDMEASURE Minimal mid-measure clef-change cross-format roundtrip`
+- Input: minimal MusicXML with clef change within a measure
+- Then:
+  - mid-measure clef-change preservation/degrade assertion per policy
+
+64. `CFFP-STEM-BEAM-DIR Minimal stem/beam-direction cross-format roundtrip`
+- Input: minimal MusicXML with `stem` up/down and beam `begin/end`
+- Then:
+  - stem/beam-direction preservation/degrade assertion per policy
+
+65. `CFFP-VOICE-STAFF-SWAP Minimal voice-staff-swap cross-format roundtrip`
+- Input: minimal MusicXML where same voice appears on staff 1 and staff 2 in one measure
+- Then:
+  - voice-staff-swap preservation/degrade assertion per policy
+
+66. `CFFP-MEASURE-STYLE Minimal measure-style cross-format roundtrip`
+- Input: minimal MusicXML with `measure-style` (`slash` start/stop + `multiple-rest`)
+- Then:
+  - measure-style preservation/degrade assertion per policy
+
+67. `CFFP-PRINT-LAYOUT-MIN Minimal print-layout cross-format roundtrip`
+- Input: minimal MusicXML with `print` hints (`new-system` / `new-page`)
+- Then:
+  - print-layout hint preservation/degrade assertion per policy
+
+68. `CFFP-MIDMEASURE-REPEAT Minimal mid-measure-repeat cross-format roundtrip`
+- Input: minimal MusicXML with mid-measure repeat-like direction/sound markers
+- Then:
+  - mid-measure repeat marker preservation/degrade assertion per policy
+
+69. `CFFP-OTTAVA-NUMBERING Minimal ottava-numbering cross-format roundtrip`
+- Input: minimal MusicXML with multiple `octave-shift` lines (`number=1/2`)
+- Then:
+  - ottava-numbering preservation/degrade assertion per policy
+
+70. `CFFP-LYRIC-BASIC Minimal lyric/melisma cross-format roundtrip`
+- Input: minimal MusicXML with lyric text and melisma extension
+- Then:
+  - lyric/melisma preservation/degrade assertion per policy
+
+71. `CFFP-LEFT-HAND-PIZZICATO Minimal left-hand-pizzicato cross-format roundtrip`
+- Input: minimal MusicXML with `technical/left-hand-pizzicato`
+- Then:
+  - left-hand-pizzicato preservation/degrade assertion per policy
+
+72. `CFFP-BOWING-DIRECTION Minimal bowing-direction cross-format roundtrip`
+- Input: minimal MusicXML with `technical/up-bow` and `technical/down-bow`
+- Then:
+  - bowing-direction preservation/degrade assertion per policy
+
+73. `CFFP-PERCUSSION-UNPITCHED Minimal unpitched percussion mapping cross-format roundtrip`
+- Input: minimal MusicXML with `unpitched` + `display-step` / `display-octave`
+- Then:
+  - unpitched mapping preservation/degrade assertion per policy
+
+74. `CFFP-PERCUSSION-NOTEHEAD Minimal percussion notehead variants cross-format roundtrip`
+- Input: minimal MusicXML with percussion `notehead` variants (`x`, `triangle`)
+- Then:
+  - percussion notehead preservation/degrade assertion per policy
+
+75. `CFFP-PERCUSSION-INSTRUMENT-ID Minimal percussion instrument-id mapping cross-format roundtrip`
+- Input: minimal MusicXML with `score-instrument` and note-level `instrument id`
+- Then:
+  - instrument-id preservation/degrade assertion per policy
+
+76. `CFFP-PERCUSSION-VOICE-LAYER Minimal percussion voice-layer split cross-format roundtrip`
+- Input: minimal MusicXML with percussion lanes split by `voice` plus `backup/forward`
+- Then:
+  - voice-layer preservation/degrade assertion per policy
+
+77. `CFFP-PERCUSSION-STAFF-LINE Minimal percussion staff-lines policy cross-format roundtrip`
+- Input: minimal MusicXML with `staff-details/staff-lines`
+- Then:
+  - staff-lines preservation/degrade assertion per policy
+
+78. `CFFP-TRANSPOSING-INSTRUMENT Minimal transposing-instrument hint cross-format roundtrip`
+- Input: minimal MusicXML with `attributes/transpose` (e.g. Clarinet in A intent)
+- Then:
+  - transpose hint preservation/degrade assertion per policy
+
+79. `CFFP-TIMEWISE-BACKUP-FORWARD Minimal backup/forward progression cross-format roundtrip`
+- Input: minimal MusicXML with combined `backup` and `forward`
+- Then:
+  - timewise progression marker preservation/degrade assertion per policy
+
+80. `CFFP-CROSS-STAFF-BEAM Minimal cross-staff beam cross-format roundtrip`
+- Input: minimal MusicXML with two staves and beam spanning staff assignment
+- Then:
+  - cross-staff beam marker preservation/degrade assertion per policy
+
+81. `CFFP-CHORD-SYMBOL-ALTER Minimal harmony alter/tension cross-format roundtrip`
+- Input: minimal MusicXML with `harmony/degree` alters (e.g. `#11`, `b9`)
+- Then:
+  - harmony alter preservation/degrade assertion per policy
+
+82. `CFFP-NOTE-TIES-CROSS-MEASURE Minimal cross-measure tie linkage cross-format roundtrip`
+- Input: minimal MusicXML with `tie` start/stop across barline
+- Then:
+  - cross-measure tie preservation/degrade assertion per policy
+
+83. `CFFP-MULTI-REST-COUNT Minimal multi-rest count cross-format roundtrip`
+- Input: minimal MusicXML with `measure-style/multiple-rest`
+- Then:
+  - multiple-rest count preservation/degrade assertion per policy
+
+84. `CFFP-REPEAT-JUMP-SOUND Minimal repeat-jump sound attributes cross-format roundtrip`
+- Input: minimal MusicXML with direction `sound` attributes (`fine` / `tocoda` / `coda` / `segno`)
+- Then:
+  - jump sound attribute preservation/degrade assertion per policy
+
+85. `CFFP-CUE-GRACE-MIX Minimal cue+grace mixed notation cross-format roundtrip`
+- Input: minimal MusicXML mixing `cue` note and `grace` note
+- Then:
+  - cue/grace marker preservation/degrade assertion per policy
+
+86. `CFFP-ACCIDENTAL-COURTESY-MODE Minimal courtesy accidental flags cross-format roundtrip`
+- Input: minimal MusicXML with `accidental` cautionary/parentheses flags
+- Then:
+  - courtesy accidental flag preservation/degrade assertion per policy
+
+87. `CFFP-LYRICS-MULTI-VERSE Minimal multi-verse lyric cross-format roundtrip`
+- Input: minimal MusicXML with `lyric number=1,2`
+- Then:
+  - multi-verse lyric preservation/degrade assertion per policy
+
+88. `CFFP-TEXT-ENCODING Minimal non-ASCII text encoding cross-format roundtrip`
+- Input: minimal MusicXML with Japanese lyric and non-ASCII words
+- Then:
+  - text encoding preservation/degrade assertion per policy
+
+89. `CFFP-HARMONIC-NATURAL-ARTIFICIAL Minimal harmonic variants cross-format roundtrip`
+- Input: minimal MusicXML with `technical/harmonic` natural/artificial
+- Then:
+  - harmonic variant preservation/degrade assertion per policy
+
+90. `CFFP-OPEN-STRING Minimal open-string technique cross-format roundtrip`
+- Input: minimal MusicXML with `technical/open-string`
+- Then:
+  - open-string preservation/degrade assertion per policy
+
+91. `CFFP-STOPPED Minimal stopped technique cross-format roundtrip`
+- Input: minimal MusicXML with `technical/stopped`
+- Then:
+  - stopped technique preservation/degrade assertion per policy
+
+92. `CFFP-SNAP-PIZZICATO Minimal snap-pizzicato technique cross-format roundtrip`
+- Input: minimal MusicXML with `technical/snap-pizzicato`
+- Then:
+  - snap-pizzicato preservation/degrade assertion per policy
+
+93. `CFFP-FINGERING Minimal fingering variants cross-format roundtrip`
+- Input: minimal MusicXML with multiple `technical/fingering` values
+- Then:
+  - fingering preservation/degrade assertion per policy
+
+94. `CFFP-STRING Minimal string indication cross-format roundtrip`
+- Input: minimal MusicXML with `technical/string` values
+- Then:
+  - string indication preservation/degrade assertion per policy
+
+95. `CFFP-DOUBLE-TRIPLE-TONGUE Minimal tonguing articulation cross-format roundtrip`
+- Input: minimal MusicXML with `double-tongue` and `triple-tongue`
+- Then:
+  - tonguing articulation preservation/degrade assertion per policy
+
+96. `CFFP-HEEL-TOE Minimal organ pedal technique cross-format roundtrip`
+- Input: minimal MusicXML with `technical/heel` and `technical/toe`
+- Then:
+  - heel/toe preservation/degrade assertion per policy
+
+97. `CFFP-PLUCK-TEXT Minimal pluck text cross-format roundtrip`
+- Input: minimal MusicXML with `technical/pluck` text (`p`, `i`, `m`, `a`)
+- Then:
+  - pluck text preservation/degrade assertion per policy
+
+98. `CFFP-BREATH-VARIANTS Minimal breath-mark variants cross-format roundtrip`
+- Input: minimal MusicXML with breath-mark variant text (comma/tick)
+- Then:
+  - breath-mark variant preservation/degrade assertion per policy
+
+99. `CFFP-BREATH-PLACEMENT Minimal breath-mark placement cross-format roundtrip`
+- Input: minimal MusicXML with breath-mark placement/default position attributes
+- Then:
+  - breath placement preservation/degrade assertion per policy
+
+100. `CFFP-CAESURA-STYLE Minimal caesura style-family cross-format roundtrip`
+- Input: minimal MusicXML with multiple caesura marks
+- Then:
+  - caesura marker/style-family preservation/degrade assertion per policy

--- a/tests/unit/cffp-series.spec.ts
+++ b/tests/unit/cffp-series.spec.ts
@@ -1,0 +1,2212 @@
+// @vitest-environment jsdom
+import { beforeAll, describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { parseMusicXmlDocument } from "../../src/ts/musicxml-io";
+import { convertAbcToMusicXml, exportMusicXmlDomToAbc } from "../../src/ts/abc-io";
+import { convertMeiToMusicXml, exportMusicXmlDomToMei } from "../../src/ts/mei-io";
+import { convertLilyPondToMusicXml, exportMusicXmlDomToLilyPond } from "../../src/ts/lilypond-io";
+import { convertMuseScoreToMusicXml, exportMusicXmlDomToMuseScore } from "../../src/ts/musescore-io";
+import { convertMusicXmlToVsqx, convertVsqxToMusicXml, isVsqxBridgeAvailable } from "../../src/ts/vsqx-io";
+import {
+  buildMidiBytesForPlayback,
+  buildPlaybackEventsFromMusicXmlDoc,
+  collectMidiControlEventsFromMusicXmlDoc,
+  collectMidiKeySignatureEventsFromMusicXmlDoc,
+  collectMidiProgramOverridesFromMusicXmlDoc,
+  collectMidiTempoEventsFromMusicXmlDoc,
+  collectMidiTimeSignatureEventsFromMusicXmlDoc,
+  convertMidiToMusicXml,
+} from "../../src/ts/midi-io";
+
+const parseDoc = (xml: string): Document => {
+  const doc = parseMusicXmlDocument(xml);
+  expect(doc).not.toBeNull();
+  if (!doc) throw new Error("failed to parse MusicXML");
+  return doc;
+};
+
+const ensureMidiWriterLoaded = (): void => {
+  const maybeWindow = window as Window & { MidiWriter?: unknown };
+  if (maybeWindow.MidiWriter) return;
+  const runtimeJs = readFileSync(resolve(process.cwd(), "src", "js", "midi-writer.js"), "utf-8");
+  window.eval(runtimeJs);
+  expect(maybeWindow.MidiWriter).toBeDefined();
+};
+
+const ensureVsqxBridgeLoaded = (): void => {
+  if (isVsqxBridgeAvailable()) return;
+  const runtimeJs = readFileSync(
+    resolve(process.cwd(), "src", "vendor", "utaformatix3", "utaformatix3-ts-plus.mikuscore.iife.js"),
+    "utf-8"
+  );
+  window.eval(runtimeJs);
+};
+
+const firstPitchedFact = (doc: Document): { step: string; octave: number; quarterLen: number; startDiv: number } => {
+  let currentDivisions = 1;
+  let cursorDiv = 0;
+  const part = doc.querySelector("score-partwise > part");
+  if (!part) throw new Error("missing part");
+  for (const measure of Array.from(part.querySelectorAll(":scope > measure"))) {
+    const parsedDivisions = Number(measure.querySelector(":scope > attributes > divisions")?.textContent?.trim() || "");
+    if (Number.isFinite(parsedDivisions) && parsedDivisions > 0) {
+      currentDivisions = parsedDivisions;
+    }
+    for (const child of Array.from(measure.children)) {
+      if (child.tagName === "backup") {
+        const d = Number(child.querySelector(":scope > duration")?.textContent?.trim() || "0");
+        if (Number.isFinite(d) && d > 0) cursorDiv = Math.max(0, cursorDiv - d);
+        continue;
+      }
+      if (child.tagName !== "note") continue;
+      const isChord = child.querySelector(":scope > chord") !== null;
+      const isRest = child.querySelector(":scope > rest") !== null;
+      const isGrace = child.querySelector(":scope > grace") !== null;
+      const duration = Number(child.querySelector(":scope > duration")?.textContent?.trim() || "0");
+      const startDiv = cursorDiv;
+      if (!isRest) {
+        const step = child.querySelector(":scope > pitch > step")?.textContent?.trim() || "";
+        const octave = Number(child.querySelector(":scope > pitch > octave")?.textContent?.trim() || "0");
+        if (step && Number.isFinite(octave)) {
+          return {
+            step,
+            octave,
+            quarterLen: (Number.isFinite(duration) && duration > 0 ? duration : 0) / currentDivisions,
+            startDiv,
+          };
+        }
+      }
+      if (!isChord && !isGrace && Number.isFinite(duration) && duration > 0) {
+        cursorDiv += duration;
+      }
+    }
+  }
+  throw new Error("no pitched note found");
+};
+
+const roundtripAbc = (srcDoc: Document): Document => parseDoc(convertAbcToMusicXml(exportMusicXmlDomToAbc(srcDoc)));
+const roundtripMei = (srcDoc: Document): Document => parseDoc(convertMeiToMusicXml(exportMusicXmlDomToMei(srcDoc)));
+const roundtripLilyPond = (srcDoc: Document): Document =>
+  parseDoc(convertLilyPondToMusicXml(exportMusicXmlDomToLilyPond(srcDoc), { debugMetadata: true }));
+const roundtripMuseScore = (srcDoc: Document): Document =>
+  parseDoc(convertMuseScoreToMusicXml(exportMusicXmlDomToMuseScore(srcDoc), { sourceMetadata: false, debugMetadata: false }));
+const roundtripMidi = (srcDoc: Document): Document => {
+  const ticksPerQuarter = 128;
+  const playback = buildPlaybackEventsFromMusicXmlDoc(srcDoc, ticksPerQuarter, { mode: "midi" });
+  const midiBytes = buildMidiBytesForPlayback(
+    playback.events,
+    playback.tempo,
+    "electric_piano_2",
+    collectMidiProgramOverridesFromMusicXmlDoc(srcDoc),
+    collectMidiControlEventsFromMusicXmlDoc(srcDoc, ticksPerQuarter),
+    collectMidiTempoEventsFromMusicXmlDoc(srcDoc, ticksPerQuarter),
+    collectMidiTimeSignatureEventsFromMusicXmlDoc(srcDoc, ticksPerQuarter),
+    collectMidiKeySignatureEventsFromMusicXmlDoc(srcDoc, ticksPerQuarter)
+  );
+  const imported = convertMidiToMusicXml(midiBytes, { quantizeGrid: "1/16" });
+  expect(imported.ok).toBe(true);
+  return parseDoc(imported.xml);
+};
+const roundtripVsqx = (srcXml: string): Document => {
+  ensureVsqxBridgeLoaded();
+  if (!isVsqxBridgeAvailable()) throw new Error("VSQX bridge unavailable");
+  const exported = convertMusicXmlToVsqx(srcXml, { musicXml: { defaultLyric: "la" } });
+  expect(exported.ok).toBe(true);
+  const imported = convertVsqxToMusicXml(exported.vsqx, { defaultLyric: "la" });
+  expect(imported.ok).toBe(true);
+  return parseDoc(imported.xml);
+};
+
+type CffpCase = {
+  id: string;
+  xml: string;
+  requirePitchedFact?: boolean;
+  preserveByFormat: Partial<Record<"abc" | "mei" | "lilypond" | "musescore" | "midi" | "vsqx", boolean>>;
+  preservePitchByFormat?: Partial<Record<"abc" | "mei" | "lilypond" | "musescore" | "midi" | "vsqx", boolean>>;
+  preserveDurationByFormat?: Partial<Record<"abc" | "mei" | "lilypond" | "musescore" | "midi" | "vsqx", boolean>>;
+  hasFeature: (doc: Document) => boolean;
+};
+
+const CFFP_CASES: CffpCase[] = [
+  {
+    id: "CFFP-TRILL",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>P1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>960</divisions><key><fifths>0</fifths></key><time><beats>4</beats><beat-type>4</beat-type></time><clef><sign>G</sign><line>2</line></clef></attributes>
+      <note><pitch><step>A</step><octave>4</octave></pitch><duration>1920</duration><voice>1</voice><type>half</type><notations><ornaments><trill-mark/></ornaments></notations></note>
+      <note><rest/><duration>1920</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: { abc: true, lilypond: true, musescore: true },
+    hasFeature: (doc) =>
+      doc.querySelector("part > measure > note > notations > ornaments > trill-mark") !== null,
+  },
+  {
+    id: "CFFP-TRILL-VARIANTS",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>P1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>960</divisions><key><fifths>0</fifths></key><time><beats>4</beats><beat-type>4</beat-type></time><clef><sign>G</sign><line>2</line></clef></attributes>
+      <note>
+        <pitch><step>A</step><octave>4</octave></pitch>
+        <duration>1920</duration><voice>1</voice><type>half</type>
+        <notations><ornaments><trill-mark/><wavy-line type="start" number="1"/><accidental-mark>sharp</accidental-mark></ornaments></notations>
+      </note>
+      <note>
+        <pitch><step>G</step><octave>4</octave></pitch>
+        <duration>1920</duration><voice>1</voice><type>half</type>
+        <notations><ornaments><wavy-line type="stop" number="1"/></ornaments></notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: {},
+    preserveDurationByFormat: { mei: false, midi: false, vsqx: false },
+    hasFeature: (doc) => {
+      const trill = doc.querySelector("part > measure > note > notations > ornaments > trill-mark");
+      const wavyStart = doc.querySelector("part > measure > note > notations > ornaments > wavy-line[type=\"start\"]");
+      const wavyStop = doc.querySelector("part > measure > note > notations > ornaments > wavy-line[type=\"stop\"]");
+      const accidental = doc.querySelector("part > measure > note > notations > ornaments > accidental-mark");
+      return trill !== null && wavyStart !== null && wavyStop !== null && accidental !== null;
+    },
+  },
+  {
+    id: "CFFP-TURN",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>P1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>960</divisions><key><fifths>0</fifths></key><time><beats>4</beats><beat-type>4</beat-type></time><clef><sign>G</sign><line>2</line></clef></attributes>
+      <note>
+        <pitch><step>G</step><octave>4</octave></pitch>
+        <duration>1920</duration><voice>1</voice><type>half</type>
+        <notations><ornaments><turn/></ornaments></notations>
+      </note>
+      <note><rest/><duration>1920</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: {},
+    preservePitchByFormat: { abc: false, mei: false, lilypond: false, musescore: false, midi: false, vsqx: false },
+    hasFeature: (doc) =>
+      doc.querySelector("part > measure > note > notations > ornaments > turn") !== null,
+  },
+  {
+    id: "CFFP-TURN-VARIANTS",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>P1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>960</divisions><key><fifths>0</fifths></key><time><beats>4</beats><beat-type>4</beat-type></time><clef><sign>G</sign><line>2</line></clef></attributes>
+      <note>
+        <pitch><step>A</step><octave>4</octave></pitch>
+        <duration>1920</duration><voice>1</voice><type>half</type>
+        <notations><ornaments><inverted-turn/><delayed-turn/></ornaments></notations>
+      </note>
+      <note><rest/><duration>1920</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: {},
+    preservePitchByFormat: { abc: false, mei: false, lilypond: false, musescore: false, midi: false, vsqx: false },
+    hasFeature: (doc) =>
+      doc.querySelector("part > measure > note > notations > ornaments > inverted-turn") !== null &&
+      doc.querySelector("part > measure > note > notations > ornaments > delayed-turn") !== null,
+  },
+  {
+    id: "CFFP-MORDENT-VARIANTS",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>P1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>960</divisions><key><fifths>0</fifths></key><time><beats>4</beats><beat-type>4</beat-type></time><clef><sign>G</sign><line>2</line></clef></attributes>
+      <note>
+        <pitch><step>B</step><octave>4</octave></pitch>
+        <duration>1920</duration><voice>1</voice><type>half</type>
+        <notations><ornaments><mordent/><inverted-mordent/></ornaments></notations>
+      </note>
+      <note><rest/><duration>1920</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: {},
+    preservePitchByFormat: { abc: false, mei: false, lilypond: false, musescore: false, midi: false, vsqx: false },
+    hasFeature: (doc) =>
+      doc.querySelector("part > measure > note > notations > ornaments > mordent") !== null &&
+      doc.querySelector("part > measure > note > notations > ornaments > inverted-mordent") !== null,
+  },
+  {
+    id: "CFFP-ORNAMENT-ACCIDENTAL-MARK",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>P1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>960</divisions><key><fifths>0</fifths></key><time><beats>4</beats><beat-type>4</beat-type></time><clef><sign>G</sign><line>2</line></clef></attributes>
+      <note>
+        <pitch><step>A</step><octave>4</octave></pitch>
+        <duration>1920</duration><voice>1</voice><type>half</type>
+        <notations><ornaments><trill-mark/><accidental-mark>flat</accidental-mark></ornaments></notations>
+      </note>
+      <note><rest/><duration>1920</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: {},
+    preservePitchByFormat: { abc: false, mei: false, lilypond: false, musescore: false, midi: false, vsqx: false },
+    hasFeature: (doc) =>
+      doc.querySelector("part > measure > note > notations > ornaments > accidental-mark") !== null,
+  },
+  {
+    id: "CFFP-SCHLEIFER",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>P1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>960</divisions><key><fifths>0</fifths></key><time><beats>4</beats><beat-type>4</beat-type></time><clef><sign>G</sign><line>2</line></clef></attributes>
+      <note>
+        <pitch><step>A</step><octave>4</octave></pitch>
+        <duration>1920</duration><voice>1</voice><type>half</type>
+        <notations><ornaments><schleifer/></ornaments></notations>
+      </note>
+      <note><rest/><duration>1920</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: {},
+    preservePitchByFormat: { abc: false, mei: false, lilypond: false, musescore: false, midi: false, vsqx: false },
+    hasFeature: (doc) =>
+      doc.querySelector("part > measure > note > notations > ornaments > schleifer") !== null,
+  },
+  {
+    id: "CFFP-SHAKE",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>P1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>960</divisions><key><fifths>0</fifths></key><time><beats>4</beats><beat-type>4</beat-type></time><clef><sign>G</sign><line>2</line></clef></attributes>
+      <note>
+        <pitch><step>B</step><octave>4</octave></pitch>
+        <duration>1920</duration><voice>1</voice><type>half</type>
+        <notations><ornaments><shake/></ornaments></notations>
+      </note>
+      <note><rest/><duration>1920</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: {},
+    preservePitchByFormat: { abc: false, mei: false, lilypond: false, musescore: false, midi: false, vsqx: false },
+    hasFeature: (doc) =>
+      doc.querySelector("part > measure > note > notations > ornaments > shake") !== null,
+  },
+  {
+    id: "CFFP-DYNAMICS-BASIC",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>P1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>960</divisions><key><fifths>0</fifths></key><time><beats>4</beats><beat-type>4</beat-type></time><clef><sign>G</sign><line>2</line></clef></attributes>
+      <direction placement="below"><direction-type><dynamics><pp/></dynamics></direction-type></direction>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>1920</duration><voice>1</voice><type>half</type></note>
+      <direction placement="below"><direction-type><dynamics><ff/></dynamics></direction-type></direction>
+      <note><rest/><duration>1920</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: {},
+    preserveDurationByFormat: { mei: false, midi: false, vsqx: false },
+    hasFeature: (doc) => {
+      const pp = doc.querySelector("part > measure > direction > direction-type > dynamics > pp");
+      const ff = doc.querySelector("part > measure > direction > direction-type > dynamics > ff");
+      return pp !== null && ff !== null;
+    },
+  },
+  {
+    id: "CFFP-DYNAMICS-ACCENTED",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>P1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>960</divisions><key><fifths>0</fifths></key><time><beats>4</beats><beat-type>4</beat-type></time><clef><sign>G</sign><line>2</line></clef></attributes>
+      <direction><direction-type><dynamics><mf/></dynamics></direction-type></direction>
+      <note><pitch><step>D</step><octave>4</octave></pitch><duration>1920</duration><voice>1</voice><type>half</type></note>
+      <direction><direction-type><dynamics><sfz/></dynamics></direction-type></direction>
+      <note><rest/><duration>1920</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: {},
+    preservePitchByFormat: { abc: false, mei: false, lilypond: false, musescore: false, midi: false, vsqx: false },
+    hasFeature: (doc) => {
+      const mf = doc.querySelector("part > measure > direction > direction-type > dynamics > mf");
+      const sfz = doc.querySelector("part > measure > direction > direction-type > dynamics > sfz");
+      return mf !== null && sfz !== null;
+    },
+  },
+  {
+    id: "CFFP-DYNAMICS-WEDGE",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>P1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>960</divisions><key><fifths>0</fifths></key><time><beats>4</beats><beat-type>4</beat-type></time><clef><sign>G</sign><line>2</line></clef></attributes>
+      <direction><direction-type><wedge type="crescendo" number="1"/></direction-type></direction>
+      <note><pitch><step>E</step><octave>4</octave></pitch><duration>1920</duration><voice>1</voice><type>half</type></note>
+      <direction><direction-type><wedge type="stop" number="1"/></direction-type></direction>
+      <direction><direction-type><wedge type="diminuendo" number="2"/></direction-type></direction>
+      <note><rest/><duration>1920</duration><voice>1</voice><type>half</type></note>
+      <direction><direction-type><wedge type="stop" number="2"/></direction-type></direction>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: {},
+    preserveDurationByFormat: { mei: false, midi: false, vsqx: false },
+    hasFeature: (doc) => {
+      const cres = doc.querySelector("part > measure > direction > direction-type > wedge[type=\"crescendo\"]");
+      const dim = doc.querySelector("part > measure > direction > direction-type > wedge[type=\"diminuendo\"]");
+      return cres !== null && dim !== null;
+    },
+  },
+  {
+    id: "CFFP-FERMATA",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>P1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>960</divisions><key><fifths>0</fifths></key><time><beats>4</beats><beat-type>4</beat-type></time><clef><sign>G</sign><line>2</line></clef></attributes>
+      <note>
+        <pitch><step>G</step><octave>4</octave></pitch>
+        <duration>3840</duration><voice>1</voice><type>whole</type>
+        <notations><fermata type="upright">normal</fermata></notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: {},
+    hasFeature: (doc) =>
+      doc.querySelector("part > measure > note > notations > fermata") !== null,
+  },
+  {
+    id: "CFFP-ARPEGGIATE",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>P1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>960</divisions><key><fifths>0</fifths></key><time><beats>4</beats><beat-type>4</beat-type></time><clef><sign>G</sign><line>2</line></clef></attributes>
+      <note>
+        <chord/>
+        <pitch><step>E</step><octave>4</octave></pitch>
+        <duration>1920</duration><voice>1</voice><type>half</type>
+        <notations><arpeggiate number="1"/></notations>
+      </note>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>1920</duration><voice>1</voice><type>half</type>
+        <notations><arpeggiate number="1"/></notations>
+      </note>
+      <note><rest/><duration>1920</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: {},
+    preservePitchByFormat: { abc: false, mei: false, lilypond: false, musescore: false, midi: false, vsqx: false },
+    hasFeature: (doc) =>
+      doc.querySelector("part > measure > note > notations > arpeggiate") !== null,
+  },
+  {
+    id: "CFFP-BREATH-CAESURA",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>P1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>960</divisions><key><fifths>0</fifths></key><time><beats>4</beats><beat-type>4</beat-type></time><clef><sign>G</sign><line>2</line></clef></attributes>
+      <note>
+        <pitch><step>E</step><octave>4</octave></pitch>
+        <duration>1920</duration><voice>1</voice><type>half</type>
+        <notations><articulations><breath-mark/><caesura/></articulations></notations>
+      </note>
+      <note><rest/><duration>1920</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: {},
+    hasFeature: (doc) =>
+      doc.querySelector("part > measure > note > notations > articulations > breath-mark") !== null &&
+      doc.querySelector("part > measure > note > notations > articulations > caesura") !== null,
+  },
+  {
+    id: "CFFP-GLISSANDO",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>P1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>960</divisions><key><fifths>0</fifths></key><time><beats>4</beats><beat-type>4</beat-type></time><clef><sign>G</sign><line>2</line></clef></attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>1920</duration><voice>1</voice><type>half</type>
+        <notations><glissando type="start" number="1">wavy</glissando></notations>
+      </note>
+      <note>
+        <pitch><step>G</step><octave>4</octave></pitch>
+        <duration>1920</duration><voice>1</voice><type>half</type>
+        <notations><glissando type="stop" number="1">wavy</glissando></notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: {},
+    hasFeature: (doc) =>
+      doc.querySelector("part > measure > note > notations > glissando[type=\"start\"]") !== null &&
+      doc.querySelector("part > measure > note > notations > glissando[type=\"stop\"]") !== null,
+  },
+  {
+    id: "CFFP-PEDAL",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>P1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>960</divisions><key><fifths>0</fifths></key><time><beats>4</beats><beat-type>4</beat-type></time><clef><sign>G</sign><line>2</line></clef></attributes>
+      <direction><direction-type><pedal type="start" number="1"/></direction-type></direction>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>1920</duration><voice>1</voice><type>half</type></note>
+      <direction><direction-type><pedal type="stop" number="1"/></direction-type></direction>
+      <note><rest/><duration>1920</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: {},
+    hasFeature: (doc) =>
+      doc.querySelector("part > measure > direction > direction-type > pedal[type=\"start\"]") !== null &&
+      doc.querySelector("part > measure > direction > direction-type > pedal[type=\"stop\"]") !== null,
+  },
+  {
+    id: "CFFP-SEGNO-CODA",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>P1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>960</divisions><key><fifths>0</fifths></key><time><beats>4</beats><beat-type>4</beat-type></time><clef><sign>G</sign><line>2</line></clef></attributes>
+      <direction><direction-type><segno/></direction-type></direction>
+      <direction><direction-type><coda/></direction-type></direction>
+      <note><pitch><step>D</step><octave>4</octave></pitch><duration>3840</duration><voice>1</voice><type>whole</type></note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: {},
+    hasFeature: (doc) =>
+      doc.querySelector("part > measure > direction > direction-type > segno") !== null &&
+      doc.querySelector("part > measure > direction > direction-type > coda") !== null,
+  },
+  {
+    id: "CFFP-HARMONY-CHORDSYMBOL",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>P1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>960</divisions><key><fifths>0</fifths></key><time><beats>4</beats><beat-type>4</beat-type></time><clef><sign>G</sign><line>2</line></clef></attributes>
+      <harmony>
+        <root><root-step>C</root-step><root-alter>1</root-alter></root>
+        <kind text="maj7">major-seventh</kind>
+        <bass><bass-step>E</bass-step></bass>
+      </harmony>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>3840</duration><voice>1</voice><type>whole</type></note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: {},
+    hasFeature: (doc) => {
+      const rootStep = doc.querySelector("part > measure > harmony > root > root-step")?.textContent?.trim();
+      const rootAlter = Number(doc.querySelector("part > measure > harmony > root > root-alter")?.textContent?.trim() ?? "");
+      const kind = doc.querySelector("part > measure > harmony > kind")?.textContent?.trim();
+      const bass = doc.querySelector("part > measure > harmony > bass > bass-step")?.textContent?.trim();
+      return rootStep === "C" && rootAlter === 1 && kind === "major-seventh" && bass === "E";
+    },
+  },
+  {
+    id: "CFFP-KEY-MODE",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>P1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths><mode>major</mode></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>3840</duration><voice>1</voice><type>whole</type></note>
+    </measure>
+    <measure number="2">
+      <attributes><key><fifths>0</fifths><mode>minor</mode></key></attributes>
+      <note><pitch><step>A</step><octave>3</octave></pitch><duration>3840</duration><voice>1</voice><type>whole</type></note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: {},
+    hasFeature: (doc) => {
+      const m1 = doc.querySelector("part > measure:nth-of-type(1) > attributes > key > mode")?.textContent?.trim().toLowerCase() ?? "";
+      const m2 = doc.querySelector("part > measure:nth-of-type(2) > attributes > key > mode")?.textContent?.trim().toLowerCase() ?? "";
+      return m1 === "major" && m2 === "minor";
+    },
+  },
+  {
+    id: "CFFP-TECHNIQUE-TEXT",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>P1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>960</divisions><key><fifths>0</fifths></key><time><beats>4</beats><beat-type>4</beat-type></time><clef><sign>G</sign><line>2</line></clef></attributes>
+      <direction><direction-type><words>pizz.</words></direction-type></direction>
+      <direction><direction-type><words>arco</words></direction-type></direction>
+      <direction><direction-type><words>con sord.</words></direction-type></direction>
+      <note><pitch><step>G</step><octave>4</octave></pitch><duration>3840</duration><voice>1</voice><type>whole</type></note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: {},
+    hasFeature: (doc) => {
+      const words = Array.from(doc.querySelectorAll("part > measure > direction > direction-type > words")).map((n) =>
+        (n.textContent?.trim().toLowerCase() ?? "")
+      );
+      return words.includes("pizz.") && words.includes("arco") && words.includes("con sord.");
+    },
+  },
+  {
+    id: "CFFP-LEFT-HAND-PIZZICATO",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>Strings</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>960</divisions><key><fifths>0</fifths></key><time><beats>4</beats><beat-type>4</beat-type></time><clef><sign>G</sign><line>2</line></clef></attributes>
+      <note>
+        <pitch><step>A</step><octave>4</octave></pitch>
+        <duration>3840</duration><voice>1</voice><type>whole</type>
+        <notations><technical><left-hand-pizzicato/></technical></notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: {},
+    hasFeature: (doc) =>
+      doc.querySelector("part > measure > note > notations > technical > left-hand-pizzicato") !== null,
+  },
+  {
+    id: "CFFP-BOWING-DIRECTION",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>Strings</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>960</divisions><key><fifths>0</fifths></key><time><beats>4</beats><beat-type>4</beat-type></time><clef><sign>G</sign><line>2</line></clef></attributes>
+      <note>
+        <pitch><step>G</step><octave>4</octave></pitch>
+        <duration>1920</duration><voice>1</voice><type>half</type>
+        <notations><technical><up-bow/></technical></notations>
+      </note>
+      <note>
+        <pitch><step>F</step><octave>4</octave></pitch>
+        <duration>1920</duration><voice>1</voice><type>half</type>
+        <notations><technical><down-bow/></technical></notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: {},
+    hasFeature: (doc) =>
+      doc.querySelector("part > measure > note > notations > technical > up-bow") !== null &&
+      doc.querySelector("part > measure > note > notations > technical > down-bow") !== null,
+  },
+  {
+    id: "CFFP-ARTICULATION-EXT",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>P1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>960</divisions><key><fifths>0</fifths></key><time><beats>4</beats><beat-type>4</beat-type></time><clef><sign>G</sign><line>2</line></clef></attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>1280</duration><voice>1</voice><type>quarter</type>
+        <notations><articulations><tenuto/></articulations></notations>
+      </note>
+      <note>
+        <pitch><step>D</step><octave>4</octave></pitch>
+        <duration>1280</duration><voice>1</voice><type>quarter</type>
+        <notations><articulations><staccatissimo/></articulations></notations>
+      </note>
+      <note>
+        <pitch><step>E</step><octave>4</octave></pitch>
+        <duration>1280</duration><voice>1</voice><type>quarter</type>
+        <notations><articulations><strong-accent/></articulations></notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: {},
+    preserveDurationByFormat: { mei: false, musescore: false },
+    hasFeature: (doc) =>
+      doc.querySelector("part > measure > note > notations > articulations > tenuto") !== null &&
+      doc.querySelector("part > measure > note > notations > articulations > staccatissimo") !== null &&
+      doc.querySelector("part > measure > note > notations > articulations > strong-accent") !== null,
+  },
+  {
+    id: "CFFP-NOTEHEAD",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>P1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>960</divisions><key><fifths>0</fifths></key><time><beats>4</beats><beat-type>4</beat-type></time><clef><sign>G</sign><line>2</line></clef></attributes>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>1920</duration><voice>1</voice><type>half</type><notehead>cross</notehead></note>
+      <note><pitch><step>E</step><octave>4</octave></pitch><duration>1920</duration><voice>1</voice><type>half</type><notehead>diamond</notehead></note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: {},
+    hasFeature: (doc) => {
+      const heads = Array.from(doc.querySelectorAll("part > measure > note > notehead"))
+        .map((n) => n.textContent?.trim().toLowerCase() ?? "");
+      return heads.includes("cross") && heads.includes("diamond");
+    },
+  },
+  {
+    id: "CFFP-CLEF-MIDMEASURE",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>P1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>960</divisions><key><fifths>0</fifths></key><time><beats>4</beats><beat-type>4</beat-type></time><clef><sign>G</sign><line>2</line></clef></attributes>
+      <note><pitch><step>G</step><octave>4</octave></pitch><duration>1920</duration><voice>1</voice><type>half</type></note>
+      <attributes><clef><sign>F</sign><line>4</line></clef></attributes>
+      <note><pitch><step>C</step><octave>3</octave></pitch><duration>1920</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: {},
+    hasFeature: (doc) => {
+      const clefs = Array.from(doc.querySelectorAll("part > measure > attributes > clef > sign"))
+        .map((n) => n.textContent?.trim().toUpperCase() ?? "");
+      return clefs.includes("G") && clefs.includes("F");
+    },
+  },
+  {
+    id: "CFFP-STEM-BEAM-DIR",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>P1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>960</divisions><key><fifths>0</fifths></key><time><beats>4</beats><beat-type>4</beat-type></time><clef><sign>G</sign><line>2</line></clef></attributes>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>480</duration><voice>1</voice><type>eighth</type><stem>up</stem><beam number="1">begin</beam></note>
+      <note><pitch><step>D</step><octave>4</octave></pitch><duration>480</duration><voice>1</voice><type>eighth</type><stem>down</stem><beam number="1">end</beam></note>
+      <note><rest/><duration>2880</duration><voice>1</voice><type>half</type><dot/></note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: {},
+    hasFeature: (doc) => {
+      const stems = Array.from(doc.querySelectorAll("part > measure > note > stem"))
+        .map((n) => n.textContent?.trim().toLowerCase() ?? "");
+      const beams = Array.from(doc.querySelectorAll("part > measure > note > beam[number=\"1\"]"))
+        .map((n) => n.textContent?.trim().toLowerCase() ?? "");
+      return stems.includes("up") && stems.includes("down") && beams.includes("begin") && beams.includes("end");
+    },
+  },
+  {
+    id: "CFFP-VOICE-STAFF-SWAP",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>Piano</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions><key><fifths>0</fifths></key><time><beats>4</beats><beat-type>4</beat-type></time>
+        <staves>2</staves>
+        <clef number="1"><sign>G</sign><line>2</line></clef>
+        <clef number="2"><sign>F</sign><line>4</line></clef>
+      </attributes>
+      <note><pitch><step>G</step><octave>4</octave></pitch><duration>1920</duration><voice>1</voice><type>half</type><staff>1</staff></note>
+      <note><pitch><step>C</step><octave>3</octave></pitch><duration>1920</duration><voice>1</voice><type>half</type><staff>2</staff></note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: {},
+    preservePitchByFormat: { abc: false, mei: false, lilypond: false, musescore: false, midi: false, vsqx: false },
+    hasFeature: (doc) => {
+      const notes = Array.from(doc.querySelectorAll("part > measure > note"));
+      const v1s1 = notes.some((n) => {
+        const v = n.querySelector(":scope > voice")?.textContent?.trim();
+        const s = n.querySelector(":scope > staff")?.textContent?.trim();
+        return v === "1" && s === "1";
+      });
+      const v1s2 = notes.some((n) => {
+        const v = n.querySelector(":scope > voice")?.textContent?.trim();
+        const s = n.querySelector(":scope > staff")?.textContent?.trim();
+        return v === "1" && s === "2";
+      });
+      return v1s1 && v1s2;
+    },
+  },
+  {
+    id: "CFFP-MEASURE-STYLE",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>P1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions><key><fifths>0</fifths></key><time><beats>4</beats><beat-type>4</beat-type></time><clef><sign>G</sign><line>2</line></clef>
+        <measure-style><slash type="start"/></measure-style>
+      </attributes>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>3840</duration><voice>1</voice><type>whole</type></note>
+    </measure>
+    <measure number="2">
+      <attributes><measure-style><multiple-rest>2</multiple-rest><slash type="stop"/></measure-style></attributes>
+      <note><pitch><step>D</step><octave>4</octave></pitch><duration>3840</duration><voice>1</voice><type>whole</type></note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: {},
+    hasFeature: (doc) => {
+      const slashStart = doc.querySelector("part > measure:nth-of-type(1) > attributes > measure-style > slash[type=\"start\"]");
+      const slashStop = doc.querySelector("part > measure:nth-of-type(2) > attributes > measure-style > slash[type=\"stop\"]");
+      const multi = Number(
+        doc.querySelector("part > measure:nth-of-type(2) > attributes > measure-style > multiple-rest")?.textContent?.trim() ?? ""
+      );
+      return slashStart !== null && slashStop !== null && multi === 2;
+    },
+  },
+  {
+    id: "CFFP-PRINT-LAYOUT-MIN",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>P1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <print new-system="yes"/>
+      <attributes><divisions>960</divisions><key><fifths>0</fifths></key><time><beats>4</beats><beat-type>4</beat-type></time><clef><sign>G</sign><line>2</line></clef></attributes>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>3840</duration><voice>1</voice><type>whole</type></note>
+    </measure>
+    <measure number="2">
+      <print new-page="yes"/>
+      <note><pitch><step>D</step><octave>4</octave></pitch><duration>3840</duration><voice>1</voice><type>whole</type></note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: {},
+    hasFeature: (doc) => {
+      const m1 = doc.querySelector("part > measure:nth-of-type(1) > print[new-system=\"yes\"]");
+      const m2 = doc.querySelector("part > measure:nth-of-type(2) > print[new-page=\"yes\"]");
+      return m1 !== null && m2 !== null;
+    },
+  },
+  {
+    id: "CFFP-MIDMEASURE-REPEAT",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>P1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>960</divisions><key><fifths>0</fifths></key><time><beats>4</beats><beat-type>4</beat-type></time><clef><sign>G</sign><line>2</line></clef></attributes>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>960</duration><voice>1</voice><type>quarter</type></note>
+      <direction><direction-type><words>||:</words></direction-type><sound forward-repeat="yes"/></direction>
+      <note><pitch><step>D</step><octave>4</octave></pitch><duration>960</duration><voice>1</voice><type>quarter</type></note>
+      <direction><direction-type><words>:||</words></direction-type><sound backward-repeat="yes"/></direction>
+      <note><pitch><step>E</step><octave>4</octave></pitch><duration>1920</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: {},
+    hasFeature: (doc) => {
+      const fwd = doc.querySelector("part > measure > direction > sound[forward-repeat=\"yes\"]");
+      const back = doc.querySelector("part > measure > direction > sound[backward-repeat=\"yes\"]");
+      return fwd !== null && back !== null;
+    },
+  },
+  {
+    id: "CFFP-OTTAVA-NUMBERING",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>P1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>960</divisions><key><fifths>0</fifths></key><time><beats>4</beats><beat-type>4</beat-type></time><clef><sign>G</sign><line>2</line></clef></attributes>
+      <direction><direction-type><octave-shift type="up" size="8" number="1"/></direction-type></direction>
+      <note><pitch><step>C</step><octave>5</octave></pitch><duration>960</duration><voice>1</voice><type>quarter</type></note>
+      <direction><direction-type><octave-shift type="up" size="8" number="2"/></direction-type></direction>
+      <note><pitch><step>D</step><octave>5</octave></pitch><duration>960</duration><voice>1</voice><type>quarter</type></note>
+      <direction><direction-type><octave-shift type="stop" size="8" number="1"/></direction-type></direction>
+      <note><pitch><step>E</step><octave>5</octave></pitch><duration>960</duration><voice>1</voice><type>quarter</type></note>
+      <direction><direction-type><octave-shift type="stop" size="8" number="2"/></direction-type></direction>
+      <note><pitch><step>F</step><octave>5</octave></pitch><duration>960</duration><voice>1</voice><type>quarter</type></note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: {},
+    preservePitchByFormat: { musescore: false, midi: false, vsqx: false },
+    hasFeature: (doc) => {
+      const starts = Array.from(doc.querySelectorAll("part > measure > direction > direction-type > octave-shift[type=\"up\"]"))
+        .map((n) => n.getAttribute("number") ?? "");
+      const stops = Array.from(doc.querySelectorAll("part > measure > direction > direction-type > octave-shift[type=\"stop\"]"))
+        .map((n) => n.getAttribute("number") ?? "");
+      return starts.includes("1") && starts.includes("2") && stops.includes("1") && stops.includes("2");
+    },
+  },
+  {
+    id: "CFFP-LYRIC-BASIC",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>Vocal</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>960</divisions><key><fifths>0</fifths></key><time><beats>4</beats><beat-type>4</beat-type></time><clef><sign>G</sign><line>2</line></clef></attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>1920</duration><voice>1</voice><type>half</type>
+        <lyric number="1"><syllabic>begin</syllabic><text>la</text></lyric>
+      </note>
+      <note>
+        <pitch><step>D</step><octave>4</octave></pitch>
+        <duration>1920</duration><voice>1</voice><type>half</type>
+        <lyric number="1"><syllabic>end</syllabic><extend/></lyric>
+      </note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: {},
+    hasFeature: (doc) => {
+      const text = doc.querySelector("part > measure > note > lyric > text")?.textContent?.trim().toLowerCase() ?? "";
+      const hasExtend = doc.querySelector("part > measure > note > lyric > extend") !== null;
+      return text === "la" && hasExtend;
+    },
+  },
+  {
+    id: "CFFP-SLIDE",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>P1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>960</divisions><key><fifths>0</fifths></key><time><beats>4</beats><beat-type>4</beat-type></time><clef><sign>G</sign><line>2</line></clef></attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>1920</duration><voice>1</voice><type>half</type>
+        <notations><slide type="start" number="1"/></notations>
+      </note>
+      <note>
+        <pitch><step>G</step><octave>4</octave></pitch>
+        <duration>1920</duration><voice>1</voice><type>half</type>
+        <notations><slide type="stop" number="1"/></notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: {},
+    hasFeature: (doc) =>
+      doc.querySelector("part > measure > note > notations > slide[type=\"start\"]") !== null &&
+      doc.querySelector("part > measure > note > notations > slide[type=\"stop\"]") !== null,
+  },
+  {
+    id: "CFFP-TREMOLO",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>P1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>960</divisions><key><fifths>0</fifths></key><time><beats>4</beats><beat-type>4</beat-type></time><clef><sign>G</sign><line>2</line></clef></attributes>
+      <note>
+        <pitch><step>E</step><octave>4</octave></pitch>
+        <duration>960</duration><voice>1</voice><type>quarter</type>
+        <notations><ornaments><tremolo type="single">3</tremolo></ornaments></notations>
+      </note>
+      <note>
+        <pitch><step>F</step><octave>4</octave></pitch>
+        <duration>1440</duration><voice>1</voice><type>quarter</type><dot/>
+        <notations><ornaments><tremolo type="start">2</tremolo></ornaments></notations>
+      </note>
+      <note>
+        <pitch><step>G</step><octave>4</octave></pitch>
+        <duration>1440</duration><voice>1</voice><type>quarter</type><dot/>
+        <notations><ornaments><tremolo type="stop">2</tremolo></ornaments></notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: {},
+    hasFeature: (doc) =>
+      doc.querySelector("part > measure > note > notations > ornaments > tremolo[type=\"single\"]") !== null &&
+      doc.querySelector("part > measure > note > notations > ornaments > tremolo[type=\"start\"]") !== null &&
+      doc.querySelector("part > measure > note > notations > ornaments > tremolo[type=\"stop\"]") !== null,
+  },
+  {
+    id: "CFFP-REHEARSAL-MARK",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>P1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>960</divisions><key><fifths>0</fifths></key><time><beats>4</beats><beat-type>4</beat-type></time><clef><sign>G</sign><line>2</line></clef></attributes>
+      <direction><direction-type><rehearsal>A1</rehearsal></direction-type></direction>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>3840</duration><voice>1</voice><type>whole</type></note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: {},
+    hasFeature: (doc) =>
+      (doc.querySelector("part > measure > direction > direction-type > rehearsal")?.textContent?.trim() ?? "") === "A1",
+  },
+  {
+    id: "CFFP-DA-CAPO-DAL-SEGNO",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>P1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>960</divisions><key><fifths>0</fifths></key><time><beats>4</beats><beat-type>4</beat-type></time><clef><sign>G</sign><line>2</line></clef></attributes>
+      <direction><direction-type><words>Da Capo</words></direction-type><sound dacapo="yes"/></direction>
+      <direction><direction-type><words>Dal Segno</words></direction-type><sound dalsegno="segno1"/></direction>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>3840</duration><voice>1</voice><type>whole</type></note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: {},
+    hasFeature: (doc) => {
+      const words = Array.from(doc.querySelectorAll("part > measure > direction > direction-type > words"))
+        .map((n) => n.textContent?.trim().toLowerCase() ?? "");
+      const hasDaCapoWord = words.some((w) => w.includes("da capo"));
+      const hasDalSegnoWord = words.some((w) => w.includes("dal segno"));
+      const hasDaCapoSound = doc.querySelector("part > measure > direction > sound[dacapo=\"yes\"]") !== null;
+      const hasDalSegnoSound = doc.querySelector("part > measure > direction > sound[dalsegno]") !== null;
+      return hasDaCapoWord && hasDalSegnoWord && hasDaCapoSound && hasDalSegnoSound;
+    },
+  },
+  {
+    id: "CFFP-ENDING-TYPE",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>P1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>960</divisions><key><fifths>0</fifths></key><time><beats>4</beats><beat-type>4</beat-type></time><clef><sign>G</sign><line>2</line></clef></attributes>
+      <barline location="left"><ending number="1" type="start"/></barline>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>3840</duration><voice>1</voice><type>whole</type></note>
+    </measure>
+    <measure number="2">
+      <barline location="left"><ending number="1" type="stop"/></barline>
+      <barline location="right"><ending number="2" type="discontinue"/></barline>
+      <note><pitch><step>D</step><octave>4</octave></pitch><duration>3840</duration><voice>1</voice><type>whole</type></note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: {},
+    hasFeature: (doc) => {
+      const start = doc.querySelector("part > measure:nth-of-type(1) > barline[location=\"left\"] > ending[type=\"start\"]");
+      const stop = doc.querySelector("part > measure:nth-of-type(2) > barline[location=\"left\"] > ending[type=\"stop\"]");
+      const discontinue = doc.querySelector("part > measure:nth-of-type(2) > barline[location=\"right\"] > ending[type=\"discontinue\"]");
+      return start !== null && stop !== null && discontinue !== null;
+    },
+  },
+  {
+    id: "CFFP-ACCIDENTAL",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>P1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>960</divisions><key><fifths>1</fifths></key><time><beats>4</beats><beat-type>4</beat-type></time><clef><sign>G</sign><line>2</line></clef></attributes>
+      <note><pitch><step>F</step><octave>4</octave></pitch><duration>960</duration><voice>1</voice><type>quarter</type><accidental>natural</accidental></note>
+      <note><pitch><step>F</step><alter>1</alter><octave>4</octave></pitch><duration>2880</duration><voice>1</voice><type>half</type><dot/></note>
+    </measure>
+    <measure number="2">
+      <note><pitch><step>F</step><alter>1</alter><octave>4</octave></pitch><duration>3840</duration><voice>1</voice><type>whole</type></note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: { abc: true, lilypond: true, musescore: true },
+    hasFeature: (doc) => {
+      const m1n1 = doc.querySelector("part > measure:nth-of-type(1) > note:nth-of-type(1)");
+      const m1n2 = doc.querySelector("part > measure:nth-of-type(1) > note:nth-of-type(2)");
+      const m2n1 = doc.querySelector("part > measure:nth-of-type(2) > note:nth-of-type(1)");
+      const a1 = m1n1?.querySelector(":scope > accidental")?.textContent?.trim().toLowerCase() ?? "";
+      const al2 = Number(m1n2?.querySelector(":scope > pitch > alter")?.textContent?.trim() ?? "0");
+      const al3 = Number(m2n1?.querySelector(":scope > pitch > alter")?.textContent?.trim() ?? "0");
+      return a1 === "natural" && al2 === 1 && al3 === 1;
+    },
+  },
+  {
+    id: "CFFP-ACCIDENTAL-RESET",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>P1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>960</divisions><key><fifths>0</fifths></key><time><beats>4</beats><beat-type>4</beat-type></time><clef><sign>G</sign><line>2</line></clef></attributes>
+      <note><pitch><step>F</step><alter>1</alter><octave>4</octave></pitch><duration>1920</duration><voice>1</voice><type>half</type><accidental>sharp</accidental></note>
+      <note><rest/><duration>1920</duration><voice>1</voice><type>half</type></note>
+    </measure>
+    <measure number="2">
+      <note><pitch><step>F</step><octave>4</octave></pitch><duration>3840</duration><voice>1</voice><type>whole</type></note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: { abc: true, mei: true, lilypond: true, musescore: true, midi: true },
+    preservePitchByFormat: { vsqx: false },
+    hasFeature: (doc) => {
+      const m1n1 = doc.querySelector("part > measure:nth-of-type(1) > note:nth-of-type(1)");
+      const m2n1 = doc.querySelector("part > measure:nth-of-type(2) > note:nth-of-type(1)");
+      const m1Alter = Number(m1n1?.querySelector(":scope > pitch > alter")?.textContent?.trim() ?? "0");
+      const m2AlterRaw = m2n1?.querySelector(":scope > pitch > alter")?.textContent?.trim() ?? "";
+      return m1Alter === 1 && (m2AlterRaw === "" || Number(m2AlterRaw) === 0);
+    },
+  },
+  {
+    id: "CFFP-COURTESY-ACCIDENTAL",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>P1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>960</divisions><key><fifths>0</fifths></key><time><beats>4</beats><beat-type>4</beat-type></time><clef><sign>G</sign><line>2</line></clef></attributes>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>3840</duration><voice>1</voice><type>whole</type><accidental cautionary="yes">natural</accidental></note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: {},
+    hasFeature: (doc) =>
+      doc.querySelector("part > measure > note > accidental[cautionary=\"yes\"]") !== null,
+  },
+  {
+    id: "CFFP-BEAM-CONTINUITY",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>P1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>960</divisions><key><fifths>0</fifths></key><time><beats>4</beats><beat-type>4</beat-type></time><clef><sign>G</sign><line>2</line></clef></attributes>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>480</duration><voice>1</voice><type>eighth</type><beam number="1">begin</beam></note>
+      <note><pitch><step>D</step><octave>4</octave></pitch><duration>480</duration><voice>1</voice><type>eighth</type><beam number="1">continue</beam></note>
+      <note><rest/><duration>480</duration><voice>1</voice><type>eighth</type></note>
+      <note><pitch><step>E</step><octave>4</octave></pitch><duration>480</duration><voice>1</voice><type>eighth</type><beam number="1">begin</beam></note>
+      <note><pitch><step>F</step><octave>4</octave></pitch><duration>480</duration><voice>1</voice><type>eighth</type><beam number="1">end</beam></note>
+      <note><rest/><duration>1440</duration><voice>1</voice><type>quarter</type><dot/></note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: { musescore: true },
+    preservePitchByFormat: { abc: false, mei: false, lilypond: false, musescore: false, midi: false, vsqx: false },
+    hasFeature: (doc) => {
+      const beams = Array.from(doc.querySelectorAll("part > measure > note > beam[number=\"1\"]")).map(
+        (n) => (n.textContent?.trim().toLowerCase() ?? "")
+      );
+      return beams.includes("begin") && (beams.includes("continue") || beams.includes("end"));
+    },
+  },
+  {
+    id: "CFFP-MULTIVOICE-BACKUP",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>P1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>960</divisions><key><fifths>0</fifths></key><time><beats>4</beats><beat-type>4</beat-type></time><clef><sign>G</sign><line>2</line></clef></attributes>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>3840</duration><voice>1</voice><type>whole</type></note>
+      <backup><duration>3840</duration></backup>
+      <note><rest/><duration>1920</duration><voice>2</voice><type>half</type></note>
+      <note><pitch><step>G</step><octave>3</octave></pitch><duration>1920</duration><voice>2</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: { musescore: true },
+    preservePitchByFormat: { abc: false, mei: false, lilypond: false, musescore: false, midi: false, vsqx: false },
+    hasFeature: (doc) => {
+      const hasV1 = doc.querySelector("part > measure > note > voice")?.textContent?.trim() === "1";
+      const hasV2 = Array.from(doc.querySelectorAll("part > measure > note > voice")).some((v) => v.textContent?.trim() === "2");
+      return hasV1 && hasV2;
+    },
+  },
+  {
+    id: "CFFP-PICKUP-IMPLICIT",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>P1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="0" implicit="yes">
+      <attributes><divisions>960</divisions><key><fifths>0</fifths></key><time><beats>4</beats><beat-type>4</beat-type></time><clef><sign>G</sign><line>2</line></clef></attributes>
+      <note><pitch><step>G</step><octave>4</octave></pitch><duration>960</duration><voice>1</voice><type>quarter</type></note>
+    </measure>
+    <measure number="1">
+      <note><pitch><step>C</step><octave>5</octave></pitch><duration>3840</duration><voice>1</voice><type>whole</type></note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: { musescore: true },
+    hasFeature: (doc) => {
+      const m1 = doc.querySelector("part > measure:nth-of-type(1)");
+      const num = m1?.getAttribute("number") ?? "";
+      const implicit = m1?.getAttribute("implicit") ?? "";
+      return num === "0" && implicit.toLowerCase() === "yes";
+    },
+  },
+  {
+    id: "CFFP-TRANSPOSE",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>P1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions><key><fifths>0</fifths></key><time><beats>4</beats><beat-type>4</beat-type></time><clef><sign>G</sign><line>2</line></clef>
+        <transpose><diatonic>1</diatonic><chromatic>2</chromatic></transpose>
+      </attributes>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>3840</duration><voice>1</voice><type>whole</type></note>
+    </measure>
+    <measure number="2">
+      <attributes><transpose><diatonic>-1</diatonic><chromatic>-2</chromatic></transpose></attributes>
+      <note><pitch><step>B</step><octave>3</octave></pitch><duration>3840</duration><voice>1</voice><type>whole</type></note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: {},
+    preservePitchByFormat: { abc: false, mei: false, lilypond: false, musescore: false, midi: false, vsqx: false },
+    hasFeature: (doc) => {
+      const m1d = Number(doc.querySelector("part > measure:nth-of-type(1) > attributes > transpose > diatonic")?.textContent?.trim() ?? "");
+      const m1c = Number(doc.querySelector("part > measure:nth-of-type(1) > attributes > transpose > chromatic")?.textContent?.trim() ?? "");
+      const m2d = Number(doc.querySelector("part > measure:nth-of-type(2) > attributes > transpose > diatonic")?.textContent?.trim() ?? "");
+      const m2c = Number(doc.querySelector("part > measure:nth-of-type(2) > attributes > transpose > chromatic")?.textContent?.trim() ?? "");
+      return m1d === 1 && m1c === 2 && m2d === -1 && m2c === -2;
+    },
+  },
+  {
+    id: "CFFP-GRANDSTAFF-MAPPING",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>Piano</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <staves>2</staves>
+        <clef number="1"><sign>G</sign><line>2</line></clef>
+        <clef number="2"><sign>F</sign><line>4</line></clef>
+      </attributes>
+      <note><pitch><step>C</step><octave>5</octave></pitch><duration>1920</duration><voice>1</voice><type>half</type><staff>1</staff></note>
+      <note><rest/><duration>1920</duration><voice>1</voice><type>half</type><staff>1</staff></note>
+      <backup><duration>3840</duration></backup>
+      <note><pitch><step>C</step><octave>3</octave></pitch><duration>3840</duration><voice>2</voice><type>whole</type><staff>2</staff></note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: { musescore: true },
+    preservePitchByFormat: { abc: false, mei: false, lilypond: false, musescore: false, midi: false, vsqx: false },
+    hasFeature: (doc) => {
+      const hasStaff1 = Array.from(doc.querySelectorAll("part > measure > note > staff")).some((n) => n.textContent?.trim() === "1");
+      const hasStaff2 = Array.from(doc.querySelectorAll("part > measure > note > staff")).some((n) => n.textContent?.trim() === "2");
+      return hasStaff1 && hasStaff2;
+    },
+  },
+  {
+    id: "CFFP-KEY-CHANGE",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>P1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>960</divisions><key><fifths>0</fifths></key><time><beats>4</beats><beat-type>4</beat-type></time><clef><sign>G</sign><line>2</line></clef></attributes>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>3840</duration><voice>1</voice><type>whole</type></note>
+    </measure>
+    <measure number="2">
+      <attributes><key><fifths>2</fifths></key></attributes>
+      <note><pitch><step>D</step><octave>4</octave></pitch><duration>3840</duration><voice>1</voice><type>whole</type></note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: {},
+    hasFeature: (doc) => {
+      const m1 = Number(doc.querySelector("part > measure:nth-of-type(1) > attributes > key > fifths")?.textContent?.trim() ?? "");
+      const m2 = Number(doc.querySelector("part > measure:nth-of-type(2) > attributes > key > fifths")?.textContent?.trim() ?? "");
+      return m1 === 0 && m2 === 2;
+    },
+  },
+  {
+    id: "CFFP-TIME-CHANGE",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>P1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>960</divisions><key><fifths>0</fifths></key><time><beats>4</beats><beat-type>4</beat-type></time><clef><sign>G</sign><line>2</line></clef></attributes>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>3840</duration><voice>1</voice><type>whole</type></note>
+    </measure>
+    <measure number="2">
+      <attributes><time><beats>3</beats><beat-type>4</beat-type></time></attributes>
+      <note><pitch><step>D</step><octave>4</octave></pitch><duration>2880</duration><voice>1</voice><type>half</type><dot/></note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: { mei: true, lilypond: true, musescore: true },
+    hasFeature: (doc) => {
+      const b1 = Number(doc.querySelector("part > measure:nth-of-type(1) > attributes > time > beats")?.textContent?.trim() ?? "");
+      const bt1 = Number(doc.querySelector("part > measure:nth-of-type(1) > attributes > time > beat-type")?.textContent?.trim() ?? "");
+      const b2 = Number(doc.querySelector("part > measure:nth-of-type(2) > attributes > time > beats")?.textContent?.trim() ?? "");
+      const bt2 = Number(doc.querySelector("part > measure:nth-of-type(2) > attributes > time > beat-type")?.textContent?.trim() ?? "");
+      return b1 === 4 && bt1 === 4 && b2 === 3 && bt2 === 4;
+    },
+  },
+  {
+    id: "CFFP-DOUBLE-BARLINE",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>P1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>960</divisions><key><fifths>0</fifths></key><time><beats>4</beats><beat-type>4</beat-type></time><clef><sign>G</sign><line>2</line></clef></attributes>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>3840</duration><voice>1</voice><type>whole</type></note>
+      <barline location="right"><bar-style>light-light</bar-style></barline>
+    </measure>
+    <measure number="2">
+      <note><pitch><step>D</step><octave>4</octave></pitch><duration>3840</duration><voice>1</voice><type>whole</type></note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: {},
+    hasFeature: (doc) => {
+      const bar = doc.querySelector("part > measure:nth-of-type(1) > barline[location=\"right\"] > bar-style");
+      return (bar?.textContent?.trim().toLowerCase() ?? "") === "light-light";
+    },
+  },
+  {
+    id: "CFFP-REPEAT-ENDING",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>P1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>960</divisions><key><fifths>0</fifths></key><time><beats>4</beats><beat-type>4</beat-type></time><clef><sign>G</sign><line>2</line></clef></attributes>
+      <barline location="left"><repeat direction="forward"/></barline>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>3840</duration><voice>1</voice><type>whole</type></note>
+    </measure>
+    <measure number="2">
+      <note><pitch><step>D</step><octave>4</octave></pitch><duration>3840</duration><voice>1</voice><type>whole</type></note>
+      <barline location="right"><bar-style>light-heavy</bar-style><repeat direction="backward"/><ending number="2" type="stop"/></barline>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: { abc: true, lilypond: true, musescore: true },
+    hasFeature: (doc) => {
+      const forward = doc.querySelector("part > measure:nth-of-type(1) > barline[location=\"left\"] > repeat[direction=\"forward\"]");
+      const backward = doc.querySelector("part > measure:nth-of-type(2) > barline[location=\"right\"] > repeat[direction=\"backward\"]");
+      return forward !== null && backward !== null;
+    },
+  },
+  {
+    id: "CFFP-TEMPO-MAP",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>P1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>960</divisions><key><fifths>0</fifths></key><time><beats>4</beats><beat-type>4</beat-type></time><clef><sign>G</sign><line>2</line></clef></attributes>
+      <direction><direction-type><metronome><beat-unit>quarter</beat-unit><per-minute>120</per-minute></metronome></direction-type><sound tempo="120"/></direction>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>3840</duration><voice>1</voice><type>whole</type></note>
+    </measure>
+    <measure number="2">
+      <direction><direction-type><metronome><beat-unit>quarter</beat-unit><per-minute>90</per-minute></metronome></direction-type><sound tempo="90"/></direction>
+      <note><pitch><step>D</step><octave>4</octave></pitch><duration>3840</duration><voice>1</voice><type>whole</type></note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: { musescore: true },
+    hasFeature: (doc) => {
+      const sounds = Array.from(doc.querySelectorAll("part > measure > direction > sound[tempo]"))
+        .map((n) => Number(n.getAttribute("tempo") ?? ""))
+        .filter((n) => Number.isFinite(n) && n > 0);
+      return sounds.includes(120) && sounds.includes(90);
+    },
+  },
+  {
+    id: "CFFP-OCTSHIFT",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>P1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>960</divisions><key><fifths>0</fifths></key><time><beats>4</beats><beat-type>4</beat-type></time><clef><sign>G</sign><line>2</line></clef></attributes>
+      <direction><direction-type><octave-shift type="up" size="8" number="1"/></direction-type></direction>
+      <note><pitch><step>C</step><octave>5</octave></pitch><duration>1920</duration><voice>1</voice><type>half</type></note>
+      <direction><direction-type><octave-shift type="stop" size="8" number="1"/></direction-type></direction>
+      <note><rest/><duration>1920</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: { lilypond: true },
+    preservePitchByFormat: { musescore: false, midi: false, vsqx: false },
+    preserveDurationByFormat: { midi: false, vsqx: false },
+    hasFeature: (doc) =>
+      doc.querySelector('part > measure > direction > direction-type > octave-shift[type="up"]') !== null,
+  },
+  {
+    id: "CFFP-SLUR",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>P1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>960</divisions><key><fifths>0</fifths></key><time><beats>4</beats><beat-type>4</beat-type></time><clef><sign>G</sign><line>2</line></clef></attributes>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>1920</duration><voice>1</voice><type>half</type><notations><slur type="start"/></notations></note>
+      <note><pitch><step>D</step><octave>4</octave></pitch><duration>1920</duration><voice>1</voice><type>half</type><notations><slur type="stop"/></notations></note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: { abc: true, musescore: true },
+    hasFeature: (doc) =>
+      doc.querySelector('part > measure > note > notations > slur[type="start"]') !== null &&
+      doc.querySelector('part > measure > note > notations > slur[type="stop"]') !== null,
+  },
+  {
+    id: "CFFP-TIE",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>P1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>960</divisions><key><fifths>0</fifths></key><time><beats>4</beats><beat-type>4</beat-type></time><clef><sign>G</sign><line>2</line></clef></attributes>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>3840</duration><voice>1</voice><type>whole</type><tie type="start"/><notations><tied type="start"/></notations></note>
+    </measure>
+    <measure number="2">
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>3840</duration><voice>1</voice><type>whole</type><tie type="stop"/><notations><tied type="stop"/></notations></note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: { abc: true, musescore: true },
+    hasFeature: (doc) =>
+      doc.querySelector('part > measure > note > tie[type="start"]') !== null &&
+      doc.querySelector('part > measure > note > tie[type="stop"]') !== null,
+  },
+  {
+    id: "CFFP-STACCATO",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>P1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>960</divisions><key><fifths>0</fifths></key><time><beats>4</beats><beat-type>4</beat-type></time><clef><sign>G</sign><line>2</line></clef></attributes>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>1920</duration><voice>1</voice><type>half</type><notations><articulations><staccato/></articulations></notations></note>
+      <note><rest/><duration>1920</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: { abc: true, mei: true, lilypond: true, musescore: true },
+    hasFeature: (doc) =>
+      doc.querySelector("part > measure > note > notations > articulations > staccato") !== null,
+  },
+  {
+    id: "CFFP-ACCENT",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>P1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>960</divisions><key><fifths>0</fifths></key><time><beats>4</beats><beat-type>4</beat-type></time><clef><sign>G</sign><line>2</line></clef></attributes>
+      <note><pitch><step>E</step><octave>4</octave></pitch><duration>1920</duration><voice>1</voice><type>half</type><notations><articulations><accent/></articulations></notations></note>
+      <note><rest/><duration>1920</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: { mei: true, lilypond: true, musescore: true },
+    hasFeature: (doc) =>
+      doc.querySelector("part > measure > note > notations > articulations > accent") !== null,
+  },
+  {
+    id: "CFFP-GRACE",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>P1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>960</divisions><key><fifths>0</fifths></key><time><beats>4</beats><beat-type>4</beat-type></time><clef><sign>G</sign><line>2</line></clef></attributes>
+      <note><grace slash="yes"/><pitch><step>G</step><octave>4</octave></pitch><voice>1</voice><type>eighth</type></note>
+      <note><pitch><step>A</step><octave>4</octave></pitch><duration>1920</duration><voice>1</voice><type>half</type></note>
+      <note><rest/><duration>1920</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: { abc: true, mei: true, lilypond: true, musescore: true },
+    hasFeature: (doc) => doc.querySelector("part > measure > note > grace") !== null,
+  },
+  {
+    id: "CFFP-TUPLET",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>P1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>960</divisions><key><fifths>0</fifths></key><time><beats>2</beats><beat-type>4</beat-type></time><clef><sign>G</sign><line>2</line></clef></attributes>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>640</duration><voice>1</voice><type>eighth</type><time-modification><actual-notes>3</actual-notes><normal-notes>2</normal-notes></time-modification><notations><tuplet type="start"/></notations></note>
+      <note><pitch><step>D</step><octave>4</octave></pitch><duration>640</duration><voice>1</voice><type>eighth</type><time-modification><actual-notes>3</actual-notes><normal-notes>2</normal-notes></time-modification></note>
+      <note><pitch><step>E</step><octave>4</octave></pitch><duration>640</duration><voice>1</voice><type>eighth</type><time-modification><actual-notes>3</actual-notes><normal-notes>2</normal-notes></time-modification><notations><tuplet type="stop"/></notations></note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: { abc: true, mei: true, lilypond: true, musescore: true },
+    preserveDurationByFormat: { mei: false, midi: false, vsqx: false },
+    hasFeature: (doc) =>
+      doc.querySelector("part > measure > note > time-modification > actual-notes") !== null,
+  },
+  {
+    id: "CFFP-TRIPLET-BRACKET",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>P1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>960</divisions><key><fifths>0</fifths></key><time><beats>2</beats><beat-type>4</beat-type></time><clef><sign>G</sign><line>2</line></clef></attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>640</duration><voice>1</voice><type>eighth</type>
+        <time-modification><actual-notes>3</actual-notes><normal-notes>2</normal-notes></time-modification>
+        <notations><tuplet type="start" number="1" bracket="yes" placement="above"/></notations>
+      </note>
+      <note>
+        <pitch><step>D</step><octave>4</octave></pitch>
+        <duration>640</duration><voice>1</voice><type>eighth</type>
+        <time-modification><actual-notes>3</actual-notes><normal-notes>2</normal-notes></time-modification>
+      </note>
+      <note>
+        <pitch><step>E</step><octave>4</octave></pitch>
+        <duration>640</duration><voice>1</voice><type>eighth</type>
+        <time-modification><actual-notes>3</actual-notes><normal-notes>2</normal-notes></time-modification>
+        <notations><tuplet type="stop" number="1" bracket="yes" placement="above"/></notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: {},
+    preserveDurationByFormat: { mei: false, midi: false, vsqx: false },
+    hasFeature: (doc) => {
+      const start = doc.querySelector("part > measure > note > notations > tuplet[type=\"start\"]");
+      const stop = doc.querySelector("part > measure > note > notations > tuplet[type=\"stop\"]");
+      const startBracket = start?.getAttribute("bracket")?.toLowerCase() ?? "";
+      const stopBracket = stop?.getAttribute("bracket")?.toLowerCase() ?? "";
+      const startPlacement = start?.getAttribute("placement")?.toLowerCase() ?? "";
+      const stopPlacement = stop?.getAttribute("placement")?.toLowerCase() ?? "";
+      return startBracket === "yes" && stopBracket === "yes" && startPlacement === "above" && stopPlacement === "above";
+    },
+  },
+  {
+    id: "CFFP-PERCUSSION-UNPITCHED",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list>
+    <score-part id="P1">
+      <part-name>Drums</part-name>
+      <score-instrument id="P1-I35"><instrument-name>Bass Drum</instrument-name></score-instrument>
+      <midi-instrument id="P1-I35"><midi-channel>10</midi-channel><midi-unpitched>36</midi-unpitched></midi-instrument>
+    </score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>960</divisions><key><fifths>0</fifths></key><time><beats>4</beats><beat-type>4</beat-type></time><clef><sign>percussion</sign><line>2</line></clef></attributes>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>960</duration><voice>1</voice><type>quarter</type></note>
+      <note><unpitched><display-step>F</display-step><display-octave>4</display-octave></unpitched><duration>960</duration><voice>1</voice><type>quarter</type><instrument id="P1-I35"/></note>
+      <note><rest/><duration>1920</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`,
+    requirePitchedFact: false,
+    preserveByFormat: {},
+    hasFeature: (doc) =>
+      doc.querySelector("part > measure > note > unpitched > display-step") !== null &&
+      doc.querySelector("part > measure > note > unpitched > display-octave") !== null,
+  },
+  {
+    id: "CFFP-PERCUSSION-NOTEHEAD",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>Drums</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>960</divisions><key><fifths>0</fifths></key><time><beats>4</beats><beat-type>4</beat-type></time><clef><sign>percussion</sign><line>2</line></clef></attributes>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>960</duration><voice>1</voice><type>quarter</type></note>
+      <note><unpitched><display-step>E</display-step><display-octave>5</display-octave></unpitched><duration>960</duration><voice>1</voice><type>quarter</type><notehead>x</notehead></note>
+      <note><unpitched><display-step>G</display-step><display-octave>5</display-octave></unpitched><duration>960</duration><voice>1</voice><type>quarter</type><notehead>triangle</notehead></note>
+      <note><rest/><duration>960</duration><voice>1</voice><type>quarter</type></note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: {},
+    hasFeature: (doc) => {
+      const heads = Array.from(doc.querySelectorAll("part > measure > note > notehead")).map((n) =>
+        n.textContent?.trim().toLowerCase() ?? ""
+      );
+      return heads.includes("x") && heads.includes("triangle");
+    },
+  },
+  {
+    id: "CFFP-PERCUSSION-INSTRUMENT-ID",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list>
+    <score-part id="P1">
+      <part-name>Drums</part-name>
+      <score-instrument id="P1-I38"><instrument-name>Snare Drum</instrument-name></score-instrument>
+    </score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>960</divisions><time><beats>4</beats><beat-type>4</beat-type></time><clef><sign>percussion</sign><line>2</line></clef></attributes>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>960</duration><voice>1</voice><type>quarter</type></note>
+      <note><unpitched><display-step>C</display-step><display-octave>5</display-octave></unpitched><duration>960</duration><voice>1</voice><type>quarter</type><instrument id="P1-I38"/></note>
+      <note><rest/><duration>1920</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: {},
+    hasFeature: (doc) =>
+      doc.querySelector("part > measure > note > instrument[id]") !== null &&
+      doc.querySelector("part-list score-part > score-instrument[id]") !== null,
+  },
+  {
+    id: "CFFP-PERCUSSION-VOICE-LAYER",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>Drums</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>960</divisions><time><beats>4</beats><beat-type>4</beat-type></time><clef><sign>percussion</sign><line>2</line></clef></attributes>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>960</duration><voice>1</voice><type>quarter</type></note>
+      <note><unpitched><display-step>F</display-step><display-octave>4</display-octave></unpitched><duration>960</duration><voice>1</voice><type>quarter</type></note>
+      <backup><duration>1920</duration></backup>
+      <note><unpitched><display-step>C</display-step><display-octave>5</display-octave></unpitched><duration>960</duration><voice>2</voice><type>quarter</type></note>
+      <note><rest/><duration>960</duration><voice>2</voice><type>quarter</type></note>
+      <forward><duration>1920</duration></forward>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: {},
+    hasFeature: (doc) => {
+      const voices = Array.from(doc.querySelectorAll("part > measure > note > voice")).map((n) => n.textContent?.trim() ?? "");
+      return voices.includes("1") && voices.includes("2");
+    },
+  },
+  {
+    id: "CFFP-PERCUSSION-STAFF-LINE",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>Percussion Staff</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions><time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>percussion</sign><line>2</line></clef><staff-details number="1"><staff-lines>1</staff-lines></staff-details>
+      </attributes>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>960</duration><voice>1</voice><type>quarter</type></note>
+      <note><rest/><duration>2880</duration><voice>1</voice><type>half</type><dot/></note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: {},
+    hasFeature: (doc) =>
+      doc.querySelector("part > measure > attributes > staff-details > staff-lines")?.textContent?.trim() === "1",
+  },
+  {
+    id: "CFFP-TRANSPOSING-INSTRUMENT",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>Clarinet in A</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions><key><fifths>0</fifths></key><time><beats>4</beats><beat-type>4</beat-type></time><clef><sign>G</sign><line>2</line></clef>
+        <transpose><diatonic>-2</diatonic><chromatic>-3</chromatic></transpose>
+      </attributes>
+      <note><pitch><step>C</step><octave>5</octave></pitch><duration>3840</duration><voice>1</voice><type>whole</type></note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: {},
+    preservePitchByFormat: { abc: false, mei: false, lilypond: false, musescore: false, midi: false, vsqx: false },
+    hasFeature: (doc) => {
+      const d = doc.querySelector("part > measure > attributes > transpose > diatonic")?.textContent?.trim();
+      const c = doc.querySelector("part > measure > attributes > transpose > chromatic")?.textContent?.trim();
+      return d === "-2" && c === "-3";
+    },
+  },
+  {
+    id: "CFFP-TIMEWISE-BACKUP-FORWARD",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>P1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>960</divisions><time><beats>4</beats><beat-type>4</beat-type></time><clef><sign>G</sign><line>2</line></clef></attributes>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>960</duration><voice>1</voice><type>quarter</type></note>
+      <forward><duration>960</duration></forward>
+      <note><pitch><step>G</step><octave>4</octave></pitch><duration>960</duration><voice>1</voice><type>quarter</type></note>
+      <backup><duration>2880</duration></backup>
+      <note><pitch><step>E</step><octave>4</octave></pitch><duration>1920</duration><voice>2</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: {},
+    hasFeature: (doc) =>
+      doc.querySelector("part > measure > backup > duration") !== null &&
+      doc.querySelector("part > measure > forward > duration") !== null,
+  },
+  {
+    id: "CFFP-CROSS-STAFF-BEAM",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>Piano</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions><time><beats>4</beats><beat-type>4</beat-type></time>
+        <staves>2</staves>
+        <clef number="1"><sign>G</sign><line>2</line></clef>
+        <clef number="2"><sign>F</sign><line>4</line></clef>
+      </attributes>
+      <note><pitch><step>C</step><octave>5</octave></pitch><duration>480</duration><voice>1</voice><type>eighth</type><staff>1</staff><beam number="1">begin</beam></note>
+      <note><pitch><step>B</step><octave>4</octave></pitch><duration>480</duration><voice>1</voice><type>eighth</type><staff>2</staff><beam number="1">end</beam></note>
+      <note><rest/><duration>2880</duration><voice>1</voice><type>half</type><dot/></note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: {},
+    hasFeature: (doc) => {
+      const st1 = doc.querySelector("part > measure > note:nth-of-type(1) > staff")?.textContent?.trim();
+      const st2 = doc.querySelector("part > measure > note:nth-of-type(2) > staff")?.textContent?.trim();
+      const b1 = doc.querySelector("part > measure > note:nth-of-type(1) > beam")?.textContent?.trim().toLowerCase();
+      const b2 = doc.querySelector("part > measure > note:nth-of-type(2) > beam")?.textContent?.trim().toLowerCase();
+      return st1 === "1" && st2 === "2" && b1 === "begin" && b2 === "end";
+    },
+  },
+  {
+    id: "CFFP-CHORD-SYMBOL-ALTER",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>P1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>960</divisions><time><beats>4</beats><beat-type>4</beat-type></time><clef><sign>G</sign><line>2</line></clef></attributes>
+      <harmony>
+        <root><root-step>C</root-step></root>
+        <kind text="7(#11,b9)">dominant</kind>
+        <degree><degree-value>11</degree-value><degree-alter>1</degree-alter><degree-type>add</degree-type></degree>
+        <degree><degree-value>9</degree-value><degree-alter>-1</degree-alter><degree-type>add</degree-type></degree>
+      </harmony>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>3840</duration><voice>1</voice><type>whole</type></note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: {},
+    hasFeature: (doc) => {
+      const d11 = doc.querySelector("part > measure > harmony > degree:nth-of-type(1) > degree-value")?.textContent?.trim();
+      const a11 = doc.querySelector("part > measure > harmony > degree:nth-of-type(1) > degree-alter")?.textContent?.trim();
+      const d9 = doc.querySelector("part > measure > harmony > degree:nth-of-type(2) > degree-value")?.textContent?.trim();
+      const a9 = doc.querySelector("part > measure > harmony > degree:nth-of-type(2) > degree-alter")?.textContent?.trim();
+      return d11 === "11" && a11 === "1" && d9 === "9" && a9 === "-1";
+    },
+  },
+  {
+    id: "CFFP-NOTE-TIES-CROSS-MEASURE",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>P1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>960</divisions><time><beats>4</beats><beat-type>4</beat-type></time><clef><sign>G</sign><line>2</line></clef></attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch><duration>3840</duration><voice>1</voice><type>whole</type>
+        <tie type="start"/><notations><tied type="start"/></notations>
+      </note>
+    </measure>
+    <measure number="2">
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch><duration>1920</duration><voice>1</voice><type>half</type>
+        <tie type="stop"/><notations><tied type="stop"/></notations>
+      </note>
+      <note><rest/><duration>1920</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: {},
+    hasFeature: (doc) =>
+      doc.querySelector("part > measure:nth-of-type(1) > note > tie[type=\"start\"]") !== null &&
+      doc.querySelector("part > measure:nth-of-type(2) > note > tie[type=\"stop\"]") !== null,
+  },
+  {
+    id: "CFFP-MULTI-REST-COUNT",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>P1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions><time><beats>4</beats><beat-type>4</beat-type></time><clef><sign>G</sign><line>2</line></clef>
+        <measure-style><multiple-rest>2</multiple-rest></measure-style>
+      </attributes>
+      <note><rest measure="yes"/><duration>3840</duration><voice>1</voice><type>whole</type></note>
+    </measure>
+    <measure number="2">
+      <note><rest measure="yes"/><duration>3840</duration><voice>1</voice><type>whole</type></note>
+    </measure>
+  </part>
+</score-partwise>`,
+    requirePitchedFact: false,
+    preserveByFormat: {},
+    hasFeature: (doc) =>
+      doc.querySelector("part > measure > attributes > measure-style > multiple-rest")?.textContent?.trim() === "2",
+  },
+  {
+    id: "CFFP-REPEAT-JUMP-SOUND",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>P1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>960</divisions><time><beats>4</beats><beat-type>4</beat-type></time><clef><sign>G</sign><line>2</line></clef></attributes>
+      <direction><direction-type><words>D.S. al Coda</words></direction-type><sound segno="seg1" tocoda="coda1"/></direction>
+      <direction><direction-type><words>Fine</words></direction-type><sound fine="yes"/></direction>
+      <direction><direction-type><words>Coda</words></direction-type><sound coda="coda1"/></direction>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>3840</duration><voice>1</voice><type>whole</type></note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: {},
+    hasFeature: (doc) =>
+      doc.querySelector("part > measure > direction > sound[segno]") !== null &&
+      doc.querySelector("part > measure > direction > sound[tocoda]") !== null &&
+      doc.querySelector("part > measure > direction > sound[fine]") !== null &&
+      doc.querySelector("part > measure > direction > sound[coda]") !== null,
+  },
+  {
+    id: "CFFP-CUE-GRACE-MIX",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>P1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>960</divisions><time><beats>4</beats><beat-type>4</beat-type></time><clef><sign>G</sign><line>2</line></clef></attributes>
+      <note><cue/><pitch><step>C</step><octave>4</octave></pitch><duration>960</duration><voice>1</voice><type>quarter</type></note>
+      <note><grace slash="yes"/><pitch><step>D</step><octave>4</octave></pitch><voice>1</voice><type>eighth</type></note>
+      <note><pitch><step>E</step><octave>4</octave></pitch><duration>2880</duration><voice>1</voice><type>half</type><dot/></note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: {},
+    hasFeature: (doc) =>
+      doc.querySelector("part > measure > note > cue") !== null &&
+      doc.querySelector("part > measure > note > grace") !== null,
+  },
+  {
+    id: "CFFP-ACCIDENTAL-COURTESY-MODE",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>P1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>960</divisions><key><fifths>0</fifths></key><time><beats>4</beats><beat-type>4</beat-type></time><clef><sign>G</sign><line>2</line></clef></attributes>
+      <note><pitch><step>F</step><alter>1</alter><octave>4</octave></pitch><duration>960</duration><voice>1</voice><type>quarter</type><accidental>sharp</accidental></note>
+      <note><pitch><step>F</step><octave>4</octave></pitch><duration>960</duration><voice>1</voice><type>quarter</type><accidental cautionary="yes" parentheses="yes">natural</accidental></note>
+      <note><rest/><duration>1920</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: {},
+    preservePitchByFormat: { vsqx: false },
+    hasFeature: (doc) =>
+      doc.querySelector("part > measure > note > accidental[cautionary=\"yes\"]") !== null &&
+      doc.querySelector("part > measure > note > accidental[parentheses=\"yes\"]") !== null,
+  },
+  {
+    id: "CFFP-LYRICS-MULTI-VERSE",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>Voice</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>960</divisions><key><fifths>0</fifths></key><time><beats>4</beats><beat-type>4</beat-type></time><clef><sign>G</sign><line>2</line></clef></attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch><duration>1920</duration><voice>1</voice><type>half</type>
+        <lyric number="1"><syllabic>single</syllabic><text>la</text></lyric>
+        <lyric number="2"><syllabic>single</syllabic><text>lu</text></lyric>
+      </note>
+      <note><rest/><duration>1920</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: {},
+    hasFeature: (doc) =>
+      doc.querySelector("part > measure > note > lyric[number=\"1\"] > text") !== null &&
+      doc.querySelector("part > measure > note > lyric[number=\"2\"] > text") !== null,
+  },
+  {
+    id: "CFFP-TEXT-ENCODING",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>Voice</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>960</divisions><time><beats>4</beats><beat-type>4</beat-type></time><clef><sign>G</sign><line>2</line></clef></attributes>
+      <direction><direction-type><words>テンポ：モデラート ♪=108</words></direction-type></direction>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch><duration>3840</duration><voice>1</voice><type>whole</type>
+        <lyric number="1"><syllabic>single</syllabic><text>こんにちは</text></lyric>
+      </note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: {},
+    hasFeature: (doc) => {
+      const words = doc.querySelector("part > measure > direction > direction-type > words")?.textContent?.trim() ?? "";
+      const lyric = doc.querySelector("part > measure > note > lyric > text")?.textContent?.trim() ?? "";
+      return words.includes("テンポ") && lyric.includes("こんにちは");
+    },
+  },
+  {
+    id: "CFFP-HARMONIC-NATURAL-ARTIFICIAL",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>Strings</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>960</divisions><time><beats>4</beats><beat-type>4</beat-type></time><clef><sign>G</sign><line>2</line></clef></attributes>
+      <note>
+        <pitch><step>G</step><octave>4</octave></pitch><duration>1920</duration><voice>1</voice><type>half</type>
+        <notations><technical><harmonic><natural/></harmonic></technical></notations>
+      </note>
+      <note>
+        <pitch><step>A</step><octave>4</octave></pitch><duration>1920</duration><voice>1</voice><type>half</type>
+        <notations><technical><harmonic><artificial/></harmonic></technical></notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: {},
+    hasFeature: (doc) =>
+      doc.querySelector("part > measure > note > notations > technical > harmonic > natural") !== null &&
+      doc.querySelector("part > measure > note > notations > technical > harmonic > artificial") !== null,
+  },
+  {
+    id: "CFFP-OPEN-STRING",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>Strings</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>960</divisions><time><beats>4</beats><beat-type>4</beat-type></time><clef><sign>G</sign><line>2</line></clef></attributes>
+      <note>
+        <pitch><step>E</step><octave>4</octave></pitch><duration>3840</duration><voice>1</voice><type>whole</type>
+        <notations><technical><open-string/></technical></notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: {},
+    hasFeature: (doc) =>
+      doc.querySelector("part > measure > note > notations > technical > open-string") !== null,
+  },
+  {
+    id: "CFFP-STOPPED",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>Brass</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>960</divisions><time><beats>4</beats><beat-type>4</beat-type></time><clef><sign>G</sign><line>2</line></clef></attributes>
+      <note>
+        <pitch><step>F</step><octave>4</octave></pitch><duration>3840</duration><voice>1</voice><type>whole</type>
+        <notations><technical><stopped/></technical></notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: {},
+    hasFeature: (doc) =>
+      doc.querySelector("part > measure > note > notations > technical > stopped") !== null,
+  },
+  {
+    id: "CFFP-SNAP-PIZZICATO",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>Strings</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>960</divisions><time><beats>4</beats><beat-type>4</beat-type></time><clef><sign>G</sign><line>2</line></clef></attributes>
+      <note>
+        <pitch><step>D</step><octave>4</octave></pitch><duration>3840</duration><voice>1</voice><type>whole</type>
+        <notations><technical><snap-pizzicato/></technical></notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: {},
+    hasFeature: (doc) =>
+      doc.querySelector("part > measure > note > notations > technical > snap-pizzicato") !== null,
+  },
+  {
+    id: "CFFP-FINGERING",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>Strings</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>960</divisions><time><beats>4</beats><beat-type>4</beat-type></time><clef><sign>G</sign><line>2</line></clef></attributes>
+      <note>
+        <pitch><step>C</step><octave>5</octave></pitch><duration>1920</duration><voice>1</voice><type>half</type>
+        <notations><technical><fingering>1</fingering><fingering substitution="yes">4</fingering></technical></notations>
+      </note>
+      <note><rest/><duration>1920</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: {},
+    hasFeature: (doc) => {
+      const values = Array.from(doc.querySelectorAll("part > measure > note > notations > technical > fingering")).map((n) =>
+        n.textContent?.trim() ?? ""
+      );
+      return values.includes("1") && values.includes("4");
+    },
+  },
+  {
+    id: "CFFP-STRING",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>Violin</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>960</divisions><time><beats>4</beats><beat-type>4</beat-type></time><clef><sign>G</sign><line>2</line></clef></attributes>
+      <note>
+        <pitch><step>G</step><octave>4</octave></pitch><duration>1920</duration><voice>1</voice><type>half</type>
+        <notations><technical><string>1</string></technical></notations>
+      </note>
+      <note>
+        <pitch><step>D</step><octave>4</octave></pitch><duration>1920</duration><voice>1</voice><type>half</type>
+        <notations><technical><string>4</string></technical></notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: {},
+    hasFeature: (doc) => {
+      const values = Array.from(doc.querySelectorAll("part > measure > note > notations > technical > string")).map((n) =>
+        n.textContent?.trim() ?? ""
+      );
+      return values.includes("1") && values.includes("4");
+    },
+  },
+  {
+    id: "CFFP-DOUBLE-TRIPLE-TONGUE",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>Woodwind</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>960</divisions><time><beats>4</beats><beat-type>4</beat-type></time><clef><sign>G</sign><line>2</line></clef></attributes>
+      <note>
+        <pitch><step>C</step><octave>5</octave></pitch><duration>1920</duration><voice>1</voice><type>half</type>
+        <notations><articulations><double-tongue/></articulations></notations>
+      </note>
+      <note>
+        <pitch><step>D</step><octave>5</octave></pitch><duration>1920</duration><voice>1</voice><type>half</type>
+        <notations><articulations><triple-tongue/></articulations></notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: {},
+    hasFeature: (doc) =>
+      doc.querySelector("part > measure > note > notations > articulations > double-tongue") !== null &&
+      doc.querySelector("part > measure > note > notations > articulations > triple-tongue") !== null,
+  },
+  {
+    id: "CFFP-HEEL-TOE",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>Organ</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>960</divisions><time><beats>4</beats><beat-type>4</beat-type></time><clef><sign>F</sign><line>4</line></clef></attributes>
+      <note>
+        <pitch><step>C</step><octave>3</octave></pitch><duration>1920</duration><voice>1</voice><type>half</type>
+        <notations><technical><heel/></technical></notations>
+      </note>
+      <note>
+        <pitch><step>D</step><octave>3</octave></pitch><duration>1920</duration><voice>1</voice><type>half</type>
+        <notations><technical><toe/></technical></notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: {},
+    hasFeature: (doc) =>
+      doc.querySelector("part > measure > note > notations > technical > heel") !== null &&
+      doc.querySelector("part > measure > note > notations > technical > toe") !== null,
+  },
+  {
+    id: "CFFP-PLUCK-TEXT",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>Guitar</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>960</divisions><time><beats>4</beats><beat-type>4</beat-type></time><clef><sign>G</sign><line>2</line></clef></attributes>
+      <note>
+        <pitch><step>E</step><octave>4</octave></pitch><duration>3840</duration><voice>1</voice><type>whole</type>
+        <notations><technical><pluck>p</pluck><pluck>i</pluck><pluck>m</pluck><pluck>a</pluck></technical></notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: {},
+    hasFeature: (doc) => {
+      const values = Array.from(doc.querySelectorAll("part > measure > note > notations > technical > pluck")).map((n) =>
+        (n.textContent?.trim() ?? "").toLowerCase()
+      );
+      return values.includes("p") && values.includes("i") && values.includes("m") && values.includes("a");
+    },
+  },
+  {
+    id: "CFFP-BREATH-VARIANTS",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>Voice</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>960</divisions><time><beats>4</beats><beat-type>4</beat-type></time><clef><sign>G</sign><line>2</line></clef></attributes>
+      <note>
+        <pitch><step>G</step><octave>4</octave></pitch><duration>1920</duration><voice>1</voice><type>half</type>
+        <notations><articulations><breath-mark>comma</breath-mark></articulations></notations>
+      </note>
+      <note>
+        <pitch><step>A</step><octave>4</octave></pitch><duration>1920</duration><voice>1</voice><type>half</type>
+        <notations><articulations><breath-mark>tick</breath-mark></articulations></notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: {},
+    hasFeature: (doc) => {
+      const marks = Array.from(doc.querySelectorAll("part > measure > note > notations > articulations > breath-mark")).map((n) =>
+        (n.textContent?.trim() ?? "").toLowerCase()
+      );
+      return marks.includes("comma") && marks.includes("tick");
+    },
+  },
+  {
+    id: "CFFP-BREATH-PLACEMENT",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>Voice</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>960</divisions><time><beats>4</beats><beat-type>4</beat-type></time><clef><sign>G</sign><line>2</line></clef></attributes>
+      <note>
+        <pitch><step>B</step><octave>4</octave></pitch><duration>3840</duration><voice>1</voice><type>whole</type>
+        <notations><articulations><breath-mark placement="above" default-x="10" default-y="8">comma</breath-mark></articulations></notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: {},
+    hasFeature: (doc) => {
+      const mark = doc.querySelector("part > measure > note > notations > articulations > breath-mark");
+      if (!mark) return false;
+      return (mark.getAttribute("placement") ?? "").toLowerCase() === "above" && mark.getAttribute("default-x") === "10";
+    },
+  },
+  {
+    id: "CFFP-CAESURA-STYLE",
+    xml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>Voice</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>960</divisions><time><beats>4</beats><beat-type>4</beat-type></time><clef><sign>G</sign><line>2</line></clef></attributes>
+      <note>
+        <pitch><step>C</step><octave>5</octave></pitch><duration>1920</duration><voice>1</voice><type>half</type>
+        <notations><articulations><caesura/></articulations></notations>
+      </note>
+      <note>
+        <pitch><step>D</step><octave>5</octave></pitch><duration>1920</duration><voice>1</voice><type>half</type>
+        <notations><articulations><caesura/></articulations></notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>`,
+    preserveByFormat: {},
+    hasFeature: (doc) =>
+      doc.querySelectorAll("part > measure > note > notations > articulations > caesura").length >= 2,
+  },
+];
+
+describe("CFFP series: minimal MusicXML -> cross-format roundtrip", () => {
+  beforeAll(() => {
+    ensureMidiWriterLoaded();
+    ensureVsqxBridgeLoaded();
+  });
+
+  for (const c of CFFP_CASES) {
+    it(`${c.id}`, () => {
+      const srcDoc = parseDoc(c.xml);
+      const srcFact = c.requirePitchedFact === false ? null : firstPitchedFact(srcDoc);
+      const formats = [
+        { name: "abc" as const, preserveDuration: true, run: () => roundtripAbc(srcDoc) },
+        { name: "mei" as const, preserveDuration: true, run: () => roundtripMei(srcDoc) },
+        { name: "lilypond" as const, preserveDuration: true, run: () => roundtripLilyPond(srcDoc) },
+        { name: "musescore" as const, preserveDuration: true, run: () => roundtripMuseScore(srcDoc) },
+        { name: "midi" as const, preserveDuration: false, run: () => roundtripMidi(srcDoc) },
+      ];
+      if (isVsqxBridgeAvailable()) {
+        formats.push({ name: "vsqx" as const, preserveDuration: false, run: () => roundtripVsqx(c.xml) });
+      }
+
+      for (const fmt of formats) {
+        const outDoc = fmt.run();
+        if (srcFact) {
+          const outFact = firstPitchedFact(outDoc);
+          const preservePitch = c.preservePitchByFormat?.[fmt.name] ?? true;
+          if (preservePitch) {
+            expect(outFact.step, `${c.id}:${fmt.name}: step`).toBe(srcFact.step);
+            expect(outFact.octave, `${c.id}:${fmt.name}: octave`).toBe(srcFact.octave);
+          }
+          expect(outFact.startDiv, `${c.id}:${fmt.name}: startDiv`).toBe(0);
+          const preserveDuration = c.preserveDurationByFormat?.[fmt.name] ?? fmt.preserveDuration;
+          if (preserveDuration) {
+            expect(outFact.quarterLen, `${c.id}:${fmt.name}: duration(quarter)`).toBeCloseTo(srcFact.quarterLen, 1);
+          }
+        }
+        if (c.preserveByFormat[fmt.name]) {
+          expect(c.hasFeature(outDoc), `${c.id}:${fmt.name}: feature must preserve`).toBe(true);
+        }
+      }
+    });
+  }
+});

--- a/tests/unit/lilypond-io.spec.ts
+++ b/tests/unit/lilypond-io.spec.ts
@@ -772,7 +772,7 @@ describe("LilyPond I/O", () => {
     expect(third?.querySelector(':scope > notations > tuplet[type="stop"]')?.getAttribute("number")).toBe("1");
   });
 
-  it("currently degrades octave-shift directions on LilyPond roundtrip (policy explicit)", () => {
+  it("exports and imports octave-shift directions via %@mks octshift metadata", () => {
     const xml = `<?xml version="1.0" encoding="UTF-8"?>
 <score-partwise version="4.0">
   <part-list><score-part id="P1"><part-name>Part 1</part-name></score-part></part-list>
@@ -796,12 +796,19 @@ describe("LilyPond I/O", () => {
     expect(doc).not.toBeNull();
     if (!doc) return;
     const lily = exportMusicXmlDomToLilyPond(doc);
+    expect(lily).toContain("% %@mks octshift voice=P1 measure=1 type=up size=8 number=1");
+    expect(lily).toContain("% %@mks octshift voice=P1 measure=2 type=stop size=8 number=1");
     const outDoc = parseMusicXmlDocument(convertLilyPondToMusicXml(lily));
     expect(outDoc).not.toBeNull();
     if (!outDoc) return;
     expect(outDoc.querySelector("part > measure:nth-of-type(1) > note > pitch > step")?.textContent?.trim()).toBe("C");
     expect(outDoc.querySelector("part > measure:nth-of-type(2) > note > pitch > step")?.textContent?.trim()).toBe("D");
-    expect(outDoc.querySelector("direction > direction-type > octave-shift")).toBeNull();
+    expect(
+      outDoc.querySelector("part > measure:nth-of-type(1) > direction > direction-type > octave-shift[type=\"up\"]")
+    ).not.toBeNull();
+    expect(
+      outDoc.querySelector("part > measure:nth-of-type(2) > direction > direction-type > octave-shift[type=\"stop\"]")
+    ).not.toBeNull();
   });
 
   it("exports and imports trill ornaments via %@mks trill metadata", () => {


### PR DESCRIPTION
## 概要

CFFP（Cross-Format Focus Parity）シリーズを新規導入し、
`MusicXML -> 各形式 -> MusicXML` の形式横断ラウンドトリップ検証を大幅に強化しました。

本PRでは、装飾記号・アーティキュレーション・調号/拍子・リピート・歌詞・打楽器・技術記号などを
最小ケース単位で網羅的にテスト可能にし、あわせて仕様ドキュメントとテストマトリクスを整備しています。

## 主な変更

- CFFP統合テストを新規追加
  - `tests/unit/cffp-series.spec.ts`（大規模追加）
- CFFP仕様ドキュメントを新規追加
  - `docs/spec/TEST_CFFP.md`
- テストマトリクスを拡張
  - `docs/spec/TEST_MATRIX.md`
- TODO更新（CFFP対応状況を反映）
  - `TODO.md`
- 既存I/O実装・関連テストを調整
  - `src/ts/abc-io.ts`
  - `src/ts/mei-io.ts`
  - `src/ts/lilypond-io.ts`
  - `tests/unit/abc-io.spec.ts`
  - `tests/unit/lilypond-io.spec.ts`
- UI/ビルド成果物の同期
  - `src/ts/main.ts`
  - `src/js/main.js`
  - `mikuscore.html`
- 仕様関連文書更新
  - `docs/spec/ABC_IO.md`
  - `docs/spec/FORMAT_IO_CHECKLIST.md`

## 変更規模（commit: 87f63861bb40607d1b915e7309a3687e84fa0505）

- 14 files changed
- 4,192 insertions / 85 deletions

## 目的・効果

- 形式ごとの差分を「個別事象ごと」に検証できるようになり、回帰検知が容易に
- must-preserve / allowed-degrade の整理が進み、仕様判断の透明性が向上
- 今後のフォーマット拡張・修正時にCFFPケースを追加するだけで横断検証を継続可能