### PR TITLE
MEI入出力の仕様追従強化（control event / transposition / meiversion / parityテスト拡…

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Its primary goal is reliability, not feature volume: edit while preserving exist
 - `utaformatix3-ts-plus` is bundled as a vendored integration (`src/vendor/utaformatix3/utaformatix3-ts-plus.mikuscore.iife.js`) for VSQX <-> MusicXML conversion.
 - We sincerely appreciate the UtaFormatix / utaformatix3 ecosystem and contributors for making this VSQX interoperability possible.
 - MEI support is currently experimental.
+- MEI reference samples used for compatibility/parity work:
+  - https://github.com/music-encoding/sample-encodings/tree/main/MEI_5.1/Music
 - LilyPond (`.ly`) support is currently experimental.
 
 ### Distribution and Development
@@ -126,6 +128,8 @@ mikuscore は、MusicXML、MuseScore、MIDI、VSQX、ABC、MEI、LilyPond の入
 - VSQX <-> MusicXML 変換のため、`utaformatix3-ts-plus` を同梱連携しています（`src/vendor/utaformatix3/utaformatix3-ts-plus.mikuscore.iife.js`）。
 - VSQX 相互運用を実現する基盤を築いてくださった UtaFormatix / utaformatix3 のエコシステムと貢献者の皆さまに、深く感謝します。
 - MEI 対応は現在 Experimental（試験対応）です。
+- MEI 互換性/パリティ確認で参照する公式サンプル:
+  - https://github.com/music-encoding/sample-encodings/tree/main/MEI_5.1/Music
 - LilyPond（`.ly`）対応は現在 Experimental（試験対応）です。
 
 ### 配布と開発方針

--- a/scripts/compare-mei-official-reports.mjs
+++ b/scripts/compare-mei-official-reports.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+import { readdirSync, readFileSync, existsSync } from "node:fs";
+import { resolve } from "node:path";
+
+const root = process.cwd();
+const baseDir = resolve(root, "tests/tmp/mei-official");
+
+if (!existsSync(baseDir)) {
+  console.error("No report directory:", baseDir);
+  process.exit(1);
+}
+
+const parseReport = (text) => {
+  const lines = text.split(/\r?\n/);
+  const blocks = [];
+  let cur = {};
+  for (const line of lines) {
+    if (!line.trim()) continue;
+    const idx = line.indexOf("=");
+    if (idx < 0) continue;
+    const k = line.slice(0, idx);
+    const v = line.slice(idx + 1);
+    if (k === "official_ref" && Object.keys(cur).length > 0) {
+      blocks.push(cur);
+      cur = {};
+    }
+    cur[k] = v;
+  }
+  if (Object.keys(cur).length > 0) blocks.push(cur);
+  return blocks;
+};
+
+const dirs = readdirSync(baseDir, { withFileTypes: true })
+  .filter((d) => d.isDirectory())
+  .map((d) => d.name)
+  .sort();
+
+const rows = [];
+for (const id of dirs) {
+  const reportPath = resolve(baseDir, id, "report.txt");
+  if (!existsSync(reportPath)) continue;
+  const blocks = parseReport(readFileSync(reportPath, "utf8"));
+  const semantics = blocks.find((b) => b.semantic_ratio !== undefined) ?? {};
+  const officials = blocks.filter((b) => b.official_ref !== undefined);
+  const officialBest = officials
+    .filter((b) => b.official_ratio !== undefined)
+    .map((b) => ({ ref: b.official_ref, ratio: Number(b.official_ratio), delta: Number(b.official_conversion_delta_ratio ?? "NaN") }))
+    .sort((a, b) => a.ratio - b.ratio)[0];
+
+  rows.push({
+    id,
+    semanticRatio: Number(semantics.semantic_ratio ?? "NaN"),
+    semanticChanged: Number(semantics.semantic_changed_ratio ?? "NaN"),
+    bestOfficialRef: officialBest?.ref ?? "-",
+    bestOfficialRatio: officialBest?.ratio ?? Number.NaN,
+    bestOfficialDelta: officialBest?.delta ?? Number.NaN,
+    skippedOfficial: officials.filter((b) => b.official_status === "skip-invalid-image").length,
+  });
+}
+
+console.log("MEI Official Visual Compare Summary");
+console.log("fixture\tsemantic_ratio\tsemantic_changed_ratio\tbest_official_ref\tbest_official_ratio\tconversion_delta\tskipped_official");
+for (const r of rows) {
+  console.log(
+    [
+      r.id,
+      Number.isFinite(r.semanticRatio) ? r.semanticRatio.toFixed(6) : "NaN",
+      Number.isFinite(r.semanticChanged) ? r.semanticChanged.toFixed(6) : "NaN",
+      r.bestOfficialRef,
+      Number.isFinite(r.bestOfficialRatio) ? r.bestOfficialRatio.toFixed(6) : "NaN",
+      Number.isFinite(r.bestOfficialDelta) ? r.bestOfficialDelta.toFixed(6) : "NaN",
+      r.skippedOfficial,
+    ].join("\t")
+  );
+}
+

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -15159,8 +15159,66 @@ const resolveClefForSlot = (part, localStaff) => {
     }
     return { shape: "G", line: 2 };
 };
-const buildSimplePitchNote = (note) => {
-    var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p, _q, _r, _s;
+const resolveTransposeForSlot = (part, localStaff) => {
+    var _a, _b;
+    if (!part)
+        return null;
+    for (const measure of Array.from(part.querySelectorAll(":scope > measure"))) {
+        const attrs = Array.from(measure.querySelectorAll(":scope > attributes"));
+        for (const attr of attrs) {
+            const transpose = attr.querySelector(":scope > transpose");
+            if (!transpose)
+                continue;
+            const chromatic = parseIntSafe((_a = transpose.querySelector(":scope > chromatic")) === null || _a === void 0 ? void 0 : _a.textContent, NaN);
+            const diatonic = parseIntSafe((_b = transpose.querySelector(":scope > diatonic")) === null || _b === void 0 ? void 0 : _b.textContent, NaN);
+            const out = {};
+            if (Number.isFinite(chromatic))
+                out.chromatic = Math.round(chromatic);
+            if (Number.isFinite(diatonic))
+                out.diatonic = Math.round(diatonic);
+            if (Object.keys(out).length > 0)
+                return out;
+        }
+        if (localStaff === 1)
+            break;
+    }
+    return null;
+};
+const toMksDur480 = (durationTicks, sourceDivisions) => {
+    const base = Math.max(1, Math.round(sourceDivisions));
+    return Math.max(1, Math.round((durationTicks * 480) / base));
+};
+const extractMeiTieFromMusicXmlNote = (note) => {
+    const tieTypes = Array.from(note.querySelectorAll(":scope > tie"))
+        .map((node) => (node.getAttribute("type") || "").trim().toLowerCase())
+        .filter(Boolean);
+    const hasStart = tieTypes.includes("start");
+    const hasStop = tieTypes.includes("stop");
+    if (hasStart && hasStop)
+        return "m";
+    if (hasStart)
+        return "i";
+    if (hasStop)
+        return "t";
+    return "";
+};
+const extractMeiSlurFromMusicXmlNote = (note) => {
+    const slurNodes = Array.from(note.querySelectorAll(":scope > notations > slur"));
+    if (slurNodes.length === 0)
+        return "";
+    const tokens = [];
+    for (const slur of slurNodes) {
+        const type = (slur.getAttribute("type") || "").trim().toLowerCase();
+        const number = Math.max(1, parseIntSafe(slur.getAttribute("number"), 1));
+        if (type === "start")
+            tokens.push(`i${number}`);
+        if (type === "stop")
+            tokens.push(`t${number}`);
+    }
+    return tokens.join(" ");
+};
+const buildSimplePitchNote = (note, sourceDivisions, includeGraceAttr = true) => {
+    var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p, _q, _r, _s, _t;
     const typeText = (_c = (_b = (_a = note.querySelector(":scope > type")) === null || _a === void 0 ? void 0 : _a.textContent) === null || _b === void 0 ? void 0 : _b.trim()) !== null && _c !== void 0 ? _c : "quarter";
     const dur = noteTypeToDur(typeText);
     const dots = note.querySelectorAll(":scope > dot").length;
@@ -15174,8 +15232,14 @@ const buildSimplePitchNote = (note) => {
         `oct="${esc(octaveText)}"`,
         `dur="${esc(dur)}"`,
     ];
-    const actual = parseIntSafe((_p = note.querySelector(":scope > time-modification > actual-notes")) === null || _p === void 0 ? void 0 : _p.textContent, NaN);
-    const normal = parseIntSafe((_q = note.querySelector(":scope > time-modification > normal-notes")) === null || _q === void 0 ? void 0 : _q.textContent, NaN);
+    const durationTicks = parseIntSafe((_p = note.querySelector(":scope > duration")) === null || _p === void 0 ? void 0 : _p.textContent, NaN);
+    if (Number.isFinite(durationTicks) && durationTicks > 0) {
+        attrs.push(`mks-dur-480="${toMksDur480(durationTicks, sourceDivisions)}"`);
+        attrs.push(`mks-dur-div="${Math.max(1, Math.round(sourceDivisions))}"`);
+        attrs.push(`mks-dur-ticks="${Math.round(durationTicks)}"`);
+    }
+    const actual = parseIntSafe((_q = note.querySelector(":scope > time-modification > actual-notes")) === null || _q === void 0 ? void 0 : _q.textContent, NaN);
+    const normal = parseIntSafe((_r = note.querySelector(":scope > time-modification > normal-notes")) === null || _r === void 0 ? void 0 : _r.textContent, NaN);
     const hasTupletStart = note.querySelector(':scope > notations > tuplet[type="start"]') !== null;
     const hasTupletStop = note.querySelector(':scope > notations > tuplet[type="stop"]') !== null;
     const arts = [];
@@ -15195,10 +15259,16 @@ const buildSimplePitchNote = (note) => {
         attrs.push('mks-tuplet-start="1"');
     if (hasTupletStop)
         attrs.push('mks-tuplet-stop="1"');
-    if (note.querySelector(":scope > grace")) {
-        const slash = ((_s = (_r = note.querySelector(":scope > grace")) === null || _r === void 0 ? void 0 : _r.getAttribute("slash")) !== null && _s !== void 0 ? _s : "").trim().toLowerCase() === "yes";
+    if (includeGraceAttr && note.querySelector(":scope > grace")) {
+        const slash = ((_t = (_s = note.querySelector(":scope > grace")) === null || _s === void 0 ? void 0 : _s.getAttribute("slash")) !== null && _t !== void 0 ? _t : "").trim().toLowerCase() === "yes";
         attrs.push(`grace="${slash ? "acc" : "unacc"}"`);
     }
+    const tieAttr = extractMeiTieFromMusicXmlNote(note);
+    if (tieAttr)
+        attrs.push(`tie="${esc(tieAttr)}"`);
+    const slurAttr = extractMeiSlurFromMusicXmlNote(note);
+    if (slurAttr)
+        attrs.push(`slur="${esc(slurAttr)}"`);
     if (arts.length)
         attrs.push(`artic="${esc(arts.join(" "))}"`);
     const lyric = extractMusicXmlLyric(note);
@@ -15209,15 +15279,22 @@ const buildSimplePitchNote = (note) => {
     }
     return `<note ${attrs.join(" ")}/>`;
 };
-const buildSimpleRest = (note) => {
-    var _a, _b, _c;
+const buildSimpleRest = (note, sourceDivisions) => {
+    var _a, _b, _c, _d;
     const typeText = (_c = (_b = (_a = note.querySelector(":scope > type")) === null || _a === void 0 ? void 0 : _a.textContent) === null || _b === void 0 ? void 0 : _b.trim()) !== null && _c !== void 0 ? _c : "quarter";
     const dur = noteTypeToDur(typeText);
     const dots = note.querySelectorAll(":scope > dot").length;
     const attrs = [`dur="${esc(dur)}"`];
+    const durationTicks = parseIntSafe((_d = note.querySelector(":scope > duration")) === null || _d === void 0 ? void 0 : _d.textContent, NaN);
+    if (Number.isFinite(durationTicks) && durationTicks > 0) {
+        attrs.push(`mks-dur-480="${toMksDur480(durationTicks, sourceDivisions)}"`);
+        attrs.push(`mks-dur-div="${Math.max(1, Math.round(sourceDivisions))}"`);
+        attrs.push(`mks-dur-ticks="${Math.round(durationTicks)}"`);
+    }
     if (dots > 0)
         attrs.push(`dots="${dots}"`);
-    return `<rest ${attrs.join(" ")}/>`;
+    const isInvisible = (note.getAttribute("print-object") || "").trim().toLowerCase() === "no";
+    return `<${isInvisible ? "space" : "rest"} ${attrs.join(" ")}/>`;
 };
 const gatherMeasureNumbers = (parts) => {
     var _a;
@@ -15238,18 +15315,51 @@ const voiceSort = (a, b) => {
         return ai - bi;
     return a.localeCompare(b);
 };
-const buildLayerContent = (notes) => {
-    var _a, _b, _c;
+const buildLayerContent = (notes, sourceDivisions, measureTicks) => {
+    var _a, _b, _c, _d, _e, _f, _g, _h, _j;
+    const pitchNotes = notes.filter((n) => !n.querySelector(":scope > rest"));
+    const simpleRests = notes.filter((n) => n.querySelector(":scope > rest"));
+    if (pitchNotes.length === 0 && simpleRests.length === 1 && notes.length === 1) {
+        const only = simpleRests[0];
+        const isGrace = only.querySelector(":scope > grace") !== null;
+        const durationTicks = parseIntSafe((_a = only.querySelector(":scope > duration")) === null || _a === void 0 ? void 0 : _a.textContent, 0);
+        if (!isGrace && durationTicks === measureTicks && measureTicks > 0) {
+            const isInvisible = (only.getAttribute("print-object") || "").trim().toLowerCase() === "no";
+            const tagName = isInvisible ? "mSpace" : "mRest";
+            const inferred = inferMeiDurAndDotsFromTicks(measureTicks, sourceDivisions);
+            const dotsAttr = inferred.dots > 0 ? ` dots="${inferred.dots}"` : "";
+            return `<${tagName} dur="${inferred.dur}"${dotsAttr} mks-dur-480="${toMksDur480(measureTicks, sourceDivisions)}" mks-dur-div="${Math.max(1, Math.round(sourceDivisions))}" mks-dur-ticks="${Math.round(measureTicks)}"/>`;
+        }
+    }
     const out = [];
     for (let i = 0; i < notes.length; i += 1) {
         const note = notes[i];
         const isRest = Boolean(note.querySelector(":scope > rest"));
         const hasChordFlag = Boolean(note.querySelector(":scope > chord"));
+        const isGracePitchNote = !isRest && !hasChordFlag && note.querySelector(":scope > grace") !== null;
+        if (isGracePitchNote) {
+            const graceGroup = [note];
+            let hasSlash = ((_c = (_b = note.querySelector(":scope > grace")) === null || _b === void 0 ? void 0 : _b.getAttribute("slash")) !== null && _c !== void 0 ? _c : "").trim().toLowerCase() === "yes";
+            for (let j = i + 1; j < notes.length; j += 1) {
+                const next = notes[j];
+                const nextIsRest = Boolean(next.querySelector(":scope > rest"));
+                const nextHasChordFlag = Boolean(next.querySelector(":scope > chord"));
+                const nextIsGracePitch = !nextIsRest && !nextHasChordFlag && next.querySelector(":scope > grace") !== null;
+                if (!nextIsGracePitch)
+                    break;
+                graceGroup.push(next);
+                hasSlash = hasSlash || ((_e = (_d = next.querySelector(":scope > grace")) === null || _d === void 0 ? void 0 : _d.getAttribute("slash")) !== null && _e !== void 0 ? _e : "").trim().toLowerCase() === "yes";
+                i = j;
+            }
+            const members = graceGroup.map((g) => buildSimplePitchNote(g, sourceDivisions, false)).join("");
+            out.push(`<graceGrp slash="${hasSlash ? "yes" : "no"}">${members}</graceGrp>`);
+            continue;
+        }
         if (isRest || hasChordFlag) {
             if (isRest)
-                out.push(buildSimpleRest(note));
+                out.push(buildSimpleRest(note, sourceDivisions));
             else
-                out.push(buildSimplePitchNote(note));
+                out.push(buildSimplePitchNote(note, sourceDivisions));
             continue;
         }
         const chordNotes = [note];
@@ -15261,13 +15371,19 @@ const buildLayerContent = (notes) => {
             i = j;
         }
         if (chordNotes.length === 1) {
-            out.push(buildSimplePitchNote(note));
+            out.push(buildSimplePitchNote(note, sourceDivisions));
             continue;
         }
-        const typeText = (_c = (_b = (_a = note.querySelector(":scope > type")) === null || _a === void 0 ? void 0 : _a.textContent) === null || _b === void 0 ? void 0 : _b.trim()) !== null && _c !== void 0 ? _c : "quarter";
+        const typeText = (_h = (_g = (_f = note.querySelector(":scope > type")) === null || _f === void 0 ? void 0 : _f.textContent) === null || _g === void 0 ? void 0 : _g.trim()) !== null && _h !== void 0 ? _h : "quarter";
         const dur = noteTypeToDur(typeText);
         const dots = note.querySelectorAll(":scope > dot").length;
         const chordAttrs = [`dur="${esc(dur)}"`];
+        const chordDurationTicks = parseIntSafe((_j = note.querySelector(":scope > duration")) === null || _j === void 0 ? void 0 : _j.textContent, NaN);
+        if (Number.isFinite(chordDurationTicks) && chordDurationTicks > 0) {
+            chordAttrs.push(`mks-dur-480="${toMksDur480(chordDurationTicks, sourceDivisions)}"`);
+            chordAttrs.push(`mks-dur-div="${Math.max(1, Math.round(sourceDivisions))}"`);
+            chordAttrs.push(`mks-dur-ticks="${Math.round(chordDurationTicks)}"`);
+        }
         if (dots > 0)
             chordAttrs.push(`dots="${dots}"`);
         const members = chordNotes.map((n) => {
@@ -15283,6 +15399,12 @@ const buildLayerContent = (notes) => {
             ];
             if (accid)
                 noteAttrs.push(`accid="${accid}"`);
+            const tieAttr = extractMeiTieFromMusicXmlNote(n);
+            if (tieAttr)
+                noteAttrs.push(`tie="${esc(tieAttr)}"`);
+            const slurAttr = extractMeiSlurFromMusicXmlNote(n);
+            if (slurAttr)
+                noteAttrs.push(`slur="${esc(slurAttr)}"`);
             const lyric = extractMusicXmlLyric(n);
             if (lyric) {
                 const wordpos = lyricWordposFromSyllabic(lyric.syllabic);
@@ -15349,8 +15471,413 @@ const encodeMeasureMetaForMei = (measure) => {
         parts.push(`doubleBar=${doubleBar}`);
     return parts.length ? parts.join(";") : null;
 };
-const exportMusicXmlDomToMei = (doc) => {
-    var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o;
+const accidentalTextFromAlter = (alter) => {
+    if (!Number.isFinite(alter) || alter === 0)
+        return "";
+    if (alter === 1)
+        return "#";
+    if (alter === -1)
+        return "b";
+    if (alter === 2)
+        return "##";
+    if (alter === -2)
+        return "bb";
+    return "";
+};
+const suffixFromHarmonyKind = (kindNode) => {
+    if (!kindNode)
+        return { suffix: "", fromText: false };
+    const textAttr = (kindNode.getAttribute("text") || "").trim();
+    if (textAttr)
+        return { suffix: textAttr, fromText: true };
+    const kind = (kindNode.textContent || "").trim().toLowerCase();
+    if (kind === "major")
+        return { suffix: "", fromText: false };
+    if (kind === "minor")
+        return { suffix: "m", fromText: false };
+    if (kind === "dominant")
+        return { suffix: "7", fromText: false };
+    if (kind === "major-seventh")
+        return { suffix: "maj7", fromText: false };
+    if (kind === "minor-seventh")
+        return { suffix: "m7", fromText: false };
+    if (kind === "diminished")
+        return { suffix: "dim", fromText: false };
+    if (kind === "augmented")
+        return { suffix: "aug", fromText: false };
+    return { suffix: kind && kind !== "other" ? kind : "", fromText: false };
+};
+const degreeSuffixFromHarmony = (harmony) => {
+    var _a, _b;
+    const out = [];
+    for (const degree of Array.from(harmony.querySelectorAll(":scope > degree"))) {
+        const value = Number.parseInt(((_a = degree.querySelector(":scope > degree-value")) === null || _a === void 0 ? void 0 : _a.textContent) || "", 10);
+        const alter = Number.parseInt(((_b = degree.querySelector(":scope > degree-alter")) === null || _b === void 0 ? void 0 : _b.textContent) || "", 10);
+        if (!Number.isFinite(value) || !Number.isFinite(alter) || alter === 0)
+            continue;
+        out.push(`${accidentalTextFromAlter(alter)}${Math.round(value)}`);
+    }
+    return out.join("");
+};
+const offsetTicksToTstamp = (offsetTicks, divisions, beatType) => {
+    const ticksPerBeat = Math.max(1, (4 * Math.max(1, divisions)) / Math.max(1, beatType));
+    const beatPos = 1 + (Math.max(0, offsetTicks) / ticksPerBeat);
+    const rounded = Math.round(beatPos * 1000) / 1000;
+    return String(rounded).replace(/\.0+$/, "").replace(/(\.\d*?)0+$/, "$1");
+};
+const buildMeiHarmFromMusicXmlHarmony = (harmony, sourceDivisions, beatType) => {
+    var _a, _b, _c, _d, _e;
+    const rootStep = (((_a = harmony.querySelector(":scope > root > root-step")) === null || _a === void 0 ? void 0 : _a.textContent) || "").trim().toUpperCase();
+    if (!/^[A-G]$/.test(rootStep))
+        return null;
+    const rootAlter = Number.parseInt(((_b = harmony.querySelector(":scope > root > root-alter")) === null || _b === void 0 ? void 0 : _b.textContent) || "0", 10);
+    const kindNode = harmony.querySelector(":scope > kind");
+    const kindSuffix = suffixFromHarmonyKind(kindNode);
+    const suffix = `${kindSuffix.suffix}${kindSuffix.fromText ? "" : degreeSuffixFromHarmony(harmony)}`;
+    const bassStep = (((_c = harmony.querySelector(":scope > bass > bass-step")) === null || _c === void 0 ? void 0 : _c.textContent) || "").trim().toUpperCase();
+    const bassAlter = Number.parseInt(((_d = harmony.querySelector(":scope > bass > bass-alter")) === null || _d === void 0 ? void 0 : _d.textContent) || "0", 10);
+    const chordText = `${rootStep}${accidentalTextFromAlter(rootAlter)}${suffix}${/^[A-G]$/.test(bassStep) ? `/${bassStep}${accidentalTextFromAlter(bassAlter)}` : ""}`;
+    if (!chordText)
+        return null;
+    const offsetTicks = parseIntSafe((_e = harmony.querySelector(":scope > offset")) === null || _e === void 0 ? void 0 : _e.textContent, 0);
+    const tstamp = offsetTicks > 0 ? offsetTicksToTstamp(offsetTicks, sourceDivisions, beatType) : "1";
+    return `<harm tstamp="${esc(tstamp)}">${esc(chordText)}</harm>`;
+};
+const collectMeiHarmsForStaff = (measure, localStaff, sourceDivisions, beatType) => {
+    var _a;
+    const out = [];
+    for (const harmony of Array.from(measure.querySelectorAll(":scope > harmony"))) {
+        const staffNo = parseIntSafe((_a = harmony.querySelector(":scope > staff")) === null || _a === void 0 ? void 0 : _a.textContent, 1);
+        if (staffNo !== localStaff)
+            continue;
+        const harm = buildMeiHarmFromMusicXmlHarmony(harmony, sourceDivisions, beatType);
+        if (harm)
+            out.push(harm);
+    }
+    return out;
+};
+const directionOffsetTicks = (direction) => {
+    var _a;
+    return Math.max(0, parseIntSafe((_a = direction.querySelector(":scope > offset")) === null || _a === void 0 ? void 0 : _a.textContent, 0));
+};
+const directionTstamp = (direction, divisions, beatType) => {
+    return offsetTicksToTstamp(directionOffsetTicks(direction), divisions, beatType);
+};
+const directionStaffMatches = (direction, localStaff) => {
+    var _a;
+    const staffNo = parseIntSafe((_a = direction.querySelector(":scope > staff")) === null || _a === void 0 ? void 0 : _a.textContent, 1);
+    return staffNo === localStaff;
+};
+const collectMeiDirectionControlsForStaff = (measure, localStaff, sourceDivisions, beatType) => {
+    var _a, _b;
+    const out = [];
+    const directions = Array.from(measure.querySelectorAll(":scope > direction")).filter((direction) => directionStaffMatches(direction, localStaff));
+    for (const direction of directions) {
+        const placement = (direction.getAttribute("placement") || "").trim().toLowerCase();
+        const placeAttr = placement === "above" || placement === "below" ? ` place="${esc(placement)}"` : "";
+        const tstamp = directionTstamp(direction, sourceDivisions, beatType);
+        const dynamicsNode = direction.querySelector(":scope > direction-type > dynamics");
+        if (dynamicsNode) {
+            const symbol = Array.from(dynamicsNode.children)
+                .map((child) => localNameOf(child))
+                .find((name) => !!name);
+            if (symbol) {
+                out.push(`<dynam tstamp="${esc(tstamp)}"${placeAttr}>${esc(symbol)}</dynam>`);
+                continue;
+            }
+        }
+        const words = (((_a = direction.querySelector(":scope > direction-type > words")) === null || _a === void 0 ? void 0 : _a.textContent) || "").trim();
+        if (words) {
+            out.push(`<dynam tstamp="${esc(tstamp)}"${placeAttr}>${esc(words)}</dynam>`);
+        }
+    }
+    const pendingByNumber = new Map();
+    for (const direction of directions) {
+        const wedge = direction.querySelector(":scope > direction-type > wedge");
+        if (!wedge)
+            continue;
+        const type = (wedge.getAttribute("type") || "").trim().toLowerCase();
+        const number = (wedge.getAttribute("number") || "1").trim() || "1";
+        const tstamp = directionTstamp(direction, sourceDivisions, beatType);
+        const placement = (direction.getAttribute("placement") || "").trim().toLowerCase();
+        const placeAttr = placement === "above" || placement === "below" ? ` place="${esc(placement)}"` : "";
+        if (type === "crescendo" || type === "diminuendo") {
+            pendingByNumber.set(number, { tstamp, form: type === "diminuendo" ? "dim" : "cres", placeAttr });
+            continue;
+        }
+        if (type === "stop") {
+            const pending = pendingByNumber.get(number);
+            if (!pending)
+                continue;
+            out.push(`<hairpin form="${pending.form}" tstamp="${esc(pending.tstamp)}" tstamp2="${esc(tstamp)}"${pending.placeAttr}/>`);
+            pendingByNumber.delete(number);
+        }
+    }
+    for (const pending of pendingByNumber.values()) {
+        out.push(`<hairpin form="${pending.form}" tstamp="${esc(pending.tstamp)}"${pending.placeAttr}/>`);
+    }
+    const pendingPedalByNumber = new Map();
+    for (const direction of directions) {
+        const pedal = direction.querySelector(":scope > direction-type > pedal");
+        if (!pedal)
+            continue;
+        const type = (pedal.getAttribute("type") || "").trim().toLowerCase();
+        const number = (pedal.getAttribute("number") || "1").trim() || "1";
+        const tstamp = directionTstamp(direction, sourceDivisions, beatType);
+        const placement = (direction.getAttribute("placement") || "").trim().toLowerCase();
+        const placeAttr = placement === "above" || placement === "below" ? ` place="${esc(placement)}"` : "";
+        if (type === "start" || type === "resume" || type === "change") {
+            pendingPedalByNumber.set(number, { tstamp, placeAttr });
+            continue;
+        }
+        if (type === "stop" || type === "discontinue") {
+            const pending = pendingPedalByNumber.get(number);
+            if (pending) {
+                out.push(`<pedal tstamp="${esc(pending.tstamp)}" tstamp2="${esc(tstamp)}"${pending.placeAttr}/>`);
+                pendingPedalByNumber.delete(number);
+            }
+            else {
+                out.push(`<pedal tstamp="${esc(tstamp)}" type="stop"${placeAttr}/>`);
+            }
+        }
+    }
+    for (const pending of pendingPedalByNumber.values()) {
+        out.push(`<pedal tstamp="${esc(pending.tstamp)}"${pending.placeAttr}/>`);
+    }
+    const pendingOctaveByNumber = new Map();
+    for (const direction of directions) {
+        const octave = direction.querySelector(":scope > direction-type > octave-shift");
+        if (!octave)
+            continue;
+        const type = (octave.getAttribute("type") || "").trim().toLowerCase();
+        const number = (octave.getAttribute("number") || "1").trim() || "1";
+        const size = parseIntSafe(octave.getAttribute("size"), 8);
+        const dis = Math.max(1, Math.round(size));
+        const disPlace = type === "down" ? "below" : "above";
+        const tstamp = directionTstamp(direction, sourceDivisions, beatType);
+        const placement = (direction.getAttribute("placement") || "").trim().toLowerCase();
+        const placeAttr = placement === "above" || placement === "below" ? ` place="${esc(placement)}"` : "";
+        if (type === "up" || type === "down") {
+            pendingOctaveByNumber.set(number, { tstamp, dis, disPlace, placeAttr });
+            continue;
+        }
+        if (type === "stop" || type === "continue") {
+            const pending = pendingOctaveByNumber.get(number);
+            if (pending) {
+                out.push(`<octave dis="${pending.dis}" dis.place="${pending.disPlace}" tstamp="${esc(pending.tstamp)}" tstamp2="${esc(tstamp)}"${pending.placeAttr}/>`);
+                pendingOctaveByNumber.delete(number);
+            }
+            else {
+                out.push(`<octave dis="${dis}" tstamp="${esc(tstamp)}" type="stop"${placeAttr}/>`);
+            }
+        }
+    }
+    for (const pending of pendingOctaveByNumber.values()) {
+        out.push(`<octave dis="${pending.dis}" dis.place="${pending.disPlace}" tstamp="${esc(pending.tstamp)}"${pending.placeAttr}/>`);
+    }
+    for (const direction of directions) {
+        const tstamp = directionTstamp(direction, sourceDivisions, beatType);
+        const placement = (direction.getAttribute("placement") || "").trim().toLowerCase();
+        const placeAttr = placement === "above" || placement === "below" ? ` place="${esc(placement)}"` : "";
+        const segno = direction.querySelector(":scope > direction-type > segno");
+        if (segno) {
+            out.push(`<repeatMark tstamp="${esc(tstamp)}"${placeAttr}>segno</repeatMark>`);
+            continue;
+        }
+        const coda = direction.querySelector(":scope > direction-type > coda");
+        if (coda) {
+            out.push(`<repeatMark tstamp="${esc(tstamp)}"${placeAttr}>coda</repeatMark>`);
+            continue;
+        }
+        const words = (((_b = direction.querySelector(":scope > direction-type > words")) === null || _b === void 0 ? void 0 : _b.textContent) || "").trim();
+        if (!words)
+            continue;
+        const lowered = words.toLowerCase();
+        if (lowered === "fine"
+            || lowered === "d.c."
+            || lowered === "da capo"
+            || lowered === "d.s."
+            || lowered === "dal segno") {
+            out.push(`<repeatMark tstamp="${esc(tstamp)}"${placeAttr}>${esc(words)}</repeatMark>`);
+        }
+    }
+    return out;
+};
+const collectStaffTimelineForExport = (measure, localStaff, divisions) => {
+    var _a, _b, _c, _d;
+    const out = [];
+    let cursor = 0;
+    for (const child of Array.from(measure.children)) {
+        const name = localNameOf(child);
+        if (name === "backup") {
+            const dur = parseIntSafe((_a = child.querySelector(":scope > duration")) === null || _a === void 0 ? void 0 : _a.textContent, 0);
+            cursor = Math.max(0, cursor - Math.max(0, dur));
+            continue;
+        }
+        if (name === "forward") {
+            const dur = parseIntSafe((_b = child.querySelector(":scope > duration")) === null || _b === void 0 ? void 0 : _b.textContent, 0);
+            cursor += Math.max(0, dur);
+            continue;
+        }
+        if (name !== "note")
+            continue;
+        const note = child;
+        const staffNo = parseIntSafe((_c = note.querySelector(":scope > staff")) === null || _c === void 0 ? void 0 : _c.textContent, 1);
+        const isChordContinuation = note.querySelector(":scope > chord") !== null;
+        const dur = parseIntSafe((_d = note.querySelector(":scope > duration")) === null || _d === void 0 ? void 0 : _d.textContent, 0);
+        if (staffNo === localStaff) {
+            out.push({ note, onset: cursor });
+        }
+        if (!isChordContinuation) {
+            cursor += Math.max(0, dur);
+        }
+    }
+    return out;
+};
+const collectMeiGlissSlideControlsForStaff = (measure, localStaff, divisions, beatType) => {
+    const out = [];
+    const timeline = collectStaffTimelineForExport(measure, localStaff, divisions);
+    const pendingByKey = new Map();
+    for (const item of timeline) {
+        const note = item.note;
+        const tstamp = offsetTicksToTstamp(item.onset, divisions, beatType);
+        const notations = note.querySelectorAll(":scope > notations > glissando, :scope > notations > slide");
+        for (const node of Array.from(notations)) {
+            const kind = localNameOf(node) === "slide" ? "slide" : "gliss";
+            const type = (node.getAttribute("type") || "").trim().toLowerCase();
+            const number = (node.getAttribute("number") || "1").trim() || "1";
+            const key = `${kind}:${number}`;
+            if (type === "start") {
+                pendingByKey.set(key, { kind, tstamp });
+            }
+            else if (type === "stop") {
+                const pending = pendingByKey.get(key);
+                if (pending) {
+                    out.push(`<${pending.kind} tstamp="${esc(pending.tstamp)}" tstamp2="${esc(tstamp)}"/>`);
+                    pendingByKey.delete(key);
+                }
+                else {
+                    out.push(`<${kind} tstamp="${esc(tstamp)}"/>`);
+                }
+            }
+        }
+    }
+    for (const pending of pendingByKey.values()) {
+        out.push(`<${pending.kind} tstamp="${esc(pending.tstamp)}"/>`);
+    }
+    return out;
+};
+const tiePitchKeyFromMusicXmlNote = (note) => {
+    var _a, _b, _c, _d;
+    const pitch = note.querySelector(":scope > pitch");
+    if (!pitch)
+        return null;
+    const step = (((_a = pitch.querySelector(":scope > step")) === null || _a === void 0 ? void 0 : _a.textContent) || "").trim().toUpperCase();
+    const octave = (((_b = pitch.querySelector(":scope > octave")) === null || _b === void 0 ? void 0 : _b.textContent) || "").trim();
+    const alter = (((_c = pitch.querySelector(":scope > alter")) === null || _c === void 0 ? void 0 : _c.textContent) || "0").trim();
+    if (!/^[A-G]$/.test(step) || !/^-?\d+$/.test(octave))
+        return null;
+    const voice = (((_d = note.querySelector(":scope > voice")) === null || _d === void 0 ? void 0 : _d.textContent) || "1").trim() || "1";
+    return `${step}:${alter}:${octave}:v${voice}`;
+};
+const collectMeiTieSlurControlsForStaff = (measure, localStaff, divisions, beatType) => {
+    const out = [];
+    const timeline = collectStaffTimelineForExport(measure, localStaff, divisions);
+    const pendingSlurByNumber = new Map();
+    const pendingTieByPitch = new Map();
+    for (const item of timeline) {
+        const note = item.note;
+        const tstamp = offsetTicksToTstamp(item.onset, divisions, beatType);
+        const slurs = Array.from(note.querySelectorAll(":scope > notations > slur"));
+        for (const slur of slurs) {
+            const type = (slur.getAttribute("type") || "").trim().toLowerCase();
+            const number = String(Math.max(1, parseIntSafe(slur.getAttribute("number"), 1)));
+            if (type === "start") {
+                pendingSlurByNumber.set(number, { tstamp });
+                continue;
+            }
+            if (type === "stop") {
+                const pending = pendingSlurByNumber.get(number);
+                if (pending) {
+                    out.push(`<slur tstamp="${esc(pending.tstamp)}" tstamp2="${esc(tstamp)}"/>`);
+                    pendingSlurByNumber.delete(number);
+                }
+            }
+        }
+        const tieTypes = Array.from(note.querySelectorAll(":scope > tie"))
+            .map((n) => (n.getAttribute("type") || "").trim().toLowerCase())
+            .filter(Boolean);
+        if (tieTypes.length > 0) {
+            const pitchKey = tiePitchKeyFromMusicXmlNote(note);
+            if (pitchKey) {
+                const hasStop = tieTypes.includes("stop");
+                const hasStart = tieTypes.includes("start");
+                if (hasStop) {
+                    const pending = pendingTieByPitch.get(pitchKey);
+                    if (pending) {
+                        out.push(`<tie tstamp="${esc(pending.tstamp)}" tstamp2="${esc(tstamp)}"/>`);
+                        pendingTieByPitch.delete(pitchKey);
+                    }
+                }
+                if (hasStart) {
+                    pendingTieByPitch.set(pitchKey, { tstamp });
+                }
+            }
+        }
+    }
+    return out;
+};
+const collectMeiOrnamentAndBreathControlsForStaff = (measure, localStaff, divisions, beatType) => {
+    const out = [];
+    const timeline = collectStaffTimelineForExport(measure, localStaff, divisions);
+    for (const item of timeline) {
+        const note = item.note;
+        const tstamp = offsetTicksToTstamp(item.onset, divisions, beatType);
+        const notePitch = note.querySelector(":scope > pitch");
+        if (!notePitch)
+            continue;
+        const notations = note.querySelector(":scope > notations");
+        if (!notations)
+            continue;
+        if (notations.querySelector(":scope > ornaments > trill-mark")) {
+            out.push(`<trill tstamp="${esc(tstamp)}"/>`);
+        }
+        if (notations.querySelector(":scope > ornaments > turn")) {
+            out.push(`<turn tstamp="${esc(tstamp)}" type="upper"/>`);
+        }
+        if (notations.querySelector(":scope > ornaments > inverted-turn")) {
+            out.push(`<turn tstamp="${esc(tstamp)}" type="inverted"/>`);
+        }
+        if (notations.querySelector(":scope > ornaments > mordent")) {
+            out.push(`<mordent tstamp="${esc(tstamp)}" type="upper"/>`);
+        }
+        if (notations.querySelector(":scope > ornaments > inverted-mordent")) {
+            out.push(`<mordent tstamp="${esc(tstamp)}" type="inverted"/>`);
+        }
+        const fermata = notations.querySelector(":scope > fermata");
+        if (fermata) {
+            const type = (fermata.getAttribute("type") || "").trim().toLowerCase();
+            const placeAttr = type === "inverted" ? ` place="below"` : "";
+            out.push(`<fermata tstamp="${esc(tstamp)}"${placeAttr}/>`);
+        }
+        if (notations.querySelector(":scope > articulations > breath-mark")) {
+            out.push(`<breath tstamp="${esc(tstamp)}"/>`);
+        }
+        if (notations.querySelector(":scope > articulations > caesura")) {
+            out.push(`<caesura tstamp="${esc(tstamp)}"/>`);
+        }
+    }
+    return out;
+};
+const normalizeMeiVersion = (raw) => {
+    const v = String(raw !== null && raw !== void 0 ? raw : "").trim();
+    if (/^\d+\.\d+(\.\d+)?$/.test(v))
+        return v;
+    return "5.1";
+};
+const exportMusicXmlDomToMei = (doc, options = {}) => {
+    var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p, _q, _r, _s, _t, _u, _v;
+    const meiVersion = normalizeMeiVersion(options.meiVersion);
     const parts = Array.from(doc.querySelectorAll("score-partwise > part"));
     if (parts.length === 0) {
         throw new Error("MusicXML part is missing.");
@@ -15373,12 +15900,25 @@ const exportMusicXmlDomToMei = (doc) => {
     for (const slot of slots) {
         const partEl = (_h = parts.find((part) => { var _a; return ((_a = part.getAttribute("id")) !== null && _a !== void 0 ? _a : "") === slot.partId; })) !== null && _h !== void 0 ? _h : null;
         const clef = resolveClefForSlot(partEl, slot.localStaff);
-        scoreDefLines.push(`<staffDef n="${slot.globalStaff}" label="${esc(slot.label)}" lines="5" clef.shape="${esc(clef.shape)}" clef.line="${clef.line}"/>`);
+        const transpose = resolveTransposeForSlot(partEl, slot.localStaff);
+        const transposeAttrs = [
+            Number.isFinite(transpose === null || transpose === void 0 ? void 0 : transpose.diatonic) ? ` trans.diat="${Math.round(Number(transpose === null || transpose === void 0 ? void 0 : transpose.diatonic))}"` : "",
+            Number.isFinite(transpose === null || transpose === void 0 ? void 0 : transpose.chromatic) ? ` trans.semi="${Math.round(Number(transpose === null || transpose === void 0 ? void 0 : transpose.chromatic))}"` : "",
+        ].join("");
+        scoreDefLines.push(`<staffDef n="${slot.globalStaff}" label="${esc(slot.label)}" lines="5" clef.shape="${esc(clef.shape)}" clef.line="${clef.line}"${transposeAttrs}/>`);
     }
     scoreDefLines.push("</staffGrp>");
     scoreDefLines.push("</scoreDef>");
     const measuresOut = [];
     const measureNumbers = gatherMeasureNumbers(parts);
+    const currentDivisionsByPart = new Map();
+    for (const part of parts) {
+        const partId = ((_j = part.getAttribute("id")) !== null && _j !== void 0 ? _j : "").trim();
+        if (!partId)
+            continue;
+        const firstDivisions = parseIntSafe((_k = part.querySelector(":scope > measure > attributes > divisions")) === null || _k === void 0 ? void 0 : _k.textContent, 1);
+        currentDivisionsByPart.set(partId, Math.max(1, firstDivisions));
+    }
     for (const number of measureNumbers) {
         const measureLines = [];
         measureLines.push(`<measure n="${esc(number)}">`);
@@ -15389,15 +15929,22 @@ const exportMusicXmlDomToMei = (doc) => {
             const measure = Array.from(part.querySelectorAll(":scope > measure")).find((m) => { var _a; return (((_a = m.getAttribute("number")) === null || _a === void 0 ? void 0 : _a.trim()) || "") === number; });
             if (!measure)
                 continue;
+            const partId = ((_l = part.getAttribute("id")) !== null && _l !== void 0 ? _l : "").trim();
+            const measureDivisions = parseIntSafe((_m = measure.querySelector(":scope > attributes > divisions")) === null || _m === void 0 ? void 0 : _m.textContent, NaN);
+            if (Number.isFinite(measureDivisions) && measureDivisions > 0 && partId) {
+                currentDivisionsByPart.set(partId, Math.round(measureDivisions));
+            }
+            const sourceDivisions = Math.max(1, Math.round((_o = currentDivisionsByPart.get(partId)) !== null && _o !== void 0 ? _o : 1));
+            const beatType = parseIntSafe((_p = measure.querySelector(":scope > attributes > time > beat-type")) === null || _p === void 0 ? void 0 : _p.textContent, meterUnit);
             const voiceMap = new Map();
             for (const note of Array.from(measure.querySelectorAll(":scope > note"))) {
-                const localStaff = parseIntSafe((_j = note.querySelector(":scope > staff")) === null || _j === void 0 ? void 0 : _j.textContent, 1);
+                const localStaff = parseIntSafe((_q = note.querySelector(":scope > staff")) === null || _q === void 0 ? void 0 : _q.textContent, 1);
                 if (localStaff !== slot.localStaff)
                     continue;
-                const voice = ((_l = (_k = note.querySelector(":scope > voice")) === null || _k === void 0 ? void 0 : _k.textContent) === null || _l === void 0 ? void 0 : _l.trim()) || "1";
+                const voice = ((_s = (_r = note.querySelector(":scope > voice")) === null || _r === void 0 ? void 0 : _r.textContent) === null || _s === void 0 ? void 0 : _s.trim()) || "1";
                 if (!voiceMap.has(voice))
                     voiceMap.set(voice, []);
-                (_m = voiceMap.get(voice)) === null || _m === void 0 ? void 0 : _m.push(note);
+                (_t = voiceMap.get(voice)) === null || _t === void 0 ? void 0 : _t.push(note);
             }
             if (voiceMap.size === 0)
                 continue;
@@ -15410,9 +15957,31 @@ const exportMusicXmlDomToMei = (doc) => {
             if (measureMeta) {
                 measureLines.push(`<annot type="musicxml-measure-meta" label="mks:measure-meta">${esc(measureMeta)}</annot>`);
             }
+            const controlNodes = collectMeiDirectionControlsForStaff(measure, slot.localStaff, sourceDivisions, beatType);
+            for (const controlNode of controlNodes) {
+                measureLines.push(controlNode);
+            }
+            const glissSlideNodes = collectMeiGlissSlideControlsForStaff(measure, slot.localStaff, sourceDivisions, beatType);
+            for (const node of glissSlideNodes) {
+                measureLines.push(node);
+            }
+            const tieSlurNodes = collectMeiTieSlurControlsForStaff(measure, slot.localStaff, sourceDivisions, beatType);
+            for (const node of tieSlurNodes) {
+                measureLines.push(node);
+            }
+            const ornamentNodes = collectMeiOrnamentAndBreathControlsForStaff(measure, slot.localStaff, sourceDivisions, beatType);
+            for (const node of ornamentNodes) {
+                measureLines.push(node);
+            }
+            const harmNodes = collectMeiHarmsForStaff(measure, slot.localStaff, sourceDivisions, beatType);
+            for (const harmNode of harmNodes) {
+                measureLines.push(harmNode);
+            }
             for (const voice of Array.from(voiceMap.keys()).sort(voiceSort)) {
-                const notes = (_o = voiceMap.get(voice)) !== null && _o !== void 0 ? _o : [];
-                const layer = buildLayerContent(notes);
+                const notes = (_u = voiceMap.get(voice)) !== null && _u !== void 0 ? _u : [];
+                const measureBeats = parseIntSafe((_v = measure.querySelector(":scope > attributes > time > beats")) === null || _v === void 0 ? void 0 : _v.textContent, meterCount);
+                const measureTicks = Math.max(1, Math.round((measureBeats * 4 * sourceDivisions) / Math.max(1, beatType)));
+                const layer = buildLayerContent(notes, sourceDivisions, measureTicks);
                 measureLines.push(`<layer n="${esc(voice)}">${layer}</layer>`);
             }
             measureLines.push("</staff>");
@@ -15422,7 +15991,7 @@ const exportMusicXmlDomToMei = (doc) => {
     }
     return [
         `<?xml version="1.0" encoding="UTF-8"?>`,
-        `<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.1">`,
+        `<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="${esc(meiVersion)}">`,
         `<meiHead><fileDesc><titleStmt><title>${esc(title)}</title></titleStmt><pubStmt><p>Generated by mikuscore</p></pubStmt></fileDesc></meiHead>`,
         `<music><body><mdiv><score>`,
         scoreDefLines.join(""),
@@ -15501,6 +16070,21 @@ const meiDurToQuarterLength = (dur) => {
         return 1;
     return 4 / denom;
 };
+const meiDurToBeamDepth = (dur) => {
+    const normalized = String(dur || "").trim().toLowerCase();
+    const denom = Number.parseInt(normalized, 10);
+    if (!Number.isFinite(denom) || denom < 8)
+        return 0;
+    let depth = 0;
+    let value = denom;
+    while (value >= 8 && Number.isFinite(value)) {
+        depth += 1;
+        value /= 2;
+        if (!Number.isFinite(value) || value <= 0)
+            break;
+    }
+    return Math.max(0, depth);
+};
 const dotsMultiplier = (dots) => {
     const safeDots = Math.max(0, Math.min(4, Math.floor(dots)));
     let sum = 1;
@@ -15510,6 +16094,24 @@ const dotsMultiplier = (dots) => {
         add /= 2;
     }
     return sum;
+};
+const inferMeiDurAndDotsFromTicks = (ticks, divisions) => {
+    const safeTicks = Math.max(1, Math.round(ticks));
+    const safeDiv = Math.max(1, Math.round(divisions));
+    const candidates = ["1", "2", "4", "8", "16", "32", "64", "128"];
+    let best = { dur: "4", dots: 0, diff: Number.POSITIVE_INFINITY };
+    for (const dur of candidates) {
+        const base = meiDurToQuarterLength(dur) * safeDiv;
+        for (let dots = 0; dots <= 3; dots += 1) {
+            const candidate = Math.max(1, Math.round(base * dotsMultiplier(dots)));
+            const diff = Math.abs(candidate - safeTicks);
+            if (diff < best.diff)
+                best = { dur, dots, diff };
+            if (diff === 0)
+                return { dur, dots };
+        }
+    }
+    return { dur: best.dur, dots: best.dots };
 };
 const accidToAlter = (accid) => {
     const normalized = String(accid || "").trim().toLowerCase();
@@ -15543,6 +16145,32 @@ const accidToMusicXmlAccidental = (accid) => {
         return "flat-flat";
     return null;
 };
+const readMeiSoundingAccid = (node) => {
+    const visualAccid = (node.getAttribute("accid") || "").trim();
+    const gesturalAccid = (node.getAttribute("accid.ges") || node.getAttribute("accid-ges") || "").trim();
+    const soundingAccid = visualAccid || gesturalAccid;
+    return { visualAccid, soundingAccid };
+};
+const accidToPitchAlterXml = (accid) => {
+    const alter = accidToAlter(accid);
+    // Prefer omitting <alter>0</alter>; keep explicit accidental display separately.
+    if (alter === null || alter === 0)
+        return "";
+    return `<alter>${alter}</alter>`;
+};
+const impliedAlterFromFifths = (step, fifths) => {
+    const normalizedStep = String(step || "").trim().toUpperCase();
+    if (!/^[A-G]$/.test(normalizedStep))
+        return 0;
+    const n = Math.max(-7, Math.min(7, Math.round(Number(fifths) || 0)));
+    if (n === 0)
+        return 0;
+    const sharpOrder = ["F", "C", "G", "D", "A", "E", "B"];
+    const flatOrder = ["B", "E", "A", "D", "G", "C", "F"];
+    if (n > 0)
+        return sharpOrder.slice(0, n).includes(normalizedStep) ? 1 : 0;
+    return flatOrder.slice(0, Math.abs(n)).includes(normalizedStep) ? -1 : 0;
+};
 const parseMeiKeySigToFifths = (value) => {
     const normalized = String(value || "").trim().toLowerCase();
     if (!normalized || normalized === "0")
@@ -15556,18 +16184,110 @@ const parseMeiKeySigToFifths = (value) => {
         return Math.max(-7, Math.min(7, -Math.abs(num)));
     return Math.max(-7, Math.min(7, num));
 };
+const readMeiKeySigAttr = (element) => {
+    if (!element)
+        return "";
+    return (element.getAttribute("key.sig") || element.getAttribute("keysig") || "").trim();
+};
+const parseMeiKeyAccidToAlter = (value) => {
+    const v = String(value || "").trim().toLowerCase();
+    if (!v || v === "n")
+        return 0;
+    if (v === "s" || v === "#")
+        return 1;
+    if (v === "ss" || v === "x" || v === "##")
+        return 2;
+    if (v === "f" || v === "b" || v === "♭")
+        return -1;
+    if (v === "ff" || v === "bb")
+        return -2;
+    return 0;
+};
+const tonicToFifths = (pname, accid, mode) => {
+    var _a, _b;
+    const step = String(pname || "").trim().toUpperCase();
+    if (!/^[A-G]$/.test(step))
+        return null;
+    const alter = parseMeiKeyAccidToAlter(accid);
+    const normalizedMode = String(mode || "").trim().toLowerCase();
+    const tonic = `${step}${alter > 0 ? "#".repeat(alter) : alter < 0 ? "b".repeat(Math.abs(alter)) : ""}`;
+    const majorMap = {
+        C: 0, G: 1, D: 2, A: 3, E: 4, B: 5, "F#": 6, "C#": 7,
+        F: -1, Bb: -2, Eb: -3, Ab: -4, Db: -5, Gb: -6, Cb: -7,
+    };
+    const minorMap = {
+        A: 0, E: 1, B: 2, "F#": 3, "C#": 4, "G#": 5, "D#": 6, "A#": 7,
+        D: -1, G: -2, C: -3, F: -4, Bb: -5, Eb: -6, Ab: -7,
+    };
+    if (normalizedMode === "minor")
+        return (_a = minorMap[tonic]) !== null && _a !== void 0 ? _a : null;
+    return (_b = majorMap[tonic]) !== null && _b !== void 0 ? _b : null;
+};
+const parseMeiKeyFifthsFromElement = (element) => {
+    if (!element)
+        return null;
+    const keySig = readMeiKeySigAttr(element);
+    if (keySig)
+        return parseMeiKeySigToFifths(keySig);
+    const keyPname = element.getAttribute("key.pname") || "";
+    const keyAccid = element.getAttribute("key.accid") || "";
+    const keyMode = element.getAttribute("key.mode") || "major";
+    return tonicToFifths(keyPname, keyAccid, keyMode);
+};
 const toHex = (value, width = 2) => {
     const safe = Math.max(0, Math.round(Number(value) || 0));
     return `0x${safe.toString(16).toUpperCase().padStart(width, "0")}`;
 };
-const buildMusicXmlNoteFromMeiNote = (meiNote, durationTicks, typeText, dots, voice) => {
+const resolveDurTicksFromMetadata = (source, fallbackTicks, targetDivisions) => {
+    const dur480 = parseIntSafe(source.getAttribute("mks-dur-480"), NaN);
+    if (Number.isFinite(dur480) && dur480 > 0)
+        return Math.round(dur480);
+    const legacyTicks = parseIntSafe(source.getAttribute("mks-dur-ticks"), NaN);
+    if (!Number.isFinite(legacyTicks) || legacyTicks <= 0)
+        return fallbackTicks;
+    const legacyDivisions = parseIntSafe(source.getAttribute("mks-dur-div"), NaN);
+    if (Number.isFinite(legacyDivisions) && legacyDivisions > 0) {
+        return Math.max(1, Math.round((legacyTicks * targetDivisions) / legacyDivisions));
+    }
+    // Legacy MEI without source divisions should keep semantic duration from dur/dots.
+    return fallbackTicks;
+};
+const parseMeiTieFlags = (raw) => {
+    const normalized = String(raw || "").trim().toLowerCase();
+    if (!normalized)
+        return { start: false, stop: false };
+    const hasMiddle = normalized.includes("m");
+    const start = hasMiddle || normalized.includes("i");
+    const stop = hasMiddle || normalized.includes("t");
+    return { start, stop };
+};
+const parseMeiSlurNotations = (raw) => {
+    const normalized = String(raw || "").trim().toLowerCase();
+    if (!normalized)
+        return [];
+    const out = [];
+    const rx = /([imt])\s*(\d+)?|(\d+)\s*([imt])/g;
+    let m;
+    while ((m = rx.exec(normalized)) !== null) {
+        const kind = (m[1] || m[4] || "").toLowerCase();
+        const nRaw = m[2] || m[3] || "1";
+        const number = Math.max(1, parseIntSafe(nRaw, 1));
+        if (kind === "i" || kind === "m")
+            out.push({ type: "start", number });
+        if (kind === "t" || kind === "m")
+            out.push({ type: "stop", number });
+    }
+    return out;
+};
+const buildMusicXmlNoteFromMeiNote = (meiNote, durationTicks, typeText, dots, voice, measureFifths) => {
     var _a, _b;
     const pname = (meiNote.getAttribute("pname") || "c").trim().toUpperCase();
     const octave = parseIntSafe(meiNote.getAttribute("oct"), 4);
-    const accid = meiNote.getAttribute("accid") || "";
-    const alter = accidToAlter(accid);
-    const alterXml = alter === null ? "" : `<alter>${alter}</alter>`;
-    const accidentalText = accidToMusicXmlAccidental(accid);
+    const { visualAccid, soundingAccid } = readMeiSoundingAccid(meiNote);
+    const explicitAlterXml = accidToPitchAlterXml(soundingAccid);
+    const impliedAlter = impliedAlterFromFifths(pname, measureFifths);
+    const alterXml = explicitAlterXml || (impliedAlter !== 0 ? `<alter>${impliedAlter}</alter>` : "");
+    const accidentalText = accidToMusicXmlAccidental(visualAccid);
     const accidentalXml = accidentalText ? `<accidental>${xmlEscape(accidentalText)}</accidental>` : "";
     const dotXml = Array.from({ length: dots }, () => "<dot/>").join("");
     const actual = parseIntSafe(meiNote.getAttribute("num"), NaN);
@@ -15585,133 +16305,1395 @@ const buildMusicXmlNoteFromMeiNote = (meiNote, durationTicks, typeText, dots, vo
         arts.push("<staccato/>");
     if (articTokens.includes("acc"))
         arts.push("<accent/>");
+    const tieFlags = parseMeiTieFlags(meiNote.getAttribute("tie") || "");
+    const tieXml = `${tieFlags.start ? '<tie type="start"/>' : ""}${tieFlags.stop ? '<tie type="stop"/>' : ""}`;
+    const tiedXml = `${tieFlags.start ? '<tied type="start"/>' : ""}${tieFlags.stop ? '<tied type="stop"/>' : ""}`;
+    const slurXml = parseMeiSlurNotations(meiNote.getAttribute("slur") || "")
+        .map((entry) => `<slur type="${entry.type}" number="${entry.number}"/>`)
+        .join("");
     const tupletXml = `${hasTupletStart ? '<tuplet type="start"/>' : ""}${hasTupletStop ? '<tuplet type="stop"/>' : ""}`;
-    const hasNotations = arts.length > 0 || tupletXml.length > 0;
+    const hasNotations = arts.length > 0 || tupletXml.length > 0 || tiedXml.length > 0 || slurXml.length > 0;
     const notationsXml = hasNotations
-        ? `<notations>${arts.length ? `<articulations>${arts.join("")}</articulations>` : ""}${tupletXml}</notations>`
+        ? `<notations>${arts.length ? `<articulations>${arts.join("")}</articulations>` : ""}${tupletXml}${tiedXml}${slurXml}</notations>`
         : "";
     const graceAttr = (meiNote.getAttribute("grace") || "").trim().toLowerCase();
     const isGrace = graceAttr === "acc" || graceAttr === "unacc";
-    const graceXml = isGrace ? `<grace${graceAttr === "acc" ? ' slash="yes"' : ""}/>` : "";
+    const stemMod = (meiNote.getAttribute("stem.mod") || "").trim().toLowerCase();
+    const hasStemSlash = stemMod.includes("slash");
+    const graceXml = isGrace ? `<grace${graceAttr === "acc" || hasStemSlash ? ' slash="yes"' : ""}/>` : "";
     const durationXml = isGrace ? "" : `<duration>${durationTicks}</duration>`;
+    const stemDir = (meiNote.getAttribute("stem.dir") || "").trim().toLowerCase();
+    const stemXml = stemDir === "up" || stemDir === "down" ? `<stem>${xmlEscape(stemDir)}</stem>` : "";
     const lyric = extractMeiLyric(meiNote);
     const lyricXml = lyric
         ? `<lyric>${lyric.syllabic ? `<syllabic>${xmlEscape(lyric.syllabic)}</syllabic>` : ""}<text>${xmlEscape(lyric.text)}</text></lyric>`
         : "";
-    return `<note>${graceXml}<pitch><step>${xmlEscape(pname)}</step>${alterXml}<octave>${octave}</octave></pitch>${durationXml}<voice>${xmlEscape(voice)}</voice><type>${xmlEscape(typeText)}</type>${dotXml}${accidentalXml}${timeModificationXml}${notationsXml}${lyricXml}</note>`;
+    return `<note>${graceXml}<pitch><step>${xmlEscape(pname)}</step>${alterXml}<octave>${octave}</octave></pitch>${tieXml}${durationXml}<voice>${xmlEscape(voice)}</voice><type>${xmlEscape(typeText)}</type>${dotXml}${stemXml}${accidentalXml}${timeModificationXml}${notationsXml}${lyricXml}</note>`;
 };
-const parseLayerEvents = (layer, divisions, voice) => {
-    var _a, _b;
+const parseLayerEvents = (layer, divisions, voice, measureTicks, measureFifths, tieCarryIn = new Map()) => {
     const events = [];
-    for (const child of Array.from(layer.children)) {
-        const name = localNameOf(child);
-        if (name === "note") {
-            const durAttr = child.getAttribute("dur") || "4";
-            const dots = parseIntSafe(child.getAttribute("dots"), 0);
-            const typeText = meiDurToMusicXmlType(durAttr);
-            const graceAttr = (child.getAttribute("grace") || "").trim().toLowerCase();
-            const isGrace = graceAttr === "acc" || graceAttr === "unacc";
-            const actual = parseIntSafe(child.getAttribute("num"), NaN);
-            const normal = parseIntSafe(child.getAttribute("numbase"), NaN);
-            const tupletRatio = Number.isFinite(actual) && Number.isFinite(normal) && actual > 0 && normal > 0
-                ? Math.max(0.0001, Math.round(normal) / Math.round(actual))
-                : 1;
-            const ticks = isGrace
-                ? 0
-                : Math.max(1, Math.round(meiDurToQuarterLength(durAttr) * dotsMultiplier(dots) * divisions * tupletRatio));
-            events.push({
-                kind: "note",
-                durationTicks: ticks,
-                xml: buildMusicXmlNoteFromMeiNote(child, ticks, typeText, dots, voice),
-            });
-            continue;
+    const idToEventIndex = new Map();
+    const tieCarryByPitch = new Map(tieCarryIn);
+    const tiePitchKey = (pname, octave) => `${String(pname || "").trim().toUpperCase()}:${Math.round(Number(octave) || 0)}`;
+    const breaksecFromNode = (node) => {
+        const raw = parseIntSafe(node.getAttribute("breaksec"), NaN);
+        if (!Number.isFinite(raw) || raw <= 0)
+            return null;
+        return Math.round(raw);
+    };
+    const pushNoteEvent = (node, forcedTuplet = null) => {
+        let effectiveNode = node;
+        if (forcedTuplet
+            && !effectiveNode.getAttribute("num")
+            && !effectiveNode.getAttribute("numbase")) {
+            effectiveNode = node.cloneNode(true);
+            effectiveNode.setAttribute("num", String(Math.round(forcedTuplet.num)));
+            effectiveNode.setAttribute("numbase", String(Math.round(forcedTuplet.numbase)));
         }
-        if (name === "rest") {
-            const durAttr = child.getAttribute("dur") || "4";
-            const dots = parseIntSafe(child.getAttribute("dots"), 0);
-            const typeText = meiDurToMusicXmlType(durAttr);
-            const ticks = Math.max(1, Math.round(meiDurToQuarterLength(durAttr) * dotsMultiplier(dots) * divisions));
-            const dotXml = Array.from({ length: dots }, () => "<dot/>").join("");
-            events.push({
-                kind: "rest",
-                durationTicks: ticks,
-                xml: `<note><rest/><duration>${ticks}</duration><voice>${xmlEscape(voice)}</voice><type>${xmlEscape(typeText)}</type>${dotXml}</note>`,
-            });
-            continue;
-        }
-        if (name === "chord") {
-            const durAttr = child.getAttribute("dur") || "4";
-            const dots = parseIntSafe(child.getAttribute("dots"), 0);
-            const typeText = meiDurToMusicXmlType(durAttr);
-            const actual = parseIntSafe(child.getAttribute("num"), NaN);
-            const normal = parseIntSafe(child.getAttribute("numbase"), NaN);
-            const tupletRatio = Number.isFinite(actual) && Number.isFinite(normal) && actual > 0 && normal > 0
-                ? Math.max(0.0001, Math.round(normal) / Math.round(actual))
-                : 1;
-            const ticks = Math.max(1, Math.round(meiDurToQuarterLength(durAttr) * dotsMultiplier(dots) * divisions * tupletRatio));
-            const noteChildren = childElementsByName(child, "note");
-            if (noteChildren.length === 0)
-                continue;
-            const dotXml = Array.from({ length: dots }, () => "<dot/>").join("");
-            const chordTupletStart = ((_a = child.getAttribute("mks-tuplet-start")) !== null && _a !== void 0 ? _a : "").trim() === "1";
-            const chordTupletStop = ((_b = child.getAttribute("mks-tuplet-stop")) !== null && _b !== void 0 ? _b : "").trim() === "1";
-            const timeModificationXml = Number.isFinite(actual) && Number.isFinite(normal) && actual > 0 && normal > 0
-                ? `<time-modification><actual-notes>${Math.round(actual)}</actual-notes><normal-notes>${Math.round(normal)}</normal-notes></time-modification>`
-                : "";
-            const chordArticRaw = (child.getAttribute("artic") || "").trim().toLowerCase();
-            const noteXml = noteChildren
-                .map((note, index) => {
-                const pname = (note.getAttribute("pname") || "c").trim().toUpperCase();
-                const octave = parseIntSafe(note.getAttribute("oct"), 4);
-                const accid = note.getAttribute("accid") || "";
-                const alter = accidToAlter(accid);
-                const alterXml = alter === null ? "" : `<alter>${alter}</alter>`;
-                const accidentalText = accidToMusicXmlAccidental(accid);
-                const accidentalXml = accidentalText ? `<accidental>${xmlEscape(accidentalText)}</accidental>` : "";
-                const chordXml = index > 0 ? "<chord/>" : "";
-                const mergedArticRaw = `${chordArticRaw} ${(note.getAttribute("artic") || "").trim().toLowerCase()}`.trim();
-                const articTokens = mergedArticRaw.split(/\s+/).filter(Boolean);
+        const durAttr = effectiveNode.getAttribute("dur") || "4";
+        const dots = parseIntSafe(node.getAttribute("dots"), 0);
+        const typeText = meiDurToMusicXmlType(durAttr);
+        const graceAttr = (effectiveNode.getAttribute("grace") || "").trim().toLowerCase();
+        const isGrace = graceAttr === "acc" || graceAttr === "unacc";
+        const actual = parseIntSafe(effectiveNode.getAttribute("num"), NaN);
+        const normal = parseIntSafe(effectiveNode.getAttribute("numbase"), NaN);
+        const tupletRatio = Number.isFinite(actual) && Number.isFinite(normal) && actual > 0 && normal > 0
+            ? Math.max(0.0001, Math.round(normal) / Math.round(actual))
+            : 1;
+        const ticks = isGrace
+            ? 0
+            : Math.max(1, Math.round(meiDurToQuarterLength(durAttr) * dotsMultiplier(dots) * divisions * tupletRatio));
+        const resolvedTicks = isGrace
+            ? 0
+            : resolveDurTicksFromMetadata(node, ticks, divisions);
+        const eventIndex = events.length;
+        const pname = (effectiveNode.getAttribute("pname") || "c").trim().toUpperCase();
+        const octave = parseIntSafe(effectiveNode.getAttribute("oct"), 4);
+        const tieFlags = parseMeiTieFlags(effectiveNode.getAttribute("tie") || "");
+        const { visualAccid, soundingAccid } = readMeiSoundingAccid(effectiveNode);
+        const explicitAlter = accidToAlter(soundingAccid);
+        const impliedAlter = impliedAlterFromFifths(pname, measureFifths);
+        const pitchKey = tiePitchKey(pname, octave);
+        const carriedAlter = tieFlags.stop && explicitAlter === null
+            ? tieCarryByPitch.get(pitchKey)
+            : undefined;
+        const resolvedAlter = explicitAlter !== null
+            ? explicitAlter
+            : Number.isFinite(carriedAlter)
+                ? Math.round(Number(carriedAlter))
+                : impliedAlter;
+        const alterXml = resolvedAlter !== 0 ? `<alter>${resolvedAlter}</alter>` : "";
+        const accidentalText = accidToMusicXmlAccidental(visualAccid);
+        const accidentalXml = accidentalText ? `<accidental>${xmlEscape(accidentalText)}</accidental>` : "";
+        const tiedXml = `${tieFlags.start ? '<tied type="start"/>' : ""}${tieFlags.stop ? '<tied type="stop"/>' : ""}`;
+        const tieXml = `${tieFlags.start ? '<tie type="start"/>' : ""}${tieFlags.stop ? '<tie type="stop"/>' : ""}`;
+        const slurXml = parseMeiSlurNotations(effectiveNode.getAttribute("slur") || "")
+            .map((entry) => `<slur type="${entry.type}" number="${entry.number}"/>`)
+            .join("");
+        const hasNotations = tiedXml.length > 0 || slurXml.length > 0;
+        const notationsXml = hasNotations ? `<notations>${tiedXml}${slurXml}</notations>` : "";
+        events.push({
+            kind: "note",
+            durationTicks: resolvedTicks,
+            xml: (() => {
+                var _a, _b;
+                const graceAttr = (effectiveNode.getAttribute("grace") || "").trim().toLowerCase();
+                const isGrace = graceAttr === "acc" || graceAttr === "unacc";
+                const stemMod = (effectiveNode.getAttribute("stem.mod") || "").trim().toLowerCase();
+                const hasStemSlash = stemMod.includes("slash");
+                const graceXml = isGrace ? `<grace${graceAttr === "acc" || hasStemSlash ? ' slash="yes"' : ""}/>` : "";
+                const durationXml = isGrace ? "" : `<duration>${resolvedTicks}</duration>`;
+                const dotXml = Array.from({ length: dots }, () => "<dot/>").join("");
+                const stemDir = (effectiveNode.getAttribute("stem.dir") || "").trim().toLowerCase();
+                const stemXml = stemDir === "up" || stemDir === "down" ? `<stem>${xmlEscape(stemDir)}</stem>` : "";
+                const lyric = extractMeiLyric(effectiveNode);
+                const lyricXml = lyric
+                    ? `<lyric>${lyric.syllabic ? `<syllabic>${xmlEscape(lyric.syllabic)}</syllabic>` : ""}<text>${xmlEscape(lyric.text)}</text></lyric>`
+                    : "";
+                const actual = parseIntSafe(effectiveNode.getAttribute("num"), NaN);
+                const normal = parseIntSafe(effectiveNode.getAttribute("numbase"), NaN);
+                const hasTimeModification = Number.isFinite(actual) && Number.isFinite(normal) && actual > 0 && normal > 0;
+                const timeModificationXml = hasTimeModification
+                    ? `<time-modification><actual-notes>${Math.round(actual)}</actual-notes><normal-notes>${Math.round(normal)}</normal-notes></time-modification>`
+                    : "";
+                const articRaw = (effectiveNode.getAttribute("artic") || "").trim().toLowerCase();
+                const articTokens = articRaw.split(/\s+/).filter(Boolean);
                 const arts = [];
                 if (articTokens.includes("stacc"))
                     arts.push("<staccato/>");
                 if (articTokens.includes("acc"))
                     arts.push("<accent/>");
-                const tupletXml = index === 0
-                    ? `${chordTupletStart ? '<tuplet type="start"/>' : ""}${chordTupletStop ? '<tuplet type="stop"/>' : ""}`
+                const tupletStart = ((_a = effectiveNode.getAttribute("mks-tuplet-start")) !== null && _a !== void 0 ? _a : "").trim() === "1";
+                const tupletStop = ((_b = effectiveNode.getAttribute("mks-tuplet-stop")) !== null && _b !== void 0 ? _b : "").trim() === "1";
+                const tupletXml = `${tupletStart ? '<tuplet type="start"/>' : ""}${tupletStop ? '<tuplet type="stop"/>' : ""}`;
+                const fullNotationsXml = arts.length > 0 || tupletXml.length > 0 || tiedXml.length > 0 || slurXml.length > 0
+                    ? `<notations>${arts.length ? `<articulations>${arts.join("")}</articulations>` : ""}${tupletXml}${tiedXml}${slurXml}</notations>`
                     : "";
-                const notationsXml = index === 0 && arts.length
-                    ? `<notations><articulations>${arts.join("")}</articulations>${tupletXml}</notations>`
-                    : index === 0 && tupletXml.length
-                        ? `<notations>${tupletXml}</notations>`
-                        : "";
-                const lyric = extractMeiLyric(note);
-                const lyricXml = lyric
-                    ? `<lyric>${lyric.syllabic ? `<syllabic>${xmlEscape(lyric.syllabic)}</syllabic>` : ""}<text>${xmlEscape(lyric.text)}</text></lyric>`
-                    : "";
-                return `<note>${chordXml}<pitch><step>${xmlEscape(pname)}</step>${alterXml}<octave>${octave}</octave></pitch><duration>${ticks}</duration><voice>${xmlEscape(voice)}</voice><type>${xmlEscape(typeText)}</type>${dotXml}${accidentalXml}${timeModificationXml}${notationsXml}${lyricXml}</note>`;
-            })
+                return `<note>${graceXml}<pitch><step>${xmlEscape(pname)}</step>${alterXml}<octave>${octave}</octave></pitch>${tieXml}${durationXml}<voice>${xmlEscape(voice)}</voice><type>${xmlEscape(typeText)}</type>${dotXml}${stemXml}${accidentalXml}${timeModificationXml}${fullNotationsXml}${lyricXml}</note>`;
+            })(),
+            beamDepth: meiDurToBeamDepth(durAttr),
+            breaksecAfter: breaksecFromNode(effectiveNode),
+        });
+        if (tieFlags.start) {
+            tieCarryByPitch.set(pitchKey, resolvedAlter);
+        }
+        else if (tieFlags.stop) {
+            tieCarryByPitch.delete(pitchKey);
+        }
+        const xmlId = (effectiveNode.getAttribute("xml:id") || effectiveNode.getAttribute("id") || "").trim();
+        if (xmlId)
+            idToEventIndex.set(xmlId, eventIndex);
+    };
+    const pushRestEvent = (node, forcedTuplet = null) => {
+        let effectiveNode = node;
+        if (forcedTuplet
+            && !effectiveNode.getAttribute("num")
+            && !effectiveNode.getAttribute("numbase")) {
+            effectiveNode = node.cloneNode(true);
+            effectiveNode.setAttribute("num", String(Math.round(forcedTuplet.num)));
+            effectiveNode.setAttribute("numbase", String(Math.round(forcedTuplet.numbase)));
+        }
+        const graceAttr = (effectiveNode.getAttribute("grace") || "").trim().toLowerCase();
+        const isGrace = graceAttr === "acc" || graceAttr === "unacc";
+        if (isGrace)
+            return;
+        const durAttr = effectiveNode.getAttribute("dur") || "4";
+        const dots = parseIntSafe(effectiveNode.getAttribute("dots"), 0);
+        const actual = parseIntSafe(effectiveNode.getAttribute("num"), NaN);
+        const normal = parseIntSafe(effectiveNode.getAttribute("numbase"), NaN);
+        const tupletRatio = Number.isFinite(actual) && Number.isFinite(normal) && actual > 0 && normal > 0
+            ? Math.max(0.0001, Math.round(normal) / Math.round(actual))
+            : 1;
+        const typeText = meiDurToMusicXmlType(durAttr);
+        const ticks = Math.max(1, Math.round(meiDurToQuarterLength(durAttr) * dotsMultiplier(dots) * divisions * tupletRatio));
+        const resolvedTicks = resolveDurTicksFromMetadata(effectiveNode, ticks, divisions);
+        const dotXml = Array.from({ length: dots }, () => "<dot/>").join("");
+        events.push({
+            kind: "rest",
+            durationTicks: resolvedTicks,
+            xml: `<note><rest/><duration>${resolvedTicks}</duration><voice>${xmlEscape(voice)}</voice><type>${xmlEscape(typeText)}</type>${dotXml}</note>`,
+            beamDepth: meiDurToBeamDepth(durAttr),
+            breaksecAfter: null,
+        });
+    };
+    const pushChordEvent = (node, forcedTuplet = null) => {
+        var _a, _b;
+        let effectiveNode = node;
+        if (forcedTuplet
+            && !effectiveNode.getAttribute("num")
+            && !effectiveNode.getAttribute("numbase")) {
+            effectiveNode = node.cloneNode(true);
+            effectiveNode.setAttribute("num", String(Math.round(forcedTuplet.num)));
+            effectiveNode.setAttribute("numbase", String(Math.round(forcedTuplet.numbase)));
+        }
+        const durAttr = effectiveNode.getAttribute("dur") || "4";
+        const dots = parseIntSafe(effectiveNode.getAttribute("dots"), 0);
+        const typeText = meiDurToMusicXmlType(durAttr);
+        const graceAttr = (effectiveNode.getAttribute("grace") || "").trim().toLowerCase();
+        const isGrace = graceAttr === "acc" || graceAttr === "unacc";
+        const actual = parseIntSafe(effectiveNode.getAttribute("num"), NaN);
+        const normal = parseIntSafe(effectiveNode.getAttribute("numbase"), NaN);
+        const tupletRatio = Number.isFinite(actual) && Number.isFinite(normal) && actual > 0 && normal > 0
+            ? Math.max(0.0001, Math.round(normal) / Math.round(actual))
+            : 1;
+        const ticks = isGrace ? 0 : Math.max(1, Math.round(meiDurToQuarterLength(durAttr) * dotsMultiplier(dots) * divisions * tupletRatio));
+        const resolvedTicks = isGrace ? 0 : resolveDurTicksFromMetadata(effectiveNode, ticks, divisions);
+        const noteChildren = childElementsByName(effectiveNode, "note");
+        if (noteChildren.length === 0)
+            return;
+        const dotXml = Array.from({ length: dots }, () => "<dot/>").join("");
+        const chordTupletStart = ((_a = effectiveNode.getAttribute("mks-tuplet-start")) !== null && _a !== void 0 ? _a : "").trim() === "1";
+        const chordTupletStop = ((_b = effectiveNode.getAttribute("mks-tuplet-stop")) !== null && _b !== void 0 ? _b : "").trim() === "1";
+        const timeModificationXml = Number.isFinite(actual) && Number.isFinite(normal) && actual > 0 && normal > 0
+            ? `<time-modification><actual-notes>${Math.round(actual)}</actual-notes><normal-notes>${Math.round(normal)}</normal-notes></time-modification>`
+            : "";
+        const chordArticRaw = (effectiveNode.getAttribute("artic") || "").trim().toLowerCase();
+        const graceXml = isGrace ? `<grace${graceAttr === "acc" ? ' slash="yes"' : ""}/>` : "";
+        const durationXml = isGrace ? "" : `<duration>${resolvedTicks}</duration>`;
+        const noteXml = noteChildren
+            .map((note, index) => {
+            const pname = (note.getAttribute("pname") || "c").trim().toUpperCase();
+            const octave = parseIntSafe(note.getAttribute("oct"), 4);
+            const { visualAccid, soundingAccid } = readMeiSoundingAccid(note);
+            const explicitAlter = accidToAlter(soundingAccid);
+            const impliedAlter = impliedAlterFromFifths(pname, measureFifths);
+            const tieFlags = parseMeiTieFlags(note.getAttribute("tie") || "");
+            const pitchKey = tiePitchKey(pname, octave);
+            const carriedAlter = tieFlags.stop && explicitAlter === null
+                ? tieCarryByPitch.get(pitchKey)
+                : undefined;
+            const resolvedAlter = explicitAlter !== null
+                ? explicitAlter
+                : Number.isFinite(carriedAlter)
+                    ? Math.round(Number(carriedAlter))
+                    : impliedAlter;
+            const alterXml = resolvedAlter !== 0 ? `<alter>${resolvedAlter}</alter>` : "";
+            const accidentalText = accidToMusicXmlAccidental(visualAccid);
+            const accidentalXml = accidentalText ? `<accidental>${xmlEscape(accidentalText)}</accidental>` : "";
+            const chordXml = index > 0 ? "<chord/>" : "";
+            const mergedArticRaw = `${chordArticRaw} ${(note.getAttribute("artic") || "").trim().toLowerCase()}`.trim();
+            const articTokens = mergedArticRaw.split(/\s+/).filter(Boolean);
+            const arts = [];
+            if (articTokens.includes("stacc"))
+                arts.push("<staccato/>");
+            if (articTokens.includes("acc"))
+                arts.push("<accent/>");
+            const tieXml = `${tieFlags.start ? '<tie type="start"/>' : ""}${tieFlags.stop ? '<tie type="stop"/>' : ""}`;
+            const tiedXml = `${tieFlags.start ? '<tied type="start"/>' : ""}${tieFlags.stop ? '<tied type="stop"/>' : ""}`;
+            const slurXml = parseMeiSlurNotations(note.getAttribute("slur") || "")
+                .map((entry) => `<slur type="${entry.type}" number="${entry.number}"/>`)
                 .join("");
-            events.push({ kind: "chord", durationTicks: ticks, xml: noteXml });
-            continue;
+            const tupletXml = index === 0
+                ? `${chordTupletStart ? '<tuplet type="start"/>' : ""}${chordTupletStop ? '<tuplet type="stop"/>' : ""}`
+                : "";
+            const notationsXml = (index === 0 && (arts.length > 0 || tupletXml.length > 0)) || tiedXml.length > 0 || slurXml.length > 0
+                ? `<notations>${index === 0 && arts.length ? `<articulations>${arts.join("")}</articulations>` : ""}${index === 0 ? tupletXml : ""}${tiedXml}${slurXml}</notations>`
+                : "";
+            const lyric = extractMeiLyric(note);
+            const lyricXml = lyric
+                ? `<lyric>${lyric.syllabic ? `<syllabic>${xmlEscape(lyric.syllabic)}</syllabic>` : ""}<text>${xmlEscape(lyric.text)}</text></lyric>`
+                : "";
+            if (tieFlags.start) {
+                tieCarryByPitch.set(pitchKey, resolvedAlter);
+            }
+            else if (tieFlags.stop) {
+                tieCarryByPitch.delete(pitchKey);
+            }
+            return `<note>${chordXml}${graceXml}<pitch><step>${xmlEscape(pname)}</step>${alterXml}<octave>${octave}</octave></pitch>${tieXml}${durationXml}<voice>${xmlEscape(voice)}</voice><type>${xmlEscape(typeText)}</type>${dotXml}${accidentalXml}${timeModificationXml}${notationsXml}${lyricXml}</note>`;
+        })
+            .join("");
+        const eventIndex = events.length;
+        events.push({ kind: "chord", durationTicks: resolvedTicks, xml: noteXml });
+        events[eventIndex] = {
+            ...events[eventIndex],
+            beamDepth: meiDurToBeamDepth(durAttr),
+            breaksecAfter: breaksecFromNode(effectiveNode),
+        };
+        const xmlId = (effectiveNode.getAttribute("xml:id") || effectiveNode.getAttribute("id") || "").trim();
+        if (xmlId)
+            idToEventIndex.set(xmlId, eventIndex);
+        for (const chordNote of noteChildren) {
+            const noteId = (chordNote.getAttribute("xml:id") || chordNote.getAttribute("id") || "").trim();
+            if (noteId && !idToEventIndex.has(noteId)) {
+                idToEventIndex.set(noteId, eventIndex);
+            }
+        }
+    };
+    const processElement = (node, forcedGrace = null, forcedTuplet = null) => {
+        const name = localNameOf(node);
+        if (name === "beam") {
+            const startIndex = events.length;
+            for (const child of Array.from(node.children)) {
+                if (child instanceof Element)
+                    processElement(child, forcedGrace, forcedTuplet);
+            }
+            const endIndex = events.length;
+            const pitchedIndexes = [];
+            for (let i = startIndex; i < endIndex; i += 1) {
+                if (events[i].kind !== "rest")
+                    pitchedIndexes.push(i);
+            }
+            if (pitchedIndexes.length >= 2) {
+                const depths = pitchedIndexes.map((idx) => Math.max(1, events[idx].beamDepth || 1));
+                const breaksecs = pitchedIndexes.map((idx) => { var _a; return (_a = events[idx].breaksecAfter) !== null && _a !== void 0 ? _a : null; });
+                const maxDepth = Math.max(1, ...depths);
+                const canConnect = (leftIdx, level) => {
+                    if (leftIdx < 0 || leftIdx >= pitchedIndexes.length - 1)
+                        return false;
+                    if (depths[leftIdx] < level)
+                        return false;
+                    if (depths[leftIdx + 1] < level)
+                        return false;
+                    const keep = breaksecs[leftIdx];
+                    if (Number.isFinite(keep) && keep < level)
+                        return false;
+                    return true;
+                };
+                for (let level = 1; level <= maxDepth; level += 1) {
+                    for (let i = 0; i < pitchedIndexes.length; i += 1) {
+                        if (depths[i] < level)
+                            continue;
+                        const prev = canConnect(i - 1, level);
+                        const next = canConnect(i, level);
+                        if (!prev && !next)
+                            continue;
+                        const value = !prev && next ? "begin" : prev && !next ? "end" : "continue";
+                        const eventIndex = pitchedIndexes[i];
+                        events[eventIndex].xml = addBeamToEventXml(events[eventIndex].xml, value, level);
+                    }
+                }
+            }
+            return;
+        }
+        if (name === "tuplet") {
+            const num = parseIntSafe(node.getAttribute("num"), NaN);
+            const numbase = parseIntSafe(node.getAttribute("numbase"), NaN);
+            const nextTuplet = Number.isFinite(num) && Number.isFinite(numbase) && num > 0 && numbase > 0
+                ? { num: Math.round(num), numbase: Math.round(numbase) }
+                : forcedTuplet;
+            for (const child of Array.from(node.children)) {
+                if (child instanceof Element)
+                    processElement(child, forcedGrace, nextTuplet);
+            }
+            return;
+        }
+        if (name === "graceGrp") {
+            const raw = (node.getAttribute("grace") || "").trim().toLowerCase();
+            const slash = (node.getAttribute("slash") || "").trim().toLowerCase() === "yes";
+            const groupGrace = raw === "acc" || raw === "unacc"
+                ? raw
+                : (slash ? "acc" : "unacc");
+            for (const child of Array.from(node.children)) {
+                if (child instanceof Element)
+                    processElement(child, forcedGrace !== null && forcedGrace !== void 0 ? forcedGrace : groupGrace, forcedTuplet);
+            }
+            return;
+        }
+        let effectiveNode = node;
+        if (forcedGrace && !effectiveNode.getAttribute("grace") && (name === "note" || name === "chord" || name === "rest")) {
+            effectiveNode = node.cloneNode(true);
+            effectiveNode.setAttribute("grace", forcedGrace);
+        }
+        if (name === "note") {
+            pushNoteEvent(effectiveNode, forcedTuplet);
+            return;
+        }
+        if (name === "rest" || name === "space" || name === "mSpace" || name === "mRest") {
+            if ((name === "mSpace" || name === "mRest") && !effectiveNode.getAttribute("mks-dur-ticks")) {
+                const inferred = inferMeiDurAndDotsFromTicks(measureTicks, divisions);
+                effectiveNode = effectiveNode.cloneNode(true);
+                effectiveNode.setAttribute("dur", inferred.dur);
+                if (inferred.dots > 0)
+                    effectiveNode.setAttribute("dots", String(inferred.dots));
+                effectiveNode.setAttribute("mks-dur-div", String(Math.max(1, Math.round(divisions))));
+                effectiveNode.setAttribute("mks-dur-480", String(toMksDur480(measureTicks, divisions)));
+                effectiveNode.setAttribute("mks-dur-ticks", String(Math.max(1, Math.round(measureTicks))));
+            }
+            pushRestEvent(effectiveNode, forcedTuplet);
+            return;
+        }
+        if (name === "chord") {
+            pushChordEvent(effectiveNode, forcedTuplet);
+        }
+    };
+    for (const child of Array.from(layer.children)) {
+        if (child instanceof Element)
+            processElement(child, null, null);
+    }
+    return { events, idToEventIndex, tieCarryOut: new Map(tieCarryByPitch) };
+};
+const addSlurNotationToSingleNoteXml = (noteXml, type, number) => {
+    const slurXml = `<slur type="${type}" number="${number}"/>`;
+    if (noteXml.includes("<notations>")) {
+        return noteXml.replace("</notations>", `${slurXml}</notations>`);
+    }
+    return noteXml.replace("</note>", `<notations>${slurXml}</notations></note>`);
+};
+const addTieToSingleNoteXml = (noteXml, type) => {
+    const tieXml = `<tie type="${type}"/>`;
+    const tiedXml = `<tied type="${type}"/>`;
+    const withTie = noteXml.includes("<duration>")
+        ? noteXml.replace("<duration>", `${tieXml}<duration>`)
+        : noteXml.replace("</note>", `${tieXml}</note>`);
+    if (withTie.includes("<notations>")) {
+        return withTie.replace("</notations>", `${tiedXml}</notations>`);
+    }
+    return withTie.replace("</note>", `<notations>${tiedXml}</notations></note>`);
+};
+const addNotationXmlToSingleNoteXml = (noteXml, notationXml) => {
+    if (noteXml.includes("<notations>")) {
+        return noteXml.replace("</notations>", `${notationXml}</notations>`);
+    }
+    return noteXml.replace("</note>", `<notations>${notationXml}</notations></note>`);
+};
+const addOrnamentXmlToSingleNoteXml = (noteXml, ornamentXml) => {
+    if (noteXml.includes("<ornaments>")) {
+        return noteXml.replace("</ornaments>", `${ornamentXml}</ornaments>`);
+    }
+    return addNotationXmlToSingleNoteXml(noteXml, `<ornaments>${ornamentXml}</ornaments>`);
+};
+const addArticulationXmlToSingleNoteXml = (noteXml, articulationXml) => {
+    if (noteXml.includes("<articulations>")) {
+        return noteXml.replace("</articulations>", `${articulationXml}</articulations>`);
+    }
+    return addNotationXmlToSingleNoteXml(noteXml, `<articulations>${articulationXml}</articulations>`);
+};
+const addSlurNotationToEventXml = (eventXml, type, number) => {
+    const firstNoteStart = eventXml.indexOf("<note>");
+    if (firstNoteStart < 0)
+        return eventXml;
+    const firstNoteEnd = eventXml.indexOf("</note>", firstNoteStart);
+    if (firstNoteEnd < 0)
+        return eventXml;
+    const before = eventXml.slice(0, firstNoteStart);
+    const noteBlock = eventXml.slice(firstNoteStart, firstNoteEnd + "</note>".length);
+    const after = eventXml.slice(firstNoteEnd + "</note>".length);
+    return before + addSlurNotationToSingleNoteXml(noteBlock, type, number) + after;
+};
+const addTieNotationToEventXml = (eventXml, type) => {
+    const firstNoteStart = eventXml.indexOf("<note>");
+    if (firstNoteStart < 0)
+        return eventXml;
+    const firstNoteEnd = eventXml.indexOf("</note>", firstNoteStart);
+    if (firstNoteEnd < 0)
+        return eventXml;
+    const before = eventXml.slice(0, firstNoteStart);
+    const noteBlock = eventXml.slice(firstNoteStart, firstNoteEnd + "</note>".length);
+    const after = eventXml.slice(firstNoteEnd + "</note>".length);
+    return before + addTieToSingleNoteXml(noteBlock, type) + after;
+};
+const addTrillNotationToEventXml = (eventXml) => {
+    const firstNoteStart = eventXml.indexOf("<note>");
+    if (firstNoteStart < 0)
+        return eventXml;
+    const firstNoteEnd = eventXml.indexOf("</note>", firstNoteStart);
+    if (firstNoteEnd < 0)
+        return eventXml;
+    const before = eventXml.slice(0, firstNoteStart);
+    const noteBlock = eventXml.slice(firstNoteStart, firstNoteEnd + "</note>".length);
+    const after = eventXml.slice(firstNoteEnd + "</note>".length);
+    return before + addOrnamentXmlToSingleNoteXml(noteBlock, "<trill-mark/>") + after;
+};
+const addFermataNotationToEventXml = (eventXml, isBelow) => {
+    const firstNoteStart = eventXml.indexOf("<note>");
+    if (firstNoteStart < 0)
+        return eventXml;
+    const firstNoteEnd = eventXml.indexOf("</note>", firstNoteStart);
+    if (firstNoteEnd < 0)
+        return eventXml;
+    const before = eventXml.slice(0, firstNoteStart);
+    const noteBlock = eventXml.slice(firstNoteStart, firstNoteEnd + "</note>".length);
+    const after = eventXml.slice(firstNoteEnd + "</note>".length);
+    const typeAttr = isBelow ? ' type="inverted"' : "";
+    return before + addNotationXmlToSingleNoteXml(noteBlock, `<fermata${typeAttr}/>`) + after;
+};
+const addGlissNotationToEventXml = (eventXml, type, number) => {
+    const firstNoteStart = eventXml.indexOf("<note>");
+    if (firstNoteStart < 0)
+        return eventXml;
+    const firstNoteEnd = eventXml.indexOf("</note>", firstNoteStart);
+    if (firstNoteEnd < 0)
+        return eventXml;
+    const before = eventXml.slice(0, firstNoteStart);
+    const noteBlock = eventXml.slice(firstNoteStart, firstNoteEnd + "</note>".length);
+    const after = eventXml.slice(firstNoteEnd + "</note>".length);
+    return before + addNotationXmlToSingleNoteXml(noteBlock, `<glissando type="${type}" number="${number}"/>`) + after;
+};
+const addSlideNotationToEventXml = (eventXml, type, number) => {
+    const firstNoteStart = eventXml.indexOf("<note>");
+    if (firstNoteStart < 0)
+        return eventXml;
+    const firstNoteEnd = eventXml.indexOf("</note>", firstNoteStart);
+    if (firstNoteEnd < 0)
+        return eventXml;
+    const before = eventXml.slice(0, firstNoteStart);
+    const noteBlock = eventXml.slice(firstNoteStart, firstNoteEnd + "</note>".length);
+    const after = eventXml.slice(firstNoteEnd + "</note>".length);
+    return before + addNotationXmlToSingleNoteXml(noteBlock, `<slide type="${type}" number="${number}"/>`) + after;
+};
+const addTurnNotationToEventXml = (eventXml, isInverted) => {
+    const firstNoteStart = eventXml.indexOf("<note>");
+    if (firstNoteStart < 0)
+        return eventXml;
+    const firstNoteEnd = eventXml.indexOf("</note>", firstNoteStart);
+    if (firstNoteEnd < 0)
+        return eventXml;
+    const before = eventXml.slice(0, firstNoteStart);
+    const noteBlock = eventXml.slice(firstNoteStart, firstNoteEnd + "</note>".length);
+    const after = eventXml.slice(firstNoteEnd + "</note>".length);
+    return before + addOrnamentXmlToSingleNoteXml(noteBlock, isInverted ? "<inverted-turn/>" : "<turn/>") + after;
+};
+const addMordentNotationToEventXml = (eventXml, isInverted) => {
+    const firstNoteStart = eventXml.indexOf("<note>");
+    if (firstNoteStart < 0)
+        return eventXml;
+    const firstNoteEnd = eventXml.indexOf("</note>", firstNoteStart);
+    if (firstNoteEnd < 0)
+        return eventXml;
+    const before = eventXml.slice(0, firstNoteStart);
+    const noteBlock = eventXml.slice(firstNoteStart, firstNoteEnd + "</note>".length);
+    const after = eventXml.slice(firstNoteEnd + "</note>".length);
+    return before + addOrnamentXmlToSingleNoteXml(noteBlock, isInverted ? "<inverted-mordent/>" : "<mordent/>") + after;
+};
+const addBreathNotationToEventXml = (eventXml) => {
+    const firstNoteStart = eventXml.indexOf("<note>");
+    if (firstNoteStart < 0)
+        return eventXml;
+    const firstNoteEnd = eventXml.indexOf("</note>", firstNoteStart);
+    if (firstNoteEnd < 0)
+        return eventXml;
+    const before = eventXml.slice(0, firstNoteStart);
+    const noteBlock = eventXml.slice(firstNoteStart, firstNoteEnd + "</note>".length);
+    const after = eventXml.slice(firstNoteEnd + "</note>".length);
+    return before + addArticulationXmlToSingleNoteXml(noteBlock, "<breath-mark/>") + after;
+};
+const addCaesuraNotationToEventXml = (eventXml) => {
+    const firstNoteStart = eventXml.indexOf("<note>");
+    if (firstNoteStart < 0)
+        return eventXml;
+    const firstNoteEnd = eventXml.indexOf("</note>", firstNoteStart);
+    if (firstNoteEnd < 0)
+        return eventXml;
+    const before = eventXml.slice(0, firstNoteStart);
+    const noteBlock = eventXml.slice(firstNoteStart, firstNoteEnd + "</note>".length);
+    const after = eventXml.slice(firstNoteEnd + "</note>".length);
+    return before + addArticulationXmlToSingleNoteXml(noteBlock, "<caesura/>") + after;
+};
+const addTupletNotationToEventXml = (eventXml, type, number) => {
+    const firstNoteStart = eventXml.indexOf("<note>");
+    if (firstNoteStart < 0)
+        return eventXml;
+    const firstNoteEnd = eventXml.indexOf("</note>", firstNoteStart);
+    if (firstNoteEnd < 0)
+        return eventXml;
+    const before = eventXml.slice(0, firstNoteStart);
+    const noteBlock = eventXml.slice(firstNoteStart, firstNoteEnd + "</note>".length);
+    const after = eventXml.slice(firstNoteEnd + "</note>".length);
+    return before + addNotationXmlToSingleNoteXml(noteBlock, `<tuplet type="${type}" number="${number}"/>`) + after;
+};
+const addBeamToSingleNoteXml = (noteXml, value, number = 1) => {
+    if (noteXml.includes(`<beam number="${number}">`))
+        return noteXml;
+    return noteXml.replace("</note>", `<beam number="${number}">${value}</beam></note>`);
+};
+const addBeamToEventXml = (eventXml, value, number = 1) => {
+    const firstNoteStart = eventXml.indexOf("<note>");
+    if (firstNoteStart < 0)
+        return eventXml;
+    const firstNoteEnd = eventXml.indexOf("</note>", firstNoteStart);
+    if (firstNoteEnd < 0)
+        return eventXml;
+    const before = eventXml.slice(0, firstNoteStart);
+    const noteBlock = eventXml.slice(firstNoteStart, firstNoteEnd + "</note>".length);
+    const after = eventXml.slice(firstNoteEnd + "</note>".length);
+    return before + addBeamToSingleNoteXml(noteBlock, value, number) + after;
+};
+const parseMeiTstampToTicks = (tstamp, divisions, beatType) => {
+    const raw = String(tstamp || "").trim();
+    if (!/^\d+(\.\d+)?$/.test(raw))
+        return null;
+    const beatPos = Number.parseFloat(raw);
+    if (!Number.isFinite(beatPos) || beatPos < 1)
+        return null;
+    const ticksPerBeat = Math.max(1, (4 * divisions) / Math.max(1, beatType));
+    return Math.max(0, Math.round((beatPos - 1) * ticksPerBeat));
+};
+const resolveEventIndexByTstamp = (events, targetTick) => {
+    if (!Number.isFinite(targetTick) || targetTick < 0)
+        return null;
+    let cursor = 0;
+    let lastPitchedIndex = null;
+    for (let i = 0; i < events.length; i += 1) {
+        const event = events[i];
+        if (event.kind !== "rest") {
+            lastPitchedIndex = i;
+            if (cursor >= targetTick)
+                return i;
+        }
+        cursor += Math.max(0, event.durationTicks);
+    }
+    return lastPitchedIndex;
+};
+const resolveEventStartTickByIndex = (events, eventIndex) => {
+    if (!Number.isInteger(eventIndex) || eventIndex < 0 || eventIndex >= events.length)
+        return null;
+    let cursor = 0;
+    for (let i = 0; i < events.length; i += 1) {
+        if (i === eventIndex)
+            return cursor;
+        cursor += Math.max(0, events[i].durationTicks);
+    }
+    return null;
+};
+const resolveControlEventEndpointIndex = (rawId, tstamp, idToEventIndex, events, divisions, beatType, rawPlist, idToEventTick) => {
+    const id = rawId.startsWith("#") ? rawId.slice(1) : "";
+    if (id) {
+        const idx = idToEventIndex.get(id);
+        if (Number.isInteger(idx))
+            return idx;
+        const tick = idToEventTick === null || idToEventTick === void 0 ? void 0 : idToEventTick.get(id);
+        if (Number.isFinite(tick)) {
+            const byTick = resolveEventIndexByTstamp(events, Math.max(0, Math.round(tick)));
+            if (Number.isInteger(byTick))
+                return byTick;
         }
     }
-    return events;
+    const plist = String(rawPlist || "").trim();
+    if (plist) {
+        const candidates = plist
+            .split(/\s+/)
+            .map((token) => token.trim())
+            .filter(Boolean)
+            .map((token) => (token.startsWith("#") ? token.slice(1) : token));
+        for (const candidate of candidates) {
+            const idx = idToEventIndex.get(candidate);
+            if (Number.isInteger(idx))
+                return idx;
+            const tick = idToEventTick === null || idToEventTick === void 0 ? void 0 : idToEventTick.get(candidate);
+            if (Number.isFinite(tick)) {
+                const byTick = resolveEventIndexByTstamp(events, Math.max(0, Math.round(tick)));
+                if (Number.isInteger(byTick))
+                    return byTick;
+            }
+        }
+    }
+    const ticks = parseMeiTstampToTicks(tstamp, divisions, beatType);
+    if (ticks === null)
+        return null;
+    return resolveEventIndexByTstamp(events, ticks);
+};
+const DYNAMICS_TAGS = new Set([
+    "pppp", "ppp", "pp", "p", "mp", "mf", "f", "ff", "fff", "ffff", "fp", "sf", "sfz", "sffz", "rfz", "rf", "fz",
+]);
+const parseHarmonyAlter = (token) => {
+    const v = token.trim();
+    if (v === "#" || v === "♯")
+        return 1;
+    if (v === "b" || v === "♭")
+        return -1;
+    if (v === "x" || v === "##")
+        return 2;
+    return 0;
+};
+const collectScoreDefsInDocOrder = (root) => Array.from(root.querySelectorAll("*")).filter((node) => node instanceof Element && localNameOf(node) === "scoreDef");
+const collectStaffDefsInDocOrder = (root) => Array.from(root.querySelectorAll("*")).filter((node) => node instanceof Element && localNameOf(node) === "staffDef");
+const findEffectiveScoreDefForNode = (node, scoreDefs) => {
+    let out = null;
+    for (const scoreDef of scoreDefs) {
+        const relation = scoreDef.compareDocumentPosition(node);
+        if ((relation & Node.DOCUMENT_POSITION_FOLLOWING) !== 0 || scoreDef === node) {
+            out = scoreDef;
+            continue;
+        }
+        if ((relation & Node.DOCUMENT_POSITION_PRECEDING) !== 0) {
+            break;
+        }
+    }
+    return out;
+};
+const findEffectiveStaffDefForNode = (node, staffNo, staffDefs) => {
+    let out = null;
+    for (const staffDef of staffDefs) {
+        const relation = staffDef.compareDocumentPosition(node);
+        if ((relation & Node.DOCUMENT_POSITION_FOLLOWING) !== 0 || staffDef === node) {
+            const n = (staffDef.getAttribute("n") || "").trim();
+            if (!n || n === staffNo)
+                out = staffDef;
+            continue;
+        }
+        if ((relation & Node.DOCUMENT_POSITION_PRECEDING) !== 0) {
+            break;
+        }
+    }
+    return out;
+};
+const parseTransposeFromStaffDefElement = (staffDef) => {
+    if (!staffDef)
+        return null;
+    const out = {};
+    const diatonic = parseIntSafe(staffDef.getAttribute("trans.diat"), NaN);
+    const chromatic = parseIntSafe(staffDef.getAttribute("trans.semi"), NaN);
+    if (Number.isFinite(chromatic))
+        out.chromatic = Math.round(chromatic);
+    if (Number.isFinite(diatonic))
+        out.diatonic = Math.round(diatonic);
+    return Object.keys(out).length ? out : null;
+};
+const parseClefFromScoreDefForStaff = (scoreDef, staffNo) => {
+    var _a;
+    if (!scoreDef)
+        return null;
+    const staffDefs = Array.from(scoreDef.querySelectorAll("*")).filter((node) => node instanceof Element && localNameOf(node) === "staffDef");
+    const matched = (_a = staffDefs.find((staffDef) => { var _a; return (((_a = staffDef.getAttribute("n")) === null || _a === void 0 ? void 0 : _a.trim()) || "") === staffNo; })) !== null && _a !== void 0 ? _a : staffDefs.find((staffDef) => !staffDef.getAttribute("n"));
+    if (!matched)
+        return null;
+    const clefFromDef = parseClefFromStaffDefElement(matched);
+    if (!clefFromDef)
+        return null;
+    const clefSign = clefFromDef.clefSign;
+    const clefLine = clefFromDef.clefLine;
+    if (!clefSign || !Number.isFinite(clefLine))
+        return null;
+    return { clefSign, clefLine: Math.max(1, Math.round(clefLine)) };
+};
+const parseClefFromStaffDefElement = (staffDef) => {
+    var _a;
+    if (!staffDef)
+        return null;
+    const attrSign = (((_a = staffDef.getAttribute("clef.shape")) === null || _a === void 0 ? void 0 : _a.trim().toUpperCase()) || "").trim();
+    const attrLine = parseIntSafe(staffDef.getAttribute("clef.line"), NaN);
+    if (attrSign && Number.isFinite(attrLine)) {
+        return { clefSign: attrSign, clefLine: Math.max(1, Math.round(attrLine)) };
+    }
+    const clefChild = childElementsByName(staffDef, "clef")[0];
+    if (!clefChild)
+        return null;
+    const childSign = (clefChild.getAttribute("shape")
+        || clefChild.getAttribute("clef.shape")
+        || "").trim().toUpperCase();
+    const childLine = parseIntSafe(clefChild.getAttribute("line") || clefChild.getAttribute("clef.line"), NaN);
+    if (!childSign || !Number.isFinite(childLine))
+        return null;
+    return { clefSign: childSign, clefLine: Math.max(1, Math.round(childLine)) };
+};
+const parseKeySigFromScoreDefForStaff = (scoreDef, staffNo, fallbackFifths) => {
+    var _a;
+    if (!scoreDef)
+        return fallbackFifths;
+    const staffDefs = Array.from(scoreDef.querySelectorAll("*")).filter((node) => node instanceof Element && localNameOf(node) === "staffDef");
+    const matched = (_a = staffDefs.find((staffDef) => { var _a; return (((_a = staffDef.getAttribute("n")) === null || _a === void 0 ? void 0 : _a.trim()) || "") === staffNo; })) !== null && _a !== void 0 ? _a : staffDefs.find((staffDef) => !staffDef.getAttribute("n"));
+    const staffFifths = parseMeiKeyFifthsFromElement(matched);
+    if (staffFifths !== null)
+        return staffFifths;
+    const scoreFifths = parseMeiKeyFifthsFromElement(scoreDef);
+    if (scoreFifths !== null)
+        return scoreFifths;
+    return fallbackFifths;
+};
+const parseTransposeFromScoreDefForStaff = (scoreDef, staffNo) => {
+    var _a;
+    if (!scoreDef)
+        return null;
+    const staffDefs = Array.from(scoreDef.querySelectorAll("*")).filter((node) => node instanceof Element && localNameOf(node) === "staffDef");
+    const matched = (_a = staffDefs.find((staffDef) => { var _a; return (((_a = staffDef.getAttribute("n")) === null || _a === void 0 ? void 0 : _a.trim()) || "") === staffNo; })) !== null && _a !== void 0 ? _a : staffDefs.find((staffDef) => !staffDef.getAttribute("n"));
+    const out = {};
+    const matchedDiatonic = parseIntSafe(matched === null || matched === void 0 ? void 0 : matched.getAttribute("trans.diat"), NaN);
+    const matchedChromatic = parseIntSafe(matched === null || matched === void 0 ? void 0 : matched.getAttribute("trans.semi"), NaN);
+    if (Number.isFinite(matchedChromatic))
+        out.chromatic = Math.round(matchedChromatic);
+    if (Number.isFinite(matchedDiatonic))
+        out.diatonic = Math.round(matchedDiatonic);
+    if (Object.keys(out).length)
+        return out;
+    const scoreDiatonic = parseIntSafe(scoreDef.getAttribute("trans.diat"), NaN);
+    const scoreChromatic = parseIntSafe(scoreDef.getAttribute("trans.semi"), NaN);
+    if (Number.isFinite(scoreChromatic))
+        out.chromatic = Math.round(scoreChromatic);
+    if (Number.isFinite(scoreDiatonic))
+        out.diatonic = Math.round(scoreDiatonic);
+    return Object.keys(out).length ? out : null;
+};
+const buildTransposeXml = (transpose) => {
+    if (!transpose)
+        return "";
+    const chromatic = Number.isFinite(transpose.chromatic) ? Math.round(Number(transpose.chromatic)) : null;
+    const diatonic = Number.isFinite(transpose.diatonic) ? Math.round(Number(transpose.diatonic)) : null;
+    if (chromatic === null && diatonic === null)
+        return "";
+    return `<transpose>${diatonic !== null ? `<diatonic>${diatonic}</diatonic>` : ""}${chromatic !== null ? `<chromatic>${chromatic}</chromatic>` : ""}</transpose>`;
+};
+const parseMeiHarmText = (text) => {
+    const raw = text.trim();
+    const m = raw.match(/^([A-Ga-g])([#bx♭♯]?)([^/]*)(?:\/([A-Ga-g])([#bx♭♯]?))?$/);
+    if (!m)
+        return null;
+    const rootStep = m[1].toUpperCase();
+    const rootAlter = parseHarmonyAlter(m[2] || "");
+    const suffix = (m[3] || "").trim();
+    const bassStep = m[4] ? m[4].toUpperCase() : undefined;
+    const bassAlter = parseHarmonyAlter(m[5] || "");
+    const suffixLower = suffix.toLowerCase();
+    let kind = "major";
+    let kindText = "";
+    if (!suffix) {
+        kind = "major";
+    }
+    else if (suffixLower === "m" || suffixLower === "min" || suffixLower === "-") {
+        kind = "minor";
+    }
+    else if (suffixLower === "7") {
+        kind = "dominant";
+    }
+    else if (suffixLower === "maj7" || suffixLower === "m7+" || suffixLower === "Δ7".toLowerCase()) {
+        kind = "major-seventh";
+    }
+    else if (suffixLower === "m7" || suffixLower === "min7" || suffixLower === "-7") {
+        kind = "minor-seventh";
+    }
+    else if (suffixLower === "dim" || suffixLower === "o") {
+        kind = "diminished";
+    }
+    else if (suffixLower === "aug" || suffixLower === "+") {
+        kind = "augmented";
+    }
+    else {
+        kind = "other";
+        kindText = suffix;
+    }
+    const degrees = [];
+    const degreeRe = /([#b♯♭x]|##)\s*(\d{1,2})/g;
+    let dm = degreeRe.exec(suffix);
+    while (dm) {
+        const alter = parseHarmonyAlter(dm[1] || "");
+        const value = Number.parseInt(dm[2] || "", 10);
+        if (Number.isFinite(value) && value > 0 && alter !== 0) {
+            degrees.push({ value: Math.round(value), alter });
+        }
+        dm = degreeRe.exec(suffix);
+    }
+    return {
+        rootStep,
+        rootAlter: rootAlter !== 0 ? rootAlter : undefined,
+        kind,
+        kindText: kindText || undefined,
+        bassStep,
+        bassAlter: bassStep && bassAlter !== 0 ? bassAlter : undefined,
+        degrees,
+    };
+};
+const buildMusicXmlDirectionFromMeiDynam = (dynam, divisions, beatType, voice, staffNo) => {
+    const rawText = (dynam.textContent || "").trim();
+    if (!rawText)
+        return null;
+    const normalized = rawText.toLowerCase();
+    const placement = (dynam.getAttribute("place") || dynam.getAttribute("placement") || "").trim().toLowerCase();
+    const placementAttr = placement === "above" || placement === "below" ? ` placement="${placement}"` : "";
+    const offsetTicks = parseMeiTstampToTicks(dynam.getAttribute("tstamp"), divisions, beatType);
+    const offsetXml = Number.isFinite(offsetTicks) && offsetTicks > 0
+        ? `<offset>${Math.round(offsetTicks)}</offset>`
+        : "";
+    const directionType = DYNAMICS_TAGS.has(normalized)
+        ? `<dynamics><${normalized}/></dynamics>`
+        : `<words>${xmlEscape(rawText)}</words>`;
+    return `<direction${placementAttr}><direction-type>${directionType}</direction-type>${offsetXml}<voice>${xmlEscape(voice)}</voice><staff>${xmlEscape(staffNo)}</staff></direction>`;
+};
+const buildMusicXmlDirectionsFromMeiHairpin = (hairpin, divisions, beatType, voice, staffNo, events, idToEventIndex, idToEventTick) => {
+    const formRaw = (hairpin.getAttribute("form") || hairpin.getAttribute("type") || "").trim().toLowerCase();
+    const wedgeType = formRaw.includes("dim") || formRaw.includes("decresc") ? "diminuendo" : "crescendo";
+    const placement = (hairpin.getAttribute("place") || hairpin.getAttribute("placement") || "").trim().toLowerCase();
+    const placementAttr = placement === "above" || placement === "below" ? ` placement="${placement}"` : "";
+    const startIndex = resolveControlEventEndpointIndex((hairpin.getAttribute("startid") || "").trim(), hairpin.getAttribute("tstamp"), idToEventIndex, events, divisions, beatType, hairpin.getAttribute("plist"), idToEventTick);
+    const endIndex = resolveControlEventEndpointIndex((hairpin.getAttribute("endid") || "").trim(), hairpin.getAttribute("tstamp2"), idToEventIndex, events, divisions, beatType, undefined, idToEventTick);
+    const startTick = Number.isInteger(startIndex) ? resolveEventStartTickByIndex(events, startIndex) : null;
+    const endTick = Number.isInteger(endIndex) ? resolveEventStartTickByIndex(events, endIndex) : null;
+    const startOffsetXml = Number.isFinite(startTick) && startTick > 0
+        ? `<offset>${Math.round(startTick)}</offset>`
+        : "";
+    const endOffsetXml = Number.isFinite(endTick) && endTick > 0
+        ? `<offset>${Math.round(endTick)}</offset>`
+        : "";
+    const startDir = `<direction${placementAttr}><direction-type><wedge type="${wedgeType}"/></direction-type>${startOffsetXml}<voice>${xmlEscape(voice)}</voice><staff>${xmlEscape(staffNo)}</staff></direction>`;
+    const stopDir = `<direction${placementAttr}><direction-type><wedge type="stop"/></direction-type>${endOffsetXml}<voice>${xmlEscape(voice)}</voice><staff>${xmlEscape(staffNo)}</staff></direction>`;
+    return `${startDir}${stopDir}`;
+};
+const buildMusicXmlDirectionsFromMeiPedal = (pedal, divisions, beatType, voice, staffNo, events, idToEventIndex, idToEventTick) => {
+    const placement = (pedal.getAttribute("place") || pedal.getAttribute("placement") || "").trim().toLowerCase();
+    const placementAttr = placement === "above" || placement === "below" ? ` placement="${placement}"` : "";
+    const semanticRaw = (pedal.getAttribute("type")
+        || pedal.getAttribute("state")
+        || pedal.getAttribute("func")
+        || pedal.getAttribute("val")
+        || "").trim().toLowerCase();
+    const isExplicitStop = semanticRaw.includes("stop")
+        || semanticRaw.includes("end")
+        || semanticRaw.includes("off")
+        || semanticRaw.includes("up")
+        || semanticRaw.includes("release");
+    const startIndex = resolveControlEventEndpointIndex((pedal.getAttribute("startid") || "").trim(), pedal.getAttribute("tstamp"), idToEventIndex, events, divisions, beatType, pedal.getAttribute("plist"), idToEventTick);
+    const endIndex = resolveControlEventEndpointIndex((pedal.getAttribute("endid") || "").trim(), pedal.getAttribute("tstamp2"), idToEventIndex, events, divisions, beatType, undefined, idToEventTick);
+    const startTick = Number.isInteger(startIndex) ? resolveEventStartTickByIndex(events, startIndex) : null;
+    const endTick = Number.isInteger(endIndex) ? resolveEventStartTickByIndex(events, endIndex) : null;
+    const startOffsetXml = Number.isFinite(startTick) && startTick > 0
+        ? `<offset>${Math.round(startTick)}</offset>`
+        : "";
+    const endOffsetXml = Number.isFinite(endTick) && endTick > 0
+        ? `<offset>${Math.round(endTick)}</offset>`
+        : "";
+    if (Number.isInteger(endIndex)) {
+        const startDir = `<direction${placementAttr}><direction-type><pedal type="start" number="1" line="yes"/></direction-type>${startOffsetXml}<voice>${xmlEscape(voice)}</voice><staff>${xmlEscape(staffNo)}</staff></direction>`;
+        const stopDir = `<direction${placementAttr}><direction-type><pedal type="stop" number="1" line="yes"/></direction-type>${endOffsetXml}<voice>${xmlEscape(voice)}</voice><staff>${xmlEscape(staffNo)}</staff></direction>`;
+        return `${startDir}${stopDir}`;
+    }
+    const singleType = isExplicitStop ? "stop" : "start";
+    return `<direction${placementAttr}><direction-type><pedal type="${singleType}" number="1" line="yes"/></direction-type>${startOffsetXml}<voice>${xmlEscape(voice)}</voice><staff>${xmlEscape(staffNo)}</staff></direction>`;
+};
+const buildMusicXmlDirectionsFromMeiOctave = (octave, divisions, beatType, voice, staffNo, events, idToEventIndex, idToEventTick) => {
+    const placement = (octave.getAttribute("place") || octave.getAttribute("placement") || "").trim().toLowerCase();
+    const placementAttr = placement === "above" || placement === "below" ? ` placement="${placement}"` : "";
+    const semanticRaw = (octave.getAttribute("type")
+        || octave.getAttribute("state")
+        || octave.getAttribute("func")
+        || octave.getAttribute("val")
+        || "").trim().toLowerCase();
+    const isExplicitStop = semanticRaw.includes("stop")
+        || semanticRaw.includes("end")
+        || semanticRaw.includes("off");
+    const disRaw = (octave.getAttribute("dis") || octave.getAttribute("size") || "").trim();
+    const dis = Number.parseInt(disRaw, 10);
+    const size = Number.isFinite(dis) && dis > 0 ? Math.round(dis) : 8;
+    const disPlace = (octave.getAttribute("dis.place") || placement).trim().toLowerCase();
+    const shiftType = disPlace === "below" ? "down" : "up";
+    const startIndex = resolveControlEventEndpointIndex((octave.getAttribute("startid") || "").trim(), octave.getAttribute("tstamp"), idToEventIndex, events, divisions, beatType, octave.getAttribute("plist"), idToEventTick);
+    const endIndex = resolveControlEventEndpointIndex((octave.getAttribute("endid") || "").trim(), octave.getAttribute("tstamp2"), idToEventIndex, events, divisions, beatType, undefined, idToEventTick);
+    const startTick = Number.isInteger(startIndex) ? resolveEventStartTickByIndex(events, startIndex) : null;
+    const endTick = Number.isInteger(endIndex) ? resolveEventStartTickByIndex(events, endIndex) : null;
+    const startOffsetXml = Number.isFinite(startTick) && startTick > 0
+        ? `<offset>${Math.round(startTick)}</offset>`
+        : "";
+    const endOffsetXml = Number.isFinite(endTick) && endTick > 0
+        ? `<offset>${Math.round(endTick)}</offset>`
+        : "";
+    if (Number.isInteger(endIndex)) {
+        const startDir = `<direction${placementAttr}><direction-type><octave-shift type="${shiftType}" size="${size}" number="1"/></direction-type>${startOffsetXml}<voice>${xmlEscape(voice)}</voice><staff>${xmlEscape(staffNo)}</staff></direction>`;
+        const stopDir = `<direction${placementAttr}><direction-type><octave-shift type="stop" size="${size}" number="1"/></direction-type>${endOffsetXml}<voice>${xmlEscape(voice)}</voice><staff>${xmlEscape(staffNo)}</staff></direction>`;
+        return `${startDir}${stopDir}`;
+    }
+    const singleType = isExplicitStop ? "stop" : shiftType;
+    return `<direction${placementAttr}><direction-type><octave-shift type="${singleType}" size="${size}" number="1"/></direction-type>${startOffsetXml}<voice>${xmlEscape(voice)}</voice><staff>${xmlEscape(staffNo)}</staff></direction>`;
+};
+const buildMusicXmlDirectionFromMeiRepeatMark = (repeatMark, divisions, beatType, voice, staffNo, events, idToEventIndex, idToEventTick) => {
+    const textRaw = (repeatMark.getAttribute("func")
+        || repeatMark.getAttribute("type")
+        || repeatMark.getAttribute("label")
+        || repeatMark.textContent
+        || "").trim();
+    if (!textRaw)
+        return null;
+    const normalized = textRaw.toLowerCase();
+    const placement = (repeatMark.getAttribute("place") || repeatMark.getAttribute("placement") || "").trim().toLowerCase();
+    const placementAttr = placement === "above" || placement === "below" ? ` placement="${placement}"` : "";
+    const startIndex = resolveControlEventEndpointIndex((repeatMark.getAttribute("startid") || "").trim(), repeatMark.getAttribute("tstamp"), idToEventIndex, events, divisions, beatType, repeatMark.getAttribute("plist"), idToEventTick);
+    const startTick = Number.isInteger(startIndex) ? resolveEventStartTickByIndex(events, startIndex) : null;
+    const offsetXml = Number.isFinite(startTick) && startTick > 0
+        ? `<offset>${Math.round(startTick)}</offset>`
+        : "";
+    let directionType = `<words>${xmlEscape(textRaw)}</words>`;
+    if (normalized.includes("segno"))
+        directionType = "<segno/>";
+    else if (normalized.includes("coda"))
+        directionType = "<coda/>";
+    else if (normalized.includes("fine"))
+        directionType = "<words>Fine</words>";
+    else if (normalized.includes("dacapo") || normalized.includes("da capo") || normalized.includes("d.c."))
+        directionType = "<words>D.C.</words>";
+    else if (normalized.includes("dalsegno") || normalized.includes("dal segno") || normalized.includes("d.s."))
+        directionType = "<words>D.S.</words>";
+    return `<direction${placementAttr}><direction-type>${directionType}</direction-type>${offsetXml}<voice>${xmlEscape(voice)}</voice><staff>${xmlEscape(staffNo)}</staff></direction>`;
+};
+const buildMusicXmlHarmonyFromMeiHarm = (harm, divisions, beatType, staffNo, events, idToEventIndex, idToEventTick) => {
+    const raw = (harm.textContent || harm.getAttribute("type") || harm.getAttribute("label") || "").trim();
+    if (!raw)
+        return null;
+    const parsed = parseMeiHarmText(raw);
+    if (!parsed) {
+        return `<harmony><kind text="${xmlEscape(raw)}">other</kind><staff>${xmlEscape(staffNo)}</staff></harmony>`;
+    }
+    const rootXml = `<root><root-step>${xmlEscape(parsed.rootStep)}</root-step>${Number.isFinite(parsed.rootAlter) ? `<root-alter>${Math.round(parsed.rootAlter)}</root-alter>` : ""}</root>`;
+    const kindXml = parsed.kindText
+        ? `<kind text="${xmlEscape(parsed.kindText)}">${xmlEscape(parsed.kind)}</kind>`
+        : `<kind>${xmlEscape(parsed.kind)}</kind>`;
+    const bassXml = parsed.bassStep
+        ? `<bass><bass-step>${xmlEscape(parsed.bassStep)}</bass-step>${Number.isFinite(parsed.bassAlter) ? `<bass-alter>${Math.round(parsed.bassAlter)}</bass-alter>` : ""}</bass>`
+        : "";
+    const degreeXml = parsed.degrees
+        .map((deg) => `<degree><degree-value>${deg.value}</degree-value><degree-alter>${deg.alter}</degree-alter><degree-type>add</degree-type></degree>`)
+        .join("");
+    const startIndex = resolveControlEventEndpointIndex((harm.getAttribute("startid") || "").trim(), harm.getAttribute("tstamp"), idToEventIndex, events, divisions, beatType, harm.getAttribute("plist"), idToEventTick);
+    const startTick = Number.isInteger(startIndex) ? resolveEventStartTickByIndex(events, startIndex) : null;
+    const offsetXml = Number.isFinite(startTick) && startTick > 0
+        ? `<offset>${Math.round(startTick)}</offset>`
+        : "";
+    return `<harmony>${rootXml}${kindXml}${bassXml}${degreeXml}${offsetXml}<staff>${xmlEscape(staffNo)}</staff></harmony>`;
+};
+const collectLayerHarmonyXml = (staff, layer, divisions, beatType, events, idToEventIndex, idToEventTick) => {
+    const staffNo = (staff.getAttribute("n") || "1").trim() || "1";
+    const harms = [...childElementsByName(layer, "harm"), ...childElementsByName(staff, "harm")];
+    const out = [];
+    for (const harm of harms) {
+        const xml = buildMusicXmlHarmonyFromMeiHarm(harm, divisions, beatType, staffNo, events, idToEventIndex, idToEventTick);
+        if (xml)
+            out.push(xml);
+    }
+    return out.join("");
+};
+const parseMeiTargetList = (raw) => {
+    const value = String(raw || "").trim();
+    if (!value)
+        return [];
+    return value
+        .split(/[\s,]+/)
+        .map((v) => v.trim())
+        .filter(Boolean);
+};
+const controlEventAppliesToLayer = (control, staffNo, layerNo, primaryLayerNo) => {
+    const staffTargets = parseMeiTargetList(control.getAttribute("staff") || "");
+    if (staffTargets.length > 0 && !staffTargets.includes(staffNo))
+        return false;
+    const layerTargets = parseMeiTargetList(control.getAttribute("layer") || "");
+    if (layerTargets.length > 0)
+        return layerTargets.includes(layerNo);
+    // Unscoped staff/measure-level controls should be emitted once (primary layer only).
+    const parent = control.parentElement;
+    const parentName = parent ? localNameOf(parent) : "";
+    if (parentName === "staff" || parentName === "measure") {
+        return layerNo === primaryLayerNo;
+    }
+    return true;
+};
+const collectControlEventsForLayer = (name, staff, layer, staffNo, layerNo, primaryLayerNo) => {
+    const measure = staff.parentElement && localNameOf(staff.parentElement) === "measure" ? staff.parentElement : null;
+    const controls = [
+        ...childElementsByName(layer, name),
+        ...childElementsByName(staff, name),
+        ...(measure ? childElementsByName(measure, name) : []),
+    ];
+    return controls.filter((control) => controlEventAppliesToLayer(control, staffNo, layerNo, primaryLayerNo));
+};
+const collectLayerDirectionXml = (staff, layer, divisions, beatType, voice, events, idToEventIndex, idToEventTick) => {
+    var _a;
+    const staffNo = (staff.getAttribute("n") || "1").trim() || "1";
+    const layerNo = (layer.getAttribute("n") || "1").trim() || "1";
+    const primaryLayerNo = (((_a = childElementsByName(staff, "layer")[0]) === null || _a === void 0 ? void 0 : _a.getAttribute("n")) || "1").trim() || "1";
+    const dyns = collectControlEventsForLayer("dynam", staff, layer, staffNo, layerNo, primaryLayerNo);
+    const hairpins = collectControlEventsForLayer("hairpin", staff, layer, staffNo, layerNo, primaryLayerNo);
+    const pedals = collectControlEventsForLayer("pedal", staff, layer, staffNo, layerNo, primaryLayerNo);
+    const octaves = collectControlEventsForLayer("octave", staff, layer, staffNo, layerNo, primaryLayerNo);
+    const repeatMarks = collectControlEventsForLayer("repeatMark", staff, layer, staffNo, layerNo, primaryLayerNo);
+    const out = [];
+    for (const dynam of dyns) {
+        const xml = buildMusicXmlDirectionFromMeiDynam(dynam, divisions, beatType, voice, staffNo);
+        if (xml)
+            out.push(xml);
+    }
+    for (const hairpin of hairpins) {
+        const xml = buildMusicXmlDirectionsFromMeiHairpin(hairpin, divisions, beatType, voice, staffNo, events, idToEventIndex, idToEventTick);
+        if (xml)
+            out.push(xml);
+    }
+    for (const pedal of pedals) {
+        const xml = buildMusicXmlDirectionsFromMeiPedal(pedal, divisions, beatType, voice, staffNo, events, idToEventIndex, idToEventTick);
+        if (xml)
+            out.push(xml);
+    }
+    for (const octave of octaves) {
+        const xml = buildMusicXmlDirectionsFromMeiOctave(octave, divisions, beatType, voice, staffNo, events, idToEventIndex, idToEventTick);
+        if (xml)
+            out.push(xml);
+    }
+    for (const repeatMark of repeatMarks) {
+        const xml = buildMusicXmlDirectionFromMeiRepeatMark(repeatMark, divisions, beatType, voice, staffNo, events, idToEventIndex, idToEventTick);
+        if (xml)
+            out.push(xml);
+    }
+    return out.join("");
+};
+const applyStaffSlurControlEvents = (staff, layer, layerEvents, idToEventIndex, idToEventTick, divisions, beatType) => {
+    if (layerEvents.length === 0)
+        return layerEvents;
+    const out = layerEvents.slice();
+    const slurs = [...childElementsByName(layer, "slur"), ...childElementsByName(staff, "slur")];
+    let slurNumber = 1;
+    for (const slur of slurs) {
+        const startIdRaw = (slur.getAttribute("startid") || "").trim();
+        const endIdRaw = (slur.getAttribute("endid") || "").trim();
+        const startIndex = resolveControlEventEndpointIndex(startIdRaw, slur.getAttribute("tstamp"), idToEventIndex, out, divisions, beatType, slur.getAttribute("plist"), idToEventTick);
+        const endIndex = resolveControlEventEndpointIndex(endIdRaw, slur.getAttribute("tstamp2"), idToEventIndex, out, divisions, beatType, undefined, idToEventTick);
+        if (!Number.isInteger(startIndex) || !Number.isInteger(endIndex))
+            continue;
+        if (startIndex < 0 || endIndex < 0 || startIndex >= out.length || endIndex >= out.length)
+            continue;
+        const startEvent = out[startIndex];
+        const endEvent = out[endIndex];
+        if (startEvent.kind !== "rest") {
+            out[startIndex] = { ...startEvent, xml: addSlurNotationToEventXml(startEvent.xml, "start", slurNumber) };
+        }
+        if (endEvent.kind !== "rest") {
+            out[endIndex] = { ...endEvent, xml: addSlurNotationToEventXml(endEvent.xml, "stop", slurNumber) };
+        }
+        slurNumber += 1;
+    }
+    const ties = [...childElementsByName(layer, "tie"), ...childElementsByName(staff, "tie")];
+    for (const tie of ties) {
+        const startIdRaw = (tie.getAttribute("startid") || "").trim();
+        const endIdRaw = (tie.getAttribute("endid") || "").trim();
+        const startIndex = resolveControlEventEndpointIndex(startIdRaw, tie.getAttribute("tstamp"), idToEventIndex, out, divisions, beatType, tie.getAttribute("plist"), idToEventTick);
+        const endIndex = resolveControlEventEndpointIndex(endIdRaw, tie.getAttribute("tstamp2"), idToEventIndex, out, divisions, beatType, undefined, idToEventTick);
+        if (!Number.isInteger(startIndex) || !Number.isInteger(endIndex))
+            continue;
+        if (startIndex < 0 || endIndex < 0 || startIndex >= out.length || endIndex >= out.length)
+            continue;
+        const startEvent = out[startIndex];
+        const endEvent = out[endIndex];
+        if (startEvent.kind !== "rest") {
+            out[startIndex] = { ...startEvent, xml: addTieNotationToEventXml(startEvent.xml, "start") };
+        }
+        if (endEvent.kind !== "rest") {
+            out[endIndex] = { ...endEvent, xml: addTieNotationToEventXml(endEvent.xml, "stop") };
+        }
+    }
+    const trills = [...childElementsByName(layer, "trill"), ...childElementsByName(staff, "trill")];
+    for (const trill of trills) {
+        const startIndex = resolveControlEventEndpointIndex((trill.getAttribute("startid") || "").trim(), trill.getAttribute("tstamp"), idToEventIndex, out, divisions, beatType, trill.getAttribute("plist"), idToEventTick);
+        if (!Number.isInteger(startIndex))
+            continue;
+        if (startIndex < 0 || startIndex >= out.length)
+            continue;
+        const startEvent = out[startIndex];
+        if (startEvent.kind !== "rest") {
+            out[startIndex] = { ...startEvent, xml: addTrillNotationToEventXml(startEvent.xml) };
+        }
+    }
+    const fermatas = [...childElementsByName(layer, "fermata"), ...childElementsByName(staff, "fermata")];
+    for (const fermata of fermatas) {
+        const startIndex = resolveControlEventEndpointIndex((fermata.getAttribute("startid") || "").trim(), fermata.getAttribute("tstamp"), idToEventIndex, out, divisions, beatType, fermata.getAttribute("plist"), idToEventTick);
+        if (!Number.isInteger(startIndex))
+            continue;
+        if (startIndex < 0 || startIndex >= out.length)
+            continue;
+        const startEvent = out[startIndex];
+        const placement = (fermata.getAttribute("place") || fermata.getAttribute("placement") || "").trim().toLowerCase();
+        if (startEvent.kind !== "rest") {
+            out[startIndex] = {
+                ...startEvent,
+                xml: addFermataNotationToEventXml(startEvent.xml, placement === "below"),
+            };
+        }
+    }
+    const turns = [...childElementsByName(layer, "turn"), ...childElementsByName(staff, "turn")];
+    for (const turn of turns) {
+        const startIndex = resolveControlEventEndpointIndex((turn.getAttribute("startid") || "").trim(), turn.getAttribute("tstamp"), idToEventIndex, out, divisions, beatType, turn.getAttribute("plist"), idToEventTick);
+        if (!Number.isInteger(startIndex))
+            continue;
+        if (startIndex < 0 || startIndex >= out.length)
+            continue;
+        const startEvent = out[startIndex];
+        const turnType = (turn.getAttribute("type") || turn.getAttribute("form") || "").trim().toLowerCase();
+        const isInverted = turnType.includes("inv") || turnType.includes("lower") || turnType.includes("down");
+        if (startEvent.kind !== "rest") {
+            out[startIndex] = { ...startEvent, xml: addTurnNotationToEventXml(startEvent.xml, isInverted) };
+        }
+    }
+    const mordents = [...childElementsByName(layer, "mordent"), ...childElementsByName(staff, "mordent")];
+    for (const mordent of mordents) {
+        const startIndex = resolveControlEventEndpointIndex((mordent.getAttribute("startid") || "").trim(), mordent.getAttribute("tstamp"), idToEventIndex, out, divisions, beatType, mordent.getAttribute("plist"), idToEventTick);
+        if (!Number.isInteger(startIndex))
+            continue;
+        if (startIndex < 0 || startIndex >= out.length)
+            continue;
+        const startEvent = out[startIndex];
+        const mordentType = (mordent.getAttribute("type") || mordent.getAttribute("form") || "").trim().toLowerCase();
+        const isInverted = mordentType.includes("inv") || mordentType.includes("lower") || mordentType.includes("down");
+        if (startEvent.kind !== "rest") {
+            out[startIndex] = { ...startEvent, xml: addMordentNotationToEventXml(startEvent.xml, isInverted) };
+        }
+    }
+    const breaths = [...childElementsByName(layer, "breath"), ...childElementsByName(staff, "breath")];
+    for (const breath of breaths) {
+        const startIndex = resolveControlEventEndpointIndex((breath.getAttribute("startid") || "").trim(), breath.getAttribute("tstamp"), idToEventIndex, out, divisions, beatType, breath.getAttribute("plist"), idToEventTick);
+        if (!Number.isInteger(startIndex))
+            continue;
+        if (startIndex < 0 || startIndex >= out.length)
+            continue;
+        const startEvent = out[startIndex];
+        if (startEvent.kind !== "rest") {
+            out[startIndex] = { ...startEvent, xml: addBreathNotationToEventXml(startEvent.xml) };
+        }
+    }
+    const caesuras = [...childElementsByName(layer, "caesura"), ...childElementsByName(staff, "caesura")];
+    for (const caesura of caesuras) {
+        const startIndex = resolveControlEventEndpointIndex((caesura.getAttribute("startid") || "").trim(), caesura.getAttribute("tstamp"), idToEventIndex, out, divisions, beatType, caesura.getAttribute("plist"), idToEventTick);
+        if (!Number.isInteger(startIndex))
+            continue;
+        if (startIndex < 0 || startIndex >= out.length)
+            continue;
+        const startEvent = out[startIndex];
+        if (startEvent.kind !== "rest") {
+            out[startIndex] = { ...startEvent, xml: addCaesuraNotationToEventXml(startEvent.xml) };
+        }
+    }
+    const tupletSpans = [...childElementsByName(layer, "tupletSpan"), ...childElementsByName(staff, "tupletSpan")];
+    let tupletNumber = 1;
+    const beamSpans = [...childElementsByName(layer, "beamSpan"), ...childElementsByName(staff, "beamSpan")];
+    for (const beamSpan of beamSpans) {
+        const startIndex = resolveControlEventEndpointIndex((beamSpan.getAttribute("startid") || "").trim(), beamSpan.getAttribute("tstamp"), idToEventIndex, out, divisions, beatType, beamSpan.getAttribute("plist"));
+        const endIndex = resolveControlEventEndpointIndex((beamSpan.getAttribute("endid") || "").trim(), beamSpan.getAttribute("tstamp2"), idToEventIndex, out, divisions, beatType);
+        if (!Number.isInteger(startIndex) || !Number.isInteger(endIndex))
+            continue;
+        if (startIndex < 0 || endIndex < 0 || startIndex >= out.length || endIndex >= out.length)
+            continue;
+        const plistRaw = String(beamSpan.getAttribute("plist") || "").trim();
+        const plistIndexes = plistRaw
+            ? plistRaw
+                .split(/\s+/)
+                .map((token) => token.trim())
+                .filter(Boolean)
+                .map((token) => (token.startsWith("#") ? token.slice(1) : token))
+                .map((id) => idToEventIndex.get(id))
+                .filter((idx) => Number.isInteger(idx))
+            : [];
+        const spanIndexes = plistIndexes.length > 0
+            ? plistIndexes
+            : (() => {
+                const from = Math.min(startIndex, endIndex);
+                const to = Math.max(startIndex, endIndex);
+                const arr = [];
+                for (let i = from; i <= to; i += 1)
+                    arr.push(i);
+                return arr;
+            })();
+        const pitchedIndexes = spanIndexes.filter((idx) => idx >= 0 && idx < out.length && out[idx].kind !== "rest");
+        if (pitchedIndexes.length < 2)
+            continue;
+        for (let i = 0; i < pitchedIndexes.length; i += 1) {
+            const idx = pitchedIndexes[i];
+            const value = i === 0 ? "begin" : i === pitchedIndexes.length - 1 ? "end" : "continue";
+            out[idx] = { ...out[idx], xml: addBeamToEventXml(out[idx].xml, value, 1) };
+        }
+    }
+    for (const tupletSpan of tupletSpans) {
+        const startIndex = resolveControlEventEndpointIndex((tupletSpan.getAttribute("startid") || "").trim(), tupletSpan.getAttribute("tstamp"), idToEventIndex, out, divisions, beatType, tupletSpan.getAttribute("plist"), idToEventTick);
+        const endIndex = resolveControlEventEndpointIndex((tupletSpan.getAttribute("endid") || "").trim(), tupletSpan.getAttribute("tstamp2"), idToEventIndex, out, divisions, beatType, undefined, idToEventTick);
+        if (!Number.isInteger(startIndex) || !Number.isInteger(endIndex))
+            continue;
+        if (startIndex < 0 || endIndex < 0 || startIndex >= out.length || endIndex >= out.length)
+            continue;
+        const startEvent = out[startIndex];
+        const endEvent = out[endIndex];
+        if (startEvent.kind !== "rest") {
+            out[startIndex] = { ...startEvent, xml: addTupletNotationToEventXml(startEvent.xml, "start", tupletNumber) };
+        }
+        if (endEvent.kind !== "rest") {
+            out[endIndex] = { ...endEvent, xml: addTupletNotationToEventXml(endEvent.xml, "stop", tupletNumber) };
+        }
+        tupletNumber += 1;
+    }
+    const glissandi = [...childElementsByName(layer, "gliss"), ...childElementsByName(staff, "gliss")];
+    let glissNumber = 1;
+    for (const gliss of glissandi) {
+        const startIndex = resolveControlEventEndpointIndex((gliss.getAttribute("startid") || "").trim(), gliss.getAttribute("tstamp"), idToEventIndex, out, divisions, beatType, gliss.getAttribute("plist"), idToEventTick);
+        const endIndex = resolveControlEventEndpointIndex((gliss.getAttribute("endid") || "").trim(), gliss.getAttribute("tstamp2"), idToEventIndex, out, divisions, beatType, undefined, idToEventTick);
+        if (!Number.isInteger(startIndex) || !Number.isInteger(endIndex))
+            continue;
+        if (startIndex < 0 || endIndex < 0 || startIndex >= out.length || endIndex >= out.length)
+            continue;
+        const startEvent = out[startIndex];
+        const endEvent = out[endIndex];
+        if (startEvent.kind !== "rest") {
+            out[startIndex] = { ...startEvent, xml: addGlissNotationToEventXml(startEvent.xml, "start", glissNumber) };
+        }
+        if (endEvent.kind !== "rest") {
+            out[endIndex] = { ...endEvent, xml: addGlissNotationToEventXml(endEvent.xml, "stop", glissNumber) };
+        }
+        glissNumber += 1;
+    }
+    const slides = [...childElementsByName(layer, "slide"), ...childElementsByName(staff, "slide")];
+    let slideNumber = 1;
+    for (const slide of slides) {
+        const startIndex = resolveControlEventEndpointIndex((slide.getAttribute("startid") || "").trim(), slide.getAttribute("tstamp"), idToEventIndex, out, divisions, beatType, slide.getAttribute("plist"), idToEventTick);
+        const endIndex = resolveControlEventEndpointIndex((slide.getAttribute("endid") || "").trim(), slide.getAttribute("tstamp2"), idToEventIndex, out, divisions, beatType, undefined, idToEventTick);
+        if (!Number.isInteger(startIndex) || !Number.isInteger(endIndex))
+            continue;
+        if (startIndex < 0 || endIndex < 0 || startIndex >= out.length || endIndex >= out.length)
+            continue;
+        const startEvent = out[startIndex];
+        const endEvent = out[endIndex];
+        if (startEvent.kind !== "rest") {
+            out[startIndex] = { ...startEvent, xml: addSlideNotationToEventXml(startEvent.xml, "start", slideNumber) };
+        }
+        if (endEvent.kind !== "rest") {
+            out[endIndex] = { ...endEvent, xml: addSlideNotationToEventXml(endEvent.xml, "stop", slideNumber) };
+        }
+        slideNumber += 1;
+    }
+    return out;
+};
+const applyTieCarryAccidentalsForLayerEvents = (events, tieCarryIn) => {
+    if (events.length === 0) {
+        return { events, tieCarryOut: new Map(tieCarryIn) };
+    }
+    const tieCarryByPitch = new Map(tieCarryIn);
+    const tiePitchKey = (pname, octave) => `${String(pname || "").trim().toUpperCase()}:${Math.round(Number(octave) || 0)}`;
+    const out = events.map((event) => {
+        var _a, _b;
+        if (event.kind === "rest")
+            return event;
+        if (!event.xml.includes("<note>"))
+            return event;
+        const wrapped = `<root>${event.xml}</root>`;
+        const parsed = new DOMParser().parseFromString(wrapped, "application/xml");
+        const root = parsed.documentElement;
+        if (!root || localNameOf(root) !== "root")
+            return event;
+        const noteNodes = Array.from(root.querySelectorAll(":scope > note"));
+        if (noteNodes.length === 0)
+            return event;
+        let changed = false;
+        for (const noteNode of noteNodes) {
+            const step = (((_a = noteNode.querySelector(":scope > pitch > step")) === null || _a === void 0 ? void 0 : _a.textContent) || "").trim().toUpperCase();
+            const octave = parseIntSafe((_b = noteNode.querySelector(":scope > pitch > octave")) === null || _b === void 0 ? void 0 : _b.textContent, NaN);
+            if (!/^[A-G]$/.test(step) || !Number.isFinite(octave))
+                continue;
+            const pitchKey = tiePitchKey(step, octave);
+            const pitchNode = noteNode.querySelector(":scope > pitch");
+            if (!pitchNode)
+                continue;
+            const tieTypes = Array.from(noteNode.querySelectorAll(":scope > tie"))
+                .map((tie) => (tie.getAttribute("type") || "").trim().toLowerCase());
+            const hasStart = tieTypes.includes("start");
+            const hasStop = tieTypes.includes("stop");
+            let alterNode = noteNode.querySelector(":scope > pitch > alter");
+            const alterMissing = alterNode === null;
+            if (hasStop && alterMissing) {
+                const carryAlter = tieCarryByPitch.get(pitchKey);
+                if (Number.isFinite(carryAlter)) {
+                    const newAlter = parsed.createElement("alter");
+                    newAlter.textContent = String(Math.round(carryAlter));
+                    const octaveNode = noteNode.querySelector(":scope > pitch > octave");
+                    if (octaveNode) {
+                        pitchNode.insertBefore(newAlter, octaveNode);
+                    }
+                    else {
+                        pitchNode.appendChild(newAlter);
+                    }
+                    alterNode = newAlter;
+                    changed = true;
+                }
+            }
+            const resolvedAlter = parseIntSafe(alterNode === null || alterNode === void 0 ? void 0 : alterNode.textContent, 0);
+            if (hasStart) {
+                tieCarryByPitch.set(pitchKey, resolvedAlter);
+            }
+            else if (hasStop) {
+                tieCarryByPitch.delete(pitchKey);
+            }
+        }
+        if (!changed)
+            return event;
+        const serialized = new XMLSerializer().serializeToString(root);
+        const xml = serialized.replace(/^<root>/, "").replace(/<\/root>$/, "");
+        return { ...event, xml };
+    });
+    return { events: out, tieCarryOut: tieCarryByPitch };
 };
 const trimLayerEventsToMeasureCapacity = (events, measureTicks) => {
     const kept = [];
     let totalTicks = 0;
     let droppedCount = 0;
     let droppedTicks = 0;
+    let trimmedCount = 0;
+    let trimmedTicks = 0;
     for (const event of events) {
-        if (totalTicks + event.durationTicks <= measureTicks) {
+        const nextTotal = totalTicks + event.durationTicks;
+        if (nextTotal <= measureTicks) {
             kept.push(event);
             totalTicks += event.durationTicks;
+            continue;
+        }
+        const overflow = nextTotal - measureTicks;
+        const isMinorOverflow = overflow > 0 && overflow <= Math.max(12, Math.round(event.durationTicks * 0.1));
+        if (isMinorOverflow) {
+            // Keep tiny overflow as-is to avoid silent note loss from rounding drift
+            // (common around tuplet-heavy imported sources).
+            kept.push(event);
+            totalTicks = nextTotal;
+            trimmedCount += 1;
+            trimmedTicks += overflow;
             continue;
         }
         droppedCount += 1;
         droppedTicks += event.durationTicks;
     }
-    return { events: kept, totalTicks, droppedCount, droppedTicks };
+    return { events: kept, totalTicks, droppedCount, droppedTicks, trimmedCount, trimmedTicks };
 };
 const extractMiscFieldsFromMeiStaff = (staff) => {
     var _a, _b, _c;
@@ -15848,45 +17830,76 @@ const buildMeiDebugFieldsFromStaff = (staff, measureNo, divisions) => {
     return fields;
 };
 const convertMeiToMusicXml = (meiSource, options = {}) => {
-    var _a, _b, _c, _d, _e, _f;
+    var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k;
     const debugMetadata = (_a = options.debugMetadata) !== null && _a !== void 0 ? _a : true;
     const sourceMetadata = (_b = options.sourceMetadata) !== null && _b !== void 0 ? _b : true;
+    const failOnOverfullDrop = (_c = options.failOnOverfullDrop) !== null && _c !== void 0 ? _c : false;
+    const meiCorpusIndex = Number.isFinite(options.meiCorpusIndex)
+        ? Math.max(0, Math.floor(options.meiCorpusIndex))
+        : null;
     const parser = new DOMParser();
     const doc = parser.parseFromString(String(meiSource || ""), "application/xml");
     if (doc.querySelector("parsererror")) {
         throw new Error("Invalid MEI XML.");
     }
     const meiRoot = doc.documentElement;
-    if (!meiRoot || localNameOf(meiRoot) !== "mei") {
-        throw new Error("MEI root must be <mei>.");
+    if (!meiRoot) {
+        throw new Error("MEI root is missing.");
     }
-    const title = firstDescendantText(doc, "title") || "mikuscore";
-    const scoreDef = Array.from(doc.querySelectorAll("*")).find((node) => node instanceof Element && localNameOf(node) === "scoreDef");
+    let meiImportRoot = null;
+    const rootName = localNameOf(meiRoot);
+    if (rootName === "mei") {
+        meiImportRoot = meiRoot;
+    }
+    else if (rootName === "meiCorpus") {
+        const meiNodes = Array.from(meiRoot.children).filter((node) => node instanceof Element && localNameOf(node) === "mei");
+        if (meiCorpusIndex !== null) {
+            meiImportRoot = (_d = meiNodes[meiCorpusIndex]) !== null && _d !== void 0 ? _d : null;
+            if (!meiImportRoot) {
+                throw new Error(`MEI corpus index out of range: ${meiCorpusIndex} (size=${meiNodes.length}).`);
+            }
+        }
+        else {
+            meiImportRoot =
+                (_f = (_e = meiNodes.find((node) => node.querySelector("measure") !== null)) !== null && _e !== void 0 ? _e : meiNodes[0]) !== null && _f !== void 0 ? _f : null;
+        }
+        if (!meiImportRoot) {
+            throw new Error("MEI corpus has no child <mei>.");
+        }
+    }
+    else {
+        throw new Error("MEI root must be <mei> or <meiCorpus>.");
+    }
+    const title = firstDescendantText(meiImportRoot, "title") || "mikuscore";
+    const scoreDefs = collectScoreDefsInDocOrder(meiImportRoot);
+    const staffDefsInDocOrder = collectStaffDefsInDocOrder(meiImportRoot);
+    const scoreDef = scoreDefs[0];
     const meterCount = parseIntSafe(scoreDef === null || scoreDef === void 0 ? void 0 : scoreDef.getAttribute("meter.count"), 4);
     const meterUnit = parseIntSafe(scoreDef === null || scoreDef === void 0 ? void 0 : scoreDef.getAttribute("meter.unit"), 4);
-    const fifths = parseMeiKeySigToFifths((scoreDef === null || scoreDef === void 0 ? void 0 : scoreDef.getAttribute("key.sig")) || "0");
+    const fifths = (_g = parseMeiKeyFifthsFromElement(scoreDef)) !== null && _g !== void 0 ? _g : 0;
     const divisions = 480;
-    const measureTicks = Math.max(1, Math.round((meterCount * 4 * divisions) / Math.max(1, meterUnit)));
-    const staffDefs = Array.from(doc.querySelectorAll("*")).filter((node) => node instanceof Element && localNameOf(node) === "staffDef");
+    const staffDefs = Array.from(meiImportRoot.querySelectorAll("*")).filter((node) => node instanceof Element && localNameOf(node) === "staffDef");
     const staffMeta = new Map();
     for (const staffDef of staffDefs) {
-        const n = (_c = staffDef.getAttribute("n")) === null || _c === void 0 ? void 0 : _c.trim();
+        const n = (_h = staffDef.getAttribute("n")) === null || _h === void 0 ? void 0 : _h.trim();
         if (!n)
             continue;
+        const parsedClef = parseClefFromStaffDefElement(staffDef);
+        const prev = staffMeta.get(n);
         staffMeta.set(n, {
-            label: ((_d = staffDef.getAttribute("label")) === null || _d === void 0 ? void 0 : _d.trim()) || `Staff ${n}`,
-            clefSign: (((_e = staffDef.getAttribute("clef.shape")) === null || _e === void 0 ? void 0 : _e.trim().toUpperCase()) || "G"),
-            clefLine: parseIntSafe(staffDef.getAttribute("clef.line"), 2),
+            label: ((_j = staffDef.getAttribute("label")) === null || _j === void 0 ? void 0 : _j.trim()) || (prev === null || prev === void 0 ? void 0 : prev.label) || `Staff ${n}`,
+            clefSign: (parsedClef === null || parsedClef === void 0 ? void 0 : parsedClef.clefSign) || (prev === null || prev === void 0 ? void 0 : prev.clefSign) || "G",
+            clefLine: (parsedClef === null || parsedClef === void 0 ? void 0 : parsedClef.clefLine) || (prev === null || prev === void 0 ? void 0 : prev.clefLine) || 2,
         });
     }
-    const measureNodes = Array.from(doc.querySelectorAll("*")).filter((node) => node instanceof Element && localNameOf(node) === "measure");
+    const measureNodes = Array.from(meiImportRoot.querySelectorAll("*")).filter((node) => node instanceof Element && localNameOf(node) === "measure");
     if (measureNodes.length === 0) {
         throw new Error("MEI has no <measure>.");
     }
     const staffNumbers = new Set();
     for (const measure of measureNodes) {
         for (const staff of childElementsByName(measure, "staff")) {
-            const n = (_f = staff.getAttribute("n")) === null || _f === void 0 ? void 0 : _f.trim();
+            const n = (_k = staff.getAttribute("n")) === null || _k === void 0 ? void 0 : _k.trim();
             if (n)
                 staffNumbers.add(n);
         }
@@ -15909,38 +17922,91 @@ const convertMeiToMusicXml = (meiSource, options = {}) => {
         const clef = staffMeta.get(staffNo) || { label: `Staff ${staffNo}`, clefSign: "G", clefLine: 2 };
         let currentBeats = Math.max(1, Math.round(meterCount));
         let currentBeatType = Math.max(1, Math.round(meterUnit));
+        let currentFifths = fifths;
+        let currentClefSign = clef.clefSign;
+        let currentClefLine = clef.clefLine;
+        let currentTranspose = parseTransposeFromScoreDefForStaff(scoreDef, staffNo);
+        let hasEmittedInitialAttributes = false;
+        const tieCarryByVoice = new Map();
         const measuresXml = measureNodes
             .map((measureNode, measureIndex) => {
-            var _a, _b, _c, _d;
+            var _a, _b, _c, _d, _e;
             const sourceMeasureNo = ((_a = measureNode.getAttribute("n")) === null || _a === void 0 ? void 0 : _a.trim()) || String(measureIndex + 1);
             const targetStaff = childElementsByName(measureNode, "staff").find((staff) => { var _a; return (((_a = staff.getAttribute("n")) === null || _a === void 0 ? void 0 : _a.trim()) || "") === staffNo; });
             if (!targetStaff) {
                 return `<measure number="${xmlEscape(sourceMeasureNo)}"></measure>`;
             }
+            const effectiveScoreDef = findEffectiveScoreDefForNode(targetStaff, scoreDefs);
+            const effectiveStaffDef = findEffectiveStaffDefForNode(targetStaff, staffNo, staffDefsInDocOrder);
             const measureMeta = parseMeasureMetaFromMeiStaff(targetStaff);
             const measureNo = ((_b = measureMeta === null || measureMeta === void 0 ? void 0 : measureMeta.number) !== null && _b !== void 0 ? _b : sourceMeasureNo).trim() || sourceMeasureNo;
             const implicitAttr = (measureMeta === null || measureMeta === void 0 ? void 0 : measureMeta.implicit) ? ' implicit="yes"' : "";
-            const measureBeats = Math.max(1, Math.round((_c = measureMeta === null || measureMeta === void 0 ? void 0 : measureMeta.beats) !== null && _c !== void 0 ? _c : currentBeats));
-            const measureBeatType = Math.max(1, Math.round((_d = measureMeta === null || measureMeta === void 0 ? void 0 : measureMeta.beatType) !== null && _d !== void 0 ? _d : currentBeatType));
+            const scoreDefBeats = parseIntSafe(effectiveScoreDef === null || effectiveScoreDef === void 0 ? void 0 : effectiveScoreDef.getAttribute("meter.count"), currentBeats);
+            const scoreDefBeatType = parseIntSafe(effectiveScoreDef === null || effectiveScoreDef === void 0 ? void 0 : effectiveScoreDef.getAttribute("meter.unit"), currentBeatType);
+            const scoreDefFifths = parseKeySigFromScoreDefForStaff(effectiveScoreDef, staffNo, currentFifths);
+            const scoreDefClef = parseClefFromScoreDefForStaff(effectiveScoreDef, staffNo);
+            const scoreDefTranspose = parseTransposeFromScoreDefForStaff(effectiveScoreDef, staffNo);
+            const staffDefFifths = parseMeiKeyFifthsFromElement(effectiveStaffDef);
+            const staffDefClef = parseClefFromStaffDefElement(effectiveStaffDef);
+            const staffDefTranspose = parseTransposeFromStaffDefElement(effectiveStaffDef);
+            const measureBeats = Math.max(1, Math.round((_c = measureMeta === null || measureMeta === void 0 ? void 0 : measureMeta.beats) !== null && _c !== void 0 ? _c : scoreDefBeats));
+            const measureBeatType = Math.max(1, Math.round((_d = measureMeta === null || measureMeta === void 0 ? void 0 : measureMeta.beatType) !== null && _d !== void 0 ? _d : scoreDefBeatType));
+            const measureFifths = Number.isFinite(staffDefFifths)
+                ? Math.round(staffDefFifths)
+                : Number.isFinite(scoreDefFifths)
+                    ? Math.round(scoreDefFifths)
+                    : currentFifths;
+            const measureClefSign = (staffDefClef === null || staffDefClef === void 0 ? void 0 : staffDefClef.clefSign) || (scoreDefClef === null || scoreDefClef === void 0 ? void 0 : scoreDefClef.clefSign) || currentClefSign;
+            const measureClefLine = (staffDefClef === null || staffDefClef === void 0 ? void 0 : staffDefClef.clefLine) || (scoreDefClef === null || scoreDefClef === void 0 ? void 0 : scoreDefClef.clefLine) || currentClefLine;
+            const measureTranspose = (_e = staffDefTranspose !== null && staffDefTranspose !== void 0 ? staffDefTranspose : scoreDefTranspose) !== null && _e !== void 0 ? _e : currentTranspose;
+            const measureTicks = Math.max(1, Math.round((measureBeats * 4 * divisions) / Math.max(1, measureBeatType)));
             const shouldEmitTime = measureIndex === 0
                 || (measureMeta === null || measureMeta === void 0 ? void 0 : measureMeta.explicitTime) === true
                 || measureBeats !== currentBeats
                 || measureBeatType !== currentBeatType;
+            const shouldEmitKey = measureIndex === 0 || measureFifths !== currentFifths;
+            const shouldEmitClef = measureIndex === 0
+                || measureClefSign !== currentClefSign
+                || measureClefLine !== currentClefLine;
+            const currentChromatic = Number.isFinite(currentTranspose === null || currentTranspose === void 0 ? void 0 : currentTranspose.chromatic) ? Math.round(Number(currentTranspose === null || currentTranspose === void 0 ? void 0 : currentTranspose.chromatic)) : null;
+            const currentDiatonic = Number.isFinite(currentTranspose === null || currentTranspose === void 0 ? void 0 : currentTranspose.diatonic) ? Math.round(Number(currentTranspose === null || currentTranspose === void 0 ? void 0 : currentTranspose.diatonic)) : null;
+            const measureChromatic = Number.isFinite(measureTranspose === null || measureTranspose === void 0 ? void 0 : measureTranspose.chromatic) ? Math.round(Number(measureTranspose === null || measureTranspose === void 0 ? void 0 : measureTranspose.chromatic)) : null;
+            const measureDiatonic = Number.isFinite(measureTranspose === null || measureTranspose === void 0 ? void 0 : measureTranspose.diatonic) ? Math.round(Number(measureTranspose === null || measureTranspose === void 0 ? void 0 : measureTranspose.diatonic)) : null;
+            const shouldEmitTranspose = measureIndex === 0 || measureChromatic !== currentChromatic || measureDiatonic !== currentDiatonic;
             const layerNodes = childElementsByName(targetStaff, "layer");
-            const layers = layerNodes
-                .map((layer, i) => {
-                var _a;
+            const parsedLayers = layerNodes.map((layer, i) => {
+                var _a, _b;
                 const voice = ((_a = layer.getAttribute("n")) === null || _a === void 0 ? void 0 : _a.trim()) || String(i + 1);
-                const parsedEvents = parseLayerEvents(layer, divisions, voice);
-                const sourceTotalTicks = parsedEvents.reduce((sum, event) => sum + event.durationTicks, 0);
-                const trimmed = trimLayerEventsToMeasureCapacity(parsedEvents, measureTicks);
+                const tieCarryIn = (_b = tieCarryByVoice.get(voice)) !== null && _b !== void 0 ? _b : new Map();
+                const parsedLayer = parseLayerEvents(layer, divisions, voice, measureTicks, measureFifths, tieCarryIn);
+                return { layer, voice, parsedLayer, tieCarryIn };
+            });
+            const staffIdToEventTick = new Map();
+            for (const entry of parsedLayers) {
+                for (const [id, idx] of entry.parsedLayer.idToEventIndex.entries()) {
+                    const tick = resolveEventStartTickByIndex(entry.parsedLayer.events, idx);
+                    if (Number.isFinite(tick))
+                        staffIdToEventTick.set(id, Math.max(0, Math.round(tick)));
+                }
+            }
+            const layers = parsedLayers
+                .map(({ layer, voice, parsedLayer, tieCarryIn }) => {
+                const slurAppliedEvents = applyStaffSlurControlEvents(targetStaff, layer, parsedLayer.events, parsedLayer.idToEventIndex, staffIdToEventTick, divisions, measureBeatType);
+                const tieApplied = applyTieCarryAccidentalsForLayerEvents(slurAppliedEvents, tieCarryIn);
+                tieCarryByVoice.set(voice, tieApplied.tieCarryOut);
+                const directionXml = collectLayerDirectionXml(targetStaff, layer, divisions, measureBeatType, voice, tieApplied.events, parsedLayer.idToEventIndex, staffIdToEventTick);
+                const harmonyXml = collectLayerHarmonyXml(targetStaff, layer, divisions, measureBeatType, tieApplied.events, parsedLayer.idToEventIndex, staffIdToEventTick);
+                const sourceTotalTicks = tieApplied.events.reduce((sum, event) => sum + event.durationTicks, 0);
+                const trimmed = trimLayerEventsToMeasureCapacity(tieApplied.events, measureTicks);
                 return {
                     voice,
-                    xml: trimmed.events.map((event) => event.xml).join(""),
+                    xml: `${harmonyXml}${directionXml}${trimmed.events.map((event) => event.xml).join("")}`,
                     totalTicks: trimmed.totalTicks,
                     sourceTotalTicks,
                     droppedCount: trimmed.droppedCount,
                     droppedTicks: trimmed.droppedTicks,
+                    trimmedCount: trimmed.trimmedCount,
+                    trimmedTicks: trimmed.trimmedTicks,
                 };
             })
                 .filter((layer) => layer.xml.length > 0);
@@ -15959,14 +18025,19 @@ const convertMeiToMusicXml = (meiSource, options = {}) => {
                 : [];
             const droppedEvents = layers.reduce((sum, layer) => sum + layer.droppedCount, 0);
             const droppedTicks = layers.reduce((sum, layer) => sum + layer.droppedTicks, 0);
+            const trimmedEvents = layers.reduce((sum, layer) => sum + layer.trimmedCount, 0);
+            const trimmedTicks = layers.reduce((sum, layer) => sum + layer.trimmedTicks, 0);
             const sourceTotalTicks = layers.reduce((sum, layer) => sum + layer.sourceTotalTicks, 0);
             const overfullDetected = layers.some((layer) => layer.sourceTotalTicks > measureTicks);
+            if (failOnOverfullDrop && droppedEvents > 0) {
+                throw new Error(`MEI overfull would drop events (measure=${measureNo}, staff=${staffNo}, droppedEvents=${droppedEvents}, droppedTicks=${droppedTicks}).`);
+            }
             const overflowFields = overfullDetected
                 ? [
                     { name: "diag:count", value: "1" },
                     {
                         name: "diag:0001",
-                        value: `level=warn;code=OVERFULL_CLAMPED;fmt=mei;measure=${measureNo};staff=${staffNo};action=clamped;sourceTicks=${sourceTotalTicks};capacityTicks=${measureTicks};droppedEvents=${droppedEvents};droppedTicks=${droppedTicks}`,
+                        value: `level=warn;code=OVERFULL_CLAMPED;fmt=mei;measure=${measureNo};staff=${staffNo};action=clamped;sourceTicks=${sourceTotalTicks};capacityTicks=${measureTicks};droppedEvents=${droppedEvents};droppedTicks=${droppedTicks};trimmedEvents=${trimmedEvents};trimmedTicks=${trimmedTicks}`,
                     },
                 ]
                 : [];
@@ -15977,16 +18048,17 @@ const convertMeiToMusicXml = (meiSource, options = {}) => {
                     .join("")}</miscellaneous>`
                 : "";
             let attributesXml = "";
-            if (measureIndex === 0) {
+            if (!hasEmittedInitialAttributes) {
                 attributesXml =
-                    `<attributes><divisions>${divisions}</divisions><key><fifths>${fifths}</fifths></key>` +
+                    `<attributes><divisions>${divisions}</divisions><key><fifths>${measureFifths}</fifths></key>` +
                         `<time><beats>${measureBeats}</beats><beat-type>${measureBeatType}</beat-type></time>` +
-                        `<clef><sign>${xmlEscape(clef.clefSign)}</sign><line>${clef.clefLine}</line></clef>` +
+                        `${buildTransposeXml(measureTranspose)}` +
+                        `<clef><sign>${xmlEscape(measureClefSign)}</sign><line>${measureClefLine}</line></clef>` +
                         `${miscellaneousXml}</attributes>`;
             }
-            else if (shouldEmitTime || miscellaneousXml) {
+            else if (shouldEmitTime || shouldEmitKey || shouldEmitTranspose || shouldEmitClef || miscellaneousXml) {
                 attributesXml =
-                    `<attributes>${shouldEmitTime ? `<time><beats>${measureBeats}</beats><beat-type>${measureBeatType}</beat-type></time>` : ""}${miscellaneousXml}</attributes>`;
+                    `<attributes>${shouldEmitKey ? `<key><fifths>${measureFifths}</fifths></key>` : ""}${shouldEmitTime ? `<time><beats>${measureBeats}</beats><beat-type>${measureBeatType}</beat-type></time>` : ""}${shouldEmitTranspose ? `${buildTransposeXml(measureTranspose)}` : ""}${shouldEmitClef ? `<clef><sign>${xmlEscape(measureClefSign)}</sign><line>${measureClefLine}</line></clef>` : ""}${miscellaneousXml}</attributes>`;
             }
             let leftBarlineXml = "";
             let rightBarlineXml = "";
@@ -16007,6 +18079,11 @@ const convertMeiToMusicXml = (meiSource, options = {}) => {
             }
             currentBeats = measureBeats;
             currentBeatType = measureBeatType;
+            currentFifths = measureFifths;
+            currentClefSign = measureClefSign;
+            currentClefLine = measureClefLine;
+            currentTranspose = measureTranspose;
+            hasEmittedInitialAttributes = true;
             return `<measure number="${xmlEscape(measureNo)}"${implicitAttr}>${attributesXml}${leftBarlineXml}${body}${rightBarlineXml}</measure>`;
         })
             .join("");
@@ -16025,6 +18102,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.convertAbcToMusicXml = exports.clefXmlFromAbcClef = exports.exportMusicXmlDomToAbc = exports.AbcCompatParser = exports.AbcCommon = void 0;
 // @ts-nocheck
 const beam_common_1 = require("./beam-common");
+const staffClefPolicy_1 = require("../../core/staffClefPolicy");
 const DEFAULT_UNIT = { num: 1, den: 8 };
 const DEFAULT_RATIO = { num: 1, den: 1 };
 const gcd = (a, b) => {
@@ -17772,6 +19850,43 @@ const normalizeVoiceForMusicXml = (voice) => {
         return "1";
     return String(Math.round(n));
 };
+const midiByStepForAbcImport = {
+    C: 0,
+    D: 2,
+    E: 4,
+    F: 5,
+    G: 7,
+    A: 9,
+    B: 11,
+};
+const noteToMidiForAbcClefInference = (note) => {
+    if (!note || note.isRest)
+        return null;
+    const step = String(note.step || "").trim().toUpperCase();
+    if (!Object.prototype.hasOwnProperty.call(midiByStepForAbcImport, step)) {
+        return null;
+    }
+    const octave = Number.isFinite(note.octave) ? Math.round(Number(note.octave)) : 4;
+    const alter = Number.isFinite(note.alter) ? Math.round(Number(note.alter)) : 0;
+    return (octave + 1) * 12 + midiByStepForAbcImport[step] + alter;
+};
+const resolveAbcImportClef = (part) => {
+    const explicit = String((part === null || part === void 0 ? void 0 : part.clef) || "").trim().toLowerCase();
+    if (explicit)
+        return explicit;
+    const keys = [];
+    for (const measure of (part === null || part === void 0 ? void 0 : part.measures) || []) {
+        for (const note of measure || []) {
+            const midi = noteToMidiForAbcClefInference(note);
+            if (Number.isFinite(midi)) {
+                keys.push(midi);
+            }
+        }
+    }
+    if (!keys.length)
+        return "";
+    return (0, staffClefPolicy_1.chooseSingleClefByKeys)(keys) === "F" ? "bass" : "treble";
+};
 const clefXmlFromAbcClef = (rawClef) => {
     const clef = String(rawClef || "").trim().toLowerCase();
     if (clef === "bass" || clef === "f") {
@@ -17899,7 +20014,11 @@ const buildMusicXmlFromAbcParsed = (parsed, abcSource, options = {}) => {
     const parts = parsed.parts && parsed.parts.length > 0
         ? parsed.parts
         : [{ partId: "P1", partName: "Voice 1", measures: [[]] }];
-    const measureCount = parts.reduce((max, part) => Math.max(max, part.measures.length), 1);
+    const resolvedParts = parts.map((part) => ({
+        ...part,
+        clef: resolveAbcImportClef(part),
+    }));
+    const measureCount = resolvedParts.reduce((max, part) => Math.max(max, part.measures.length), 1);
     const title = ((_d = parsed.meta) === null || _d === void 0 ? void 0 : _d.title) || "mikuscore";
     const composer = ((_e = parsed.meta) === null || _e === void 0 ? void 0 : _e.composer) || "Unknown";
     const beats = ((_g = (_f = parsed.meta) === null || _f === void 0 ? void 0 : _f.meter) === null || _g === void 0 ? void 0 : _g.beats) || 4;
@@ -17912,7 +20031,7 @@ const buildMusicXmlFromAbcParsed = (parsed, abcSource, options = {}) => {
     const tempoBpm = Number.isFinite((_m = parsed.meta) === null || _m === void 0 ? void 0 : _m.tempoBpm) && Number((_o = parsed.meta) === null || _o === void 0 ? void 0 : _o.tempoBpm) > 0
         ? Math.max(20, Math.min(300, Math.round(Number((_p = parsed.meta) === null || _p === void 0 ? void 0 : _p.tempoBpm))))
         : null;
-    const partListXml = parts
+    const partListXml = resolvedParts
         .map((part, index) => {
         const midiChannel = ((index % 16) + 1 === 10) ? 11 : ((index % 16) + 1);
         return [
@@ -17926,7 +20045,7 @@ const buildMusicXmlFromAbcParsed = (parsed, abcSource, options = {}) => {
         ].join("");
     })
         .join("");
-    const partBodyXml = parts
+    const partBodyXml = resolvedParts
         .map((part, partIndex) => {
         var _a, _b, _c, _d, _e, _f;
         const measuresXml = [];

--- a/src/ts/mei-io.ts
+++ b/src/ts/mei-io.ts
@@ -10,6 +10,12 @@ type StaffSlot = {
 export type MeiImportOptions = {
   debugMetadata?: boolean;
   sourceMetadata?: boolean;
+  failOnOverfullDrop?: boolean;
+  meiCorpusIndex?: number;
+};
+
+export type MeiExportOptions = {
+  meiVersion?: string;
 };
 
 const esc = (value: string): string =>
@@ -191,7 +197,59 @@ const resolveClefForSlot = (
   return { shape: "G", line: 2 };
 };
 
-const buildSimplePitchNote = (note: Element): string => {
+const resolveTransposeForSlot = (
+  part: Element | null,
+  localStaff: number
+): { chromatic?: number; diatonic?: number } | null => {
+  if (!part) return null;
+  for (const measure of Array.from(part.querySelectorAll(":scope > measure"))) {
+    const attrs = Array.from(measure.querySelectorAll(":scope > attributes"));
+    for (const attr of attrs) {
+      const transpose = attr.querySelector(":scope > transpose");
+      if (!transpose) continue;
+      const chromatic = parseIntSafe(transpose.querySelector(":scope > chromatic")?.textContent, NaN);
+      const diatonic = parseIntSafe(transpose.querySelector(":scope > diatonic")?.textContent, NaN);
+      const out: { chromatic?: number; diatonic?: number } = {};
+      if (Number.isFinite(chromatic)) out.chromatic = Math.round(chromatic);
+      if (Number.isFinite(diatonic)) out.diatonic = Math.round(diatonic);
+      if (Object.keys(out).length > 0) return out;
+    }
+    if (localStaff === 1) break;
+  }
+  return null;
+};
+
+const toMksDur480 = (durationTicks: number, sourceDivisions: number): number => {
+  const base = Math.max(1, Math.round(sourceDivisions));
+  return Math.max(1, Math.round((durationTicks * 480) / base));
+};
+
+const extractMeiTieFromMusicXmlNote = (note: Element): string => {
+  const tieTypes = Array.from(note.querySelectorAll(":scope > tie"))
+    .map((node) => (node.getAttribute("type") || "").trim().toLowerCase())
+    .filter(Boolean);
+  const hasStart = tieTypes.includes("start");
+  const hasStop = tieTypes.includes("stop");
+  if (hasStart && hasStop) return "m";
+  if (hasStart) return "i";
+  if (hasStop) return "t";
+  return "";
+};
+
+const extractMeiSlurFromMusicXmlNote = (note: Element): string => {
+  const slurNodes = Array.from(note.querySelectorAll(":scope > notations > slur"));
+  if (slurNodes.length === 0) return "";
+  const tokens: string[] = [];
+  for (const slur of slurNodes) {
+    const type = (slur.getAttribute("type") || "").trim().toLowerCase();
+    const number = Math.max(1, parseIntSafe(slur.getAttribute("number"), 1));
+    if (type === "start") tokens.push(`i${number}`);
+    if (type === "stop") tokens.push(`t${number}`);
+  }
+  return tokens.join(" ");
+};
+
+const buildSimplePitchNote = (note: Element, sourceDivisions: number, includeGraceAttr = true): string => {
   const typeText = note.querySelector(":scope > type")?.textContent?.trim() ?? "quarter";
   const dur = noteTypeToDur(typeText);
   const dots = note.querySelectorAll(":scope > dot").length;
@@ -207,6 +265,12 @@ const buildSimplePitchNote = (note: Element): string => {
     `oct="${esc(octaveText)}"`,
     `dur="${esc(dur)}"`,
   ];
+  const durationTicks = parseIntSafe(note.querySelector(":scope > duration")?.textContent, NaN);
+  if (Number.isFinite(durationTicks) && durationTicks > 0) {
+    attrs.push(`mks-dur-480="${toMksDur480(durationTicks, sourceDivisions)}"`);
+    attrs.push(`mks-dur-div="${Math.max(1, Math.round(sourceDivisions))}"`);
+    attrs.push(`mks-dur-ticks="${Math.round(durationTicks)}"`);
+  }
   const actual = parseIntSafe(note.querySelector(":scope > time-modification > actual-notes")?.textContent, NaN);
   const normal = parseIntSafe(note.querySelector(":scope > time-modification > normal-notes")?.textContent, NaN);
   const hasTupletStart = note.querySelector(':scope > notations > tuplet[type="start"]') !== null;
@@ -222,10 +286,14 @@ const buildSimplePitchNote = (note: Element): string => {
   }
   if (hasTupletStart) attrs.push('mks-tuplet-start="1"');
   if (hasTupletStop) attrs.push('mks-tuplet-stop="1"');
-  if (note.querySelector(":scope > grace")) {
+  if (includeGraceAttr && note.querySelector(":scope > grace")) {
     const slash = (note.querySelector(":scope > grace")?.getAttribute("slash") ?? "").trim().toLowerCase() === "yes";
     attrs.push(`grace="${slash ? "acc" : "unacc"}"`);
   }
+  const tieAttr = extractMeiTieFromMusicXmlNote(note);
+  if (tieAttr) attrs.push(`tie="${esc(tieAttr)}"`);
+  const slurAttr = extractMeiSlurFromMusicXmlNote(note);
+  if (slurAttr) attrs.push(`slur="${esc(slurAttr)}"`);
   if (arts.length) attrs.push(`artic="${esc(arts.join(" "))}"`);
   const lyric = extractMusicXmlLyric(note);
   if (lyric) {
@@ -236,13 +304,20 @@ const buildSimplePitchNote = (note: Element): string => {
   return `<note ${attrs.join(" ")}/>`;
 };
 
-const buildSimpleRest = (note: Element): string => {
+const buildSimpleRest = (note: Element, sourceDivisions: number): string => {
   const typeText = note.querySelector(":scope > type")?.textContent?.trim() ?? "quarter";
   const dur = noteTypeToDur(typeText);
   const dots = note.querySelectorAll(":scope > dot").length;
   const attrs = [`dur="${esc(dur)}"`];
+  const durationTicks = parseIntSafe(note.querySelector(":scope > duration")?.textContent, NaN);
+  if (Number.isFinite(durationTicks) && durationTicks > 0) {
+    attrs.push(`mks-dur-480="${toMksDur480(durationTicks, sourceDivisions)}"`);
+    attrs.push(`mks-dur-div="${Math.max(1, Math.round(sourceDivisions))}"`);
+    attrs.push(`mks-dur-ticks="${Math.round(durationTicks)}"`);
+  }
   if (dots > 0) attrs.push(`dots="${dots}"`);
-  return `<rest ${attrs.join(" ")}/>`;
+  const isInvisible = (note.getAttribute("print-object") || "").trim().toLowerCase() === "no";
+  return `<${isInvisible ? "space" : "rest"} ${attrs.join(" ")}/>`;
 };
 
 const gatherMeasureNumbers = (parts: Element[]): string[] => {
@@ -263,15 +338,50 @@ const voiceSort = (a: string, b: string): number => {
   return a.localeCompare(b);
 };
 
-const buildLayerContent = (notes: Element[]): string => {
+const buildLayerContent = (notes: Element[], sourceDivisions: number, measureTicks: number): string => {
+  const pitchNotes = notes.filter((n) => !n.querySelector(":scope > rest"));
+  const simpleRests = notes.filter((n) => n.querySelector(":scope > rest"));
+  if (pitchNotes.length === 0 && simpleRests.length === 1 && notes.length === 1) {
+    const only = simpleRests[0];
+    const isGrace = only.querySelector(":scope > grace") !== null;
+    const durationTicks = parseIntSafe(only.querySelector(":scope > duration")?.textContent, 0);
+    if (!isGrace && durationTicks === measureTicks && measureTicks > 0) {
+      const isInvisible = (only.getAttribute("print-object") || "").trim().toLowerCase() === "no";
+      const tagName = isInvisible ? "mSpace" : "mRest";
+      const inferred = inferMeiDurAndDotsFromTicks(measureTicks, sourceDivisions);
+      const dotsAttr = inferred.dots > 0 ? ` dots="${inferred.dots}"` : "";
+      return `<${tagName} dur="${inferred.dur}"${dotsAttr} mks-dur-480="${toMksDur480(measureTicks, sourceDivisions)}" mks-dur-div="${Math.max(
+        1,
+        Math.round(sourceDivisions)
+      )}" mks-dur-ticks="${Math.round(measureTicks)}"/>`;
+    }
+  }
   const out: string[] = [];
   for (let i = 0; i < notes.length; i += 1) {
     const note = notes[i];
     const isRest = Boolean(note.querySelector(":scope > rest"));
     const hasChordFlag = Boolean(note.querySelector(":scope > chord"));
+    const isGracePitchNote = !isRest && !hasChordFlag && note.querySelector(":scope > grace") !== null;
+    if (isGracePitchNote) {
+      const graceGroup: Element[] = [note];
+      let hasSlash = (note.querySelector(":scope > grace")?.getAttribute("slash") ?? "").trim().toLowerCase() === "yes";
+      for (let j = i + 1; j < notes.length; j += 1) {
+        const next = notes[j];
+        const nextIsRest = Boolean(next.querySelector(":scope > rest"));
+        const nextHasChordFlag = Boolean(next.querySelector(":scope > chord"));
+        const nextIsGracePitch = !nextIsRest && !nextHasChordFlag && next.querySelector(":scope > grace") !== null;
+        if (!nextIsGracePitch) break;
+        graceGroup.push(next);
+        hasSlash = hasSlash || (next.querySelector(":scope > grace")?.getAttribute("slash") ?? "").trim().toLowerCase() === "yes";
+        i = j;
+      }
+      const members = graceGroup.map((g) => buildSimplePitchNote(g, sourceDivisions, false)).join("");
+      out.push(`<graceGrp slash="${hasSlash ? "yes" : "no"}">${members}</graceGrp>`);
+      continue;
+    }
     if (isRest || hasChordFlag) {
-      if (isRest) out.push(buildSimpleRest(note));
-      else out.push(buildSimplePitchNote(note));
+      if (isRest) out.push(buildSimpleRest(note, sourceDivisions));
+      else out.push(buildSimplePitchNote(note, sourceDivisions));
       continue;
     }
 
@@ -283,7 +393,7 @@ const buildLayerContent = (notes: Element[]): string => {
       i = j;
     }
     if (chordNotes.length === 1) {
-      out.push(buildSimplePitchNote(note));
+      out.push(buildSimplePitchNote(note, sourceDivisions));
       continue;
     }
 
@@ -291,6 +401,12 @@ const buildLayerContent = (notes: Element[]): string => {
     const dur = noteTypeToDur(typeText);
     const dots = note.querySelectorAll(":scope > dot").length;
     const chordAttrs = [`dur="${esc(dur)}"`];
+    const chordDurationTicks = parseIntSafe(note.querySelector(":scope > duration")?.textContent, NaN);
+    if (Number.isFinite(chordDurationTicks) && chordDurationTicks > 0) {
+      chordAttrs.push(`mks-dur-480="${toMksDur480(chordDurationTicks, sourceDivisions)}"`);
+      chordAttrs.push(`mks-dur-div="${Math.max(1, Math.round(sourceDivisions))}"`);
+      chordAttrs.push(`mks-dur-ticks="${Math.round(chordDurationTicks)}"`);
+    }
     if (dots > 0) chordAttrs.push(`dots="${dots}"`);
     const members = chordNotes.map((n) => {
       const step = n.querySelector(":scope > pitch > step")?.textContent?.trim() ?? "C";
@@ -305,6 +421,10 @@ const buildLayerContent = (notes: Element[]): string => {
         `oct="${esc(octaveText)}"`,
       ];
       if (accid) noteAttrs.push(`accid="${accid}"`);
+      const tieAttr = extractMeiTieFromMusicXmlNote(n);
+      if (tieAttr) noteAttrs.push(`tie="${esc(tieAttr)}"`);
+      const slurAttr = extractMeiSlurFromMusicXmlNote(n);
+      if (slurAttr) noteAttrs.push(`slur="${esc(slurAttr)}"`);
       const lyric = extractMusicXmlLyric(n);
       if (lyric) {
         const wordpos = lyricWordposFromSyllabic(lyric.syllabic);
@@ -370,7 +490,440 @@ const encodeMeasureMetaForMei = (measure: Element): string | null => {
   return parts.length ? parts.join(";") : null;
 };
 
-export const exportMusicXmlDomToMei = (doc: Document): string => {
+const accidentalTextFromAlter = (alter: number): string => {
+  if (!Number.isFinite(alter) || alter === 0) return "";
+  if (alter === 1) return "#";
+  if (alter === -1) return "b";
+  if (alter === 2) return "##";
+  if (alter === -2) return "bb";
+  return "";
+};
+
+const suffixFromHarmonyKind = (kindNode: Element | null): { suffix: string; fromText: boolean } => {
+  if (!kindNode) return { suffix: "", fromText: false };
+  const textAttr = (kindNode.getAttribute("text") || "").trim();
+  if (textAttr) return { suffix: textAttr, fromText: true };
+  const kind = (kindNode.textContent || "").trim().toLowerCase();
+  if (kind === "major") return { suffix: "", fromText: false };
+  if (kind === "minor") return { suffix: "m", fromText: false };
+  if (kind === "dominant") return { suffix: "7", fromText: false };
+  if (kind === "major-seventh") return { suffix: "maj7", fromText: false };
+  if (kind === "minor-seventh") return { suffix: "m7", fromText: false };
+  if (kind === "diminished") return { suffix: "dim", fromText: false };
+  if (kind === "augmented") return { suffix: "aug", fromText: false };
+  return { suffix: kind && kind !== "other" ? kind : "", fromText: false };
+};
+
+const degreeSuffixFromHarmony = (harmony: Element): string => {
+  const out: string[] = [];
+  for (const degree of Array.from(harmony.querySelectorAll(":scope > degree"))) {
+    const value = Number.parseInt(degree.querySelector(":scope > degree-value")?.textContent || "", 10);
+    const alter = Number.parseInt(degree.querySelector(":scope > degree-alter")?.textContent || "", 10);
+    if (!Number.isFinite(value) || !Number.isFinite(alter) || alter === 0) continue;
+    out.push(`${accidentalTextFromAlter(alter)}${Math.round(value)}`);
+  }
+  return out.join("");
+};
+
+const offsetTicksToTstamp = (offsetTicks: number, divisions: number, beatType: number): string => {
+  const ticksPerBeat = Math.max(1, (4 * Math.max(1, divisions)) / Math.max(1, beatType));
+  const beatPos = 1 + (Math.max(0, offsetTicks) / ticksPerBeat);
+  const rounded = Math.round(beatPos * 1000) / 1000;
+  return String(rounded).replace(/\.0+$/, "").replace(/(\.\d*?)0+$/, "$1");
+};
+
+const buildMeiHarmFromMusicXmlHarmony = (
+  harmony: Element,
+  sourceDivisions: number,
+  beatType: number
+): string | null => {
+  const rootStep = (harmony.querySelector(":scope > root > root-step")?.textContent || "").trim().toUpperCase();
+  if (!/^[A-G]$/.test(rootStep)) return null;
+  const rootAlter = Number.parseInt(harmony.querySelector(":scope > root > root-alter")?.textContent || "0", 10);
+  const kindNode = harmony.querySelector(":scope > kind");
+  const kindSuffix = suffixFromHarmonyKind(kindNode);
+  const suffix = `${kindSuffix.suffix}${kindSuffix.fromText ? "" : degreeSuffixFromHarmony(harmony)}`;
+  const bassStep = (harmony.querySelector(":scope > bass > bass-step")?.textContent || "").trim().toUpperCase();
+  const bassAlter = Number.parseInt(harmony.querySelector(":scope > bass > bass-alter")?.textContent || "0", 10);
+  const chordText =
+    `${rootStep}${accidentalTextFromAlter(rootAlter)}${suffix}${/^[A-G]$/.test(bassStep) ? `/${bassStep}${accidentalTextFromAlter(bassAlter)}` : ""}`;
+  if (!chordText) return null;
+  const offsetTicks = parseIntSafe(harmony.querySelector(":scope > offset")?.textContent, 0);
+  const tstamp = offsetTicks > 0 ? offsetTicksToTstamp(offsetTicks, sourceDivisions, beatType) : "1";
+  return `<harm tstamp="${esc(tstamp)}">${esc(chordText)}</harm>`;
+};
+
+const collectMeiHarmsForStaff = (measure: Element, localStaff: number, sourceDivisions: number, beatType: number): string[] => {
+  const out: string[] = [];
+  for (const harmony of Array.from(measure.querySelectorAll(":scope > harmony"))) {
+    const staffNo = parseIntSafe(harmony.querySelector(":scope > staff")?.textContent, 1);
+    if (staffNo !== localStaff) continue;
+    const harm = buildMeiHarmFromMusicXmlHarmony(harmony, sourceDivisions, beatType);
+    if (harm) out.push(harm);
+  }
+  return out;
+};
+
+const directionOffsetTicks = (direction: Element): number => {
+  return Math.max(0, parseIntSafe(direction.querySelector(":scope > offset")?.textContent, 0));
+};
+
+const directionTstamp = (direction: Element, divisions: number, beatType: number): string => {
+  return offsetTicksToTstamp(directionOffsetTicks(direction), divisions, beatType);
+};
+
+const directionStaffMatches = (direction: Element, localStaff: number): boolean => {
+  const staffNo = parseIntSafe(direction.querySelector(":scope > staff")?.textContent, 1);
+  return staffNo === localStaff;
+};
+
+const collectMeiDirectionControlsForStaff = (
+  measure: Element,
+  localStaff: number,
+  sourceDivisions: number,
+  beatType: number
+): string[] => {
+  const out: string[] = [];
+  const directions = Array.from(measure.querySelectorAll(":scope > direction")).filter((direction) =>
+    directionStaffMatches(direction, localStaff)
+  );
+
+  for (const direction of directions) {
+    const placement = (direction.getAttribute("placement") || "").trim().toLowerCase();
+    const placeAttr = placement === "above" || placement === "below" ? ` place="${esc(placement)}"` : "";
+    const tstamp = directionTstamp(direction, sourceDivisions, beatType);
+    const dynamicsNode = direction.querySelector(":scope > direction-type > dynamics");
+    if (dynamicsNode) {
+      const symbol = Array.from(dynamicsNode.children)
+        .map((child) => localNameOf(child))
+        .find((name) => !!name);
+      if (symbol) {
+        out.push(`<dynam tstamp="${esc(tstamp)}"${placeAttr}>${esc(symbol)}</dynam>`);
+        continue;
+      }
+    }
+    const words = (direction.querySelector(":scope > direction-type > words")?.textContent || "").trim();
+    if (words) {
+      out.push(`<dynam tstamp="${esc(tstamp)}"${placeAttr}>${esc(words)}</dynam>`);
+    }
+  }
+
+  type PendingWedge = { tstamp: string; form: "cres" | "dim"; placeAttr: string };
+  const pendingByNumber = new Map<string, PendingWedge>();
+  for (const direction of directions) {
+    const wedge = direction.querySelector(":scope > direction-type > wedge");
+    if (!wedge) continue;
+    const type = (wedge.getAttribute("type") || "").trim().toLowerCase();
+    const number = (wedge.getAttribute("number") || "1").trim() || "1";
+    const tstamp = directionTstamp(direction, sourceDivisions, beatType);
+    const placement = (direction.getAttribute("placement") || "").trim().toLowerCase();
+    const placeAttr = placement === "above" || placement === "below" ? ` place="${esc(placement)}"` : "";
+    if (type === "crescendo" || type === "diminuendo") {
+      pendingByNumber.set(number, { tstamp, form: type === "diminuendo" ? "dim" : "cres", placeAttr });
+      continue;
+    }
+    if (type === "stop") {
+      const pending = pendingByNumber.get(number);
+      if (!pending) continue;
+      out.push(
+        `<hairpin form="${pending.form}" tstamp="${esc(pending.tstamp)}" tstamp2="${esc(tstamp)}"${pending.placeAttr}/>`
+      );
+      pendingByNumber.delete(number);
+    }
+  }
+  for (const pending of pendingByNumber.values()) {
+    out.push(`<hairpin form="${pending.form}" tstamp="${esc(pending.tstamp)}"${pending.placeAttr}/>`);
+  }
+
+  type PendingPedal = { tstamp: string; placeAttr: string };
+  const pendingPedalByNumber = new Map<string, PendingPedal>();
+  for (const direction of directions) {
+    const pedal = direction.querySelector(":scope > direction-type > pedal");
+    if (!pedal) continue;
+    const type = (pedal.getAttribute("type") || "").trim().toLowerCase();
+    const number = (pedal.getAttribute("number") || "1").trim() || "1";
+    const tstamp = directionTstamp(direction, sourceDivisions, beatType);
+    const placement = (direction.getAttribute("placement") || "").trim().toLowerCase();
+    const placeAttr = placement === "above" || placement === "below" ? ` place="${esc(placement)}"` : "";
+    if (type === "start" || type === "resume" || type === "change") {
+      pendingPedalByNumber.set(number, { tstamp, placeAttr });
+      continue;
+    }
+    if (type === "stop" || type === "discontinue") {
+      const pending = pendingPedalByNumber.get(number);
+      if (pending) {
+        out.push(`<pedal tstamp="${esc(pending.tstamp)}" tstamp2="${esc(tstamp)}"${pending.placeAttr}/>`);
+        pendingPedalByNumber.delete(number);
+      } else {
+        out.push(`<pedal tstamp="${esc(tstamp)}" type="stop"${placeAttr}/>`);
+      }
+    }
+  }
+  for (const pending of pendingPedalByNumber.values()) {
+    out.push(`<pedal tstamp="${esc(pending.tstamp)}"${pending.placeAttr}/>`);
+  }
+
+  type PendingOctave = { tstamp: string; dis: number; disPlace: "above" | "below"; placeAttr: string };
+  const pendingOctaveByNumber = new Map<string, PendingOctave>();
+  for (const direction of directions) {
+    const octave = direction.querySelector(":scope > direction-type > octave-shift");
+    if (!octave) continue;
+    const type = (octave.getAttribute("type") || "").trim().toLowerCase();
+    const number = (octave.getAttribute("number") || "1").trim() || "1";
+    const size = parseIntSafe(octave.getAttribute("size"), 8);
+    const dis = Math.max(1, Math.round(size));
+    const disPlace: "above" | "below" = type === "down" ? "below" : "above";
+    const tstamp = directionTstamp(direction, sourceDivisions, beatType);
+    const placement = (direction.getAttribute("placement") || "").trim().toLowerCase();
+    const placeAttr = placement === "above" || placement === "below" ? ` place="${esc(placement)}"` : "";
+    if (type === "up" || type === "down") {
+      pendingOctaveByNumber.set(number, { tstamp, dis, disPlace, placeAttr });
+      continue;
+    }
+    if (type === "stop" || type === "continue") {
+      const pending = pendingOctaveByNumber.get(number);
+      if (pending) {
+        out.push(
+          `<octave dis="${pending.dis}" dis.place="${pending.disPlace}" tstamp="${esc(pending.tstamp)}" tstamp2="${esc(tstamp)}"${pending.placeAttr}/>`
+        );
+        pendingOctaveByNumber.delete(number);
+      } else {
+        out.push(`<octave dis="${dis}" tstamp="${esc(tstamp)}" type="stop"${placeAttr}/>`);
+      }
+    }
+  }
+  for (const pending of pendingOctaveByNumber.values()) {
+    out.push(
+      `<octave dis="${pending.dis}" dis.place="${pending.disPlace}" tstamp="${esc(pending.tstamp)}"${pending.placeAttr}/>`
+    );
+  }
+
+  for (const direction of directions) {
+    const tstamp = directionTstamp(direction, sourceDivisions, beatType);
+    const placement = (direction.getAttribute("placement") || "").trim().toLowerCase();
+    const placeAttr = placement === "above" || placement === "below" ? ` place="${esc(placement)}"` : "";
+    const segno = direction.querySelector(":scope > direction-type > segno");
+    if (segno) {
+      out.push(`<repeatMark tstamp="${esc(tstamp)}"${placeAttr}>segno</repeatMark>`);
+      continue;
+    }
+    const coda = direction.querySelector(":scope > direction-type > coda");
+    if (coda) {
+      out.push(`<repeatMark tstamp="${esc(tstamp)}"${placeAttr}>coda</repeatMark>`);
+      continue;
+    }
+    const words = (direction.querySelector(":scope > direction-type > words")?.textContent || "").trim();
+    if (!words) continue;
+    const lowered = words.toLowerCase();
+    if (
+      lowered === "fine"
+      || lowered === "d.c."
+      || lowered === "da capo"
+      || lowered === "d.s."
+      || lowered === "dal segno"
+    ) {
+      out.push(`<repeatMark tstamp="${esc(tstamp)}"${placeAttr}>${esc(words)}</repeatMark>`);
+    }
+  }
+  return out;
+};
+
+const collectStaffTimelineForExport = (
+  measure: Element,
+  localStaff: number,
+  divisions: number
+): Array<{ note: Element; onset: number }> => {
+  const out: Array<{ note: Element; onset: number }> = [];
+  let cursor = 0;
+  for (const child of Array.from(measure.children)) {
+    const name = localNameOf(child);
+    if (name === "backup") {
+      const dur = parseIntSafe(child.querySelector(":scope > duration")?.textContent, 0);
+      cursor = Math.max(0, cursor - Math.max(0, dur));
+      continue;
+    }
+    if (name === "forward") {
+      const dur = parseIntSafe(child.querySelector(":scope > duration")?.textContent, 0);
+      cursor += Math.max(0, dur);
+      continue;
+    }
+    if (name !== "note") continue;
+    const note = child;
+    const staffNo = parseIntSafe(note.querySelector(":scope > staff")?.textContent, 1);
+    const isChordContinuation = note.querySelector(":scope > chord") !== null;
+    const dur = parseIntSafe(note.querySelector(":scope > duration")?.textContent, 0);
+    if (staffNo === localStaff) {
+      out.push({ note, onset: cursor });
+    }
+    if (!isChordContinuation) {
+      cursor += Math.max(0, dur);
+    }
+  }
+  return out;
+};
+
+const collectMeiGlissSlideControlsForStaff = (
+  measure: Element,
+  localStaff: number,
+  divisions: number,
+  beatType: number
+): string[] => {
+  const out: string[] = [];
+  const timeline = collectStaffTimelineForExport(measure, localStaff, divisions);
+  type Pending = { kind: "gliss" | "slide"; tstamp: string };
+  const pendingByKey = new Map<string, Pending>();
+  for (const item of timeline) {
+    const note = item.note;
+    const tstamp = offsetTicksToTstamp(item.onset, divisions, beatType);
+    const notations = note.querySelectorAll(":scope > notations > glissando, :scope > notations > slide");
+    for (const node of Array.from(notations)) {
+      const kind = localNameOf(node) === "slide" ? "slide" : "gliss";
+      const type = (node.getAttribute("type") || "").trim().toLowerCase();
+      const number = (node.getAttribute("number") || "1").trim() || "1";
+      const key = `${kind}:${number}`;
+      if (type === "start") {
+        pendingByKey.set(key, { kind, tstamp });
+      } else if (type === "stop") {
+        const pending = pendingByKey.get(key);
+        if (pending) {
+          out.push(`<${pending.kind} tstamp="${esc(pending.tstamp)}" tstamp2="${esc(tstamp)}"/>`);
+          pendingByKey.delete(key);
+        } else {
+          out.push(`<${kind} tstamp="${esc(tstamp)}"/>`);
+        }
+      }
+    }
+  }
+  for (const pending of pendingByKey.values()) {
+    out.push(`<${pending.kind} tstamp="${esc(pending.tstamp)}"/>`);
+  }
+  return out;
+};
+
+const tiePitchKeyFromMusicXmlNote = (note: Element): string | null => {
+  const pitch = note.querySelector(":scope > pitch");
+  if (!pitch) return null;
+  const step = (pitch.querySelector(":scope > step")?.textContent || "").trim().toUpperCase();
+  const octave = (pitch.querySelector(":scope > octave")?.textContent || "").trim();
+  const alter = (pitch.querySelector(":scope > alter")?.textContent || "0").trim();
+  if (!/^[A-G]$/.test(step) || !/^-?\d+$/.test(octave)) return null;
+  const voice = (note.querySelector(":scope > voice")?.textContent || "1").trim() || "1";
+  return `${step}:${alter}:${octave}:v${voice}`;
+};
+
+const collectMeiTieSlurControlsForStaff = (
+  measure: Element,
+  localStaff: number,
+  divisions: number,
+  beatType: number
+): string[] => {
+  const out: string[] = [];
+  const timeline = collectStaffTimelineForExport(measure, localStaff, divisions);
+
+  const pendingSlurByNumber = new Map<string, { tstamp: string }>();
+  const pendingTieByPitch = new Map<string, { tstamp: string }>();
+
+  for (const item of timeline) {
+    const note = item.note;
+    const tstamp = offsetTicksToTstamp(item.onset, divisions, beatType);
+
+    const slurs = Array.from(note.querySelectorAll(":scope > notations > slur"));
+    for (const slur of slurs) {
+      const type = (slur.getAttribute("type") || "").trim().toLowerCase();
+      const number = String(Math.max(1, parseIntSafe(slur.getAttribute("number"), 1)));
+      if (type === "start") {
+        pendingSlurByNumber.set(number, { tstamp });
+        continue;
+      }
+      if (type === "stop") {
+        const pending = pendingSlurByNumber.get(number);
+        if (pending) {
+          out.push(`<slur tstamp="${esc(pending.tstamp)}" tstamp2="${esc(tstamp)}"/>`);
+          pendingSlurByNumber.delete(number);
+        }
+      }
+    }
+
+    const tieTypes = Array.from(note.querySelectorAll(":scope > tie"))
+      .map((n) => (n.getAttribute("type") || "").trim().toLowerCase())
+      .filter(Boolean);
+    if (tieTypes.length > 0) {
+      const pitchKey = tiePitchKeyFromMusicXmlNote(note);
+      if (pitchKey) {
+        const hasStop = tieTypes.includes("stop");
+        const hasStart = tieTypes.includes("start");
+        if (hasStop) {
+          const pending = pendingTieByPitch.get(pitchKey);
+          if (pending) {
+            out.push(`<tie tstamp="${esc(pending.tstamp)}" tstamp2="${esc(tstamp)}"/>`);
+            pendingTieByPitch.delete(pitchKey);
+          }
+        }
+        if (hasStart) {
+          pendingTieByPitch.set(pitchKey, { tstamp });
+        }
+      }
+    }
+  }
+
+  return out;
+};
+
+const collectMeiOrnamentAndBreathControlsForStaff = (
+  measure: Element,
+  localStaff: number,
+  divisions: number,
+  beatType: number
+): string[] => {
+  const out: string[] = [];
+  const timeline = collectStaffTimelineForExport(measure, localStaff, divisions);
+  for (const item of timeline) {
+    const note = item.note;
+    const tstamp = offsetTicksToTstamp(item.onset, divisions, beatType);
+    const notePitch = note.querySelector(":scope > pitch");
+    if (!notePitch) continue;
+    const notations = note.querySelector(":scope > notations");
+    if (!notations) continue;
+
+    if (notations.querySelector(":scope > ornaments > trill-mark")) {
+      out.push(`<trill tstamp="${esc(tstamp)}"/>`);
+    }
+    if (notations.querySelector(":scope > ornaments > turn")) {
+      out.push(`<turn tstamp="${esc(tstamp)}" type="upper"/>`);
+    }
+    if (notations.querySelector(":scope > ornaments > inverted-turn")) {
+      out.push(`<turn tstamp="${esc(tstamp)}" type="inverted"/>`);
+    }
+    if (notations.querySelector(":scope > ornaments > mordent")) {
+      out.push(`<mordent tstamp="${esc(tstamp)}" type="upper"/>`);
+    }
+    if (notations.querySelector(":scope > ornaments > inverted-mordent")) {
+      out.push(`<mordent tstamp="${esc(tstamp)}" type="inverted"/>`);
+    }
+    const fermata = notations.querySelector(":scope > fermata");
+    if (fermata) {
+      const type = (fermata.getAttribute("type") || "").trim().toLowerCase();
+      const placeAttr = type === "inverted" ? ` place="below"` : "";
+      out.push(`<fermata tstamp="${esc(tstamp)}"${placeAttr}/>`);
+    }
+    if (notations.querySelector(":scope > articulations > breath-mark")) {
+      out.push(`<breath tstamp="${esc(tstamp)}"/>`);
+    }
+    if (notations.querySelector(":scope > articulations > caesura")) {
+      out.push(`<caesura tstamp="${esc(tstamp)}"/>`);
+    }
+  }
+  return out;
+};
+
+const normalizeMeiVersion = (raw: string | undefined): string => {
+  const v = String(raw ?? "").trim();
+  if (/^\d+\.\d+(\.\d+)?$/.test(v)) return v;
+  return "5.1";
+};
+
+export const exportMusicXmlDomToMei = (doc: Document, options: MeiExportOptions = {}): string => {
+  const meiVersion = normalizeMeiVersion(options.meiVersion);
   const parts = Array.from(doc.querySelectorAll("score-partwise > part"));
   if (parts.length === 0) {
     throw new Error("MusicXML part is missing.");
@@ -401,8 +954,13 @@ export const exportMusicXmlDomToMei = (doc: Document): string => {
   for (const slot of slots) {
     const partEl = parts.find((part) => (part.getAttribute("id") ?? "") === slot.partId) ?? null;
     const clef = resolveClefForSlot(partEl, slot.localStaff);
+    const transpose = resolveTransposeForSlot(partEl, slot.localStaff);
+    const transposeAttrs = [
+      Number.isFinite(transpose?.diatonic) ? ` trans.diat="${Math.round(Number(transpose?.diatonic))}"` : "",
+      Number.isFinite(transpose?.chromatic) ? ` trans.semi="${Math.round(Number(transpose?.chromatic))}"` : "",
+    ].join("");
     scoreDefLines.push(
-      `<staffDef n="${slot.globalStaff}" label="${esc(slot.label)}" lines="5" clef.shape="${esc(clef.shape)}" clef.line="${clef.line}"/>`
+      `<staffDef n="${slot.globalStaff}" label="${esc(slot.label)}" lines="5" clef.shape="${esc(clef.shape)}" clef.line="${clef.line}"${transposeAttrs}/>`
     );
   }
   scoreDefLines.push("</staffGrp>");
@@ -410,6 +968,16 @@ export const exportMusicXmlDomToMei = (doc: Document): string => {
 
   const measuresOut: string[] = [];
   const measureNumbers = gatherMeasureNumbers(parts);
+  const currentDivisionsByPart = new Map<string, number>();
+  for (const part of parts) {
+    const partId = (part.getAttribute("id") ?? "").trim();
+    if (!partId) continue;
+    const firstDivisions = parseIntSafe(
+      part.querySelector(":scope > measure > attributes > divisions")?.textContent,
+      1
+    );
+    currentDivisionsByPart.set(partId, Math.max(1, firstDivisions));
+  }
   for (const number of measureNumbers) {
     const measureLines: string[] = [];
     measureLines.push(`<measure n="${esc(number)}">`);
@@ -421,6 +989,22 @@ export const exportMusicXmlDomToMei = (doc: Document): string => {
         (m) => (m.getAttribute("number")?.trim() || "") === number
       );
       if (!measure) continue;
+      const partId = (part.getAttribute("id") ?? "").trim();
+      const measureDivisions = parseIntSafe(
+        measure.querySelector(":scope > attributes > divisions")?.textContent,
+        NaN
+      );
+      if (Number.isFinite(measureDivisions) && measureDivisions > 0 && partId) {
+        currentDivisionsByPart.set(partId, Math.round(measureDivisions));
+      }
+      const sourceDivisions = Math.max(
+        1,
+        Math.round(currentDivisionsByPart.get(partId) ?? 1)
+      );
+      const beatType = parseIntSafe(
+        measure.querySelector(":scope > attributes > time > beat-type")?.textContent,
+        meterUnit
+      );
 
       const voiceMap = new Map<string, Element[]>();
       for (const note of Array.from(measure.querySelectorAll(":scope > note"))) {
@@ -445,9 +1029,34 @@ export const exportMusicXmlDomToMei = (doc: Document): string => {
           `<annot type="musicxml-measure-meta" label="mks:measure-meta">${esc(measureMeta)}</annot>`
         );
       }
+      const controlNodes = collectMeiDirectionControlsForStaff(measure, slot.localStaff, sourceDivisions, beatType);
+      for (const controlNode of controlNodes) {
+        measureLines.push(controlNode);
+      }
+      const glissSlideNodes = collectMeiGlissSlideControlsForStaff(measure, slot.localStaff, sourceDivisions, beatType);
+      for (const node of glissSlideNodes) {
+        measureLines.push(node);
+      }
+      const tieSlurNodes = collectMeiTieSlurControlsForStaff(measure, slot.localStaff, sourceDivisions, beatType);
+      for (const node of tieSlurNodes) {
+        measureLines.push(node);
+      }
+      const ornamentNodes = collectMeiOrnamentAndBreathControlsForStaff(measure, slot.localStaff, sourceDivisions, beatType);
+      for (const node of ornamentNodes) {
+        measureLines.push(node);
+      }
+      const harmNodes = collectMeiHarmsForStaff(measure, slot.localStaff, sourceDivisions, beatType);
+      for (const harmNode of harmNodes) {
+        measureLines.push(harmNode);
+      }
       for (const voice of Array.from(voiceMap.keys()).sort(voiceSort)) {
         const notes = voiceMap.get(voice) ?? [];
-        const layer = buildLayerContent(notes);
+        const measureBeats = parseIntSafe(
+          measure.querySelector(":scope > attributes > time > beats")?.textContent,
+          meterCount
+        );
+        const measureTicks = Math.max(1, Math.round((measureBeats * 4 * sourceDivisions) / Math.max(1, beatType)));
+        const layer = buildLayerContent(notes, sourceDivisions, measureTicks);
         measureLines.push(`<layer n="${esc(voice)}">${layer}</layer>`);
       }
       measureLines.push("</staff>");
@@ -459,7 +1068,7 @@ export const exportMusicXmlDomToMei = (doc: Document): string => {
 
   return [
     `<?xml version="1.0" encoding="UTF-8"?>`,
-    `<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.1">`,
+    `<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="${esc(meiVersion)}">`,
     `<meiHead><fileDesc><titleStmt><title>${esc(title)}</title></titleStmt><pubStmt><p>Generated by mikuscore</p></pubStmt></fileDesc></meiHead>`,
     `<music><body><mdiv><score>`,
     scoreDefLines.join(""),
@@ -536,6 +1145,20 @@ const meiDurToQuarterLength = (dur: string): number => {
   return 4 / denom;
 };
 
+const meiDurToBeamDepth = (dur: string): number => {
+  const normalized = String(dur || "").trim().toLowerCase();
+  const denom = Number.parseInt(normalized, 10);
+  if (!Number.isFinite(denom) || denom < 8) return 0;
+  let depth = 0;
+  let value = denom;
+  while (value >= 8 && Number.isFinite(value)) {
+    depth += 1;
+    value /= 2;
+    if (!Number.isFinite(value) || value <= 0) break;
+  }
+  return Math.max(0, depth);
+};
+
 const dotsMultiplier = (dots: number): number => {
   const safeDots = Math.max(0, Math.min(4, Math.floor(dots)));
   let sum = 1;
@@ -545,6 +1168,26 @@ const dotsMultiplier = (dots: number): number => {
     add /= 2;
   }
   return sum;
+};
+
+const inferMeiDurAndDotsFromTicks = (
+  ticks: number,
+  divisions: number
+): { dur: string; dots: number } => {
+  const safeTicks = Math.max(1, Math.round(ticks));
+  const safeDiv = Math.max(1, Math.round(divisions));
+  const candidates = ["1", "2", "4", "8", "16", "32", "64", "128"];
+  let best = { dur: "4", dots: 0, diff: Number.POSITIVE_INFINITY };
+  for (const dur of candidates) {
+    const base = meiDurToQuarterLength(dur) * safeDiv;
+    for (let dots = 0; dots <= 3; dots += 1) {
+      const candidate = Math.max(1, Math.round(base * dotsMultiplier(dots)));
+      const diff = Math.abs(candidate - safeTicks);
+      if (diff < best.diff) best = { dur, dots, diff };
+      if (diff === 0) return { dur, dots };
+    }
+  }
+  return { dur: best.dur, dots: best.dots };
 };
 
 const accidToAlter = (accid: string): number | null => {
@@ -569,6 +1212,31 @@ const accidToMusicXmlAccidental = (accid: string): string | null => {
   return null;
 };
 
+const readMeiSoundingAccid = (node: Element): { visualAccid: string; soundingAccid: string } => {
+  const visualAccid = (node.getAttribute("accid") || "").trim();
+  const gesturalAccid = (node.getAttribute("accid.ges") || node.getAttribute("accid-ges") || "").trim();
+  const soundingAccid = visualAccid || gesturalAccid;
+  return { visualAccid, soundingAccid };
+};
+
+const accidToPitchAlterXml = (accid: string): string => {
+  const alter = accidToAlter(accid);
+  // Prefer omitting <alter>0</alter>; keep explicit accidental display separately.
+  if (alter === null || alter === 0) return "";
+  return `<alter>${alter}</alter>`;
+};
+
+const impliedAlterFromFifths = (step: string, fifths: number): number => {
+  const normalizedStep = String(step || "").trim().toUpperCase();
+  if (!/^[A-G]$/.test(normalizedStep)) return 0;
+  const n = Math.max(-7, Math.min(7, Math.round(Number(fifths) || 0)));
+  if (n === 0) return 0;
+  const sharpOrder = ["F", "C", "G", "D", "A", "E", "B"];
+  const flatOrder = ["B", "E", "A", "D", "G", "C", "F"];
+  if (n > 0) return sharpOrder.slice(0, n).includes(normalizedStep) ? 1 : 0;
+  return flatOrder.slice(0, Math.abs(n)).includes(normalizedStep) ? -1 : 0;
+};
+
 const parseMeiKeySigToFifths = (value: string): number => {
   const normalized = String(value || "").trim().toLowerCase();
   if (!normalized || normalized === "0") return 0;
@@ -577,6 +1245,49 @@ const parseMeiKeySigToFifths = (value: string): number => {
   if (normalized.endsWith("s")) return Math.max(-7, Math.min(7, num));
   if (normalized.endsWith("f")) return Math.max(-7, Math.min(7, -Math.abs(num)));
   return Math.max(-7, Math.min(7, num));
+};
+
+const readMeiKeySigAttr = (element: Element | null | undefined): string => {
+  if (!element) return "";
+  return (element.getAttribute("key.sig") || element.getAttribute("keysig") || "").trim();
+};
+
+const parseMeiKeyAccidToAlter = (value: string): number => {
+  const v = String(value || "").trim().toLowerCase();
+  if (!v || v === "n") return 0;
+  if (v === "s" || v === "#") return 1;
+  if (v === "ss" || v === "x" || v === "##") return 2;
+  if (v === "f" || v === "b" || v === "♭") return -1;
+  if (v === "ff" || v === "bb") return -2;
+  return 0;
+};
+
+const tonicToFifths = (pname: string, accid: string, mode: string): number | null => {
+  const step = String(pname || "").trim().toUpperCase();
+  if (!/^[A-G]$/.test(step)) return null;
+  const alter = parseMeiKeyAccidToAlter(accid);
+  const normalizedMode = String(mode || "").trim().toLowerCase();
+  const tonic = `${step}${alter > 0 ? "#".repeat(alter) : alter < 0 ? "b".repeat(Math.abs(alter)) : ""}`;
+  const majorMap: Record<string, number> = {
+    C: 0, G: 1, D: 2, A: 3, E: 4, B: 5, "F#": 6, "C#": 7,
+    F: -1, Bb: -2, Eb: -3, Ab: -4, Db: -5, Gb: -6, Cb: -7,
+  };
+  const minorMap: Record<string, number> = {
+    A: 0, E: 1, B: 2, "F#": 3, "C#": 4, "G#": 5, "D#": 6, "A#": 7,
+    D: -1, G: -2, C: -3, F: -4, Bb: -5, Eb: -6, Ab: -7,
+  };
+  if (normalizedMode === "minor") return minorMap[tonic] ?? null;
+  return majorMap[tonic] ?? null;
+};
+
+const parseMeiKeyFifthsFromElement = (element: Element | null | undefined): number | null => {
+  if (!element) return null;
+  const keySig = readMeiKeySigAttr(element);
+  if (keySig) return parseMeiKeySigToFifths(keySig);
+  const keyPname = element.getAttribute("key.pname") || "";
+  const keyAccid = element.getAttribute("key.accid") || "";
+  const keyMode = element.getAttribute("key.mode") || "major";
+  return tonicToFifths(keyPname, keyAccid, keyMode);
 };
 
 const toHex = (value: number, width = 2): string => {
@@ -589,31 +1300,87 @@ type ParsedMeiEvent =
       kind: "note";
       durationTicks: number;
       xml: string;
+      beamDepth?: number;
+      breaksecAfter?: number | null;
     }
   | {
       kind: "rest";
       durationTicks: number;
       xml: string;
+      beamDepth?: number;
+      breaksecAfter?: number | null;
     }
   | {
       kind: "chord";
       durationTicks: number;
       xml: string;
+      beamDepth?: number;
+      breaksecAfter?: number | null;
     };
+
+type ParsedMeiLayer = {
+  events: ParsedMeiEvent[];
+  idToEventIndex: Map<string, number>;
+  tieCarryOut: Map<string, number>;
+};
+
+const resolveDurTicksFromMetadata = (
+  source: Element,
+  fallbackTicks: number,
+  targetDivisions: number
+): number => {
+  const dur480 = parseIntSafe(source.getAttribute("mks-dur-480"), NaN);
+  if (Number.isFinite(dur480) && dur480 > 0) return Math.round(dur480);
+  const legacyTicks = parseIntSafe(source.getAttribute("mks-dur-ticks"), NaN);
+  if (!Number.isFinite(legacyTicks) || legacyTicks <= 0) return fallbackTicks;
+  const legacyDivisions = parseIntSafe(source.getAttribute("mks-dur-div"), NaN);
+  if (Number.isFinite(legacyDivisions) && legacyDivisions > 0) {
+    return Math.max(1, Math.round((legacyTicks * targetDivisions) / legacyDivisions));
+  }
+  // Legacy MEI without source divisions should keep semantic duration from dur/dots.
+  return fallbackTicks;
+};
+
+const parseMeiTieFlags = (raw: string): { start: boolean; stop: boolean } => {
+  const normalized = String(raw || "").trim().toLowerCase();
+  if (!normalized) return { start: false, stop: false };
+  const hasMiddle = normalized.includes("m");
+  const start = hasMiddle || normalized.includes("i");
+  const stop = hasMiddle || normalized.includes("t");
+  return { start, stop };
+};
+
+const parseMeiSlurNotations = (raw: string): Array<{ type: "start" | "stop"; number: number }> => {
+  const normalized = String(raw || "").trim().toLowerCase();
+  if (!normalized) return [];
+  const out: Array<{ type: "start" | "stop"; number: number }> = [];
+  const rx = /([imt])\s*(\d+)?|(\d+)\s*([imt])/g;
+  let m: RegExpExecArray | null;
+  while ((m = rx.exec(normalized)) !== null) {
+    const kind = (m[1] || m[4] || "").toLowerCase();
+    const nRaw = m[2] || m[3] || "1";
+    const number = Math.max(1, parseIntSafe(nRaw, 1));
+    if (kind === "i" || kind === "m") out.push({ type: "start", number });
+    if (kind === "t" || kind === "m") out.push({ type: "stop", number });
+  }
+  return out;
+};
 
 const buildMusicXmlNoteFromMeiNote = (
   meiNote: Element,
   durationTicks: number,
   typeText: string,
   dots: number,
-  voice: string
+  voice: string,
+  measureFifths: number
 ): string => {
   const pname = (meiNote.getAttribute("pname") || "c").trim().toUpperCase();
   const octave = parseIntSafe(meiNote.getAttribute("oct"), 4);
-  const accid = meiNote.getAttribute("accid") || "";
-  const alter = accidToAlter(accid);
-  const alterXml = alter === null ? "" : `<alter>${alter}</alter>`;
-  const accidentalText = accidToMusicXmlAccidental(accid);
+  const { visualAccid, soundingAccid } = readMeiSoundingAccid(meiNote);
+  const explicitAlterXml = accidToPitchAlterXml(soundingAccid);
+  const impliedAlter = impliedAlterFromFifths(pname, measureFifths);
+  const alterXml = explicitAlterXml || (impliedAlter !== 0 ? `<alter>${impliedAlter}</alter>` : "");
+  const accidentalText = accidToMusicXmlAccidental(visualAccid);
   const accidentalXml = accidentalText ? `<accidental>${xmlEscape(accidentalText)}</accidental>` : "";
   const dotXml = Array.from({ length: dots }, () => "<dot/>").join("");
   const actual = parseIntSafe(meiNote.getAttribute("num"), NaN);
@@ -631,143 +1398,1821 @@ const buildMusicXmlNoteFromMeiNote = (
   const arts: string[] = [];
   if (articTokens.includes("stacc")) arts.push("<staccato/>");
   if (articTokens.includes("acc")) arts.push("<accent/>");
+  const tieFlags = parseMeiTieFlags(meiNote.getAttribute("tie") || "");
+  const tieXml = `${tieFlags.start ? '<tie type="start"/>' : ""}${tieFlags.stop ? '<tie type="stop"/>' : ""}`;
+  const tiedXml = `${tieFlags.start ? '<tied type="start"/>' : ""}${tieFlags.stop ? '<tied type="stop"/>' : ""}`;
+  const slurXml = parseMeiSlurNotations(meiNote.getAttribute("slur") || "")
+    .map((entry) => `<slur type="${entry.type}" number="${entry.number}"/>`)
+    .join("");
   const tupletXml = `${hasTupletStart ? '<tuplet type="start"/>' : ""}${hasTupletStop ? '<tuplet type="stop"/>' : ""}`;
-  const hasNotations = arts.length > 0 || tupletXml.length > 0;
+  const hasNotations = arts.length > 0 || tupletXml.length > 0 || tiedXml.length > 0 || slurXml.length > 0;
   const notationsXml = hasNotations
-    ? `<notations>${arts.length ? `<articulations>${arts.join("")}</articulations>` : ""}${tupletXml}</notations>`
+    ? `<notations>${arts.length ? `<articulations>${arts.join("")}</articulations>` : ""}${tupletXml}${tiedXml}${slurXml}</notations>`
     : "";
   const graceAttr = (meiNote.getAttribute("grace") || "").trim().toLowerCase();
   const isGrace = graceAttr === "acc" || graceAttr === "unacc";
-  const graceXml = isGrace ? `<grace${graceAttr === "acc" ? ' slash="yes"' : ""}/>` : "";
+  const stemMod = (meiNote.getAttribute("stem.mod") || "").trim().toLowerCase();
+  const hasStemSlash = stemMod.includes("slash");
+  const graceXml = isGrace ? `<grace${graceAttr === "acc" || hasStemSlash ? ' slash="yes"' : ""}/>` : "";
   const durationXml = isGrace ? "" : `<duration>${durationTicks}</duration>`;
+  const stemDir = (meiNote.getAttribute("stem.dir") || "").trim().toLowerCase();
+  const stemXml = stemDir === "up" || stemDir === "down" ? `<stem>${xmlEscape(stemDir)}</stem>` : "";
   const lyric = extractMeiLyric(meiNote);
   const lyricXml = lyric
     ? `<lyric>${lyric.syllabic ? `<syllabic>${xmlEscape(lyric.syllabic)}</syllabic>` : ""}<text>${xmlEscape(lyric.text)}</text></lyric>`
     : "";
-  return `<note>${graceXml}<pitch><step>${xmlEscape(pname)}</step>${alterXml}<octave>${octave}</octave></pitch>${durationXml}<voice>${xmlEscape(
+  return `<note>${graceXml}<pitch><step>${xmlEscape(pname)}</step>${alterXml}<octave>${octave}</octave></pitch>${tieXml}${durationXml}<voice>${xmlEscape(
     voice
-  )}</voice><type>${xmlEscape(typeText)}</type>${dotXml}${accidentalXml}${timeModificationXml}${notationsXml}${lyricXml}</note>`;
+  )}</voice><type>${xmlEscape(typeText)}</type>${dotXml}${stemXml}${accidentalXml}${timeModificationXml}${notationsXml}${lyricXml}</note>`;
 };
 
-const parseLayerEvents = (layer: Element, divisions: number, voice: string): ParsedMeiEvent[] => {
+const parseLayerEvents = (
+  layer: Element,
+  divisions: number,
+  voice: string,
+  measureTicks: number,
+  measureFifths: number,
+  tieCarryIn: Map<string, number> = new Map()
+): ParsedMeiLayer => {
   const events: ParsedMeiEvent[] = [];
-  for (const child of Array.from(layer.children)) {
-    const name = localNameOf(child);
-    if (name === "note") {
-      const durAttr = child.getAttribute("dur") || "4";
-      const dots = parseIntSafe(child.getAttribute("dots"), 0);
-      const typeText = meiDurToMusicXmlType(durAttr);
-      const graceAttr = (child.getAttribute("grace") || "").trim().toLowerCase();
-      const isGrace = graceAttr === "acc" || graceAttr === "unacc";
-      const actual = parseIntSafe(child.getAttribute("num"), NaN);
-      const normal = parseIntSafe(child.getAttribute("numbase"), NaN);
-      const tupletRatio =
-        Number.isFinite(actual) && Number.isFinite(normal) && actual > 0 && normal > 0
-          ? Math.max(0.0001, Math.round(normal) / Math.round(actual))
-          : 1;
-      const ticks = isGrace
-        ? 0
-        : Math.max(1, Math.round(meiDurToQuarterLength(durAttr) * dotsMultiplier(dots) * divisions * tupletRatio));
-      events.push({
-        kind: "note",
-        durationTicks: ticks,
-        xml: buildMusicXmlNoteFromMeiNote(child, ticks, typeText, dots, voice),
-      });
-      continue;
+  const idToEventIndex = new Map<string, number>();
+  const tieCarryByPitch = new Map<string, number>(tieCarryIn);
+  const tiePitchKey = (pname: string, octave: number): string =>
+    `${String(pname || "").trim().toUpperCase()}:${Math.round(Number(octave) || 0)}`;
+  const breaksecFromNode = (node: Element): number | null => {
+    const raw = parseIntSafe(node.getAttribute("breaksec"), NaN);
+    if (!Number.isFinite(raw) || raw <= 0) return null;
+    return Math.round(raw);
+  };
+  const pushNoteEvent = (node: Element, forcedTuplet: { num: number; numbase: number } | null = null) => {
+    let effectiveNode = node;
+    if (
+      forcedTuplet
+      && !effectiveNode.getAttribute("num")
+      && !effectiveNode.getAttribute("numbase")
+    ) {
+      effectiveNode = node.cloneNode(true) as Element;
+      effectiveNode.setAttribute("num", String(Math.round(forcedTuplet.num)));
+      effectiveNode.setAttribute("numbase", String(Math.round(forcedTuplet.numbase)));
     }
-    if (name === "rest") {
-      const durAttr = child.getAttribute("dur") || "4";
-      const dots = parseIntSafe(child.getAttribute("dots"), 0);
-      const typeText = meiDurToMusicXmlType(durAttr);
-      const ticks = Math.max(1, Math.round(meiDurToQuarterLength(durAttr) * dotsMultiplier(dots) * divisions));
-      const dotXml = Array.from({ length: dots }, () => "<dot/>").join("");
-      events.push({
-        kind: "rest",
-        durationTicks: ticks,
-        xml: `<note><rest/><duration>${ticks}</duration><voice>${xmlEscape(voice)}</voice><type>${xmlEscape(
-          typeText
-        )}</type>${dotXml}</note>`,
-      });
-      continue;
-    }
-    if (name === "chord") {
-      const durAttr = child.getAttribute("dur") || "4";
-      const dots = parseIntSafe(child.getAttribute("dots"), 0);
-      const typeText = meiDurToMusicXmlType(durAttr);
-      const actual = parseIntSafe(child.getAttribute("num"), NaN);
-      const normal = parseIntSafe(child.getAttribute("numbase"), NaN);
-      const tupletRatio =
-        Number.isFinite(actual) && Number.isFinite(normal) && actual > 0 && normal > 0
-          ? Math.max(0.0001, Math.round(normal) / Math.round(actual))
-          : 1;
-      const ticks = Math.max(1, Math.round(meiDurToQuarterLength(durAttr) * dotsMultiplier(dots) * divisions * tupletRatio));
-      const noteChildren = childElementsByName(child, "note");
-      if (noteChildren.length === 0) continue;
-      const dotXml = Array.from({ length: dots }, () => "<dot/>").join("");
-      const chordTupletStart = (child.getAttribute("mks-tuplet-start") ?? "").trim() === "1";
-      const chordTupletStop = (child.getAttribute("mks-tuplet-stop") ?? "").trim() === "1";
-      const timeModificationXml =
-        Number.isFinite(actual) && Number.isFinite(normal) && actual > 0 && normal > 0
+    const durAttr = effectiveNode.getAttribute("dur") || "4";
+    const dots = parseIntSafe(node.getAttribute("dots"), 0);
+    const typeText = meiDurToMusicXmlType(durAttr);
+    const graceAttr = (effectiveNode.getAttribute("grace") || "").trim().toLowerCase();
+    const isGrace = graceAttr === "acc" || graceAttr === "unacc";
+    const actual = parseIntSafe(effectiveNode.getAttribute("num"), NaN);
+    const normal = parseIntSafe(effectiveNode.getAttribute("numbase"), NaN);
+    const tupletRatio =
+      Number.isFinite(actual) && Number.isFinite(normal) && actual > 0 && normal > 0
+        ? Math.max(0.0001, Math.round(normal) / Math.round(actual))
+        : 1;
+    const ticks = isGrace
+      ? 0
+      : Math.max(1, Math.round(meiDurToQuarterLength(durAttr) * dotsMultiplier(dots) * divisions * tupletRatio));
+    const resolvedTicks = isGrace
+      ? 0
+      : resolveDurTicksFromMetadata(node, ticks, divisions);
+    const eventIndex = events.length;
+    const pname = (effectiveNode.getAttribute("pname") || "c").trim().toUpperCase();
+    const octave = parseIntSafe(effectiveNode.getAttribute("oct"), 4);
+    const tieFlags = parseMeiTieFlags(effectiveNode.getAttribute("tie") || "");
+    const { visualAccid, soundingAccid } = readMeiSoundingAccid(effectiveNode);
+    const explicitAlter = accidToAlter(soundingAccid);
+    const impliedAlter = impliedAlterFromFifths(pname, measureFifths);
+    const pitchKey = tiePitchKey(pname, octave);
+    const carriedAlter =
+      tieFlags.stop && explicitAlter === null
+        ? tieCarryByPitch.get(pitchKey)
+        : undefined;
+    const resolvedAlter =
+      explicitAlter !== null
+        ? explicitAlter
+        : Number.isFinite(carriedAlter as number)
+          ? Math.round(Number(carriedAlter))
+          : impliedAlter;
+    const alterXml = resolvedAlter !== 0 ? `<alter>${resolvedAlter}</alter>` : "";
+    const accidentalText = accidToMusicXmlAccidental(visualAccid);
+    const accidentalXml = accidentalText ? `<accidental>${xmlEscape(accidentalText)}</accidental>` : "";
+    const tiedXml = `${tieFlags.start ? '<tied type="start"/>' : ""}${tieFlags.stop ? '<tied type="stop"/>' : ""}`;
+    const tieXml = `${tieFlags.start ? '<tie type="start"/>' : ""}${tieFlags.stop ? '<tie type="stop"/>' : ""}`;
+    const slurXml = parseMeiSlurNotations(effectiveNode.getAttribute("slur") || "")
+      .map((entry) => `<slur type="${entry.type}" number="${entry.number}"/>`)
+      .join("");
+    const hasNotations = tiedXml.length > 0 || slurXml.length > 0;
+    const notationsXml = hasNotations ? `<notations>${tiedXml}${slurXml}</notations>` : "";
+    events.push({
+      kind: "note",
+      durationTicks: resolvedTicks,
+      xml: (() => {
+        const graceAttr = (effectiveNode.getAttribute("grace") || "").trim().toLowerCase();
+        const isGrace = graceAttr === "acc" || graceAttr === "unacc";
+        const stemMod = (effectiveNode.getAttribute("stem.mod") || "").trim().toLowerCase();
+        const hasStemSlash = stemMod.includes("slash");
+        const graceXml = isGrace ? `<grace${graceAttr === "acc" || hasStemSlash ? ' slash="yes"' : ""}/>` : "";
+        const durationXml = isGrace ? "" : `<duration>${resolvedTicks}</duration>`;
+        const dotXml = Array.from({ length: dots }, () => "<dot/>").join("");
+        const stemDir = (effectiveNode.getAttribute("stem.dir") || "").trim().toLowerCase();
+        const stemXml = stemDir === "up" || stemDir === "down" ? `<stem>${xmlEscape(stemDir)}</stem>` : "";
+        const lyric = extractMeiLyric(effectiveNode);
+        const lyricXml = lyric
+          ? `<lyric>${lyric.syllabic ? `<syllabic>${xmlEscape(lyric.syllabic)}</syllabic>` : ""}<text>${xmlEscape(lyric.text)}</text></lyric>`
+          : "";
+        const actual = parseIntSafe(effectiveNode.getAttribute("num"), NaN);
+        const normal = parseIntSafe(effectiveNode.getAttribute("numbase"), NaN);
+        const hasTimeModification = Number.isFinite(actual) && Number.isFinite(normal) && actual > 0 && normal > 0;
+        const timeModificationXml = hasTimeModification
           ? `<time-modification><actual-notes>${Math.round(actual)}</actual-notes><normal-notes>${Math.round(normal)}</normal-notes></time-modification>`
           : "";
-      const chordArticRaw = (child.getAttribute("artic") || "").trim().toLowerCase();
-      const noteXml = noteChildren
-        .map((note, index) => {
-          const pname = (note.getAttribute("pname") || "c").trim().toUpperCase();
-          const octave = parseIntSafe(note.getAttribute("oct"), 4);
-          const accid = note.getAttribute("accid") || "";
-          const alter = accidToAlter(accid);
-          const alterXml = alter === null ? "" : `<alter>${alter}</alter>`;
-          const accidentalText = accidToMusicXmlAccidental(accid);
-          const accidentalXml = accidentalText ? `<accidental>${xmlEscape(accidentalText)}</accidental>` : "";
-          const chordXml = index > 0 ? "<chord/>" : "";
-          const mergedArticRaw = `${chordArticRaw} ${(note.getAttribute("artic") || "").trim().toLowerCase()}`.trim();
-          const articTokens = mergedArticRaw.split(/\s+/).filter(Boolean);
-          const arts: string[] = [];
-          if (articTokens.includes("stacc")) arts.push("<staccato/>");
-          if (articTokens.includes("acc")) arts.push("<accent/>");
-          const tupletXml = index === 0
-            ? `${chordTupletStart ? '<tuplet type="start"/>' : ""}${chordTupletStop ? '<tuplet type="stop"/>' : ""}`
-            : "";
-          const notationsXml = index === 0 && arts.length
-            ? `<notations><articulations>${arts.join("")}</articulations>${tupletXml}</notations>`
-            : index === 0 && tupletXml.length
-              ? `<notations>${tupletXml}</notations>`
-            : "";
-          const lyric = extractMeiLyric(note);
-          const lyricXml = lyric
-            ? `<lyric>${lyric.syllabic ? `<syllabic>${xmlEscape(lyric.syllabic)}</syllabic>` : ""}<text>${xmlEscape(lyric.text)}</text></lyric>`
-            : "";
-          return `<note>${chordXml}<pitch><step>${xmlEscape(pname)}</step>${alterXml}<octave>${octave}</octave></pitch><duration>${ticks}</duration><voice>${xmlEscape(
-            voice
-          )}</voice><type>${xmlEscape(typeText)}</type>${dotXml}${accidentalXml}${timeModificationXml}${notationsXml}${lyricXml}</note>`;
-        })
-        .join("");
-      events.push({ kind: "chord", durationTicks: ticks, xml: noteXml });
-      continue;
+        const articRaw = (effectiveNode.getAttribute("artic") || "").trim().toLowerCase();
+        const articTokens = articRaw.split(/\s+/).filter(Boolean);
+        const arts: string[] = [];
+        if (articTokens.includes("stacc")) arts.push("<staccato/>");
+        if (articTokens.includes("acc")) arts.push("<accent/>");
+        const tupletStart = (effectiveNode.getAttribute("mks-tuplet-start") ?? "").trim() === "1";
+        const tupletStop = (effectiveNode.getAttribute("mks-tuplet-stop") ?? "").trim() === "1";
+        const tupletXml = `${tupletStart ? '<tuplet type="start"/>' : ""}${tupletStop ? '<tuplet type="stop"/>' : ""}`;
+        const fullNotationsXml = arts.length > 0 || tupletXml.length > 0 || tiedXml.length > 0 || slurXml.length > 0
+          ? `<notations>${arts.length ? `<articulations>${arts.join("")}</articulations>` : ""}${tupletXml}${tiedXml}${slurXml}</notations>`
+          : "";
+        return `<note>${graceXml}<pitch><step>${xmlEscape(pname)}</step>${alterXml}<octave>${octave}</octave></pitch>${tieXml}${durationXml}<voice>${xmlEscape(
+          voice
+        )}</voice><type>${xmlEscape(typeText)}</type>${dotXml}${stemXml}${accidentalXml}${timeModificationXml}${fullNotationsXml}${lyricXml}</note>`;
+      })(),
+      beamDepth: meiDurToBeamDepth(durAttr),
+      breaksecAfter: breaksecFromNode(effectiveNode),
+    });
+    if (tieFlags.start) {
+      tieCarryByPitch.set(pitchKey, resolvedAlter);
+    } else if (tieFlags.stop) {
+      tieCarryByPitch.delete(pitchKey);
+    }
+    const xmlId = (effectiveNode.getAttribute("xml:id") || effectiveNode.getAttribute("id") || "").trim();
+    if (xmlId) idToEventIndex.set(xmlId, eventIndex);
+  };
+
+  const pushRestEvent = (node: Element, forcedTuplet: { num: number; numbase: number } | null = null) => {
+    let effectiveNode = node;
+    if (
+      forcedTuplet
+      && !effectiveNode.getAttribute("num")
+      && !effectiveNode.getAttribute("numbase")
+    ) {
+      effectiveNode = node.cloneNode(true) as Element;
+      effectiveNode.setAttribute("num", String(Math.round(forcedTuplet.num)));
+      effectiveNode.setAttribute("numbase", String(Math.round(forcedTuplet.numbase)));
+    }
+    const graceAttr = (effectiveNode.getAttribute("grace") || "").trim().toLowerCase();
+    const isGrace = graceAttr === "acc" || graceAttr === "unacc";
+    if (isGrace) return;
+    const durAttr = effectiveNode.getAttribute("dur") || "4";
+    const dots = parseIntSafe(effectiveNode.getAttribute("dots"), 0);
+    const actual = parseIntSafe(effectiveNode.getAttribute("num"), NaN);
+    const normal = parseIntSafe(effectiveNode.getAttribute("numbase"), NaN);
+    const tupletRatio =
+      Number.isFinite(actual) && Number.isFinite(normal) && actual > 0 && normal > 0
+        ? Math.max(0.0001, Math.round(normal) / Math.round(actual))
+        : 1;
+    const typeText = meiDurToMusicXmlType(durAttr);
+    const ticks = Math.max(1, Math.round(meiDurToQuarterLength(durAttr) * dotsMultiplier(dots) * divisions * tupletRatio));
+    const resolvedTicks = resolveDurTicksFromMetadata(effectiveNode, ticks, divisions);
+    const dotXml = Array.from({ length: dots }, () => "<dot/>").join("");
+    events.push({
+      kind: "rest",
+      durationTicks: resolvedTicks,
+      xml: `<note><rest/><duration>${resolvedTicks}</duration><voice>${xmlEscape(voice)}</voice><type>${xmlEscape(
+        typeText
+      )}</type>${dotXml}</note>`,
+      beamDepth: meiDurToBeamDepth(durAttr),
+      breaksecAfter: null,
+    });
+  };
+
+  const pushChordEvent = (node: Element, forcedTuplet: { num: number; numbase: number } | null = null) => {
+    let effectiveNode = node;
+    if (
+      forcedTuplet
+      && !effectiveNode.getAttribute("num")
+      && !effectiveNode.getAttribute("numbase")
+    ) {
+      effectiveNode = node.cloneNode(true) as Element;
+      effectiveNode.setAttribute("num", String(Math.round(forcedTuplet.num)));
+      effectiveNode.setAttribute("numbase", String(Math.round(forcedTuplet.numbase)));
+    }
+    const durAttr = effectiveNode.getAttribute("dur") || "4";
+    const dots = parseIntSafe(effectiveNode.getAttribute("dots"), 0);
+    const typeText = meiDurToMusicXmlType(durAttr);
+    const graceAttr = (effectiveNode.getAttribute("grace") || "").trim().toLowerCase();
+    const isGrace = graceAttr === "acc" || graceAttr === "unacc";
+    const actual = parseIntSafe(effectiveNode.getAttribute("num"), NaN);
+    const normal = parseIntSafe(effectiveNode.getAttribute("numbase"), NaN);
+    const tupletRatio =
+      Number.isFinite(actual) && Number.isFinite(normal) && actual > 0 && normal > 0
+        ? Math.max(0.0001, Math.round(normal) / Math.round(actual))
+        : 1;
+    const ticks = isGrace ? 0 : Math.max(1, Math.round(meiDurToQuarterLength(durAttr) * dotsMultiplier(dots) * divisions * tupletRatio));
+    const resolvedTicks = isGrace ? 0 : resolveDurTicksFromMetadata(effectiveNode, ticks, divisions);
+    const noteChildren = childElementsByName(effectiveNode, "note");
+    if (noteChildren.length === 0) return;
+    const dotXml = Array.from({ length: dots }, () => "<dot/>").join("");
+    const chordTupletStart = (effectiveNode.getAttribute("mks-tuplet-start") ?? "").trim() === "1";
+    const chordTupletStop = (effectiveNode.getAttribute("mks-tuplet-stop") ?? "").trim() === "1";
+    const timeModificationXml =
+      Number.isFinite(actual) && Number.isFinite(normal) && actual > 0 && normal > 0
+        ? `<time-modification><actual-notes>${Math.round(actual)}</actual-notes><normal-notes>${Math.round(normal)}</normal-notes></time-modification>`
+        : "";
+    const chordArticRaw = (effectiveNode.getAttribute("artic") || "").trim().toLowerCase();
+    const graceXml = isGrace ? `<grace${graceAttr === "acc" ? ' slash="yes"' : ""}/>` : "";
+    const durationXml = isGrace ? "" : `<duration>${resolvedTicks}</duration>`;
+    const noteXml = noteChildren
+      .map((note, index) => {
+        const pname = (note.getAttribute("pname") || "c").trim().toUpperCase();
+        const octave = parseIntSafe(note.getAttribute("oct"), 4);
+        const { visualAccid, soundingAccid } = readMeiSoundingAccid(note);
+        const explicitAlter = accidToAlter(soundingAccid);
+        const impliedAlter = impliedAlterFromFifths(pname, measureFifths);
+        const tieFlags = parseMeiTieFlags(note.getAttribute("tie") || "");
+        const pitchKey = tiePitchKey(pname, octave);
+        const carriedAlter =
+          tieFlags.stop && explicitAlter === null
+            ? tieCarryByPitch.get(pitchKey)
+            : undefined;
+        const resolvedAlter =
+          explicitAlter !== null
+            ? explicitAlter
+            : Number.isFinite(carriedAlter as number)
+              ? Math.round(Number(carriedAlter))
+              : impliedAlter;
+        const alterXml = resolvedAlter !== 0 ? `<alter>${resolvedAlter}</alter>` : "";
+        const accidentalText = accidToMusicXmlAccidental(visualAccid);
+        const accidentalXml = accidentalText ? `<accidental>${xmlEscape(accidentalText)}</accidental>` : "";
+        const chordXml = index > 0 ? "<chord/>" : "";
+        const mergedArticRaw = `${chordArticRaw} ${(note.getAttribute("artic") || "").trim().toLowerCase()}`.trim();
+        const articTokens = mergedArticRaw.split(/\s+/).filter(Boolean);
+        const arts: string[] = [];
+        if (articTokens.includes("stacc")) arts.push("<staccato/>");
+        if (articTokens.includes("acc")) arts.push("<accent/>");
+        const tieXml = `${tieFlags.start ? '<tie type="start"/>' : ""}${tieFlags.stop ? '<tie type="stop"/>' : ""}`;
+        const tiedXml = `${tieFlags.start ? '<tied type="start"/>' : ""}${tieFlags.stop ? '<tied type="stop"/>' : ""}`;
+        const slurXml = parseMeiSlurNotations(note.getAttribute("slur") || "")
+          .map((entry) => `<slur type="${entry.type}" number="${entry.number}"/>`)
+          .join("");
+        const tupletXml = index === 0
+          ? `${chordTupletStart ? '<tuplet type="start"/>' : ""}${chordTupletStop ? '<tuplet type="stop"/>' : ""}`
+          : "";
+        const notationsXml = (index === 0 && (arts.length > 0 || tupletXml.length > 0)) || tiedXml.length > 0 || slurXml.length > 0
+          ? `<notations>${index === 0 && arts.length ? `<articulations>${arts.join("")}</articulations>` : ""}${index === 0 ? tupletXml : ""}${tiedXml}${slurXml}</notations>`
+          : "";
+        const lyric = extractMeiLyric(note);
+        const lyricXml = lyric
+          ? `<lyric>${lyric.syllabic ? `<syllabic>${xmlEscape(lyric.syllabic)}</syllabic>` : ""}<text>${xmlEscape(lyric.text)}</text></lyric>`
+          : "";
+        if (tieFlags.start) {
+          tieCarryByPitch.set(pitchKey, resolvedAlter);
+        } else if (tieFlags.stop) {
+          tieCarryByPitch.delete(pitchKey);
+        }
+        return `<note>${chordXml}${graceXml}<pitch><step>${xmlEscape(pname)}</step>${alterXml}<octave>${octave}</octave></pitch>${tieXml}${durationXml}<voice>${xmlEscape(
+          voice
+        )}</voice><type>${xmlEscape(typeText)}</type>${dotXml}${accidentalXml}${timeModificationXml}${notationsXml}${lyricXml}</note>`;
+      })
+      .join("");
+    const eventIndex = events.length;
+    events.push({ kind: "chord", durationTicks: resolvedTicks, xml: noteXml });
+    events[eventIndex] = {
+      ...events[eventIndex],
+      beamDepth: meiDurToBeamDepth(durAttr),
+      breaksecAfter: breaksecFromNode(effectiveNode),
+    };
+    const xmlId = (effectiveNode.getAttribute("xml:id") || effectiveNode.getAttribute("id") || "").trim();
+    if (xmlId) idToEventIndex.set(xmlId, eventIndex);
+    for (const chordNote of noteChildren) {
+      const noteId = (chordNote.getAttribute("xml:id") || chordNote.getAttribute("id") || "").trim();
+      if (noteId && !idToEventIndex.has(noteId)) {
+        idToEventIndex.set(noteId, eventIndex);
+      }
+    }
+  };
+
+  const processElement = (
+    node: Element,
+    forcedGrace: "acc" | "unacc" | null = null,
+    forcedTuplet: { num: number; numbase: number } | null = null
+  ) => {
+    const name = localNameOf(node);
+    if (name === "beam") {
+      const startIndex = events.length;
+      for (const child of Array.from(node.children)) {
+        if (child instanceof Element) processElement(child, forcedGrace, forcedTuplet);
+      }
+      const endIndex = events.length;
+      const pitchedIndexes: number[] = [];
+      for (let i = startIndex; i < endIndex; i += 1) {
+        if (events[i].kind !== "rest") pitchedIndexes.push(i);
+      }
+      if (pitchedIndexes.length >= 2) {
+        const depths = pitchedIndexes.map((idx) => Math.max(1, events[idx].beamDepth || 1));
+        const breaksecs = pitchedIndexes.map((idx) => events[idx].breaksecAfter ?? null);
+        const maxDepth = Math.max(1, ...depths);
+        const canConnect = (leftIdx: number, level: number): boolean => {
+          if (leftIdx < 0 || leftIdx >= pitchedIndexes.length - 1) return false;
+          if (depths[leftIdx] < level) return false;
+          if (depths[leftIdx + 1] < level) return false;
+          const keep = breaksecs[leftIdx];
+          if (Number.isFinite(keep as number) && (keep as number) < level) return false;
+          return true;
+        };
+        for (let level = 1; level <= maxDepth; level += 1) {
+          for (let i = 0; i < pitchedIndexes.length; i += 1) {
+            if (depths[i] < level) continue;
+            const prev = canConnect(i - 1, level);
+            const next = canConnect(i, level);
+            if (!prev && !next) continue;
+            const value: "begin" | "continue" | "end" =
+              !prev && next ? "begin" : prev && !next ? "end" : "continue";
+            const eventIndex = pitchedIndexes[i];
+            events[eventIndex].xml = addBeamToEventXml(events[eventIndex].xml, value, level);
+          }
+        }
+      }
+      return;
+    }
+    if (name === "tuplet") {
+      const num = parseIntSafe(node.getAttribute("num"), NaN);
+      const numbase = parseIntSafe(node.getAttribute("numbase"), NaN);
+      const nextTuplet =
+        Number.isFinite(num) && Number.isFinite(numbase) && num > 0 && numbase > 0
+          ? { num: Math.round(num), numbase: Math.round(numbase) }
+          : forcedTuplet;
+      for (const child of Array.from(node.children)) {
+        if (child instanceof Element) processElement(child, forcedGrace, nextTuplet);
+      }
+      return;
+    }
+    if (name === "graceGrp") {
+      const raw = (node.getAttribute("grace") || "").trim().toLowerCase();
+      const slash = (node.getAttribute("slash") || "").trim().toLowerCase() === "yes";
+      const groupGrace: "acc" | "unacc" =
+        raw === "acc" || raw === "unacc"
+          ? (raw as "acc" | "unacc")
+          : (slash ? "acc" : "unacc");
+      for (const child of Array.from(node.children)) {
+        if (child instanceof Element) processElement(child, forcedGrace ?? groupGrace, forcedTuplet);
+      }
+      return;
+    }
+
+    let effectiveNode = node;
+    if (forcedGrace && !effectiveNode.getAttribute("grace") && (name === "note" || name === "chord" || name === "rest")) {
+      effectiveNode = node.cloneNode(true) as Element;
+      effectiveNode.setAttribute("grace", forcedGrace);
+    }
+
+    if (name === "note") {
+      pushNoteEvent(effectiveNode, forcedTuplet);
+      return;
+    }
+    if (name === "rest" || name === "space" || name === "mSpace" || name === "mRest") {
+      if ((name === "mSpace" || name === "mRest") && !effectiveNode.getAttribute("mks-dur-ticks")) {
+        const inferred = inferMeiDurAndDotsFromTicks(measureTicks, divisions);
+        effectiveNode = effectiveNode.cloneNode(true) as Element;
+        effectiveNode.setAttribute("dur", inferred.dur);
+        if (inferred.dots > 0) effectiveNode.setAttribute("dots", String(inferred.dots));
+        effectiveNode.setAttribute("mks-dur-div", String(Math.max(1, Math.round(divisions))));
+        effectiveNode.setAttribute("mks-dur-480", String(toMksDur480(measureTicks, divisions)));
+        effectiveNode.setAttribute("mks-dur-ticks", String(Math.max(1, Math.round(measureTicks))));
+      }
+      pushRestEvent(effectiveNode, forcedTuplet);
+      return;
+    }
+    if (name === "chord") {
+      pushChordEvent(effectiveNode, forcedTuplet);
+    }
+  };
+
+  for (const child of Array.from(layer.children)) {
+    if (child instanceof Element) processElement(child, null, null);
+  }
+  return { events, idToEventIndex, tieCarryOut: new Map(tieCarryByPitch) };
+};
+
+const addSlurNotationToSingleNoteXml = (noteXml: string, type: "start" | "stop", number: number): string => {
+  const slurXml = `<slur type="${type}" number="${number}"/>`;
+  if (noteXml.includes("<notations>")) {
+    return noteXml.replace("</notations>", `${slurXml}</notations>`);
+  }
+  return noteXml.replace("</note>", `<notations>${slurXml}</notations></note>`);
+};
+
+const addTieToSingleNoteXml = (noteXml: string, type: "start" | "stop"): string => {
+  const tieXml = `<tie type="${type}"/>`;
+  const tiedXml = `<tied type="${type}"/>`;
+  const withTie =
+    noteXml.includes("<duration>")
+      ? noteXml.replace("<duration>", `${tieXml}<duration>`)
+      : noteXml.replace("</note>", `${tieXml}</note>`);
+  if (withTie.includes("<notations>")) {
+    return withTie.replace("</notations>", `${tiedXml}</notations>`);
+  }
+  return withTie.replace("</note>", `<notations>${tiedXml}</notations></note>`);
+};
+
+const addNotationXmlToSingleNoteXml = (noteXml: string, notationXml: string): string => {
+  if (noteXml.includes("<notations>")) {
+    return noteXml.replace("</notations>", `${notationXml}</notations>`);
+  }
+  return noteXml.replace("</note>", `<notations>${notationXml}</notations></note>`);
+};
+
+const addOrnamentXmlToSingleNoteXml = (noteXml: string, ornamentXml: string): string => {
+  if (noteXml.includes("<ornaments>")) {
+    return noteXml.replace("</ornaments>", `${ornamentXml}</ornaments>`);
+  }
+  return addNotationXmlToSingleNoteXml(noteXml, `<ornaments>${ornamentXml}</ornaments>`);
+};
+
+const addArticulationXmlToSingleNoteXml = (noteXml: string, articulationXml: string): string => {
+  if (noteXml.includes("<articulations>")) {
+    return noteXml.replace("</articulations>", `${articulationXml}</articulations>`);
+  }
+  return addNotationXmlToSingleNoteXml(noteXml, `<articulations>${articulationXml}</articulations>`);
+};
+
+const addSlurNotationToEventXml = (eventXml: string, type: "start" | "stop", number: number): string => {
+  const firstNoteStart = eventXml.indexOf("<note>");
+  if (firstNoteStart < 0) return eventXml;
+  const firstNoteEnd = eventXml.indexOf("</note>", firstNoteStart);
+  if (firstNoteEnd < 0) return eventXml;
+  const before = eventXml.slice(0, firstNoteStart);
+  const noteBlock = eventXml.slice(firstNoteStart, firstNoteEnd + "</note>".length);
+  const after = eventXml.slice(firstNoteEnd + "</note>".length);
+  return before + addSlurNotationToSingleNoteXml(noteBlock, type, number) + after;
+};
+
+const addTieNotationToEventXml = (eventXml: string, type: "start" | "stop"): string => {
+  const firstNoteStart = eventXml.indexOf("<note>");
+  if (firstNoteStart < 0) return eventXml;
+  const firstNoteEnd = eventXml.indexOf("</note>", firstNoteStart);
+  if (firstNoteEnd < 0) return eventXml;
+  const before = eventXml.slice(0, firstNoteStart);
+  const noteBlock = eventXml.slice(firstNoteStart, firstNoteEnd + "</note>".length);
+  const after = eventXml.slice(firstNoteEnd + "</note>".length);
+  return before + addTieToSingleNoteXml(noteBlock, type) + after;
+};
+
+const addTrillNotationToEventXml = (eventXml: string): string => {
+  const firstNoteStart = eventXml.indexOf("<note>");
+  if (firstNoteStart < 0) return eventXml;
+  const firstNoteEnd = eventXml.indexOf("</note>", firstNoteStart);
+  if (firstNoteEnd < 0) return eventXml;
+  const before = eventXml.slice(0, firstNoteStart);
+  const noteBlock = eventXml.slice(firstNoteStart, firstNoteEnd + "</note>".length);
+  const after = eventXml.slice(firstNoteEnd + "</note>".length);
+  return before + addOrnamentXmlToSingleNoteXml(noteBlock, "<trill-mark/>") + after;
+};
+
+const addFermataNotationToEventXml = (eventXml: string, isBelow: boolean): string => {
+  const firstNoteStart = eventXml.indexOf("<note>");
+  if (firstNoteStart < 0) return eventXml;
+  const firstNoteEnd = eventXml.indexOf("</note>", firstNoteStart);
+  if (firstNoteEnd < 0) return eventXml;
+  const before = eventXml.slice(0, firstNoteStart);
+  const noteBlock = eventXml.slice(firstNoteStart, firstNoteEnd + "</note>".length);
+  const after = eventXml.slice(firstNoteEnd + "</note>".length);
+  const typeAttr = isBelow ? ' type="inverted"' : "";
+  return before + addNotationXmlToSingleNoteXml(noteBlock, `<fermata${typeAttr}/>`)+ after;
+};
+
+const addGlissNotationToEventXml = (eventXml: string, type: "start" | "stop", number: number): string => {
+  const firstNoteStart = eventXml.indexOf("<note>");
+  if (firstNoteStart < 0) return eventXml;
+  const firstNoteEnd = eventXml.indexOf("</note>", firstNoteStart);
+  if (firstNoteEnd < 0) return eventXml;
+  const before = eventXml.slice(0, firstNoteStart);
+  const noteBlock = eventXml.slice(firstNoteStart, firstNoteEnd + "</note>".length);
+  const after = eventXml.slice(firstNoteEnd + "</note>".length);
+  return before + addNotationXmlToSingleNoteXml(noteBlock, `<glissando type="${type}" number="${number}"/>`) + after;
+};
+
+const addSlideNotationToEventXml = (eventXml: string, type: "start" | "stop", number: number): string => {
+  const firstNoteStart = eventXml.indexOf("<note>");
+  if (firstNoteStart < 0) return eventXml;
+  const firstNoteEnd = eventXml.indexOf("</note>", firstNoteStart);
+  if (firstNoteEnd < 0) return eventXml;
+  const before = eventXml.slice(0, firstNoteStart);
+  const noteBlock = eventXml.slice(firstNoteStart, firstNoteEnd + "</note>".length);
+  const after = eventXml.slice(firstNoteEnd + "</note>".length);
+  return before + addNotationXmlToSingleNoteXml(noteBlock, `<slide type="${type}" number="${number}"/>`) + after;
+};
+
+const addTurnNotationToEventXml = (eventXml: string, isInverted: boolean): string => {
+  const firstNoteStart = eventXml.indexOf("<note>");
+  if (firstNoteStart < 0) return eventXml;
+  const firstNoteEnd = eventXml.indexOf("</note>", firstNoteStart);
+  if (firstNoteEnd < 0) return eventXml;
+  const before = eventXml.slice(0, firstNoteStart);
+  const noteBlock = eventXml.slice(firstNoteStart, firstNoteEnd + "</note>".length);
+  const after = eventXml.slice(firstNoteEnd + "</note>".length);
+  return before + addOrnamentXmlToSingleNoteXml(noteBlock, isInverted ? "<inverted-turn/>" : "<turn/>") + after;
+};
+
+const addMordentNotationToEventXml = (eventXml: string, isInverted: boolean): string => {
+  const firstNoteStart = eventXml.indexOf("<note>");
+  if (firstNoteStart < 0) return eventXml;
+  const firstNoteEnd = eventXml.indexOf("</note>", firstNoteStart);
+  if (firstNoteEnd < 0) return eventXml;
+  const before = eventXml.slice(0, firstNoteStart);
+  const noteBlock = eventXml.slice(firstNoteStart, firstNoteEnd + "</note>".length);
+  const after = eventXml.slice(firstNoteEnd + "</note>".length);
+  return before + addOrnamentXmlToSingleNoteXml(noteBlock, isInverted ? "<inverted-mordent/>" : "<mordent/>") + after;
+};
+
+const addBreathNotationToEventXml = (eventXml: string): string => {
+  const firstNoteStart = eventXml.indexOf("<note>");
+  if (firstNoteStart < 0) return eventXml;
+  const firstNoteEnd = eventXml.indexOf("</note>", firstNoteStart);
+  if (firstNoteEnd < 0) return eventXml;
+  const before = eventXml.slice(0, firstNoteStart);
+  const noteBlock = eventXml.slice(firstNoteStart, firstNoteEnd + "</note>".length);
+  const after = eventXml.slice(firstNoteEnd + "</note>".length);
+  return before + addArticulationXmlToSingleNoteXml(noteBlock, "<breath-mark/>") + after;
+};
+
+const addCaesuraNotationToEventXml = (eventXml: string): string => {
+  const firstNoteStart = eventXml.indexOf("<note>");
+  if (firstNoteStart < 0) return eventXml;
+  const firstNoteEnd = eventXml.indexOf("</note>", firstNoteStart);
+  if (firstNoteEnd < 0) return eventXml;
+  const before = eventXml.slice(0, firstNoteStart);
+  const noteBlock = eventXml.slice(firstNoteStart, firstNoteEnd + "</note>".length);
+  const after = eventXml.slice(firstNoteEnd + "</note>".length);
+  return before + addArticulationXmlToSingleNoteXml(noteBlock, "<caesura/>") + after;
+};
+
+const addTupletNotationToEventXml = (eventXml: string, type: "start" | "stop", number: number): string => {
+  const firstNoteStart = eventXml.indexOf("<note>");
+  if (firstNoteStart < 0) return eventXml;
+  const firstNoteEnd = eventXml.indexOf("</note>", firstNoteStart);
+  if (firstNoteEnd < 0) return eventXml;
+  const before = eventXml.slice(0, firstNoteStart);
+  const noteBlock = eventXml.slice(firstNoteStart, firstNoteEnd + "</note>".length);
+  const after = eventXml.slice(firstNoteEnd + "</note>".length);
+  return before + addNotationXmlToSingleNoteXml(noteBlock, `<tuplet type="${type}" number="${number}"/>`) + after;
+};
+
+const addBeamToSingleNoteXml = (noteXml: string, value: "begin" | "continue" | "end", number = 1): string => {
+  if (noteXml.includes(`<beam number="${number}">`)) return noteXml;
+  return noteXml.replace("</note>", `<beam number="${number}">${value}</beam></note>`);
+};
+
+const addBeamToEventXml = (eventXml: string, value: "begin" | "continue" | "end", number = 1): string => {
+  const firstNoteStart = eventXml.indexOf("<note>");
+  if (firstNoteStart < 0) return eventXml;
+  const firstNoteEnd = eventXml.indexOf("</note>", firstNoteStart);
+  if (firstNoteEnd < 0) return eventXml;
+  const before = eventXml.slice(0, firstNoteStart);
+  const noteBlock = eventXml.slice(firstNoteStart, firstNoteEnd + "</note>".length);
+  const after = eventXml.slice(firstNoteEnd + "</note>".length);
+  return before + addBeamToSingleNoteXml(noteBlock, value, number) + after;
+};
+
+const parseMeiTstampToTicks = (
+  tstamp: string | null,
+  divisions: number,
+  beatType: number
+): number | null => {
+  const raw = String(tstamp || "").trim();
+  if (!/^\d+(\.\d+)?$/.test(raw)) return null;
+  const beatPos = Number.parseFloat(raw);
+  if (!Number.isFinite(beatPos) || beatPos < 1) return null;
+  const ticksPerBeat = Math.max(1, (4 * divisions) / Math.max(1, beatType));
+  return Math.max(0, Math.round((beatPos - 1) * ticksPerBeat));
+};
+
+const resolveEventIndexByTstamp = (events: ParsedMeiEvent[], targetTick: number): number | null => {
+  if (!Number.isFinite(targetTick) || targetTick < 0) return null;
+  let cursor = 0;
+  let lastPitchedIndex: number | null = null;
+  for (let i = 0; i < events.length; i += 1) {
+    const event = events[i];
+    if (event.kind !== "rest") {
+      lastPitchedIndex = i;
+      if (cursor >= targetTick) return i;
+    }
+    cursor += Math.max(0, event.durationTicks);
+  }
+  return lastPitchedIndex;
+};
+
+const resolveEventStartTickByIndex = (events: ParsedMeiEvent[], eventIndex: number): number | null => {
+  if (!Number.isInteger(eventIndex) || eventIndex < 0 || eventIndex >= events.length) return null;
+  let cursor = 0;
+  for (let i = 0; i < events.length; i += 1) {
+    if (i === eventIndex) return cursor;
+    cursor += Math.max(0, events[i].durationTicks);
+  }
+  return null;
+};
+
+const resolveControlEventEndpointIndex = (
+  rawId: string,
+  tstamp: string | null,
+  idToEventIndex: Map<string, number>,
+  events: ParsedMeiEvent[],
+  divisions: number,
+  beatType: number,
+  rawPlist?: string | null,
+  idToEventTick?: Map<string, number>
+): number | null => {
+  const id = rawId.startsWith("#") ? rawId.slice(1) : "";
+  if (id) {
+    const idx = idToEventIndex.get(id);
+    if (Number.isInteger(idx)) return idx as number;
+    const tick = idToEventTick?.get(id);
+    if (Number.isFinite(tick)) {
+      const byTick = resolveEventIndexByTstamp(events, Math.max(0, Math.round(tick as number)));
+      if (Number.isInteger(byTick)) return byTick as number;
     }
   }
-  return events;
+  const plist = String(rawPlist || "").trim();
+  if (plist) {
+    const candidates = plist
+      .split(/\s+/)
+      .map((token) => token.trim())
+      .filter(Boolean)
+      .map((token) => (token.startsWith("#") ? token.slice(1) : token));
+    for (const candidate of candidates) {
+      const idx = idToEventIndex.get(candidate);
+      if (Number.isInteger(idx)) return idx as number;
+      const tick = idToEventTick?.get(candidate);
+      if (Number.isFinite(tick)) {
+        const byTick = resolveEventIndexByTstamp(events, Math.max(0, Math.round(tick as number)));
+        if (Number.isInteger(byTick)) return byTick as number;
+      }
+    }
+  }
+  const ticks = parseMeiTstampToTicks(tstamp, divisions, beatType);
+  if (ticks === null) return null;
+  return resolveEventIndexByTstamp(events, ticks);
+};
+
+const DYNAMICS_TAGS = new Set([
+  "pppp", "ppp", "pp", "p", "mp", "mf", "f", "ff", "fff", "ffff", "fp", "sf", "sfz", "sffz", "rfz", "rf", "fz",
+]);
+
+const parseHarmonyAlter = (token: string): number => {
+  const v = token.trim();
+  if (v === "#" || v === "♯") return 1;
+  if (v === "b" || v === "♭") return -1;
+  if (v === "x" || v === "##") return 2;
+  return 0;
+};
+
+const collectScoreDefsInDocOrder = (root: Element): Element[] =>
+  Array.from(root.querySelectorAll("*")).filter(
+    (node): node is Element => node instanceof Element && localNameOf(node) === "scoreDef"
+  );
+
+const collectStaffDefsInDocOrder = (root: Element): Element[] =>
+  Array.from(root.querySelectorAll("*")).filter(
+    (node): node is Element => node instanceof Element && localNameOf(node) === "staffDef"
+  );
+
+const findEffectiveScoreDefForNode = (node: Element, scoreDefs: Element[]): Element | null => {
+  let out: Element | null = null;
+  for (const scoreDef of scoreDefs) {
+    const relation = scoreDef.compareDocumentPosition(node);
+    if ((relation & Node.DOCUMENT_POSITION_FOLLOWING) !== 0 || scoreDef === node) {
+      out = scoreDef;
+      continue;
+    }
+    if ((relation & Node.DOCUMENT_POSITION_PRECEDING) !== 0) {
+      break;
+    }
+  }
+  return out;
+};
+
+const findEffectiveStaffDefForNode = (
+  node: Element,
+  staffNo: string,
+  staffDefs: Element[]
+): Element | null => {
+  let out: Element | null = null;
+  for (const staffDef of staffDefs) {
+    const relation = staffDef.compareDocumentPosition(node);
+    if ((relation & Node.DOCUMENT_POSITION_FOLLOWING) !== 0 || staffDef === node) {
+      const n = (staffDef.getAttribute("n") || "").trim();
+      if (!n || n === staffNo) out = staffDef;
+      continue;
+    }
+    if ((relation & Node.DOCUMENT_POSITION_PRECEDING) !== 0) {
+      break;
+    }
+  }
+  return out;
+};
+
+const parseTransposeFromStaffDefElement = (
+  staffDef: Element | null | undefined
+): { chromatic?: number; diatonic?: number } | null => {
+  if (!staffDef) return null;
+  const out: { chromatic?: number; diatonic?: number } = {};
+  const diatonic = parseIntSafe(staffDef.getAttribute("trans.diat"), NaN);
+  const chromatic = parseIntSafe(staffDef.getAttribute("trans.semi"), NaN);
+  if (Number.isFinite(chromatic)) out.chromatic = Math.round(chromatic);
+  if (Number.isFinite(diatonic)) out.diatonic = Math.round(diatonic);
+  return Object.keys(out).length ? out : null;
+};
+
+const parseClefFromScoreDefForStaff = (
+  scoreDef: Element | null,
+  staffNo: string
+): { clefSign: string; clefLine: number } | null => {
+  if (!scoreDef) return null;
+  const staffDefs = Array.from(scoreDef.querySelectorAll("*")).filter(
+    (node): node is Element => node instanceof Element && localNameOf(node) === "staffDef"
+  );
+  const matched =
+    staffDefs.find((staffDef) => (staffDef.getAttribute("n")?.trim() || "") === staffNo)
+    ?? staffDefs.find((staffDef) => !staffDef.getAttribute("n"));
+  if (!matched) return null;
+  const clefFromDef = parseClefFromStaffDefElement(matched);
+  if (!clefFromDef) return null;
+  const clefSign = clefFromDef.clefSign;
+  const clefLine = clefFromDef.clefLine;
+  if (!clefSign || !Number.isFinite(clefLine)) return null;
+  return { clefSign, clefLine: Math.max(1, Math.round(clefLine)) };
+};
+
+const parseClefFromStaffDefElement = (
+  staffDef: Element | null | undefined
+): { clefSign: string; clefLine: number } | null => {
+  if (!staffDef) return null;
+  const attrSign = (staffDef.getAttribute("clef.shape")?.trim().toUpperCase() || "").trim();
+  const attrLine = parseIntSafe(staffDef.getAttribute("clef.line"), NaN);
+  if (attrSign && Number.isFinite(attrLine)) {
+    return { clefSign: attrSign, clefLine: Math.max(1, Math.round(attrLine)) };
+  }
+  const clefChild = childElementsByName(staffDef, "clef")[0];
+  if (!clefChild) return null;
+  const childSign = (
+    clefChild.getAttribute("shape")
+    || clefChild.getAttribute("clef.shape")
+    || ""
+  ).trim().toUpperCase();
+  const childLine = parseIntSafe(
+    clefChild.getAttribute("line") || clefChild.getAttribute("clef.line"),
+    NaN
+  );
+  if (!childSign || !Number.isFinite(childLine)) return null;
+  return { clefSign: childSign, clefLine: Math.max(1, Math.round(childLine)) };
+};
+
+const parseKeySigFromScoreDefForStaff = (
+  scoreDef: Element | null,
+  staffNo: string,
+  fallbackFifths: number
+): number => {
+  if (!scoreDef) return fallbackFifths;
+  const staffDefs = Array.from(scoreDef.querySelectorAll("*")).filter(
+    (node): node is Element => node instanceof Element && localNameOf(node) === "staffDef"
+  );
+  const matched =
+    staffDefs.find((staffDef) => (staffDef.getAttribute("n")?.trim() || "") === staffNo)
+    ?? staffDefs.find((staffDef) => !staffDef.getAttribute("n"));
+  const staffFifths = parseMeiKeyFifthsFromElement(matched);
+  if (staffFifths !== null) return staffFifths;
+  const scoreFifths = parseMeiKeyFifthsFromElement(scoreDef);
+  if (scoreFifths !== null) return scoreFifths;
+  return fallbackFifths;
+};
+
+const parseTransposeFromScoreDefForStaff = (
+  scoreDef: Element | null,
+  staffNo: string
+): { chromatic?: number; diatonic?: number } | null => {
+  if (!scoreDef) return null;
+  const staffDefs = Array.from(scoreDef.querySelectorAll("*")).filter(
+    (node): node is Element => node instanceof Element && localNameOf(node) === "staffDef"
+  );
+  const matched =
+    staffDefs.find((staffDef) => (staffDef.getAttribute("n")?.trim() || "") === staffNo)
+    ?? staffDefs.find((staffDef) => !staffDef.getAttribute("n"));
+  const out: { chromatic?: number; diatonic?: number } = {};
+  const matchedDiatonic = parseIntSafe(matched?.getAttribute("trans.diat"), NaN);
+  const matchedChromatic = parseIntSafe(matched?.getAttribute("trans.semi"), NaN);
+  if (Number.isFinite(matchedChromatic)) out.chromatic = Math.round(matchedChromatic);
+  if (Number.isFinite(matchedDiatonic)) out.diatonic = Math.round(matchedDiatonic);
+  if (Object.keys(out).length) return out;
+  const scoreDiatonic = parseIntSafe(scoreDef.getAttribute("trans.diat"), NaN);
+  const scoreChromatic = parseIntSafe(scoreDef.getAttribute("trans.semi"), NaN);
+  if (Number.isFinite(scoreChromatic)) out.chromatic = Math.round(scoreChromatic);
+  if (Number.isFinite(scoreDiatonic)) out.diatonic = Math.round(scoreDiatonic);
+  return Object.keys(out).length ? out : null;
+};
+
+const buildTransposeXml = (transpose: { chromatic?: number; diatonic?: number } | null): string => {
+  if (!transpose) return "";
+  const chromatic = Number.isFinite(transpose.chromatic) ? Math.round(Number(transpose.chromatic)) : null;
+  const diatonic = Number.isFinite(transpose.diatonic) ? Math.round(Number(transpose.diatonic)) : null;
+  if (chromatic === null && diatonic === null) return "";
+  return `<transpose>${diatonic !== null ? `<diatonic>${diatonic}</diatonic>` : ""}${chromatic !== null ? `<chromatic>${chromatic}</chromatic>` : ""}</transpose>`;
+};
+
+const parseMeiHarmText = (
+  text: string
+): {
+  rootStep: string;
+  rootAlter?: number;
+  kind: string;
+  kindText?: string;
+  bassStep?: string;
+  bassAlter?: number;
+  degrees: Array<{ value: number; alter: number }>;
+} | null => {
+  const raw = text.trim();
+  const m = raw.match(/^([A-Ga-g])([#bx♭♯]?)([^/]*)(?:\/([A-Ga-g])([#bx♭♯]?))?$/);
+  if (!m) return null;
+  const rootStep = m[1].toUpperCase();
+  const rootAlter = parseHarmonyAlter(m[2] || "");
+  const suffix = (m[3] || "").trim();
+  const bassStep = m[4] ? m[4].toUpperCase() : undefined;
+  const bassAlter = parseHarmonyAlter(m[5] || "");
+
+  const suffixLower = suffix.toLowerCase();
+  let kind = "major";
+  let kindText = "";
+  if (!suffix) {
+    kind = "major";
+  } else if (suffixLower === "m" || suffixLower === "min" || suffixLower === "-") {
+    kind = "minor";
+  } else if (suffixLower === "7") {
+    kind = "dominant";
+  } else if (suffixLower === "maj7" || suffixLower === "m7+" || suffixLower === "Δ7".toLowerCase()) {
+    kind = "major-seventh";
+  } else if (suffixLower === "m7" || suffixLower === "min7" || suffixLower === "-7") {
+    kind = "minor-seventh";
+  } else if (suffixLower === "dim" || suffixLower === "o") {
+    kind = "diminished";
+  } else if (suffixLower === "aug" || suffixLower === "+") {
+    kind = "augmented";
+  } else {
+    kind = "other";
+    kindText = suffix;
+  }
+
+  const degrees: Array<{ value: number; alter: number }> = [];
+  const degreeRe = /([#b♯♭x]|##)\s*(\d{1,2})/g;
+  let dm: RegExpExecArray | null = degreeRe.exec(suffix);
+  while (dm) {
+    const alter = parseHarmonyAlter(dm[1] || "");
+    const value = Number.parseInt(dm[2] || "", 10);
+    if (Number.isFinite(value) && value > 0 && alter !== 0) {
+      degrees.push({ value: Math.round(value), alter });
+    }
+    dm = degreeRe.exec(suffix);
+  }
+
+  return {
+    rootStep,
+    rootAlter: rootAlter !== 0 ? rootAlter : undefined,
+    kind,
+    kindText: kindText || undefined,
+    bassStep,
+    bassAlter: bassStep && bassAlter !== 0 ? bassAlter : undefined,
+    degrees,
+  };
+};
+
+const buildMusicXmlDirectionFromMeiDynam = (
+  dynam: Element,
+  divisions: number,
+  beatType: number,
+  voice: string,
+  staffNo: string
+): string | null => {
+  const rawText = (dynam.textContent || "").trim();
+  if (!rawText) return null;
+  const normalized = rawText.toLowerCase();
+  const placement = (dynam.getAttribute("place") || dynam.getAttribute("placement") || "").trim().toLowerCase();
+  const placementAttr = placement === "above" || placement === "below" ? ` placement="${placement}"` : "";
+  const offsetTicks = parseMeiTstampToTicks(dynam.getAttribute("tstamp"), divisions, beatType);
+  const offsetXml = Number.isFinite(offsetTicks) && (offsetTicks as number) > 0
+    ? `<offset>${Math.round(offsetTicks as number)}</offset>`
+    : "";
+  const directionType = DYNAMICS_TAGS.has(normalized)
+    ? `<dynamics><${normalized}/></dynamics>`
+    : `<words>${xmlEscape(rawText)}</words>`;
+  return `<direction${placementAttr}><direction-type>${directionType}</direction-type>${offsetXml}<voice>${xmlEscape(
+    voice
+  )}</voice><staff>${xmlEscape(staffNo)}</staff></direction>`;
+};
+
+const buildMusicXmlDirectionsFromMeiHairpin = (
+  hairpin: Element,
+  divisions: number,
+  beatType: number,
+  voice: string,
+  staffNo: string,
+  events: ParsedMeiEvent[],
+  idToEventIndex: Map<string, number>,
+  idToEventTick: Map<string, number>
+): string => {
+  const formRaw = (hairpin.getAttribute("form") || hairpin.getAttribute("type") || "").trim().toLowerCase();
+  const wedgeType = formRaw.includes("dim") || formRaw.includes("decresc") ? "diminuendo" : "crescendo";
+  const placement = (hairpin.getAttribute("place") || hairpin.getAttribute("placement") || "").trim().toLowerCase();
+  const placementAttr = placement === "above" || placement === "below" ? ` placement="${placement}"` : "";
+  const startIndex = resolveControlEventEndpointIndex(
+    (hairpin.getAttribute("startid") || "").trim(),
+    hairpin.getAttribute("tstamp"),
+    idToEventIndex,
+    events,
+    divisions,
+    beatType,
+    hairpin.getAttribute("plist"),
+    idToEventTick
+  );
+  const endIndex = resolveControlEventEndpointIndex(
+    (hairpin.getAttribute("endid") || "").trim(),
+    hairpin.getAttribute("tstamp2"),
+    idToEventIndex,
+    events,
+    divisions,
+    beatType,
+    undefined,
+    idToEventTick
+  );
+  const startTick = Number.isInteger(startIndex) ? resolveEventStartTickByIndex(events, startIndex as number) : null;
+  const endTick = Number.isInteger(endIndex) ? resolveEventStartTickByIndex(events, endIndex as number) : null;
+  const startOffsetXml = Number.isFinite(startTick) && (startTick as number) > 0
+    ? `<offset>${Math.round(startTick as number)}</offset>`
+    : "";
+  const endOffsetXml = Number.isFinite(endTick) && (endTick as number) > 0
+    ? `<offset>${Math.round(endTick as number)}</offset>`
+    : "";
+  const startDir = `<direction${placementAttr}><direction-type><wedge type="${wedgeType}"/></direction-type>${startOffsetXml}<voice>${xmlEscape(
+    voice
+  )}</voice><staff>${xmlEscape(staffNo)}</staff></direction>`;
+  const stopDir = `<direction${placementAttr}><direction-type><wedge type="stop"/></direction-type>${endOffsetXml}<voice>${xmlEscape(
+    voice
+  )}</voice><staff>${xmlEscape(staffNo)}</staff></direction>`;
+  return `${startDir}${stopDir}`;
+};
+
+const buildMusicXmlDirectionsFromMeiPedal = (
+  pedal: Element,
+  divisions: number,
+  beatType: number,
+  voice: string,
+  staffNo: string,
+  events: ParsedMeiEvent[],
+  idToEventIndex: Map<string, number>,
+  idToEventTick: Map<string, number>
+): string => {
+  const placement = (pedal.getAttribute("place") || pedal.getAttribute("placement") || "").trim().toLowerCase();
+  const placementAttr = placement === "above" || placement === "below" ? ` placement="${placement}"` : "";
+  const semanticRaw = (
+    pedal.getAttribute("type")
+    || pedal.getAttribute("state")
+    || pedal.getAttribute("func")
+    || pedal.getAttribute("val")
+    || ""
+  ).trim().toLowerCase();
+  const isExplicitStop =
+    semanticRaw.includes("stop")
+    || semanticRaw.includes("end")
+    || semanticRaw.includes("off")
+    || semanticRaw.includes("up")
+    || semanticRaw.includes("release");
+  const startIndex = resolveControlEventEndpointIndex(
+    (pedal.getAttribute("startid") || "").trim(),
+    pedal.getAttribute("tstamp"),
+    idToEventIndex,
+    events,
+    divisions,
+    beatType,
+    pedal.getAttribute("plist"),
+    idToEventTick
+  );
+  const endIndex = resolveControlEventEndpointIndex(
+    (pedal.getAttribute("endid") || "").trim(),
+    pedal.getAttribute("tstamp2"),
+    idToEventIndex,
+    events,
+    divisions,
+    beatType,
+    undefined,
+    idToEventTick
+  );
+  const startTick = Number.isInteger(startIndex) ? resolveEventStartTickByIndex(events, startIndex as number) : null;
+  const endTick = Number.isInteger(endIndex) ? resolveEventStartTickByIndex(events, endIndex as number) : null;
+  const startOffsetXml = Number.isFinite(startTick) && (startTick as number) > 0
+    ? `<offset>${Math.round(startTick as number)}</offset>`
+    : "";
+  const endOffsetXml = Number.isFinite(endTick) && (endTick as number) > 0
+    ? `<offset>${Math.round(endTick as number)}</offset>`
+    : "";
+
+  if (Number.isInteger(endIndex)) {
+    const startDir = `<direction${placementAttr}><direction-type><pedal type="start" number="1" line="yes"/></direction-type>${startOffsetXml}<voice>${xmlEscape(
+      voice
+    )}</voice><staff>${xmlEscape(staffNo)}</staff></direction>`;
+    const stopDir = `<direction${placementAttr}><direction-type><pedal type="stop" number="1" line="yes"/></direction-type>${endOffsetXml}<voice>${xmlEscape(
+      voice
+    )}</voice><staff>${xmlEscape(staffNo)}</staff></direction>`;
+    return `${startDir}${stopDir}`;
+  }
+
+  const singleType = isExplicitStop ? "stop" : "start";
+  return `<direction${placementAttr}><direction-type><pedal type="${singleType}" number="1" line="yes"/></direction-type>${startOffsetXml}<voice>${xmlEscape(
+    voice
+  )}</voice><staff>${xmlEscape(staffNo)}</staff></direction>`;
+};
+
+const buildMusicXmlDirectionsFromMeiOctave = (
+  octave: Element,
+  divisions: number,
+  beatType: number,
+  voice: string,
+  staffNo: string,
+  events: ParsedMeiEvent[],
+  idToEventIndex: Map<string, number>,
+  idToEventTick: Map<string, number>
+): string => {
+  const placement = (octave.getAttribute("place") || octave.getAttribute("placement") || "").trim().toLowerCase();
+  const placementAttr = placement === "above" || placement === "below" ? ` placement="${placement}"` : "";
+  const semanticRaw = (
+    octave.getAttribute("type")
+    || octave.getAttribute("state")
+    || octave.getAttribute("func")
+    || octave.getAttribute("val")
+    || ""
+  ).trim().toLowerCase();
+  const isExplicitStop =
+    semanticRaw.includes("stop")
+    || semanticRaw.includes("end")
+    || semanticRaw.includes("off");
+  const disRaw = (octave.getAttribute("dis") || octave.getAttribute("size") || "").trim();
+  const dis = Number.parseInt(disRaw, 10);
+  const size = Number.isFinite(dis) && dis > 0 ? Math.round(dis) : 8;
+  const disPlace = (octave.getAttribute("dis.place") || placement).trim().toLowerCase();
+  const shiftType = disPlace === "below" ? "down" : "up";
+  const startIndex = resolveControlEventEndpointIndex(
+    (octave.getAttribute("startid") || "").trim(),
+    octave.getAttribute("tstamp"),
+    idToEventIndex,
+    events,
+    divisions,
+    beatType,
+    octave.getAttribute("plist"),
+    idToEventTick
+  );
+  const endIndex = resolveControlEventEndpointIndex(
+    (octave.getAttribute("endid") || "").trim(),
+    octave.getAttribute("tstamp2"),
+    idToEventIndex,
+    events,
+    divisions,
+    beatType,
+    undefined,
+    idToEventTick
+  );
+  const startTick = Number.isInteger(startIndex) ? resolveEventStartTickByIndex(events, startIndex as number) : null;
+  const endTick = Number.isInteger(endIndex) ? resolveEventStartTickByIndex(events, endIndex as number) : null;
+  const startOffsetXml = Number.isFinite(startTick) && (startTick as number) > 0
+    ? `<offset>${Math.round(startTick as number)}</offset>`
+    : "";
+  const endOffsetXml = Number.isFinite(endTick) && (endTick as number) > 0
+    ? `<offset>${Math.round(endTick as number)}</offset>`
+    : "";
+
+  if (Number.isInteger(endIndex)) {
+    const startDir = `<direction${placementAttr}><direction-type><octave-shift type="${shiftType}" size="${size}" number="1"/></direction-type>${startOffsetXml}<voice>${xmlEscape(
+      voice
+    )}</voice><staff>${xmlEscape(staffNo)}</staff></direction>`;
+    const stopDir = `<direction${placementAttr}><direction-type><octave-shift type="stop" size="${size}" number="1"/></direction-type>${endOffsetXml}<voice>${xmlEscape(
+      voice
+    )}</voice><staff>${xmlEscape(staffNo)}</staff></direction>`;
+    return `${startDir}${stopDir}`;
+  }
+
+  const singleType = isExplicitStop ? "stop" : shiftType;
+  return `<direction${placementAttr}><direction-type><octave-shift type="${singleType}" size="${size}" number="1"/></direction-type>${startOffsetXml}<voice>${xmlEscape(
+    voice
+  )}</voice><staff>${xmlEscape(staffNo)}</staff></direction>`;
+};
+
+const buildMusicXmlDirectionFromMeiRepeatMark = (
+  repeatMark: Element,
+  divisions: number,
+  beatType: number,
+  voice: string,
+  staffNo: string,
+  events: ParsedMeiEvent[],
+  idToEventIndex: Map<string, number>,
+  idToEventTick: Map<string, number>
+): string | null => {
+  const textRaw = (
+    repeatMark.getAttribute("func")
+    || repeatMark.getAttribute("type")
+    || repeatMark.getAttribute("label")
+    || repeatMark.textContent
+    || ""
+  ).trim();
+  if (!textRaw) return null;
+  const normalized = textRaw.toLowerCase();
+  const placement = (repeatMark.getAttribute("place") || repeatMark.getAttribute("placement") || "").trim().toLowerCase();
+  const placementAttr = placement === "above" || placement === "below" ? ` placement="${placement}"` : "";
+  const startIndex = resolveControlEventEndpointIndex(
+    (repeatMark.getAttribute("startid") || "").trim(),
+    repeatMark.getAttribute("tstamp"),
+    idToEventIndex,
+    events,
+    divisions,
+    beatType,
+    repeatMark.getAttribute("plist"),
+    idToEventTick
+  );
+  const startTick = Number.isInteger(startIndex) ? resolveEventStartTickByIndex(events, startIndex as number) : null;
+  const offsetXml = Number.isFinite(startTick) && (startTick as number) > 0
+    ? `<offset>${Math.round(startTick as number)}</offset>`
+    : "";
+
+  let directionType = `<words>${xmlEscape(textRaw)}</words>`;
+  if (normalized.includes("segno")) directionType = "<segno/>";
+  else if (normalized.includes("coda")) directionType = "<coda/>";
+  else if (normalized.includes("fine")) directionType = "<words>Fine</words>";
+  else if (normalized.includes("dacapo") || normalized.includes("da capo") || normalized.includes("d.c.")) directionType = "<words>D.C.</words>";
+  else if (normalized.includes("dalsegno") || normalized.includes("dal segno") || normalized.includes("d.s.")) directionType = "<words>D.S.</words>";
+
+  return `<direction${placementAttr}><direction-type>${directionType}</direction-type>${offsetXml}<voice>${xmlEscape(
+    voice
+  )}</voice><staff>${xmlEscape(staffNo)}</staff></direction>`;
+};
+
+const buildMusicXmlHarmonyFromMeiHarm = (
+  harm: Element,
+  divisions: number,
+  beatType: number,
+  staffNo: string,
+  events: ParsedMeiEvent[],
+  idToEventIndex: Map<string, number>,
+  idToEventTick: Map<string, number>
+): string | null => {
+  const raw = (harm.textContent || harm.getAttribute("type") || harm.getAttribute("label") || "").trim();
+  if (!raw) return null;
+  const parsed = parseMeiHarmText(raw);
+  if (!parsed) {
+    return `<harmony><kind text="${xmlEscape(raw)}">other</kind><staff>${xmlEscape(staffNo)}</staff></harmony>`;
+  }
+  const rootXml = `<root><root-step>${xmlEscape(parsed.rootStep)}</root-step>${Number.isFinite(parsed.rootAlter) ? `<root-alter>${Math.round(parsed.rootAlter as number)}</root-alter>` : ""}</root>`;
+  const kindXml = parsed.kindText
+    ? `<kind text="${xmlEscape(parsed.kindText)}">${xmlEscape(parsed.kind)}</kind>`
+    : `<kind>${xmlEscape(parsed.kind)}</kind>`;
+  const bassXml = parsed.bassStep
+    ? `<bass><bass-step>${xmlEscape(parsed.bassStep)}</bass-step>${Number.isFinite(parsed.bassAlter) ? `<bass-alter>${Math.round(parsed.bassAlter as number)}</bass-alter>` : ""}</bass>`
+    : "";
+  const degreeXml = parsed.degrees
+    .map((deg) => `<degree><degree-value>${deg.value}</degree-value><degree-alter>${deg.alter}</degree-alter><degree-type>add</degree-type></degree>`)
+    .join("");
+  const startIndex = resolveControlEventEndpointIndex(
+    (harm.getAttribute("startid") || "").trim(),
+    harm.getAttribute("tstamp"),
+    idToEventIndex,
+    events,
+    divisions,
+    beatType,
+    harm.getAttribute("plist"),
+    idToEventTick
+  );
+  const startTick = Number.isInteger(startIndex) ? resolveEventStartTickByIndex(events, startIndex as number) : null;
+  const offsetXml = Number.isFinite(startTick) && (startTick as number) > 0
+    ? `<offset>${Math.round(startTick as number)}</offset>`
+    : "";
+  return `<harmony>${rootXml}${kindXml}${bassXml}${degreeXml}${offsetXml}<staff>${xmlEscape(staffNo)}</staff></harmony>`;
+};
+
+const collectLayerHarmonyXml = (
+  staff: Element,
+  layer: Element,
+  divisions: number,
+  beatType: number,
+  events: ParsedMeiEvent[],
+  idToEventIndex: Map<string, number>,
+  idToEventTick: Map<string, number>
+): string => {
+  const staffNo = (staff.getAttribute("n") || "1").trim() || "1";
+  const harms = [...childElementsByName(layer, "harm"), ...childElementsByName(staff, "harm")];
+  const out: string[] = [];
+  for (const harm of harms) {
+    const xml = buildMusicXmlHarmonyFromMeiHarm(harm, divisions, beatType, staffNo, events, idToEventIndex, idToEventTick);
+    if (xml) out.push(xml);
+  }
+  return out.join("");
+};
+
+const parseMeiTargetList = (raw: string): string[] => {
+  const value = String(raw || "").trim();
+  if (!value) return [];
+  return value
+    .split(/[\s,]+/)
+    .map((v) => v.trim())
+    .filter(Boolean);
+};
+
+const controlEventAppliesToLayer = (
+  control: Element,
+  staffNo: string,
+  layerNo: string,
+  primaryLayerNo: string
+): boolean => {
+  const staffTargets = parseMeiTargetList(control.getAttribute("staff") || "");
+  if (staffTargets.length > 0 && !staffTargets.includes(staffNo)) return false;
+
+  const layerTargets = parseMeiTargetList(control.getAttribute("layer") || "");
+  if (layerTargets.length > 0) return layerTargets.includes(layerNo);
+
+  // Unscoped staff/measure-level controls should be emitted once (primary layer only).
+  const parent = control.parentElement;
+  const parentName = parent ? localNameOf(parent) : "";
+  if (parentName === "staff" || parentName === "measure") {
+    return layerNo === primaryLayerNo;
+  }
+  return true;
+};
+
+const collectControlEventsForLayer = (
+  name: string,
+  staff: Element,
+  layer: Element,
+  staffNo: string,
+  layerNo: string,
+  primaryLayerNo: string
+): Element[] => {
+  const measure = staff.parentElement && localNameOf(staff.parentElement) === "measure" ? staff.parentElement : null;
+  const controls = [
+    ...childElementsByName(layer, name),
+    ...childElementsByName(staff, name),
+    ...(measure ? childElementsByName(measure, name) : []),
+  ];
+  return controls.filter((control) => controlEventAppliesToLayer(control, staffNo, layerNo, primaryLayerNo));
+};
+
+const collectLayerDirectionXml = (
+  staff: Element,
+  layer: Element,
+  divisions: number,
+  beatType: number,
+  voice: string,
+  events: ParsedMeiEvent[],
+  idToEventIndex: Map<string, number>,
+  idToEventTick: Map<string, number>
+): string => {
+  const staffNo = (staff.getAttribute("n") || "1").trim() || "1";
+  const layerNo = (layer.getAttribute("n") || "1").trim() || "1";
+  const primaryLayerNo = (childElementsByName(staff, "layer")[0]?.getAttribute("n") || "1").trim() || "1";
+  const dyns = collectControlEventsForLayer("dynam", staff, layer, staffNo, layerNo, primaryLayerNo);
+  const hairpins = collectControlEventsForLayer("hairpin", staff, layer, staffNo, layerNo, primaryLayerNo);
+  const pedals = collectControlEventsForLayer("pedal", staff, layer, staffNo, layerNo, primaryLayerNo);
+  const octaves = collectControlEventsForLayer("octave", staff, layer, staffNo, layerNo, primaryLayerNo);
+  const repeatMarks = collectControlEventsForLayer("repeatMark", staff, layer, staffNo, layerNo, primaryLayerNo);
+  const out: string[] = [];
+  for (const dynam of dyns) {
+    const xml = buildMusicXmlDirectionFromMeiDynam(dynam, divisions, beatType, voice, staffNo);
+    if (xml) out.push(xml);
+  }
+  for (const hairpin of hairpins) {
+    const xml = buildMusicXmlDirectionsFromMeiHairpin(
+      hairpin,
+      divisions,
+      beatType,
+      voice,
+      staffNo,
+      events,
+      idToEventIndex,
+      idToEventTick
+    );
+    if (xml) out.push(xml);
+  }
+  for (const pedal of pedals) {
+    const xml = buildMusicXmlDirectionsFromMeiPedal(
+      pedal,
+      divisions,
+      beatType,
+      voice,
+      staffNo,
+      events,
+      idToEventIndex,
+      idToEventTick
+    );
+    if (xml) out.push(xml);
+  }
+  for (const octave of octaves) {
+    const xml = buildMusicXmlDirectionsFromMeiOctave(
+      octave,
+      divisions,
+      beatType,
+      voice,
+      staffNo,
+      events,
+      idToEventIndex,
+      idToEventTick
+    );
+    if (xml) out.push(xml);
+  }
+  for (const repeatMark of repeatMarks) {
+    const xml = buildMusicXmlDirectionFromMeiRepeatMark(
+      repeatMark,
+      divisions,
+      beatType,
+      voice,
+      staffNo,
+      events,
+      idToEventIndex,
+      idToEventTick
+    );
+    if (xml) out.push(xml);
+  }
+  return out.join("");
+};
+
+const applyStaffSlurControlEvents = (
+  staff: Element,
+  layer: Element,
+  layerEvents: ParsedMeiEvent[],
+  idToEventIndex: Map<string, number>,
+  idToEventTick: Map<string, number>,
+  divisions: number,
+  beatType: number
+): ParsedMeiEvent[] => {
+  if (layerEvents.length === 0) return layerEvents;
+  const out = layerEvents.slice();
+  const slurs = [...childElementsByName(layer, "slur"), ...childElementsByName(staff, "slur")];
+  let slurNumber = 1;
+  for (const slur of slurs) {
+    const startIdRaw = (slur.getAttribute("startid") || "").trim();
+    const endIdRaw = (slur.getAttribute("endid") || "").trim();
+    const startIndex = resolveControlEventEndpointIndex(
+      startIdRaw,
+      slur.getAttribute("tstamp"),
+      idToEventIndex,
+      out,
+      divisions,
+      beatType,
+      slur.getAttribute("plist"),
+      idToEventTick
+    );
+    const endIndex = resolveControlEventEndpointIndex(
+      endIdRaw,
+      slur.getAttribute("tstamp2"),
+      idToEventIndex,
+      out,
+      divisions,
+      beatType,
+      undefined,
+      idToEventTick
+    );
+    if (!Number.isInteger(startIndex) || !Number.isInteger(endIndex)) continue;
+    if (startIndex! < 0 || endIndex! < 0 || startIndex! >= out.length || endIndex! >= out.length) continue;
+    const startEvent = out[startIndex!];
+    const endEvent = out[endIndex!];
+    if (startEvent.kind !== "rest") {
+      out[startIndex!] = { ...startEvent, xml: addSlurNotationToEventXml(startEvent.xml, "start", slurNumber) };
+    }
+    if (endEvent.kind !== "rest") {
+      out[endIndex!] = { ...endEvent, xml: addSlurNotationToEventXml(endEvent.xml, "stop", slurNumber) };
+    }
+    slurNumber += 1;
+  }
+  const ties = [...childElementsByName(layer, "tie"), ...childElementsByName(staff, "tie")];
+  for (const tie of ties) {
+    const startIdRaw = (tie.getAttribute("startid") || "").trim();
+    const endIdRaw = (tie.getAttribute("endid") || "").trim();
+    const startIndex = resolveControlEventEndpointIndex(
+      startIdRaw,
+      tie.getAttribute("tstamp"),
+      idToEventIndex,
+      out,
+      divisions,
+      beatType,
+      tie.getAttribute("plist"),
+      idToEventTick
+    );
+    const endIndex = resolveControlEventEndpointIndex(
+      endIdRaw,
+      tie.getAttribute("tstamp2"),
+      idToEventIndex,
+      out,
+      divisions,
+      beatType,
+      undefined,
+      idToEventTick
+    );
+    if (!Number.isInteger(startIndex) || !Number.isInteger(endIndex)) continue;
+    if (startIndex! < 0 || endIndex! < 0 || startIndex! >= out.length || endIndex! >= out.length) continue;
+    const startEvent = out[startIndex!];
+    const endEvent = out[endIndex!];
+    if (startEvent.kind !== "rest") {
+      out[startIndex!] = { ...startEvent, xml: addTieNotationToEventXml(startEvent.xml, "start") };
+    }
+    if (endEvent.kind !== "rest") {
+      out[endIndex!] = { ...endEvent, xml: addTieNotationToEventXml(endEvent.xml, "stop") };
+    }
+  }
+  const trills = [...childElementsByName(layer, "trill"), ...childElementsByName(staff, "trill")];
+  for (const trill of trills) {
+    const startIndex = resolveControlEventEndpointIndex(
+      (trill.getAttribute("startid") || "").trim(),
+      trill.getAttribute("tstamp"),
+      idToEventIndex,
+      out,
+      divisions,
+      beatType,
+      trill.getAttribute("plist"),
+      idToEventTick
+    );
+    if (!Number.isInteger(startIndex)) continue;
+    if (startIndex! < 0 || startIndex! >= out.length) continue;
+    const startEvent = out[startIndex!];
+    if (startEvent.kind !== "rest") {
+      out[startIndex!] = { ...startEvent, xml: addTrillNotationToEventXml(startEvent.xml) };
+    }
+  }
+  const fermatas = [...childElementsByName(layer, "fermata"), ...childElementsByName(staff, "fermata")];
+  for (const fermata of fermatas) {
+    const startIndex = resolveControlEventEndpointIndex(
+      (fermata.getAttribute("startid") || "").trim(),
+      fermata.getAttribute("tstamp"),
+      idToEventIndex,
+      out,
+      divisions,
+      beatType,
+      fermata.getAttribute("plist"),
+      idToEventTick
+    );
+    if (!Number.isInteger(startIndex)) continue;
+    if (startIndex! < 0 || startIndex! >= out.length) continue;
+    const startEvent = out[startIndex!];
+    const placement = (fermata.getAttribute("place") || fermata.getAttribute("placement") || "").trim().toLowerCase();
+    if (startEvent.kind !== "rest") {
+      out[startIndex!] = {
+        ...startEvent,
+        xml: addFermataNotationToEventXml(startEvent.xml, placement === "below"),
+      };
+    }
+  }
+  const turns = [...childElementsByName(layer, "turn"), ...childElementsByName(staff, "turn")];
+  for (const turn of turns) {
+    const startIndex = resolveControlEventEndpointIndex(
+      (turn.getAttribute("startid") || "").trim(),
+      turn.getAttribute("tstamp"),
+      idToEventIndex,
+      out,
+      divisions,
+      beatType,
+      turn.getAttribute("plist"),
+      idToEventTick
+    );
+    if (!Number.isInteger(startIndex)) continue;
+    if (startIndex! < 0 || startIndex! >= out.length) continue;
+    const startEvent = out[startIndex!];
+    const turnType = (turn.getAttribute("type") || turn.getAttribute("form") || "").trim().toLowerCase();
+    const isInverted = turnType.includes("inv") || turnType.includes("lower") || turnType.includes("down");
+    if (startEvent.kind !== "rest") {
+      out[startIndex!] = { ...startEvent, xml: addTurnNotationToEventXml(startEvent.xml, isInverted) };
+    }
+  }
+  const mordents = [...childElementsByName(layer, "mordent"), ...childElementsByName(staff, "mordent")];
+  for (const mordent of mordents) {
+    const startIndex = resolveControlEventEndpointIndex(
+      (mordent.getAttribute("startid") || "").trim(),
+      mordent.getAttribute("tstamp"),
+      idToEventIndex,
+      out,
+      divisions,
+      beatType,
+      mordent.getAttribute("plist"),
+      idToEventTick
+    );
+    if (!Number.isInteger(startIndex)) continue;
+    if (startIndex! < 0 || startIndex! >= out.length) continue;
+    const startEvent = out[startIndex!];
+    const mordentType = (mordent.getAttribute("type") || mordent.getAttribute("form") || "").trim().toLowerCase();
+    const isInverted = mordentType.includes("inv") || mordentType.includes("lower") || mordentType.includes("down");
+    if (startEvent.kind !== "rest") {
+      out[startIndex!] = { ...startEvent, xml: addMordentNotationToEventXml(startEvent.xml, isInverted) };
+    }
+  }
+  const breaths = [...childElementsByName(layer, "breath"), ...childElementsByName(staff, "breath")];
+  for (const breath of breaths) {
+    const startIndex = resolveControlEventEndpointIndex(
+      (breath.getAttribute("startid") || "").trim(),
+      breath.getAttribute("tstamp"),
+      idToEventIndex,
+      out,
+      divisions,
+      beatType,
+      breath.getAttribute("plist"),
+      idToEventTick
+    );
+    if (!Number.isInteger(startIndex)) continue;
+    if (startIndex! < 0 || startIndex! >= out.length) continue;
+    const startEvent = out[startIndex!];
+    if (startEvent.kind !== "rest") {
+      out[startIndex!] = { ...startEvent, xml: addBreathNotationToEventXml(startEvent.xml) };
+    }
+  }
+  const caesuras = [...childElementsByName(layer, "caesura"), ...childElementsByName(staff, "caesura")];
+  for (const caesura of caesuras) {
+    const startIndex = resolveControlEventEndpointIndex(
+      (caesura.getAttribute("startid") || "").trim(),
+      caesura.getAttribute("tstamp"),
+      idToEventIndex,
+      out,
+      divisions,
+      beatType,
+      caesura.getAttribute("plist"),
+      idToEventTick
+    );
+    if (!Number.isInteger(startIndex)) continue;
+    if (startIndex! < 0 || startIndex! >= out.length) continue;
+    const startEvent = out[startIndex!];
+    if (startEvent.kind !== "rest") {
+      out[startIndex!] = { ...startEvent, xml: addCaesuraNotationToEventXml(startEvent.xml) };
+    }
+  }
+  const tupletSpans = [...childElementsByName(layer, "tupletSpan"), ...childElementsByName(staff, "tupletSpan")];
+  let tupletNumber = 1;
+  const beamSpans = [...childElementsByName(layer, "beamSpan"), ...childElementsByName(staff, "beamSpan")];
+  for (const beamSpan of beamSpans) {
+    const startIndex = resolveControlEventEndpointIndex(
+      (beamSpan.getAttribute("startid") || "").trim(),
+      beamSpan.getAttribute("tstamp"),
+      idToEventIndex,
+      out,
+      divisions,
+      beatType,
+      beamSpan.getAttribute("plist")
+    );
+    const endIndex = resolveControlEventEndpointIndex(
+      (beamSpan.getAttribute("endid") || "").trim(),
+      beamSpan.getAttribute("tstamp2"),
+      idToEventIndex,
+      out,
+      divisions,
+      beatType
+    );
+    if (!Number.isInteger(startIndex) || !Number.isInteger(endIndex)) continue;
+    if (startIndex! < 0 || endIndex! < 0 || startIndex! >= out.length || endIndex! >= out.length) continue;
+
+    const plistRaw = String(beamSpan.getAttribute("plist") || "").trim();
+    const plistIndexes = plistRaw
+      ? plistRaw
+          .split(/\s+/)
+          .map((token) => token.trim())
+          .filter(Boolean)
+          .map((token) => (token.startsWith("#") ? token.slice(1) : token))
+          .map((id) => idToEventIndex.get(id))
+          .filter((idx): idx is number => Number.isInteger(idx))
+      : [];
+
+    const spanIndexes = plistIndexes.length > 0
+      ? plistIndexes
+      : (() => {
+          const from = Math.min(startIndex as number, endIndex as number);
+          const to = Math.max(startIndex as number, endIndex as number);
+          const arr: number[] = [];
+          for (let i = from; i <= to; i += 1) arr.push(i);
+          return arr;
+        })();
+
+    const pitchedIndexes = spanIndexes.filter((idx) => idx >= 0 && idx < out.length && out[idx].kind !== "rest");
+    if (pitchedIndexes.length < 2) continue;
+
+    for (let i = 0; i < pitchedIndexes.length; i += 1) {
+      const idx = pitchedIndexes[i];
+      const value: "begin" | "continue" | "end" =
+        i === 0 ? "begin" : i === pitchedIndexes.length - 1 ? "end" : "continue";
+      out[idx] = { ...out[idx], xml: addBeamToEventXml(out[idx].xml, value, 1) };
+    }
+  }
+
+  for (const tupletSpan of tupletSpans) {
+    const startIndex = resolveControlEventEndpointIndex(
+      (tupletSpan.getAttribute("startid") || "").trim(),
+      tupletSpan.getAttribute("tstamp"),
+      idToEventIndex,
+      out,
+      divisions,
+      beatType,
+      tupletSpan.getAttribute("plist"),
+      idToEventTick
+    );
+    const endIndex = resolveControlEventEndpointIndex(
+      (tupletSpan.getAttribute("endid") || "").trim(),
+      tupletSpan.getAttribute("tstamp2"),
+      idToEventIndex,
+      out,
+      divisions,
+      beatType,
+      undefined,
+      idToEventTick
+    );
+    if (!Number.isInteger(startIndex) || !Number.isInteger(endIndex)) continue;
+    if (startIndex! < 0 || endIndex! < 0 || startIndex! >= out.length || endIndex! >= out.length) continue;
+    const startEvent = out[startIndex!];
+    const endEvent = out[endIndex!];
+    if (startEvent.kind !== "rest") {
+      out[startIndex!] = { ...startEvent, xml: addTupletNotationToEventXml(startEvent.xml, "start", tupletNumber) };
+    }
+    if (endEvent.kind !== "rest") {
+      out[endIndex!] = { ...endEvent, xml: addTupletNotationToEventXml(endEvent.xml, "stop", tupletNumber) };
+    }
+    tupletNumber += 1;
+  }
+  const glissandi = [...childElementsByName(layer, "gliss"), ...childElementsByName(staff, "gliss")];
+  let glissNumber = 1;
+  for (const gliss of glissandi) {
+    const startIndex = resolveControlEventEndpointIndex(
+      (gliss.getAttribute("startid") || "").trim(),
+      gliss.getAttribute("tstamp"),
+      idToEventIndex,
+      out,
+      divisions,
+      beatType,
+      gliss.getAttribute("plist"),
+      idToEventTick
+    );
+    const endIndex = resolveControlEventEndpointIndex(
+      (gliss.getAttribute("endid") || "").trim(),
+      gliss.getAttribute("tstamp2"),
+      idToEventIndex,
+      out,
+      divisions,
+      beatType,
+      undefined,
+      idToEventTick
+    );
+    if (!Number.isInteger(startIndex) || !Number.isInteger(endIndex)) continue;
+    if (startIndex! < 0 || endIndex! < 0 || startIndex! >= out.length || endIndex! >= out.length) continue;
+    const startEvent = out[startIndex!];
+    const endEvent = out[endIndex!];
+    if (startEvent.kind !== "rest") {
+      out[startIndex!] = { ...startEvent, xml: addGlissNotationToEventXml(startEvent.xml, "start", glissNumber) };
+    }
+    if (endEvent.kind !== "rest") {
+      out[endIndex!] = { ...endEvent, xml: addGlissNotationToEventXml(endEvent.xml, "stop", glissNumber) };
+    }
+    glissNumber += 1;
+  }
+  const slides = [...childElementsByName(layer, "slide"), ...childElementsByName(staff, "slide")];
+  let slideNumber = 1;
+  for (const slide of slides) {
+    const startIndex = resolveControlEventEndpointIndex(
+      (slide.getAttribute("startid") || "").trim(),
+      slide.getAttribute("tstamp"),
+      idToEventIndex,
+      out,
+      divisions,
+      beatType,
+      slide.getAttribute("plist"),
+      idToEventTick
+    );
+    const endIndex = resolveControlEventEndpointIndex(
+      (slide.getAttribute("endid") || "").trim(),
+      slide.getAttribute("tstamp2"),
+      idToEventIndex,
+      out,
+      divisions,
+      beatType,
+      undefined,
+      idToEventTick
+    );
+    if (!Number.isInteger(startIndex) || !Number.isInteger(endIndex)) continue;
+    if (startIndex! < 0 || endIndex! < 0 || startIndex! >= out.length || endIndex! >= out.length) continue;
+    const startEvent = out[startIndex!];
+    const endEvent = out[endIndex!];
+    if (startEvent.kind !== "rest") {
+      out[startIndex!] = { ...startEvent, xml: addSlideNotationToEventXml(startEvent.xml, "start", slideNumber) };
+    }
+    if (endEvent.kind !== "rest") {
+      out[endIndex!] = { ...endEvent, xml: addSlideNotationToEventXml(endEvent.xml, "stop", slideNumber) };
+    }
+    slideNumber += 1;
+  }
+  return out;
+};
+
+const applyTieCarryAccidentalsForLayerEvents = (
+  events: ParsedMeiEvent[],
+  tieCarryIn: Map<string, number>
+): { events: ParsedMeiEvent[]; tieCarryOut: Map<string, number> } => {
+  if (events.length === 0) {
+    return { events, tieCarryOut: new Map(tieCarryIn) };
+  }
+  const tieCarryByPitch = new Map<string, number>(tieCarryIn);
+  const tiePitchKey = (pname: string, octave: number): string =>
+    `${String(pname || "").trim().toUpperCase()}:${Math.round(Number(octave) || 0)}`;
+
+  const out = events.map((event) => {
+    if (event.kind === "rest") return event;
+    if (!event.xml.includes("<note>")) return event;
+
+    const wrapped = `<root>${event.xml}</root>`;
+    const parsed = new DOMParser().parseFromString(wrapped, "application/xml");
+    const root = parsed.documentElement;
+    if (!root || localNameOf(root) !== "root") return event;
+    const noteNodes = Array.from(root.querySelectorAll(":scope > note"));
+    if (noteNodes.length === 0) return event;
+
+    let changed = false;
+    for (const noteNode of noteNodes) {
+      const step = (noteNode.querySelector(":scope > pitch > step")?.textContent || "").trim().toUpperCase();
+      const octave = parseIntSafe(noteNode.querySelector(":scope > pitch > octave")?.textContent, NaN);
+      if (!/^[A-G]$/.test(step) || !Number.isFinite(octave)) continue;
+      const pitchKey = tiePitchKey(step, octave);
+      const pitchNode = noteNode.querySelector(":scope > pitch");
+      if (!pitchNode) continue;
+
+      const tieTypes = Array.from(noteNode.querySelectorAll(":scope > tie"))
+        .map((tie) => (tie.getAttribute("type") || "").trim().toLowerCase());
+      const hasStart = tieTypes.includes("start");
+      const hasStop = tieTypes.includes("stop");
+
+      let alterNode = noteNode.querySelector(":scope > pitch > alter");
+      const alterMissing = alterNode === null;
+      if (hasStop && alterMissing) {
+        const carryAlter = tieCarryByPitch.get(pitchKey);
+        if (Number.isFinite(carryAlter)) {
+          const newAlter = parsed.createElement("alter");
+          newAlter.textContent = String(Math.round(carryAlter as number));
+          const octaveNode = noteNode.querySelector(":scope > pitch > octave");
+          if (octaveNode) {
+            pitchNode.insertBefore(newAlter, octaveNode);
+          } else {
+            pitchNode.appendChild(newAlter);
+          }
+          alterNode = newAlter;
+          changed = true;
+        }
+      }
+
+      const resolvedAlter = parseIntSafe(alterNode?.textContent, 0);
+      if (hasStart) {
+        tieCarryByPitch.set(pitchKey, resolvedAlter);
+      } else if (hasStop) {
+        tieCarryByPitch.delete(pitchKey);
+      }
+    }
+
+    if (!changed) return event;
+    const serialized = new XMLSerializer().serializeToString(root);
+    const xml = serialized.replace(/^<root>/, "").replace(/<\/root>$/, "");
+    return { ...event, xml };
+  });
+
+  return { events: out, tieCarryOut: tieCarryByPitch };
 };
 
 const trimLayerEventsToMeasureCapacity = (
   events: ParsedMeiEvent[],
   measureTicks: number
-): { events: ParsedMeiEvent[]; totalTicks: number; droppedCount: number; droppedTicks: number } => {
+): {
+  events: ParsedMeiEvent[];
+  totalTicks: number;
+  droppedCount: number;
+  droppedTicks: number;
+  trimmedCount: number;
+  trimmedTicks: number;
+} => {
   const kept: ParsedMeiEvent[] = [];
   let totalTicks = 0;
   let droppedCount = 0;
   let droppedTicks = 0;
+  let trimmedCount = 0;
+  let trimmedTicks = 0;
   for (const event of events) {
-    if (totalTicks + event.durationTicks <= measureTicks) {
+    const nextTotal = totalTicks + event.durationTicks;
+    if (nextTotal <= measureTicks) {
       kept.push(event);
       totalTicks += event.durationTicks;
+      continue;
+    }
+    const overflow = nextTotal - measureTicks;
+    const isMinorOverflow = overflow > 0 && overflow <= Math.max(12, Math.round(event.durationTicks * 0.1));
+    if (isMinorOverflow) {
+      // Keep tiny overflow as-is to avoid silent note loss from rounding drift
+      // (common around tuplet-heavy imported sources).
+      kept.push(event);
+      totalTicks = nextTotal;
+      trimmedCount += 1;
+      trimmedTicks += overflow;
       continue;
     }
     droppedCount += 1;
     droppedTicks += event.durationTicks;
   }
-  return { events: kept, totalTicks, droppedCount, droppedTicks };
+  return { events: kept, totalTicks, droppedCount, droppedTicks, trimmedCount, trimmedTicks };
 };
 
 const extractMiscFieldsFromMeiStaff = (staff: Element): Array<{ name: string; value: string }> => {
@@ -907,6 +3352,10 @@ const buildMeiDebugFieldsFromStaff = (
 export const convertMeiToMusicXml = (meiSource: string, options: MeiImportOptions = {}): string => {
   const debugMetadata = options.debugMetadata ?? true;
   const sourceMetadata = options.sourceMetadata ?? true;
+  const failOnOverfullDrop = options.failOnOverfullDrop ?? false;
+  const meiCorpusIndex = Number.isFinite(options.meiCorpusIndex)
+    ? Math.max(0, Math.floor(options.meiCorpusIndex as number))
+    : null;
   const parser = new DOMParser();
   const doc = parser.parseFromString(String(meiSource || ""), "application/xml");
   if (doc.querySelector("parsererror")) {
@@ -914,21 +3363,45 @@ export const convertMeiToMusicXml = (meiSource: string, options: MeiImportOption
   }
 
   const meiRoot = doc.documentElement;
-  if (!meiRoot || localNameOf(meiRoot) !== "mei") {
-    throw new Error("MEI root must be <mei>.");
+  if (!meiRoot) {
+    throw new Error("MEI root is missing.");
+  }
+  let meiImportRoot: Element | null = null;
+  const rootName = localNameOf(meiRoot);
+  if (rootName === "mei") {
+    meiImportRoot = meiRoot;
+  } else if (rootName === "meiCorpus") {
+    const meiNodes = Array.from(meiRoot.children).filter(
+      (node): node is Element => node instanceof Element && localNameOf(node) === "mei"
+    );
+    if (meiCorpusIndex !== null) {
+      meiImportRoot = meiNodes[meiCorpusIndex] ?? null;
+      if (!meiImportRoot) {
+        throw new Error(`MEI corpus index out of range: ${meiCorpusIndex} (size=${meiNodes.length}).`);
+      }
+    } else {
+      meiImportRoot =
+        meiNodes.find((node) => node.querySelector("measure") !== null)
+        ?? meiNodes[0]
+        ?? null;
+    }
+    if (!meiImportRoot) {
+      throw new Error("MEI corpus has no child <mei>.");
+    }
+  } else {
+    throw new Error("MEI root must be <mei> or <meiCorpus>.");
   }
 
-  const title = firstDescendantText(doc, "title") || "mikuscore";
-  const scoreDef = Array.from(doc.querySelectorAll("*")).find(
-    (node) => node instanceof Element && localNameOf(node) === "scoreDef"
-  ) as Element | undefined;
+  const title = firstDescendantText(meiImportRoot, "title") || "mikuscore";
+  const scoreDefs = collectScoreDefsInDocOrder(meiImportRoot);
+  const staffDefsInDocOrder = collectStaffDefsInDocOrder(meiImportRoot);
+  const scoreDef = scoreDefs[0];
   const meterCount = parseIntSafe(scoreDef?.getAttribute("meter.count"), 4);
   const meterUnit = parseIntSafe(scoreDef?.getAttribute("meter.unit"), 4);
-  const fifths = parseMeiKeySigToFifths(scoreDef?.getAttribute("key.sig") || "0");
+  const fifths = parseMeiKeyFifthsFromElement(scoreDef) ?? 0;
   const divisions = 480;
-  const measureTicks = Math.max(1, Math.round((meterCount * 4 * divisions) / Math.max(1, meterUnit)));
 
-  const staffDefs = Array.from(doc.querySelectorAll("*")).filter(
+  const staffDefs = Array.from(meiImportRoot.querySelectorAll("*")).filter(
     (node): node is Element => node instanceof Element && localNameOf(node) === "staffDef"
   );
   const staffMeta = new Map<
@@ -938,14 +3411,16 @@ export const convertMeiToMusicXml = (meiSource: string, options: MeiImportOption
   for (const staffDef of staffDefs) {
     const n = staffDef.getAttribute("n")?.trim();
     if (!n) continue;
+    const parsedClef = parseClefFromStaffDefElement(staffDef);
+    const prev = staffMeta.get(n);
     staffMeta.set(n, {
-      label: staffDef.getAttribute("label")?.trim() || `Staff ${n}`,
-      clefSign: (staffDef.getAttribute("clef.shape")?.trim().toUpperCase() || "G"),
-      clefLine: parseIntSafe(staffDef.getAttribute("clef.line"), 2),
+      label: staffDef.getAttribute("label")?.trim() || prev?.label || `Staff ${n}`,
+      clefSign: parsedClef?.clefSign || prev?.clefSign || "G",
+      clefLine: parsedClef?.clefLine || prev?.clefLine || 2,
     });
   }
 
-  const measureNodes = Array.from(doc.querySelectorAll("*")).filter(
+  const measureNodes = Array.from(meiImportRoot.querySelectorAll("*")).filter(
     (node): node is Element => node instanceof Element && localNameOf(node) === "measure"
   );
   if (measureNodes.length === 0) {
@@ -978,6 +3453,12 @@ export const convertMeiToMusicXml = (meiSource: string, options: MeiImportOption
       const clef = staffMeta.get(staffNo) || { label: `Staff ${staffNo}`, clefSign: "G", clefLine: 2 };
       let currentBeats = Math.max(1, Math.round(meterCount));
       let currentBeatType = Math.max(1, Math.round(meterUnit));
+      let currentFifths = fifths;
+      let currentClefSign = clef.clefSign;
+      let currentClefLine = clef.clefLine;
+      let currentTranspose = parseTransposeFromScoreDefForStaff(scoreDef, staffNo);
+      let hasEmittedInitialAttributes = false;
+      const tieCarryByVoice = new Map<string, Map<string, number>>();
       const measuresXml = measureNodes
         .map((measureNode, measureIndex) => {
           const sourceMeasureNo = measureNode.getAttribute("n")?.trim() || String(measureIndex + 1);
@@ -987,31 +3468,111 @@ export const convertMeiToMusicXml = (meiSource: string, options: MeiImportOption
           if (!targetStaff) {
             return `<measure number="${xmlEscape(sourceMeasureNo)}"></measure>`;
           }
+          const effectiveScoreDef = findEffectiveScoreDefForNode(targetStaff, scoreDefs);
+          const effectiveStaffDef = findEffectiveStaffDefForNode(targetStaff, staffNo, staffDefsInDocOrder);
           const measureMeta = parseMeasureMetaFromMeiStaff(targetStaff);
           const measureNo = (measureMeta?.number ?? sourceMeasureNo).trim() || sourceMeasureNo;
           const implicitAttr = measureMeta?.implicit ? ' implicit="yes"' : "";
-          const measureBeats = Math.max(1, Math.round(measureMeta?.beats ?? currentBeats));
-          const measureBeatType = Math.max(1, Math.round(measureMeta?.beatType ?? currentBeatType));
+          const scoreDefBeats = parseIntSafe(effectiveScoreDef?.getAttribute("meter.count"), currentBeats);
+          const scoreDefBeatType = parseIntSafe(effectiveScoreDef?.getAttribute("meter.unit"), currentBeatType);
+          const scoreDefFifths = parseKeySigFromScoreDefForStaff(effectiveScoreDef, staffNo, currentFifths);
+          const scoreDefClef = parseClefFromScoreDefForStaff(effectiveScoreDef, staffNo);
+          const scoreDefTranspose = parseTransposeFromScoreDefForStaff(effectiveScoreDef, staffNo);
+          const staffDefFifths = parseMeiKeyFifthsFromElement(effectiveStaffDef);
+          const staffDefClef = parseClefFromStaffDefElement(effectiveStaffDef);
+          const staffDefTranspose = parseTransposeFromStaffDefElement(effectiveStaffDef);
+          const measureBeats = Math.max(1, Math.round(measureMeta?.beats ?? scoreDefBeats));
+          const measureBeatType = Math.max(1, Math.round(measureMeta?.beatType ?? scoreDefBeatType));
+          const measureFifths = Number.isFinite(staffDefFifths)
+            ? Math.round(staffDefFifths as number)
+            : Number.isFinite(scoreDefFifths)
+              ? Math.round(scoreDefFifths)
+              : currentFifths;
+          const measureClefSign = staffDefClef?.clefSign || scoreDefClef?.clefSign || currentClefSign;
+          const measureClefLine = staffDefClef?.clefLine || scoreDefClef?.clefLine || currentClefLine;
+          const measureTranspose = staffDefTranspose ?? scoreDefTranspose ?? currentTranspose;
+          const measureTicks = Math.max(1, Math.round((measureBeats * 4 * divisions) / Math.max(1, measureBeatType)));
           const shouldEmitTime =
             measureIndex === 0
             || measureMeta?.explicitTime === true
             || measureBeats !== currentBeats
             || measureBeatType !== currentBeatType;
+          const shouldEmitKey = measureIndex === 0 || measureFifths !== currentFifths;
+          const shouldEmitClef =
+            measureIndex === 0
+            || measureClefSign !== currentClefSign
+            || measureClefLine !== currentClefLine;
+          const currentChromatic = Number.isFinite(currentTranspose?.chromatic) ? Math.round(Number(currentTranspose?.chromatic)) : null;
+          const currentDiatonic = Number.isFinite(currentTranspose?.diatonic) ? Math.round(Number(currentTranspose?.diatonic)) : null;
+          const measureChromatic = Number.isFinite(measureTranspose?.chromatic) ? Math.round(Number(measureTranspose?.chromatic)) : null;
+          const measureDiatonic = Number.isFinite(measureTranspose?.diatonic) ? Math.round(Number(measureTranspose?.diatonic)) : null;
+          const shouldEmitTranspose =
+            measureIndex === 0 || measureChromatic !== currentChromatic || measureDiatonic !== currentDiatonic;
 
           const layerNodes = childElementsByName(targetStaff, "layer");
-          const layers = layerNodes
-            .map((layer, i) => {
-              const voice = layer.getAttribute("n")?.trim() || String(i + 1);
-              const parsedEvents = parseLayerEvents(layer, divisions, voice);
-              const sourceTotalTicks = parsedEvents.reduce((sum, event) => sum + event.durationTicks, 0);
-              const trimmed = trimLayerEventsToMeasureCapacity(parsedEvents, measureTicks);
+          const parsedLayers = layerNodes.map((layer, i) => {
+            const voice = layer.getAttribute("n")?.trim() || String(i + 1);
+            const tieCarryIn = tieCarryByVoice.get(voice) ?? new Map();
+            const parsedLayer = parseLayerEvents(
+              layer,
+              divisions,
+              voice,
+              measureTicks,
+              measureFifths,
+              tieCarryIn
+            );
+            return { layer, voice, parsedLayer, tieCarryIn };
+          });
+          const staffIdToEventTick = new Map<string, number>();
+          for (const entry of parsedLayers) {
+            for (const [id, idx] of entry.parsedLayer.idToEventIndex.entries()) {
+              const tick = resolveEventStartTickByIndex(entry.parsedLayer.events, idx);
+              if (Number.isFinite(tick)) staffIdToEventTick.set(id, Math.max(0, Math.round(tick as number)));
+            }
+          }
+          const layers = parsedLayers
+            .map(({ layer, voice, parsedLayer, tieCarryIn }) => {
+              const slurAppliedEvents = applyStaffSlurControlEvents(
+                targetStaff,
+                layer,
+                parsedLayer.events,
+                parsedLayer.idToEventIndex,
+                staffIdToEventTick,
+                divisions,
+                measureBeatType
+              );
+              const tieApplied = applyTieCarryAccidentalsForLayerEvents(slurAppliedEvents, tieCarryIn);
+              tieCarryByVoice.set(voice, tieApplied.tieCarryOut);
+              const directionXml = collectLayerDirectionXml(
+                targetStaff,
+                layer,
+                divisions,
+                measureBeatType,
+                voice,
+                tieApplied.events,
+                parsedLayer.idToEventIndex,
+                staffIdToEventTick
+              );
+              const harmonyXml = collectLayerHarmonyXml(
+                targetStaff,
+                layer,
+                divisions,
+                measureBeatType,
+                tieApplied.events,
+                parsedLayer.idToEventIndex,
+                staffIdToEventTick
+              );
+              const sourceTotalTicks = tieApplied.events.reduce((sum, event) => sum + event.durationTicks, 0);
+              const trimmed = trimLayerEventsToMeasureCapacity(tieApplied.events, measureTicks);
               return {
                 voice,
-                xml: trimmed.events.map((event) => event.xml).join(""),
+                xml: `${harmonyXml}${directionXml}${trimmed.events.map((event) => event.xml).join("")}`,
                 totalTicks: trimmed.totalTicks,
                 sourceTotalTicks,
                 droppedCount: trimmed.droppedCount,
                 droppedTicks: trimmed.droppedTicks,
+                trimmedCount: trimmed.trimmedCount,
+                trimmedTicks: trimmed.trimmedTicks,
               };
             })
             .filter((layer) => layer.xml.length > 0);
@@ -1032,15 +3593,22 @@ export const convertMeiToMusicXml = (meiSource: string, options: MeiImportOption
             : [];
           const droppedEvents = layers.reduce((sum, layer) => sum + layer.droppedCount, 0);
           const droppedTicks = layers.reduce((sum, layer) => sum + layer.droppedTicks, 0);
+          const trimmedEvents = layers.reduce((sum, layer) => sum + layer.trimmedCount, 0);
+          const trimmedTicks = layers.reduce((sum, layer) => sum + layer.trimmedTicks, 0);
           const sourceTotalTicks = layers.reduce((sum, layer) => sum + layer.sourceTotalTicks, 0);
           const overfullDetected = layers.some((layer) => layer.sourceTotalTicks > measureTicks);
+          if (failOnOverfullDrop && droppedEvents > 0) {
+            throw new Error(
+              `MEI overfull would drop events (measure=${measureNo}, staff=${staffNo}, droppedEvents=${droppedEvents}, droppedTicks=${droppedTicks}).`
+            );
+          }
           const overflowFields: Array<{ name: string; value: string }> =
             overfullDetected
               ? [
                   { name: "diag:count", value: "1" },
                   {
                     name: "diag:0001",
-                    value: `level=warn;code=OVERFULL_CLAMPED;fmt=mei;measure=${measureNo};staff=${staffNo};action=clamped;sourceTicks=${sourceTotalTicks};capacityTicks=${measureTicks};droppedEvents=${droppedEvents};droppedTicks=${droppedTicks}`,
+                    value: `level=warn;code=OVERFULL_CLAMPED;fmt=mei;measure=${measureNo};staff=${staffNo};action=clamped;sourceTicks=${sourceTotalTicks};capacityTicks=${measureTicks};droppedEvents=${droppedEvents};droppedTicks=${droppedTicks};trimmedEvents=${trimmedEvents};trimmedTicks=${trimmedTicks}`,
                   },
                 ]
               : [];
@@ -1055,15 +3623,24 @@ export const convertMeiToMusicXml = (meiSource: string, options: MeiImportOption
                   .join("")}</miscellaneous>`
               : "";
           let attributesXml = "";
-          if (measureIndex === 0) {
+          if (!hasEmittedInitialAttributes) {
             attributesXml =
-              `<attributes><divisions>${divisions}</divisions><key><fifths>${fifths}</fifths></key>` +
+              `<attributes><divisions>${divisions}</divisions><key><fifths>${measureFifths}</fifths></key>` +
               `<time><beats>${measureBeats}</beats><beat-type>${measureBeatType}</beat-type></time>` +
-              `<clef><sign>${xmlEscape(clef.clefSign)}</sign><line>${clef.clefLine}</line></clef>` +
+              `${buildTransposeXml(measureTranspose)}` +
+              `<clef><sign>${xmlEscape(measureClefSign)}</sign><line>${measureClefLine}</line></clef>` +
               `${miscellaneousXml}</attributes>`;
-          } else if (shouldEmitTime || miscellaneousXml) {
+          } else if (shouldEmitTime || shouldEmitKey || shouldEmitTranspose || shouldEmitClef || miscellaneousXml) {
             attributesXml =
-              `<attributes>${shouldEmitTime ? `<time><beats>${measureBeats}</beats><beat-type>${measureBeatType}</beat-type></time>` : ""}${miscellaneousXml}</attributes>`;
+              `<attributes>${
+                shouldEmitKey ? `<key><fifths>${measureFifths}</fifths></key>` : ""
+              }${
+                shouldEmitTime ? `<time><beats>${measureBeats}</beats><beat-type>${measureBeatType}</beat-type></time>` : ""
+              }${
+                shouldEmitTranspose ? `${buildTransposeXml(measureTranspose)}` : ""
+              }${
+                shouldEmitClef ? `<clef><sign>${xmlEscape(measureClefSign)}</sign><line>${measureClefLine}</line></clef>` : ""
+              }${miscellaneousXml}</attributes>`;
           }
           let leftBarlineXml = "";
           let rightBarlineXml = "";
@@ -1085,6 +3662,11 @@ export const convertMeiToMusicXml = (meiSource: string, options: MeiImportOption
           }
           currentBeats = measureBeats;
           currentBeatType = measureBeatType;
+          currentFifths = measureFifths;
+          currentClefSign = measureClefSign;
+          currentClefLine = measureClefLine;
+          currentTranspose = measureTranspose;
+          hasEmittedInitialAttributes = true;
           return `<measure number="${xmlEscape(measureNo)}"${implicitAttr}>${attributesXml}${leftBarlineXml}${body}${rightBarlineXml}</measure>`;
         })
         .join("");

--- a/tests/roundtrip/musescore/musicxml-musescore-sample1.roundtrip.spec.ts
+++ b/tests/roundtrip/musescore/musicxml-musescore-sample1.roundtrip.spec.ts
@@ -249,6 +249,6 @@ describe("MuseScore roundtrip (public/local cases)", () => {
         pitch: "E/3",
       })).toBe(1);
     }
-    });
+    }, 15000);
   }
 });

--- a/tests/spot/local-mei-official-visual.spot.spec.ts
+++ b/tests/spot/local-mei-official-visual.spot.spec.ts
@@ -1,0 +1,302 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync, copyFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { createRequire } from "node:module";
+import { spawnSync } from "node:child_process";
+import { describe, expect, it } from "vitest";
+import { convertMeiToMusicXml } from "../../src/ts/mei-io";
+import { parseMusicXmlDocument } from "../../src/ts/musicxml-io";
+
+const run = (cmd: string, args: string[], allowNonZero = false): { stdout: string; stderr: string; status: number } => {
+  const r = spawnSync(cmd, args, { encoding: "utf8" });
+  if (!allowNonZero && (r.status ?? 1) !== 0) {
+    throw new Error(`${cmd} ${args.join(" ")} failed: ${r.stderr || r.stdout}`);
+  }
+  return { stdout: r.stdout ?? "", stderr: r.stderr ?? "", status: r.status ?? 1 };
+};
+
+const imageArea = (magick: string, path: string): number => {
+  const out = run(magick, ["identify", "-format", "%[fx:w*h]", path]).stdout.trim();
+  return Number(out);
+};
+
+const changedPixelRatio = (magick: string, path: string): { changed: number; total: number; ratio: number } => {
+  const total = imageArea(magick, path);
+  const hist = run(magick, [path, "-format", "%c", "histogram:info:-"]).stdout;
+  const m = hist.match(/^\s*([0-9]+):/m);
+  const dominant = m ? Number(m[1]) : 0;
+  const changed = total - dominant;
+  const ratio = total > 0 ? changed / total : Number.NaN;
+  return { changed, total, ratio };
+};
+
+const trimGeometry = (magick: string, path: string): string => {
+  return run(magick, [path, "-fuzz", "0%", "-trim", "-format", "%wx%h+%X+%Y", "info:"]).stdout.trim();
+};
+
+const waitForToolkit = async (Verovio: { toolkit: new () => unknown }): Promise<unknown> => {
+  for (let i = 0; i < 50; i += 1) {
+    try {
+      return new Verovio.toolkit();
+    } catch {
+      await new Promise((r) => setTimeout(r, 100));
+    }
+  }
+  throw new Error("Timed out while waiting for verovio toolkit initialization.");
+};
+
+const assertStructuralSemantics = (fixtureId: string, musicXml: string): void => {
+  const doc = parseMusicXmlDocument(musicXml);
+  expect(doc).not.toBeNull();
+  if (!doc) return;
+  expect(doc.querySelectorAll("part > measure > note").length).toBeGreaterThan(0);
+
+  const mustContain = (selector: string): void => {
+    expect(doc.querySelector(selector)).not.toBeNull();
+  };
+
+  switch (fixtureId) {
+    case "beam-grace":
+      mustContain("part > measure > note > grace");
+      break;
+    case "beam-secondary":
+      mustContain("part > measure > note > beam[number=\"2\"]");
+      break;
+    case "beamspan-min":
+      mustContain("part > measure > note > beam");
+      break;
+    case "tie-crossbar-min":
+      mustContain("part > measure > note > tie[type=\"start\"]");
+      mustContain("part > measure > note > tie[type=\"stop\"]");
+      break;
+    case "slur-min":
+      mustContain("part > measure > note > notations > slur[type=\"start\"]");
+      mustContain("part > measure > note > notations > slur[type=\"stop\"]");
+      break;
+    case "hairpin-min":
+      expect(
+        doc.querySelector("part > measure > direction > direction-type > wedge[type=\"start\"]")
+        || doc.querySelector("part > measure > direction > direction-type > wedge[type=\"crescendo\"]")
+        || doc.querySelector("part > measure > direction > direction-type > wedge[type=\"diminuendo\"]")
+      ).not.toBeNull();
+      mustContain("part > measure > direction > direction-type > wedge[type=\"stop\"]");
+      break;
+    case "dynam-min":
+      expect(
+        doc.querySelector("part > measure > direction > direction-type > dynamics")
+        || doc.querySelector("part > measure > direction > direction-type > words")
+      ).not.toBeNull();
+      break;
+    case "tuplet-min":
+      mustContain("part > measure > note > time-modification");
+      break;
+    case "fermata-min":
+      mustContain("part > measure > note > notations > fermata");
+      break;
+    case "gliss-min":
+      mustContain("part > measure > note > notations > glissando[type=\"start\"]");
+      mustContain("part > measure > note > notations > glissando[type=\"stop\"]");
+      break;
+    default:
+      break;
+  }
+};
+
+describe("local mei official visual compare", () => {
+  it("converts official MEI fixtures and compares rendered images", async () => {
+    const magick = run("which", ["magick"], true).stdout.trim();
+    const rsvgConvert = run("which", ["rsvg-convert"], true).stdout.trim();
+    if (!magick || !rsvgConvert) {
+      return;
+    }
+
+    const root = process.cwd();
+    const fixtures = [
+      {
+        id: "beam-grace",
+        meiFile: "source-listing-132-snippet.mei",
+        refImages: ["grace-300.png", "grace-300-v4.png"],
+        w: 673,
+        h: 110,
+        semanticThreshold: 0.08,
+      },
+      {
+        id: "beam-secondary",
+        meiFile: "source-listing-142-snippet.mei",
+        refImages: ["beam-a-20100510.png"],
+        w: 640,
+        h: 160,
+        semanticThreshold: 0.14,
+      },
+      {
+        id: "beamspan-min",
+        meiFile: "source-listing-147-inspired.mei",
+        refImages: [],
+        w: 800,
+        h: 160,
+        semanticThreshold: 0.1,
+      },
+      {
+        id: "tie-crossbar-min",
+        meiFile: "source-listing-148-inspired.mei",
+        refImages: [],
+        w: 800,
+        h: 160,
+        semanticThreshold: 0.1,
+      },
+      {
+        id: "slur-min",
+        meiFile: "source-listing-152-inspired.mei",
+        refImages: [],
+        w: 800,
+        h: 160,
+        semanticThreshold: 0.1,
+      },
+      {
+        id: "hairpin-min",
+        meiFile: "source-hairpin-inspired.mei",
+        refImages: [],
+        w: 800,
+        h: 180,
+        semanticThreshold: 0.1,
+      },
+      {
+        id: "dynam-min",
+        meiFile: "source-dynam-inspired.mei",
+        refImages: [],
+        w: 800,
+        h: 180,
+        semanticThreshold: 0.1,
+      },
+      {
+        id: "tuplet-min",
+        meiFile: "source-tuplet-inspired.mei",
+        refImages: [],
+        w: 800,
+        h: 180,
+        semanticThreshold: 0.1,
+      },
+      {
+        id: "fermata-min",
+        meiFile: "source-fermata-inspired.mei",
+        refImages: [],
+        w: 800,
+        h: 180,
+        semanticThreshold: 0.1,
+      },
+      {
+        id: "gliss-min",
+        meiFile: "source-gliss-inspired.mei",
+        refImages: [],
+        w: 800,
+        h: 180,
+        semanticThreshold: 0.1,
+      },
+    ] as const;
+
+    for (const fixture of fixtures) {
+      const fixtureDir = resolve(root, "tests/fixtures-local/mei-official", fixture.id);
+      const outDir = resolve(root, "tests/tmp/mei-official", fixture.id);
+      mkdirSync(outDir, { recursive: true });
+
+      const meiPath = resolve(fixtureDir, fixture.meiFile);
+      const mxPath = resolve(outDir, "converted.musicxml");
+      const svgPath = resolve(outDir, "converted.svg");
+      const meiSvgPath = resolve(outDir, "original-mei.svg");
+      const renderedPngPath = resolve(outDir, "converted.png");
+      const meiRenderedPngPath = resolve(outDir, "original-mei.png");
+      const diffSemanticPngPath = resolve(outDir, "diff-semantic.png");
+      const reportPath = resolve(outDir, "report.txt");
+
+      const mei = readFileSync(meiPath, "utf8");
+      const musicXml = convertMeiToMusicXml(mei);
+      assertStructuralSemantics(fixture.id, musicXml);
+      writeFileSync(mxPath, musicXml, "utf8");
+
+      const verovioCjsPath = resolve(outDir, "verovio.cjs");
+      copyFileSync(resolve(root, "src/js/verovio.js"), verovioCjsPath);
+      const require = createRequire(import.meta.url);
+      const verovio = require(verovioCjsPath) as { toolkit: new () => { loadData: (data: string, options: Record<string, unknown>) => number; renderToSVG: (page: number, options: Record<string, unknown>) => string } };
+      const toolkit = (await waitForToolkit(verovio)) as {
+        loadData: (data: string, options: Record<string, unknown>) => number;
+        renderToSVG: (page: number, options: Record<string, unknown>) => string;
+      };
+
+      const loadedMei = toolkit.loadData(mei, { inputFrom: "mei" });
+      expect(loadedMei).toBe(1);
+      const meiSvg = toolkit.renderToSVG(1, {});
+      writeFileSync(meiSvgPath, meiSvg, "utf8");
+
+      const loadedMx = toolkit.loadData(musicXml, { inputFrom: "musicxml" });
+      expect(loadedMx).toBe(1);
+      const mxSvg = toolkit.renderToSVG(1, {});
+      writeFileSync(svgPath, mxSvg, "utf8");
+
+      run(rsvgConvert, ["-w", String(fixture.w), "-h", String(fixture.h), meiSvgPath, "-o", meiRenderedPngPath]);
+      run(rsvgConvert, ["-w", String(fixture.w), "-h", String(fixture.h), svgPath, "-o", renderedPngPath]);
+      run(magick, [meiRenderedPngPath, "-background", "white", "-alpha", "remove", "-alpha", "off", "-colorspace", "sRGB", meiRenderedPngPath]);
+      run(magick, [renderedPngPath, "-background", "white", "-alpha", "remove", "-alpha", "off", "-colorspace", "sRGB", renderedPngPath]);
+
+      const officialLines: string[] = [];
+      if (fixture.refImages.length === 0) {
+        officialLines.push("official_status=no-official-reference\n");
+      }
+      for (const refImage of fixture.refImages) {
+        const refPngPath = resolve(fixtureDir, refImage);
+        const identify = run(magick, ["identify", refPngPath], true);
+        if (identify.status !== 0) {
+          officialLines.push(`official_ref=${refImage}\nofficial_status=skip-invalid-image\n`);
+          continue;
+        }
+        const refNormPngPath = resolve(outDir, `reference-${refImage}`);
+        const refDiffPngPath = resolve(outDir, `diff-official-${refImage}`);
+        const refVsMeiDiffPngPath = resolve(outDir, `diff-official-vs-original-${refImage}`);
+        run(magick, [refPngPath, "-colorspace", "sRGB", refNormPngPath]);
+        const cmp = run(magick, ["compare", "-metric", "AE", refNormPngPath, renderedPngPath, refDiffPngPath], true);
+        const cmpRefVsMei = run(magick, ["compare", "-metric", "AE", refNormPngPath, meiRenderedPngPath, refVsMeiDiffPngPath], true);
+        const metricRaw = (cmp.stderr || cmp.stdout).trim().split(/\s+/)[0] ?? "";
+        const metric = Number(metricRaw);
+        const ratio = Number.isFinite(metric) ? metric / (fixture.w * fixture.h) : Number.NaN;
+        const baselineRaw = (cmpRefVsMei.stderr || cmpRefVsMei.stdout).trim().split(/\s+/)[0] ?? "";
+        const baseline = Number(baselineRaw);
+        const baselineRatio = Number.isFinite(baseline) ? baseline / (fixture.w * fixture.h) : Number.NaN;
+        const conversionDelta = Number.isFinite(ratio) && Number.isFinite(baselineRatio) ? ratio - baselineRatio : Number.NaN;
+        const offChanged = changedPixelRatio(magick, refDiffPngPath);
+        const offVsMeiChanged = changedPixelRatio(magick, refVsMeiDiffPngPath);
+        const offBBox = trimGeometry(magick, refDiffPngPath);
+        const offVsMeiBBox = trimGeometry(magick, refVsMeiDiffPngPath);
+        officialLines.push(
+          `official_ref=${refImage}\nofficial_metricAE=${metricRaw}\nofficial_ratio=${ratio}\nofficial_status=${cmp.status}\n` +
+            `official_vs_original_metricAE=${baselineRaw}\nofficial_vs_original_ratio=${baselineRatio}\nofficial_vs_original_status=${cmpRefVsMei.status}\n` +
+            `official_conversion_delta_ratio=${conversionDelta}\n` +
+            `official_changed_pixels=${offChanged.changed}\nofficial_changed_total=${offChanged.total}\nofficial_changed_ratio=${offChanged.ratio}\n` +
+            `official_bbox=${offBBox}\n` +
+            `official_vs_original_changed_pixels=${offVsMeiChanged.changed}\nofficial_vs_original_changed_total=${offVsMeiChanged.total}\nofficial_vs_original_changed_ratio=${offVsMeiChanged.ratio}\n` +
+            `official_vs_original_bbox=${offVsMeiBBox}\n` +
+            `reference=${refNormPngPath}\ndiff_official=${refDiffPngPath}\ndiff_official_vs_original=${refVsMeiDiffPngPath}\n`
+        );
+      }
+
+      const cmpSemantic = run(magick, ["compare", "-metric", "AE", meiRenderedPngPath, renderedPngPath, diffSemanticPngPath], true);
+      const semanticRaw = (cmpSemantic.stderr || cmpSemantic.stdout).trim().split(/\s+/)[0] ?? "";
+      const semanticMetric = Number(semanticRaw);
+      const semanticRatio = Number.isFinite(semanticMetric) ? semanticMetric / (fixture.w * fixture.h) : Number.NaN;
+      const semChanged = changedPixelRatio(magick, diffSemanticPngPath);
+      const semBBox = trimGeometry(magick, diffSemanticPngPath);
+      writeFileSync(
+        reportPath,
+        `${officialLines.join("")}` +
+          `semantic_metricAE=${semanticRaw}\nsemantic_ratio=${semanticRatio}\nsemantic_status=${cmpSemantic.status}\n` +
+          `semantic_changed_pixels=${semChanged.changed}\nsemantic_changed_total=${semChanged.total}\nsemantic_changed_ratio=${semChanged.ratio}\n` +
+          `semantic_bbox=${semBBox}\n` +
+          `rendered=${renderedPngPath}\noriginalMeiRendered=${meiRenderedPngPath}\n` +
+          `diff_semantic=${diffSemanticPngPath}\n`,
+        "utf8"
+      );
+
+      expect(officialLines.length).toBeGreaterThan(0);
+      expect(existsSync(diffSemanticPngPath)).toBe(true);
+      expect(Number.isFinite(semanticMetric)).toBe(true);
+      expect(semanticRatio).toBeLessThanOrEqual(fixture.semanticThreshold);
+    }
+  }, 30000);
+});

--- a/tests/spot/local-mei-roundtrip-parity.spot.spec.ts
+++ b/tests/spot/local-mei-roundtrip-parity.spot.spec.ts
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { exportMusicXmlDomToMei, convertMeiToMusicXml } from "../../src/ts/mei-io";
+import { parseMusicXmlDocument } from "../../src/ts/musicxml-io";
+
+type NoteKey = {
+  measure: string;
+  step: string;
+  alter: string;
+  octave: string;
+  duration: string;
+};
+
+const parseDoc = (xml: string): Document => {
+  const doc = parseMusicXmlDocument(xml);
+  expect(doc).not.toBeNull();
+  if (!doc) throw new Error("failed to parse MusicXML");
+  return doc;
+};
+
+const collectNoteKeys = (doc: Document): NoteKey[] => {
+  const out: NoteKey[] = [];
+  for (const measure of Array.from(doc.querySelectorAll("score-partwise > part > measure"))) {
+    const measureNo = measure.getAttribute("number")?.trim() ?? "";
+    for (const note of Array.from(measure.querySelectorAll(":scope > note"))) {
+      if (note.querySelector(":scope > rest")) continue;
+      const step = note.querySelector(":scope > pitch > step")?.textContent?.trim() ?? "";
+      const octave = note.querySelector(":scope > pitch > octave")?.textContent?.trim() ?? "";
+      if (!step || !octave) continue;
+      const alter = note.querySelector(":scope > pitch > alter")?.textContent?.trim() ?? "";
+      const duration = note.querySelector(":scope > duration")?.textContent?.trim() ?? "";
+      out.push({ measure: measureNo, step, alter, octave, duration });
+    }
+  }
+  return out;
+};
+
+const countByKey = (notes: NoteKey[], key: NoteKey): number =>
+  notes.filter(
+    (n) =>
+      n.measure === key.measure
+      && n.step === key.step
+      && n.alter === key.alter
+      && n.octave === key.octave
+      && n.duration === key.duration
+  ).length;
+
+describe("Local parity: MusicXML -> MEI -> MusicXML (paganini)", () => {
+  it("keeps known previously-missing pitch+timing notes in measures 138/140/153", { timeout: 20000 }, () => {
+    const root = resolve(process.cwd(), "tests", "fixtures-local", "roundtrip", "musescore", "paganini");
+    const referencePath = resolve(root, "24no-qi-xiang-qu-di24fan-i-duan-diao-paganini.musicxml");
+    const referenceXml = readFileSync(referencePath, "utf-8");
+
+    const sourceDoc = parseDoc(referenceXml);
+    const mei = exportMusicXmlDomToMei(sourceDoc);
+    const candidateXml = convertMeiToMusicXml(mei);
+    const candidateDoc = parseDoc(candidateXml);
+
+    const artifactsDir = resolve(process.cwd(), "tests", "artifacts", "roundtrip", "mei", "paganini");
+    mkdirSync(artifactsDir, { recursive: true });
+    writeFileSync(resolve(artifactsDir, "candidate.musicxml"), candidateXml, "utf-8");
+    writeFileSync(resolve(artifactsDir, "candidate.mei"), mei, "utf-8");
+
+    const refNotes = collectNoteKeys(sourceDoc);
+    const candNotes = collectNoteKeys(candidateDoc);
+
+    const checkpoints: NoteKey[] = [
+      { measure: "138", step: "D", alter: "", octave: "7", duration: "120" },
+      { measure: "140", step: "C", alter: "", octave: "7", duration: "120" },
+      { measure: "153", step: "C", alter: "1", octave: "4", duration: "69" },
+    ];
+
+    for (const cp of checkpoints) {
+      const refCount = countByKey(refNotes, cp);
+      const candCount = countByKey(candNotes, cp);
+      expect(candCount, `missing note ${JSON.stringify(cp)} (ref=${refCount})`).toBe(refCount);
+    }
+  });
+});

--- a/tests/unit/abc-io.spec.ts
+++ b/tests/unit/abc-io.spec.ts
@@ -216,6 +216,25 @@ C D E F |`;
     expect(save.ok).toBe(true);
   });
 
+  it("ABC import infers bass clef from low notes when clef is omitted", () => {
+    const abc = `X:1
+T:Clef inference
+M:4/4
+L:1/4
+K:C
+V:1
+C,, D,, E,, F,, |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    const sign = outDoc.querySelector("part > measure > attributes > clef > sign")?.textContent?.trim();
+    const line = outDoc.querySelector("part > measure > attributes > clef > line")?.textContent?.trim();
+    expect(sign).toBe("F");
+    expect(line).toBe("4");
+  });
+
   it("ABC import reflows overfull measure content to avoid MEASURE_OVERFULL", () => {
     const overfullAbc = `X:1
 T:Overfull

--- a/tests/unit/mei-io.spec.ts
+++ b/tests/unit/mei-io.spec.ts
@@ -1,4 +1,6 @@
 // @vitest-environment jsdom
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import { convertMeiToMusicXml, exportMusicXmlDomToMei } from "../../src/ts/mei-io";
 import { parseMusicXmlDocument } from "../../src/ts/musicxml-io";
@@ -37,6 +39,126 @@ describe("MEI export", () => {
     expect(mei).toContain("<note ");
     expect(mei).toContain("<rest ");
     expect(mei).toContain("<title>MEI test</title>");
+  });
+
+  it("exports MusicXML transpose into MEI staffDef trans.diat/trans.semi", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Clarinet in A</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>480</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <transpose><diatonic>-2</diatonic><chromatic>-3</chromatic></transpose>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>480</duration><voice>1</voice><type>quarter</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const doc = parseMusicXmlDocument(xml);
+    expect(doc).not.toBeNull();
+    if (!doc) return;
+    const mei = exportMusicXmlDomToMei(doc);
+    expect(mei).toContain('trans.diat="-2"');
+    expect(mei).toContain('trans.semi="-3"');
+  });
+
+  it("exports MEI with default meiversion=5.1", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list><score-part id="P1"><part-name>Piano</part-name></score-part></part-list>
+  <part id="P1"><measure number="1"><note><rest/><duration>480</duration><voice>1</voice><type>quarter</type></note></measure></part>
+</score-partwise>`;
+    const doc = parseMusicXmlDocument(xml);
+    expect(doc).not.toBeNull();
+    if (!doc) return;
+    const mei = exportMusicXmlDomToMei(doc);
+    expect(mei).toContain('meiversion="5.1"');
+  });
+
+  it("exports MEI with custom meiversion when specified", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list><score-part id="P1"><part-name>Piano</part-name></score-part></part-list>
+  <part id="P1"><measure number="1"><note><rest/><duration>480</duration><voice>1</voice><type>quarter</type></note></measure></part>
+</score-partwise>`;
+    const doc = parseMusicXmlDocument(xml);
+    expect(doc).not.toBeNull();
+    if (!doc) return;
+    const mei = exportMusicXmlDomToMei(doc, { meiVersion: "4.0.1" });
+    expect(mei).toContain('meiversion="4.0.1"');
+  });
+
+  it("exports full-measure rest as MEI mRest", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list><score-part id="P1"><part-name>Piano</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>480</divisions>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+      </attributes>
+      <note><rest/><duration>1920</duration><voice>1</voice><type>whole</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const doc = parseMusicXmlDocument(xml);
+    expect(doc).not.toBeNull();
+    if (!doc) return;
+    const mei = exportMusicXmlDomToMei(doc);
+    expect(mei).toContain("<mRest ");
+    expect(mei).toContain('dur="1"');
+  });
+
+  it("exports invisible rest (print-object=no) as MEI space", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list><score-part id="P1"><part-name>Piano</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>480</divisions>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+      </attributes>
+      <note print-object="no"><rest/><duration>480</duration><voice>1</voice><type>quarter</type></note>
+      <note><rest/><duration>480</duration><voice>1</voice><type>quarter</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const doc = parseMusicXmlDocument(xml);
+    expect(doc).not.toBeNull();
+    if (!doc) return;
+    const mei = exportMusicXmlDomToMei(doc);
+    expect(mei).toContain("<space ");
+    expect(mei).toContain("<rest ");
+  });
+
+  it("exports full-measure invisible rest as MEI mSpace", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list><score-part id="P1"><part-name>Piano</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>480</divisions>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+      </attributes>
+      <note print-object="no"><rest/><duration>1920</duration><voice>1</voice><type>whole</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const doc = parseMusicXmlDocument(xml);
+    expect(doc).not.toBeNull();
+    if (!doc) return;
+    const mei = exportMusicXmlDomToMei(doc);
+    expect(mei).toContain("<mSpace ");
+    expect(mei).toContain('dur="1"');
   });
 
   it("imports simple MEI note sequence into MusicXML", () => {
@@ -97,6 +219,1977 @@ describe("MEI export", () => {
     ).toContain("k=note");
   });
 
+  it("imports mid-score scoreDef changes (time/key/clef) into subsequent MusicXML measure attributes", () => {
+    const mei = `<?xml version="1.0" encoding="UTF-8"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
+  <music>
+    <body>
+      <mdiv>
+        <score>
+          <scoreDef meter.count="4" meter.unit="4" key.sig="0">
+            <staffGrp><staffDef n="1" label="Lead" clef.shape="G" clef.line="2"/></staffGrp>
+          </scoreDef>
+          <section>
+            <measure n="1">
+              <staff n="1"><layer n="1"><note pname="c" oct="4" dur="4"/></layer></staff>
+            </measure>
+            <scoreDef meter.count="3" meter.unit="4" key.sig="2s">
+              <staffGrp><staffDef n="1" clef.shape="F" clef.line="4"/></staffGrp>
+            </scoreDef>
+            <measure n="2">
+              <staff n="1"><layer n="1"><note pname="d" oct="3" dur="4"/></layer></staff>
+            </measure>
+          </section>
+        </score>
+      </mdiv>
+    </body>
+  </music>
+</mei>`;
+
+    const xml = convertMeiToMusicXml(mei);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    expect(outDoc.querySelector('part > measure[number="1"] > attributes > time > beats')?.textContent?.trim()).toBe("4");
+    expect(outDoc.querySelector('part > measure[number="1"] > attributes > key > fifths')?.textContent?.trim()).toBe("0");
+    expect(outDoc.querySelector('part > measure[number="1"] > attributes > clef > sign')?.textContent?.trim()).toBe("G");
+
+    expect(outDoc.querySelector('part > measure[number="2"] > attributes > time > beats')?.textContent?.trim()).toBe("3");
+    expect(outDoc.querySelector('part > measure[number="2"] > attributes > key > fifths')?.textContent?.trim()).toBe("2");
+    expect(outDoc.querySelector('part > measure[number="2"] > attributes > clef > sign')?.textContent?.trim()).toBe("F");
+    expect(outDoc.querySelector('part > measure[number="2"] > attributes > clef > line')?.textContent?.trim()).toBe("4");
+  });
+
+  it("imports mid-score staffDef changes (key/clef/transpose) for the target staff", () => {
+    const mei = `<?xml version="1.0" encoding="UTF-8"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
+  <music>
+    <body>
+      <mdiv>
+        <score>
+          <scoreDef meter.count="4" meter.unit="4" key.sig="0">
+            <staffGrp><staffDef n="1" label="Lead" clef.shape="G" clef.line="2"/></staffGrp>
+          </scoreDef>
+          <section>
+            <measure n="1">
+              <staff n="1"><layer n="1"><note pname="c" oct="4" dur="4"/></layer></staff>
+            </measure>
+            <measure n="2">
+              <staffDef n="1" key.sig="2" clef.shape="F" clef.line="4" trans.diat="1" trans.semi="2"/>
+              <staff n="1"><layer n="1"><note pname="d" oct="4" dur="4"/></layer></staff>
+            </measure>
+          </section>
+        </score>
+      </mdiv>
+    </body>
+  </music>
+</mei>`;
+
+    const xml = convertMeiToMusicXml(mei);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    const measure2 = outDoc.querySelector('part > measure[number="2"]');
+    expect(measure2).not.toBeNull();
+    if (!measure2) return;
+    expect(measure2.querySelector(":scope > attributes > key > fifths")?.textContent?.trim()).toBe("2");
+    expect(measure2.querySelector(":scope > attributes > clef > sign")?.textContent?.trim()).toBe("F");
+    expect(measure2.querySelector(":scope > attributes > clef > line")?.textContent?.trim()).toBe("4");
+    expect(measure2.querySelector(":scope > attributes > transpose > diatonic")?.textContent?.trim()).toBe("1");
+    expect(measure2.querySelector(":scope > attributes > transpose > chromatic")?.textContent?.trim()).toBe("2");
+  });
+
+  it("imports transposition from MEI staffDef trans.diat/trans.semi into MusicXML transpose", () => {
+    const mei = `<?xml version="1.0" encoding="UTF-8"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
+  <music>
+    <body>
+      <mdiv>
+        <score>
+          <scoreDef meter.count="4" meter.unit="4" key.sig="0">
+            <staffGrp>
+              <staffDef n="1" label="Clarinet in A" clef.shape="G" clef.line="2" trans.diat="-2" trans.semi="-3"/>
+            </staffGrp>
+          </scoreDef>
+          <section>
+            <measure n="1">
+              <staff n="1"><layer n="1"><note pname="c" oct="5" dur="4"/></layer></staff>
+            </measure>
+          </section>
+        </score>
+      </mdiv>
+    </body>
+  </music>
+</mei>`;
+    const xml = convertMeiToMusicXml(mei);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector("part > measure > attributes > transpose > diatonic")?.textContent?.trim()).toBe("-2");
+    expect(outDoc.querySelector("part > measure > attributes > transpose > chromatic")?.textContent?.trim()).toBe("-3");
+  });
+
+  it("imports transposition from scoreDef trans.diat/trans.semi when staffDef omits transposition", () => {
+    const mei = `<?xml version="1.0" encoding="UTF-8"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
+  <music>
+    <body>
+      <mdiv>
+        <score>
+          <scoreDef meter.count="4" meter.unit="4" key.sig="0" trans.diat="-2" trans.semi="-3">
+            <staffGrp>
+              <staffDef n="1" label="Clarinet in A" clef.shape="G" clef.line="2"/>
+            </staffGrp>
+          </scoreDef>
+          <section>
+            <measure n="1">
+              <staff n="1"><layer n="1"><note pname="c" oct="5" dur="4"/></layer></staff>
+            </measure>
+          </section>
+        </score>
+      </mdiv>
+    </body>
+  </music>
+</mei>`;
+    const xml = convertMeiToMusicXml(mei);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector("part > measure > attributes > transpose > diatonic")?.textContent?.trim()).toBe("-2");
+    expect(outDoc.querySelector("part > measure > attributes > transpose > chromatic")?.textContent?.trim()).toBe("-3");
+  });
+
+  it("keeps accidental pitch on cross-measure tie even when tied note omits accid", () => {
+    const mei = `<?xml version="1.0" encoding="UTF-8"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
+  <music>
+    <body>
+      <mdiv>
+        <score>
+          <scoreDef meter.count="4" meter.unit="4" key.sig="0">
+            <staffGrp><staffDef n="1" label="Lead" clef.shape="G" clef.line="2"/></staffGrp>
+          </scoreDef>
+          <section>
+            <measure n="1">
+              <staff n="1">
+                <layer n="1">
+                  <note pname="f" oct="4" dur="4" accid="s" tie="i"/>
+                </layer>
+              </staff>
+            </measure>
+            <measure n="2">
+              <staff n="1">
+                <layer n="1">
+                  <note pname="f" oct="4" dur="4" tie="t"/>
+                </layer>
+              </staff>
+            </measure>
+          </section>
+        </score>
+      </mdiv>
+    </body>
+  </music>
+</mei>`;
+    const xml = convertMeiToMusicXml(mei);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    const m1Alter = outDoc.querySelector('part > measure[number="1"] > note > pitch > alter')?.textContent?.trim();
+    const m2Alter = outDoc.querySelector('part > measure[number="2"] > note > pitch > alter')?.textContent?.trim();
+    expect(m1Alter).toBe("1");
+    expect(m2Alter).toBe("1");
+    expect(outDoc.querySelector('part > measure[number="1"] > note > tie[type="start"]')).not.toBeNull();
+    expect(outDoc.querySelector('part > measure[number="2"] > note > tie[type="stop"]')).not.toBeNull();
+  });
+
+  it("prefers staffDef transposition over scoreDef transposition for target staff", () => {
+    const mei = `<?xml version="1.0" encoding="UTF-8"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
+  <music>
+    <body>
+      <mdiv>
+        <score>
+          <scoreDef meter.count="4" meter.unit="4" key.sig="0" trans.diat="-2" trans.semi="-3">
+            <staffGrp>
+              <staffDef n="1" label="Eb Clarinet" clef.shape="G" clef.line="2" trans.diat="2" trans.semi="3"/>
+            </staffGrp>
+          </scoreDef>
+          <section>
+            <measure n="1">
+              <staff n="1"><layer n="1"><note pname="g" oct="4" dur="4"/></layer></staff>
+            </measure>
+          </section>
+        </score>
+      </mdiv>
+    </body>
+  </music>
+</mei>`;
+    const xml = convertMeiToMusicXml(mei);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector("part > measure > attributes > transpose > diatonic")?.textContent?.trim()).toBe("2");
+    expect(outDoc.querySelector("part > measure > attributes > transpose > chromatic")?.textContent?.trim()).toBe("3");
+  });
+
+  it("imports viola alto clef from staffDef child <clef> (C3)", () => {
+    const mei = `<?xml version="1.0" encoding="UTF-8"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
+  <music>
+    <body>
+      <mdiv>
+        <score>
+          <scoreDef meter.count="4" meter.unit="4" key.sig="0">
+            <staffGrp>
+              <staffDef n="1" label="Viola" lines="5">
+                <clef shape="C" line="3"/>
+              </staffDef>
+            </staffGrp>
+          </scoreDef>
+          <section>
+            <measure n="1">
+              <staff n="1"><layer n="1"><note pname="c" oct="4" dur="4"/></layer></staff>
+            </measure>
+          </section>
+        </score>
+      </mdiv>
+    </body>
+  </music>
+</mei>`;
+
+    const xml = convertMeiToMusicXml(mei);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    expect(outDoc.querySelector('part > measure[number="1"] > attributes > clef > sign')?.textContent?.trim()).toBe("C");
+    expect(outDoc.querySelector('part > measure[number="1"] > attributes > clef > line')?.textContent?.trim()).toBe("3");
+  });
+
+  it("keeps prior alto clef when later staffDef omits clef", () => {
+    const mei = `<?xml version="1.0" encoding="UTF-8"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
+  <music>
+    <body>
+      <mdiv>
+        <score>
+          <scoreDef meter.count="4" meter.unit="4" key.sig="0">
+            <staffGrp>
+              <staffDef n="1" label="Viola" lines="5" clef.shape="C" clef.line="3"/>
+            </staffGrp>
+          </scoreDef>
+          <section>
+            <scoreDef>
+              <staffGrp>
+                <staffDef n="1" label="Viola"/>
+              </staffGrp>
+            </scoreDef>
+            <measure n="1">
+              <staff n="1"><layer n="1"><note pname="c" oct="4" dur="4"/></layer></staff>
+            </measure>
+          </section>
+        </score>
+      </mdiv>
+    </body>
+  </music>
+</mei>`;
+
+    const xml = convertMeiToMusicXml(mei);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    expect(outDoc.querySelector('part > measure[number="1"] > attributes > clef > sign')?.textContent?.trim()).toBe("C");
+    expect(outDoc.querySelector('part > measure[number="1"] > attributes > clef > line')?.textContent?.trim()).toBe("3");
+  });
+
+  it("applies scoreDef placed inside a measure before staff content", () => {
+    const mei = `<?xml version="1.0" encoding="UTF-8"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
+  <music>
+    <body>
+      <mdiv>
+        <score>
+          <scoreDef meter.count="4" meter.unit="4" key.sig="0">
+            <staffGrp><staffDef n="1" label="Lead" clef.shape="G" clef.line="2"/></staffGrp>
+          </scoreDef>
+          <section>
+            <measure n="1">
+              <scoreDef key.sig="2s">
+                <staffGrp><staffDef n="1" clef.shape="F" clef.line="4"/></staffGrp>
+              </scoreDef>
+              <staff n="1"><layer n="1"><note pname="d" oct="3" dur="4"/></layer></staff>
+            </measure>
+          </section>
+        </score>
+      </mdiv>
+    </body>
+  </music>
+</mei>`;
+
+    const xml = convertMeiToMusicXml(mei);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    expect(outDoc.querySelector('part > measure[number="1"] > attributes > key > fifths')?.textContent?.trim()).toBe("2");
+    expect(outDoc.querySelector('part > measure[number="1"] > attributes > clef > sign')?.textContent?.trim()).toBe("F");
+    expect(outDoc.querySelector('part > measure[number="1"] > attributes > clef > line')?.textContent?.trim()).toBe("4");
+  });
+
+  it("emits initial key/time/clef on first measure that contains target staff", () => {
+    const mei = `<?xml version="1.0" encoding="UTF-8"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
+  <music>
+    <body>
+      <mdiv>
+        <score>
+          <scoreDef meter.count="3" meter.unit="4" key.sig="2f">
+            <staffGrp>
+              <staffDef n="1" label="Main" clef.shape="G" clef.line="2"/>
+              <staffDef n="2" label="Other" clef.shape="F" clef.line="4"/>
+            </staffGrp>
+          </scoreDef>
+          <section>
+            <measure n="1">
+              <staff n="2"><layer n="1"><rest dur="4"/></layer></staff>
+            </measure>
+            <measure n="2">
+              <staff n="1"><layer n="1"><note pname="b" oct="4" dur="4"/></layer></staff>
+            </measure>
+          </section>
+        </score>
+      </mdiv>
+    </body>
+  </music>
+</mei>`;
+    const xml = convertMeiToMusicXml(mei);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const m2attrs = outDoc.querySelector('part[id="P1"] > measure[number="2"] > attributes');
+    expect(m2attrs).not.toBeNull();
+    expect(m2attrs?.querySelector(":scope > divisions")?.textContent?.trim()).toBe("480");
+    expect(m2attrs?.querySelector(":scope > key > fifths")?.textContent?.trim()).toBe("-2");
+    expect(m2attrs?.querySelector(":scope > time > beats")?.textContent?.trim()).toBe("3");
+    expect(m2attrs?.querySelector(":scope > clef > sign")?.textContent?.trim()).toBe("G");
+  });
+
+  it("applies key signature implied accidental to pitch alter when MEI accid is omitted", () => {
+    const mei = `<?xml version="1.0" encoding="UTF-8"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
+  <music>
+    <body>
+      <mdiv>
+        <score>
+          <scoreDef meter.count="4" meter.unit="4" key.sig="1s">
+            <staffGrp><staffDef n="1" label="Lead" clef.shape="G" clef.line="2"/></staffGrp>
+          </scoreDef>
+          <section>
+            <measure n="1">
+              <staff n="1">
+                <layer n="1">
+                  <note pname="f" oct="4" dur="4"/>
+                  <note pname="c" oct="4" dur="4"/>
+                  <note pname="g" oct="4" dur="4"/>
+                </layer>
+              </staff>
+            </measure>
+          </section>
+        </score>
+      </mdiv>
+    </body>
+  </music>
+</mei>`;
+    const xml = convertMeiToMusicXml(mei);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const n1 = outDoc.querySelector("part > measure > note:nth-of-type(1)");
+    const n2 = outDoc.querySelector("part > measure > note:nth-of-type(2)");
+    const n3 = outDoc.querySelector("part > measure > note:nth-of-type(3)");
+    expect(n1?.querySelector(":scope > pitch > alter")?.textContent?.trim()).toBe("1");
+    expect(n2?.querySelector(":scope > pitch > alter")).toBeNull();
+    expect(n3?.querySelector(":scope > pitch > alter")).toBeNull();
+    expect(n1?.querySelector(":scope > accidental")).toBeNull();
+  });
+
+  it("prefers staffDef key.sig over scoreDef key.sig for the target staff", () => {
+    const mei = `<?xml version="1.0" encoding="UTF-8"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
+  <music>
+    <body>
+      <mdiv>
+        <score>
+          <scoreDef meter.count="4" meter.unit="4" key.sig="0">
+            <staffGrp>
+              <staffDef n="1" label="Lead" key.sig="1s" clef.shape="G" clef.line="2"/>
+            </staffGrp>
+          </scoreDef>
+          <section>
+            <measure n="1">
+              <staff n="1">
+                <layer n="1">
+                  <note pname="f" oct="4" dur="4"/>
+                </layer>
+              </staff>
+            </measure>
+          </section>
+        </score>
+      </mdiv>
+    </body>
+  </music>
+</mei>`;
+    const xml = convertMeiToMusicXml(mei);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    expect(outDoc.querySelector("part > measure > attributes > key > fifths")?.textContent?.trim()).toBe("1");
+    expect(outDoc.querySelector("part > measure > note > pitch > alter")?.textContent?.trim()).toBe("1");
+  });
+
+  it("accepts MEI keysig alias (without dot) on scoreDef/staffDef", () => {
+    const mei = `<?xml version="1.0" encoding="UTF-8"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
+  <music>
+    <body>
+      <mdiv>
+        <score>
+          <scoreDef meter.count="4" meter.unit="4" keysig="0">
+            <staffGrp>
+              <staffDef n="1" label="Lead" keysig="1s" clef.shape="G" clef.line="2"/>
+            </staffGrp>
+          </scoreDef>
+          <section>
+            <measure n="1">
+              <staff n="1">
+                <layer n="1">
+                  <note pname="f" oct="4" dur="4"/>
+                </layer>
+              </staff>
+            </measure>
+          </section>
+        </score>
+      </mdiv>
+    </body>
+  </music>
+</mei>`;
+    const xml = convertMeiToMusicXml(mei);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    expect(outDoc.querySelector("part > measure > attributes > key > fifths")?.textContent?.trim()).toBe("1");
+    expect(outDoc.querySelector("part > measure > note > pitch > alter")?.textContent?.trim()).toBe("1");
+  });
+
+  it("infers key fifths from MEI key.pname/key.mode when keysig is absent", () => {
+    const mei = `<?xml version="1.0" encoding="UTF-8"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
+  <music>
+    <body>
+      <mdiv>
+        <score>
+          <scoreDef meter.count="4" meter.unit="4" key.pname="g" key.mode="major">
+            <staffGrp>
+              <staffDef n="1" label="Lead" clef.shape="G" clef.line="2"/>
+            </staffGrp>
+          </scoreDef>
+          <section>
+            <measure n="1">
+              <staff n="1">
+                <layer n="1">
+                  <note pname="f" oct="4" dur="4"/>
+                </layer>
+              </staff>
+            </measure>
+          </section>
+        </score>
+      </mdiv>
+    </body>
+  </music>
+</mei>`;
+    const xml = convertMeiToMusicXml(mei);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    expect(outDoc.querySelector("part > measure > attributes > key > fifths")?.textContent?.trim()).toBe("1");
+    expect(outDoc.querySelector("part > measure > note > pitch > alter")?.textContent?.trim()).toBe("1");
+  });
+
+  it("infers minor key fifths from MEI key.pname/key.mode when keysig is absent", () => {
+    const mei = `<?xml version="1.0" encoding="UTF-8"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
+  <music>
+    <body>
+      <mdiv>
+        <score>
+          <scoreDef meter.count="4" meter.unit="4" key.pname="d" key.mode="minor">
+            <staffGrp>
+              <staffDef n="1" label="Lead" clef.shape="G" clef.line="2"/>
+            </staffGrp>
+          </scoreDef>
+          <section>
+            <measure n="1">
+              <staff n="1">
+                <layer n="1">
+                  <note pname="b" oct="4" dur="4"/>
+                </layer>
+              </staff>
+            </measure>
+          </section>
+        </score>
+      </mdiv>
+    </body>
+  </music>
+</mei>`;
+    const xml = convertMeiToMusicXml(mei);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    expect(outDoc.querySelector("part > measure > attributes > key > fifths")?.textContent?.trim()).toBe("-1");
+    expect(outDoc.querySelector("part > measure > note > pitch > alter")?.textContent?.trim()).toBe("-1");
+  });
+
+  it("infers key fifths from MEI key.pname + key.accid when keysig is absent", () => {
+    const mei = `<?xml version="1.0" encoding="UTF-8"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
+  <music>
+    <body>
+      <mdiv>
+        <score>
+          <scoreDef meter.count="4" meter.unit="4" key.pname="f" key.accid="s" key.mode="major">
+            <staffGrp>
+              <staffDef n="1" label="Lead" clef.shape="G" clef.line="2"/>
+            </staffGrp>
+          </scoreDef>
+          <section>
+            <measure n="1">
+              <staff n="1">
+                <layer n="1">
+                  <note pname="c" oct="4" dur="4"/>
+                </layer>
+              </staff>
+            </measure>
+          </section>
+        </score>
+      </mdiv>
+    </body>
+  </music>
+</mei>`;
+    const xml = convertMeiToMusicXml(mei);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    expect(outDoc.querySelector("part > measure > attributes > key > fifths")?.textContent?.trim()).toBe("6");
+    expect(outDoc.querySelector("part > measure > note > pitch > alter")?.textContent?.trim()).toBe("1");
+  });
+
+  it("imports first child <mei> with score content when root is <meiCorpus>", () => {
+    const meiCorpus = `<?xml version="1.0" encoding="UTF-8"?>
+<meiCorpus xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
+  <meiHead>
+    <fileDesc><titleStmt><title>Corpus</title></titleStmt><pubStmt><p>test</p></pubStmt></fileDesc>
+  </meiHead>
+  <mei>
+    <meiHead>
+      <fileDesc><titleStmt><title>First score</title></titleStmt><pubStmt><p>test</p></pubStmt></fileDesc>
+    </meiHead>
+    <music>
+      <body><mdiv><score>
+        <scoreDef meter.count="4" meter.unit="4" key.sig="0"><staffGrp><staffDef n="1" label="S1" clef.shape="G" clef.line="2"/></staffGrp></scoreDef>
+        <section><measure n="1"><staff n="1"><layer n="1"><note pname="c" oct="4" dur="4"/></layer></staff></measure></section>
+      </score></mdiv></body>
+    </music>
+  </mei>
+  <mei>
+    <meiHead>
+      <fileDesc><titleStmt><title>Second score</title></titleStmt><pubStmt><p>test</p></pubStmt></fileDesc>
+    </meiHead>
+    <music>
+      <body><mdiv><score>
+        <scoreDef meter.count="4" meter.unit="4" key.sig="0"><staffGrp><staffDef n="1" label="S2" clef.shape="G" clef.line="2"/></staffGrp></scoreDef>
+        <section><measure n="1"><staff n="1"><layer n="1"><note pname="d" oct="5" dur="4"/></layer></staff></measure></section>
+      </score></mdiv></body>
+    </music>
+  </mei>
+</meiCorpus>`;
+
+    const xml = convertMeiToMusicXml(meiCorpus);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector("work > work-title")?.textContent?.trim()).toBe("First score");
+    expect(outDoc.querySelector("part > measure > note > pitch > step")?.textContent?.trim()).toBe("C");
+    expect(outDoc.querySelector("part > measure > note > pitch > octave")?.textContent?.trim()).toBe("4");
+  });
+
+  it("falls through empty first child <mei> in <meiCorpus> and imports next score-bearing <mei>", () => {
+    const meiCorpus = `<?xml version="1.0" encoding="UTF-8"?>
+<meiCorpus xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
+  <mei>
+    <meiHead><fileDesc><titleStmt><title>Header only</title></titleStmt><pubStmt><p>test</p></pubStmt></fileDesc></meiHead>
+  </mei>
+  <mei>
+    <meiHead><fileDesc><titleStmt><title>Playable score</title></titleStmt><pubStmt><p>test</p></pubStmt></fileDesc></meiHead>
+    <music>
+      <body><mdiv><score>
+        <scoreDef meter.count="4" meter.unit="4" key.sig="0"><staffGrp><staffDef n="1" label="S" clef.shape="G" clef.line="2"/></staffGrp></scoreDef>
+        <section><measure n="1"><staff n="1"><layer n="1"><note pname="e" oct="5" dur="4"/></layer></staff></measure></section>
+      </score></mdiv></body>
+    </music>
+  </mei>
+</meiCorpus>`;
+
+    const xml = convertMeiToMusicXml(meiCorpus);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector("work > work-title")?.textContent?.trim()).toBe("Playable score");
+    expect(outDoc.querySelector("part > measure > note > pitch > step")?.textContent?.trim()).toBe("E");
+    expect(outDoc.querySelector("part > measure > note > pitch > octave")?.textContent?.trim()).toBe("5");
+  });
+
+  it("supports selecting meiCorpus child by index", () => {
+    const meiCorpus = `<?xml version="1.0" encoding="UTF-8"?>
+<meiCorpus xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
+  <mei>
+    <meiHead><fileDesc><titleStmt><title>First score</title></titleStmt><pubStmt><p>test</p></pubStmt></fileDesc></meiHead>
+    <music>
+      <body><mdiv><score>
+        <scoreDef meter.count="4" meter.unit="4" key.sig="0"><staffGrp><staffDef n="1" label="S1" clef.shape="G" clef.line="2"/></staffGrp></scoreDef>
+        <section><measure n="1"><staff n="1"><layer n="1"><note pname="c" oct="4" dur="4"/></layer></staff></measure></section>
+      </score></mdiv></body>
+    </music>
+  </mei>
+  <mei>
+    <meiHead><fileDesc><titleStmt><title>Second score</title></titleStmt><pubStmt><p>test</p></pubStmt></fileDesc></meiHead>
+    <music>
+      <body><mdiv><score>
+        <scoreDef meter.count="4" meter.unit="4" key.sig="0"><staffGrp><staffDef n="1" label="S2" clef.shape="G" clef.line="2"/></staffGrp></scoreDef>
+        <section><measure n="1"><staff n="1"><layer n="1"><note pname="d" oct="5" dur="4"/></layer></staff></measure></section>
+      </score></mdiv></body>
+    </music>
+  </mei>
+</meiCorpus>`;
+
+    const xml = convertMeiToMusicXml(meiCorpus, { meiCorpusIndex: 1 });
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector("work > work-title")?.textContent?.trim()).toBe("Second score");
+    expect(outDoc.querySelector("part > measure > note > pitch > step")?.textContent?.trim()).toBe("D");
+    expect(outDoc.querySelector("part > measure > note > pitch > octave")?.textContent?.trim()).toBe("5");
+  });
+
+  it("throws when meiCorpusIndex is out of range", () => {
+    const meiCorpus = `<?xml version="1.0" encoding="UTF-8"?>
+<meiCorpus xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
+  <mei><meiHead><fileDesc><titleStmt><title>A</title></titleStmt><pubStmt><p>x</p></pubStmt></fileDesc></meiHead></mei>
+</meiCorpus>`;
+    expect(() => convertMeiToMusicXml(meiCorpus, { meiCorpusIndex: 3 })).toThrow(/index out of range/i);
+  });
+
+  it("imports staff-level slur control events via startid/endid into note notations", () => {
+    const mei = `<?xml version="1.0" encoding="UTF-8"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
+  <music>
+    <body>
+      <mdiv>
+        <score>
+          <scoreDef meter.count="4" meter.unit="4" key.sig="0">
+            <staffGrp><staffDef n="1" label="Lead" clef.shape="G" clef.line="2"/></staffGrp>
+          </scoreDef>
+          <section>
+            <measure n="1">
+              <staff n="1">
+                <layer n="1">
+                  <note xml:id="n1" pname="c" oct="4" dur="4"/>
+                  <note xml:id="n2" pname="d" oct="4" dur="4"/>
+                </layer>
+                <slur startid="#n1" endid="#n2"/>
+              </staff>
+            </measure>
+          </section>
+        </score>
+      </mdiv>
+    </body>
+  </music>
+</mei>`;
+
+    const xml = convertMeiToMusicXml(mei);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    const first = outDoc.querySelector("part > measure > note:nth-of-type(1)");
+    const second = outDoc.querySelector("part > measure > note:nth-of-type(2)");
+    expect(first?.querySelector(':scope > notations > slur[type="start"]')).not.toBeNull();
+    expect(second?.querySelector(':scope > notations > slur[type="stop"]')).not.toBeNull();
+  });
+
+  it("imports staff-level tie control events via startid/endid into tie/tied", () => {
+    const mei = `<?xml version="1.0" encoding="UTF-8"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
+  <music>
+    <body>
+      <mdiv>
+        <score>
+          <scoreDef meter.count="4" meter.unit="4" key.sig="0">
+            <staffGrp><staffDef n="1" label="Lead" clef.shape="G" clef.line="2"/></staffGrp>
+          </scoreDef>
+          <section>
+            <measure n="1">
+              <staff n="1">
+                <layer n="1">
+                  <note xml:id="n1" pname="c" oct="4" dur="4"/>
+                  <note xml:id="n2" pname="c" oct="4" dur="4"/>
+                </layer>
+                <tie startid="#n1" endid="#n2"/>
+              </staff>
+            </measure>
+          </section>
+        </score>
+      </mdiv>
+    </body>
+  </music>
+</mei>`;
+
+    const xml = convertMeiToMusicXml(mei);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    const first = outDoc.querySelector("part > measure > note:nth-of-type(1)");
+    const second = outDoc.querySelector("part > measure > note:nth-of-type(2)");
+    expect(first?.querySelector(':scope > tie[type="start"]')).not.toBeNull();
+    expect(first?.querySelector(':scope > notations > tied[type="start"]')).not.toBeNull();
+    expect(second?.querySelector(':scope > tie[type="stop"]')).not.toBeNull();
+    expect(second?.querySelector(':scope > notations > tied[type="stop"]')).not.toBeNull();
+  });
+
+  it("resolves tie control-event startid from xml:id on chord child note", () => {
+    const mei = `<?xml version="1.0" encoding="UTF-8"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
+  <music>
+    <body>
+      <mdiv>
+        <score>
+          <scoreDef meter.count="4" meter.unit="4" key.sig="0">
+            <staffGrp><staffDef n="1" label="Lead" clef.shape="G" clef.line="2"/></staffGrp>
+          </scoreDef>
+          <section>
+            <measure n="1">
+              <staff n="1">
+                <layer n="1">
+                  <chord dur="4">
+                    <note xml:id="cn1" pname="c" oct="4"/>
+                    <note pname="e" oct="4"/>
+                  </chord>
+                  <note xml:id="n2" pname="c" oct="4" dur="4"/>
+                </layer>
+                <tie startid="#cn1" endid="#n2"/>
+              </staff>
+            </measure>
+          </section>
+        </score>
+      </mdiv>
+    </body>
+  </music>
+</mei>`;
+
+    const xml = convertMeiToMusicXml(mei);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    const first = outDoc.querySelector("part > measure > note:nth-of-type(1)");
+    const third = outDoc.querySelector("part > measure > note:nth-of-type(3)");
+    expect(first?.querySelector(':scope > tie[type="start"]')).not.toBeNull();
+    expect(third?.querySelector(':scope > tie[type="stop"]')).not.toBeNull();
+  });
+
+  it("applies tie-control accidental carry when tied stop omits accid", () => {
+    const mei = `<?xml version="1.0" encoding="UTF-8"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
+  <music>
+    <body>
+      <mdiv>
+        <score>
+          <scoreDef meter.count="4" meter.unit="4" key.sig="0">
+            <staffGrp><staffDef n="1" label="Lead" clef.shape="G" clef.line="2"/></staffGrp>
+          </scoreDef>
+          <section>
+            <measure n="1">
+              <staff n="1">
+                <layer n="1">
+                  <note xml:id="n1" pname="f" oct="4" dur="4" accid="s"/>
+                  <note xml:id="n2" pname="f" oct="4" dur="4"/>
+                </layer>
+                <tie startid="#n1" endid="#n2"/>
+              </staff>
+            </measure>
+          </section>
+        </score>
+      </mdiv>
+    </body>
+  </music>
+</mei>`;
+
+    const xml = convertMeiToMusicXml(mei);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    const first = outDoc.querySelector("part > measure > note:nth-of-type(1)");
+    const second = outDoc.querySelector("part > measure > note:nth-of-type(2)");
+    expect(first?.querySelector(":scope > pitch > alter")?.textContent?.trim()).toBe("1");
+    expect(second?.querySelector(":scope > pitch > alter")?.textContent?.trim()).toBe("1");
+    expect(first?.querySelector(':scope > tie[type="start"]')).not.toBeNull();
+    expect(second?.querySelector(':scope > tie[type="stop"]')).not.toBeNull();
+  });
+
+  it("imports staff-level slur control events via tstamp/tstamp2", () => {
+    const mei = `<?xml version="1.0" encoding="UTF-8"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
+  <music>
+    <body>
+      <mdiv>
+        <score>
+          <scoreDef meter.count="4" meter.unit="4" key.sig="0">
+            <staffGrp><staffDef n="1" label="Lead" clef.shape="G" clef.line="2"/></staffGrp>
+          </scoreDef>
+          <section>
+            <measure n="1">
+              <staff n="1">
+                <layer n="1">
+                  <note pname="c" oct="4" dur="4"/>
+                  <note pname="d" oct="4" dur="4"/>
+                </layer>
+                <slur tstamp="1" tstamp2="2"/>
+              </staff>
+            </measure>
+          </section>
+        </score>
+      </mdiv>
+    </body>
+  </music>
+</mei>`;
+    const xml = convertMeiToMusicXml(mei);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    const first = outDoc.querySelector("part > measure > note:nth-of-type(1)");
+    const second = outDoc.querySelector("part > measure > note:nth-of-type(2)");
+    expect(first?.querySelector(':scope > notations > slur[type="start"]')).not.toBeNull();
+    expect(second?.querySelector(':scope > notations > slur[type="stop"]')).not.toBeNull();
+  });
+
+  it("imports staff-level tie control events via tstamp/tstamp2", () => {
+    const mei = `<?xml version="1.0" encoding="UTF-8"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
+  <music>
+    <body>
+      <mdiv>
+        <score>
+          <scoreDef meter.count="4" meter.unit="4" key.sig="0">
+            <staffGrp><staffDef n="1" label="Lead" clef.shape="G" clef.line="2"/></staffGrp>
+          </scoreDef>
+          <section>
+            <measure n="1">
+              <staff n="1">
+                <layer n="1">
+                  <note pname="c" oct="4" dur="4"/>
+                  <note pname="c" oct="4" dur="4"/>
+                </layer>
+                <tie tstamp="1" tstamp2="2"/>
+              </staff>
+            </measure>
+          </section>
+        </score>
+      </mdiv>
+    </body>
+  </music>
+</mei>`;
+    const xml = convertMeiToMusicXml(mei);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    const first = outDoc.querySelector("part > measure > note:nth-of-type(1)");
+    const second = outDoc.querySelector("part > measure > note:nth-of-type(2)");
+    expect(first?.querySelector(':scope > tie[type="start"]')).not.toBeNull();
+    expect(first?.querySelector(':scope > notations > tied[type="start"]')).not.toBeNull();
+    expect(second?.querySelector(':scope > tie[type="stop"]')).not.toBeNull();
+    expect(second?.querySelector(':scope > notations > tied[type="stop"]')).not.toBeNull();
+  });
+
+  it("imports layer-level slur control events via startid/endid", () => {
+    const mei = `<?xml version="1.0" encoding="UTF-8"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
+  <music>
+    <body>
+      <mdiv>
+        <score>
+          <scoreDef meter.count="4" meter.unit="4" key.sig="0">
+            <staffGrp><staffDef n="1" label="Lead" clef.shape="G" clef.line="2"/></staffGrp>
+          </scoreDef>
+          <section>
+            <measure n="1">
+              <staff n="1">
+                <layer n="1">
+                  <note xml:id="ln1" pname="e" oct="4" dur="4"/>
+                  <note xml:id="ln2" pname="f" oct="4" dur="4"/>
+                  <slur startid="#ln1" endid="#ln2"/>
+                </layer>
+              </staff>
+            </measure>
+          </section>
+        </score>
+      </mdiv>
+    </body>
+  </music>
+</mei>`;
+    const xml = convertMeiToMusicXml(mei);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    const first = outDoc.querySelector("part > measure > note:nth-of-type(1)");
+    const second = outDoc.querySelector("part > measure > note:nth-of-type(2)");
+    expect(first?.querySelector(':scope > notations > slur[type="start"]')).not.toBeNull();
+    expect(second?.querySelector(':scope > notations > slur[type="stop"]')).not.toBeNull();
+  });
+
+  it("imports layer-level tie control events via startid/endid", () => {
+    const mei = `<?xml version="1.0" encoding="UTF-8"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
+  <music>
+    <body>
+      <mdiv>
+        <score>
+          <scoreDef meter.count="4" meter.unit="4" key.sig="0">
+            <staffGrp><staffDef n="1" label="Lead" clef.shape="G" clef.line="2"/></staffGrp>
+          </scoreDef>
+          <section>
+            <measure n="1">
+              <staff n="1">
+                <layer n="1">
+                  <note xml:id="tn1" pname="g" oct="4" dur="4"/>
+                  <note xml:id="tn2" pname="g" oct="4" dur="4"/>
+                  <tie startid="#tn1" endid="#tn2"/>
+                </layer>
+              </staff>
+            </measure>
+          </section>
+        </score>
+      </mdiv>
+    </body>
+  </music>
+</mei>`;
+    const xml = convertMeiToMusicXml(mei);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    const first = outDoc.querySelector("part > measure > note:nth-of-type(1)");
+    const second = outDoc.querySelector("part > measure > note:nth-of-type(2)");
+    expect(first?.querySelector(':scope > tie[type="start"]')).not.toBeNull();
+    expect(first?.querySelector(':scope > notations > tied[type="start"]')).not.toBeNull();
+    expect(second?.querySelector(':scope > tie[type="stop"]')).not.toBeNull();
+    expect(second?.querySelector(':scope > notations > tied[type="stop"]')).not.toBeNull();
+  });
+
+  it("imports note-level MEI tie/slur attributes into MusicXML tie+tied and slur notations", () => {
+    const mei = `<?xml version="1.0" encoding="UTF-8"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
+  <music>
+    <body>
+      <mdiv>
+        <score>
+          <scoreDef meter.count="4" meter.unit="4" key.sig="0">
+            <staffGrp><staffDef n="1" label="Lead" clef.shape="G" clef.line="2"/></staffGrp>
+          </scoreDef>
+          <section>
+            <measure n="1">
+              <staff n="1">
+                <layer n="1">
+                  <note pname="c" oct="4" dur="4" tie="i" slur="i1"/>
+                  <note pname="d" oct="4" dur="4" tie="t" slur="t1"/>
+                </layer>
+              </staff>
+            </measure>
+          </section>
+        </score>
+      </mdiv>
+    </body>
+  </music>
+</mei>`;
+    const xml = convertMeiToMusicXml(mei);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    const first = outDoc.querySelector("part > measure > note:nth-of-type(1)");
+    const second = outDoc.querySelector("part > measure > note:nth-of-type(2)");
+    expect(first?.querySelector(':scope > tie[type="start"]')).not.toBeNull();
+    expect(first?.querySelector(':scope > notations > tied[type="start"]')).not.toBeNull();
+    expect(first?.querySelector(':scope > notations > slur[type="start"][number="1"]')).not.toBeNull();
+    expect(second?.querySelector(':scope > tie[type="stop"]')).not.toBeNull();
+    expect(second?.querySelector(':scope > notations > tied[type="stop"]')).not.toBeNull();
+    expect(second?.querySelector(':scope > notations > slur[type="stop"][number="1"]')).not.toBeNull();
+  });
+
+  it("imports MEI graceGrp notes as MusicXML grace notes", () => {
+    const mei = `<?xml version="1.0" encoding="UTF-8"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
+  <music>
+    <body>
+      <mdiv>
+        <score>
+          <scoreDef meter.count="4" meter.unit="4" key.sig="0">
+            <staffGrp><staffDef n="1" label="Lead" clef.shape="G" clef.line="2"/></staffGrp>
+          </scoreDef>
+          <section>
+            <measure n="1">
+              <staff n="1">
+                <layer n="1">
+                  <graceGrp slash="yes">
+                    <note pname="c" oct="5" dur="8"/>
+                    <note pname="d" oct="5" dur="8"/>
+                  </graceGrp>
+                  <note pname="e" oct="5" dur="4"/>
+                </layer>
+              </staff>
+            </measure>
+          </section>
+        </score>
+      </mdiv>
+    </body>
+  </music>
+</mei>`;
+    const xml = convertMeiToMusicXml(mei);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    const first = outDoc.querySelector("part > measure > note:nth-of-type(1)");
+    const second = outDoc.querySelector("part > measure > note:nth-of-type(2)");
+    const third = outDoc.querySelector("part > measure > note:nth-of-type(3)");
+    expect(first?.querySelector(":scope > grace[slash=\"yes\"]")).not.toBeNull();
+    expect(second?.querySelector(":scope > grace[slash=\"yes\"]")).not.toBeNull();
+    expect(first?.querySelector(":scope > duration")).toBeNull();
+    expect(second?.querySelector(":scope > duration")).toBeNull();
+    expect(third?.querySelector(":scope > duration")?.textContent?.trim()).toBe("480");
+  });
+
+  it("imports MEI beam/tuplet containers without dropping nested notes", () => {
+    const mei = `<?xml version="1.0" encoding="UTF-8"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
+  <music>
+    <body>
+      <mdiv>
+        <score>
+          <scoreDef meter.count="4" meter.unit="4" key.sig="0">
+            <staffGrp><staffDef n="1" label="Lead" clef.shape="G" clef.line="2"/></staffGrp>
+          </scoreDef>
+          <section>
+            <measure n="1">
+              <staff n="1">
+                <layer n="1">
+                  <beam>
+                    <note pname="c" oct="4" dur="8"/>
+                    <tuplet>
+                      <note pname="d" oct="4" dur="8"/>
+                      <note pname="e" oct="4" dur="8"/>
+                    </tuplet>
+                  </beam>
+                </layer>
+              </staff>
+            </measure>
+          </section>
+        </score>
+      </mdiv>
+    </body>
+  </music>
+</mei>`;
+    const xml = convertMeiToMusicXml(mei);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    const notes = outDoc.querySelectorAll("part > measure > note");
+    expect(notes.length).toBe(3);
+  });
+
+  it("imports MEI dynam as MusicXML dynamics direction", () => {
+    const mei = `<?xml version="1.0" encoding="UTF-8"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
+  <music>
+    <body>
+      <mdiv>
+        <score>
+          <scoreDef meter.count="4" meter.unit="4" key.sig="0">
+            <staffGrp><staffDef n="1" label="Lead" clef.shape="G" clef.line="2"/></staffGrp>
+          </scoreDef>
+          <section>
+            <measure n="1">
+              <staff n="1">
+                <layer n="1">
+                  <dynam tstamp="2">mf</dynam>
+                  <note pname="c" oct="4" dur="4"/>
+                  <note pname="d" oct="4" dur="4"/>
+                </layer>
+              </staff>
+            </measure>
+          </section>
+        </score>
+      </mdiv>
+    </body>
+  </music>
+</mei>`;
+    const xml = convertMeiToMusicXml(mei);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector("part > measure > direction > direction-type > dynamics > mf")).not.toBeNull();
+    expect(outDoc.querySelector("part > measure > direction > offset")?.textContent?.trim()).toBe("480");
+  });
+
+  it("imports measure-level MEI dynam with @staff into MusicXML dynamics direction", () => {
+    const mei = `<?xml version="1.0" encoding="UTF-8"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
+  <music>
+    <body>
+      <mdiv>
+        <score>
+          <scoreDef meter.count="4" meter.unit="4" key.sig="0">
+            <staffGrp><staffDef n="1" label="Lead" clef.shape="G" clef.line="2"/></staffGrp>
+          </scoreDef>
+          <section>
+            <measure n="1">
+              <staff n="1">
+                <layer n="1">
+                  <note pname="c" oct="4" dur="4"/>
+                  <note pname="d" oct="4" dur="4"/>
+                </layer>
+              </staff>
+              <dynam staff="1" tstamp="1">ff</dynam>
+            </measure>
+          </section>
+        </score>
+      </mdiv>
+    </body>
+  </music>
+</mei>`;
+    const xml = convertMeiToMusicXml(mei);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector("part > measure > direction > direction-type > dynamics > ff")).not.toBeNull();
+  });
+
+  it("imports MEI dynam free text as MusicXML words direction", () => {
+    const mei = `<?xml version="1.0" encoding="UTF-8"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
+  <music>
+    <body>
+      <mdiv>
+        <score>
+          <scoreDef meter.count="4" meter.unit="4" key.sig="0">
+            <staffGrp><staffDef n="1" label="Lead" clef.shape="G" clef.line="2"/></staffGrp>
+          </scoreDef>
+          <section>
+            <measure n="1">
+              <staff n="1">
+                <layer n="1">
+                  <dynam place="above">dolce</dynam>
+                  <note pname="e" oct="4" dur="4"/>
+                </layer>
+              </staff>
+            </measure>
+          </section>
+        </score>
+      </mdiv>
+    </body>
+  </music>
+</mei>`;
+    const xml = convertMeiToMusicXml(mei);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    const dir = outDoc.querySelector("part > measure > direction");
+    expect(dir?.getAttribute("placement")).toBe("above");
+    expect(outDoc.querySelector("part > measure > direction > direction-type > words")?.textContent?.trim()).toBe("dolce");
+  });
+
+  it("imports MEI hairpin via startid/endid as MusicXML wedge start/stop", () => {
+    const mei = `<?xml version="1.0" encoding="UTF-8"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
+  <music>
+    <body>
+      <mdiv>
+        <score>
+          <scoreDef meter.count="4" meter.unit="4" key.sig="0">
+            <staffGrp><staffDef n="1" label="Lead" clef.shape="G" clef.line="2"/></staffGrp>
+          </scoreDef>
+          <section>
+            <measure n="1">
+              <staff n="1">
+                <layer n="1">
+                  <note xml:id="h1" pname="c" oct="4" dur="4"/>
+                  <note xml:id="h2" pname="d" oct="4" dur="4"/>
+                  <hairpin form="cres" startid="#h1" endid="#h2"/>
+                </layer>
+              </staff>
+            </measure>
+          </section>
+        </score>
+      </mdiv>
+    </body>
+  </music>
+</mei>`;
+    const xml = convertMeiToMusicXml(mei);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector('part > measure > direction:nth-of-type(1) > direction-type > wedge[type="crescendo"]')).not.toBeNull();
+    expect(outDoc.querySelector('part > measure > direction:nth-of-type(2) > direction-type > wedge[type="stop"]')).not.toBeNull();
+  });
+
+  it("imports MEI hairpin via tstamp/tstamp2 as MusicXML wedge with offsets", () => {
+    const mei = `<?xml version="1.0" encoding="UTF-8"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
+  <music>
+    <body>
+      <mdiv>
+        <score>
+          <scoreDef meter.count="4" meter.unit="4" key.sig="0">
+            <staffGrp><staffDef n="1" label="Lead" clef.shape="G" clef.line="2"/></staffGrp>
+          </scoreDef>
+          <section>
+            <measure n="1">
+              <staff n="1">
+                <layer n="1">
+                  <note pname="c" oct="4" dur="4"/>
+                  <note pname="d" oct="4" dur="4"/>
+                  <hairpin form="dim" tstamp="1" tstamp2="2" place="below"/>
+                </layer>
+              </staff>
+            </measure>
+          </section>
+        </score>
+      </mdiv>
+    </body>
+  </music>
+</mei>`;
+    const xml = convertMeiToMusicXml(mei);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    const startDir = outDoc.querySelector("part > measure > direction:nth-of-type(1)");
+    const stopDir = outDoc.querySelector("part > measure > direction:nth-of-type(2)");
+    expect(startDir?.getAttribute("placement")).toBe("below");
+    expect(startDir?.querySelector(':scope > direction-type > wedge[type="diminuendo"]')).not.toBeNull();
+    expect(stopDir?.querySelector(':scope > direction-type > wedge[type="stop"]')).not.toBeNull();
+    expect(stopDir?.querySelector(":scope > offset")?.textContent?.trim()).toBe("480");
+  });
+
+  it("imports MEI trill control event to MusicXML trill-mark notation", () => {
+    const mei = `<?xml version="1.0" encoding="UTF-8"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
+  <music>
+    <body>
+      <mdiv>
+        <score>
+          <scoreDef meter.count="4" meter.unit="4" key.sig="0">
+            <staffGrp><staffDef n="1" label="Lead" clef.shape="G" clef.line="2"/></staffGrp>
+          </scoreDef>
+          <section>
+            <measure n="1">
+              <staff n="1">
+                <layer n="1">
+                  <note xml:id="t1" pname="c" oct="4" dur="4"/>
+                  <note pname="d" oct="4" dur="4"/>
+                  <trill startid="#t1"/>
+                </layer>
+              </staff>
+            </measure>
+          </section>
+        </score>
+      </mdiv>
+    </body>
+  </music>
+</mei>`;
+    const xml = convertMeiToMusicXml(mei);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    const first = outDoc.querySelector("part > measure > note:nth-of-type(1)");
+    expect(first?.querySelector(":scope > notations > ornaments > trill-mark")).not.toBeNull();
+  });
+
+  it("imports MEI control event using plist when startid is absent", () => {
+    const mei = `<?xml version="1.0" encoding="UTF-8"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
+  <music>
+    <body>
+      <mdiv>
+        <score>
+          <scoreDef meter.count="4" meter.unit="4" key.sig="0">
+            <staffGrp><staffDef n="1" label="Lead" clef.shape="G" clef.line="2"/></staffGrp>
+          </scoreDef>
+          <section>
+            <measure n="1">
+              <staff n="1">
+                <layer n="1">
+                  <note xml:id="p1" pname="c" oct="4" dur="4"/>
+                  <note xml:id="p2" pname="d" oct="4" dur="4"/>
+                  <trill plist="#p1 #p2"/>
+                </layer>
+              </staff>
+            </measure>
+          </section>
+        </score>
+      </mdiv>
+    </body>
+  </music>
+</mei>`;
+    const xml = convertMeiToMusicXml(mei);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    const first = outDoc.querySelector("part > measure > note:nth-of-type(1)");
+    expect(first?.querySelector(":scope > notations > ornaments > trill-mark")).not.toBeNull();
+  });
+
+  it("imports MEI slur span using plist+tstamp2 when startid/endid are absent", () => {
+    const mei = `<?xml version="1.0" encoding="UTF-8"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
+  <music>
+    <body>
+      <mdiv>
+        <score>
+          <scoreDef meter.count="4" meter.unit="4" key.sig="0">
+            <staffGrp><staffDef n="1" label="Lead" clef.shape="G" clef.line="2"/></staffGrp>
+          </scoreDef>
+          <section>
+            <measure n="1">
+              <staff n="1">
+                <layer n="1">
+                  <note xml:id="sp1" pname="c" oct="4" dur="4"/>
+                  <note xml:id="sp2" pname="d" oct="4" dur="4"/>
+                  <slur plist="#sp1" tstamp2="2"/>
+                </layer>
+              </staff>
+            </measure>
+          </section>
+        </score>
+      </mdiv>
+    </body>
+  </music>
+</mei>`;
+    const xml = convertMeiToMusicXml(mei);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    const first = outDoc.querySelector("part > measure > note:nth-of-type(1)");
+    const second = outDoc.querySelector("part > measure > note:nth-of-type(2)");
+    expect(first?.querySelector(':scope > notations > slur[type="start"]')).not.toBeNull();
+    expect(second?.querySelector(':scope > notations > slur[type="stop"]')).not.toBeNull();
+  });
+
+  it("uses accid.ges for pitch alter when visual accid is omitted", () => {
+    const mei = `<?xml version="1.0" encoding="UTF-8"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
+  <music>
+    <body>
+      <mdiv>
+        <score>
+          <scoreDef meter.count="4" meter.unit="4" key.sig="0">
+            <staffGrp><staffDef n="1" label="Lead" clef.shape="G" clef.line="2"/></staffGrp>
+          </scoreDef>
+          <section>
+            <measure n="1">
+              <staff n="1">
+                <layer n="1">
+                  <note pname="f" oct="4" dur="4" accid.ges="s"/>
+                </layer>
+              </staff>
+            </measure>
+          </section>
+        </score>
+      </mdiv>
+    </body>
+  </music>
+</mei>`;
+
+    const xml = convertMeiToMusicXml(mei);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    const note = outDoc.querySelector("part > measure > note");
+    expect(note?.querySelector(":scope > pitch > alter")?.textContent?.trim()).toBe("1");
+    // accid.ges is sounding-only; accidental glyph should stay absent unless accid is present.
+    expect(note?.querySelector(":scope > accidental")).toBeNull();
+  });
+
+  it("uses chord-note accid.ges for alter on each chord member", () => {
+    const mei = `<?xml version="1.0" encoding="UTF-8"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
+  <music>
+    <body>
+      <mdiv>
+        <score>
+          <scoreDef meter.count="4" meter.unit="4" key.sig="0">
+            <staffGrp><staffDef n="1" label="Lead" clef.shape="G" clef.line="2"/></staffGrp>
+          </scoreDef>
+          <section>
+            <measure n="1">
+              <staff n="1">
+                <layer n="1">
+                  <chord dur="4">
+                    <note pname="f" oct="4" accid.ges="s"/>
+                    <note pname="b" oct="4" accid.ges="f"/>
+                  </chord>
+                </layer>
+              </staff>
+            </measure>
+          </section>
+        </score>
+      </mdiv>
+    </body>
+  </music>
+</mei>`;
+
+    const xml = convertMeiToMusicXml(mei);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    const notes = Array.from(outDoc.querySelectorAll("part > measure > note"));
+    expect(notes.length).toBe(2);
+    expect(notes[0]?.querySelector(":scope > pitch > alter")?.textContent?.trim()).toBe("1");
+    expect(notes[1]?.querySelector(":scope > pitch > alter")?.textContent?.trim()).toBe("-1");
+  });
+
+  it("imports MEI fermata control event to MusicXML fermata notation", () => {
+    const mei = `<?xml version="1.0" encoding="UTF-8"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
+  <music>
+    <body>
+      <mdiv>
+        <score>
+          <scoreDef meter.count="4" meter.unit="4" key.sig="0">
+            <staffGrp><staffDef n="1" label="Lead" clef.shape="G" clef.line="2"/></staffGrp>
+          </scoreDef>
+          <section>
+            <measure n="1">
+              <staff n="1">
+                <layer n="1">
+                  <note pname="e" oct="4" dur="4"/>
+                  <note pname="f" oct="4" dur="4"/>
+                  <fermata tstamp="2" place="below"/>
+                </layer>
+              </staff>
+            </measure>
+          </section>
+        </score>
+      </mdiv>
+    </body>
+  </music>
+</mei>`;
+    const xml = convertMeiToMusicXml(mei);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    const second = outDoc.querySelector("part > measure > note:nth-of-type(2)");
+    expect(second?.querySelector(':scope > notations > fermata[type="inverted"]')).not.toBeNull();
+  });
+
+  it("imports MEI pedal via startid/endid as MusicXML pedal start/stop directions", () => {
+    const mei = `<?xml version="1.0" encoding="UTF-8"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
+  <music>
+    <body>
+      <mdiv>
+        <score>
+          <scoreDef meter.count="4" meter.unit="4" key.sig="0">
+            <staffGrp><staffDef n="1" label="Lead" clef.shape="G" clef.line="2"/></staffGrp>
+          </scoreDef>
+          <section>
+            <measure n="1">
+              <staff n="1">
+                <layer n="1">
+                  <note xml:id="p1" pname="c" oct="4" dur="4"/>
+                  <note xml:id="p2" pname="d" oct="4" dur="4"/>
+                  <pedal startid="#p1" endid="#p2" place="below"/>
+                </layer>
+              </staff>
+            </measure>
+          </section>
+        </score>
+      </mdiv>
+    </body>
+  </music>
+</mei>`;
+    const xml = convertMeiToMusicXml(mei);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    const startDir = outDoc.querySelector("part > measure > direction:nth-of-type(1)");
+    const stopDir = outDoc.querySelector("part > measure > direction:nth-of-type(2)");
+    expect(startDir?.getAttribute("placement")).toBe("below");
+    expect(startDir?.querySelector(':scope > direction-type > pedal[type="start"]')).not.toBeNull();
+    expect(stopDir?.querySelector(':scope > direction-type > pedal[type="stop"]')).not.toBeNull();
+    expect(stopDir?.querySelector(":scope > offset")?.textContent?.trim()).toBe("480");
+  });
+
+  it("imports MEI pedal explicit stop event as single MusicXML pedal stop direction", () => {
+    const mei = `<?xml version="1.0" encoding="UTF-8"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
+  <music>
+    <body>
+      <mdiv>
+        <score>
+          <scoreDef meter.count="4" meter.unit="4" key.sig="0">
+            <staffGrp><staffDef n="1" label="Lead" clef.shape="G" clef.line="2"/></staffGrp>
+          </scoreDef>
+          <section>
+            <measure n="1">
+              <staff n="1">
+                <layer n="1">
+                  <note pname="e" oct="4" dur="4"/>
+                  <note pname="f" oct="4" dur="4"/>
+                  <pedal type="stop" tstamp="2"/>
+                </layer>
+              </staff>
+            </measure>
+          </section>
+        </score>
+      </mdiv>
+    </body>
+  </music>
+</mei>`;
+    const xml = convertMeiToMusicXml(mei);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    const dir = outDoc.querySelector("part > measure > direction");
+    expect(dir?.querySelector(':scope > direction-type > pedal[type="stop"]')).not.toBeNull();
+    expect(dir?.querySelector(":scope > offset")?.textContent?.trim()).toBe("480");
+  });
+
+  it("imports MEI gliss via startid/endid as MusicXML glissando start/stop notations", () => {
+    const mei = `<?xml version="1.0" encoding="UTF-8"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
+  <music>
+    <body>
+      <mdiv>
+        <score>
+          <scoreDef meter.count="4" meter.unit="4" key.sig="0">
+            <staffGrp><staffDef n="1" label="Lead" clef.shape="G" clef.line="2"/></staffGrp>
+          </scoreDef>
+          <section>
+            <measure n="1">
+              <staff n="1">
+                <layer n="1">
+                  <note xml:id="g1" pname="c" oct="4" dur="4"/>
+                  <note xml:id="g2" pname="e" oct="4" dur="4"/>
+                  <gliss startid="#g1" endid="#g2"/>
+                </layer>
+              </staff>
+            </measure>
+          </section>
+        </score>
+      </mdiv>
+    </body>
+  </music>
+</mei>`;
+    const xml = convertMeiToMusicXml(mei);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    const first = outDoc.querySelector("part > measure > note:nth-of-type(1)");
+    const second = outDoc.querySelector("part > measure > note:nth-of-type(2)");
+    expect(first?.querySelector(':scope > notations > glissando[type="start"]')).not.toBeNull();
+    expect(second?.querySelector(':scope > notations > glissando[type="stop"]')).not.toBeNull();
+  });
+
+  it("imports MEI gliss via tstamp/tstamp2 as MusicXML glissando start/stop notations", () => {
+    const mei = `<?xml version="1.0" encoding="UTF-8"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
+  <music>
+    <body>
+      <mdiv>
+        <score>
+          <scoreDef meter.count="4" meter.unit="4" key.sig="0">
+            <staffGrp><staffDef n="1" label="Lead" clef.shape="G" clef.line="2"/></staffGrp>
+          </scoreDef>
+          <section>
+            <measure n="1">
+              <staff n="1">
+                <layer n="1">
+                  <note pname="d" oct="4" dur="4"/>
+                  <note pname="f" oct="4" dur="4"/>
+                  <gliss tstamp="1" tstamp2="2"/>
+                </layer>
+              </staff>
+            </measure>
+          </section>
+        </score>
+      </mdiv>
+    </body>
+  </music>
+</mei>`;
+    const xml = convertMeiToMusicXml(mei);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    const first = outDoc.querySelector("part > measure > note:nth-of-type(1)");
+    const second = outDoc.querySelector("part > measure > note:nth-of-type(2)");
+    expect(first?.querySelector(':scope > notations > glissando[type="start"]')).not.toBeNull();
+    expect(second?.querySelector(':scope > notations > glissando[type="stop"]')).not.toBeNull();
+  });
+
+  it("imports MEI slide via startid/endid as MusicXML slide start/stop notations", () => {
+    const mei = `<?xml version="1.0" encoding="UTF-8"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
+  <music>
+    <body>
+      <mdiv>
+        <score>
+          <scoreDef meter.count="4" meter.unit="4" key.sig="0">
+            <staffGrp><staffDef n="1" label="Lead" clef.shape="G" clef.line="2"/></staffGrp>
+          </scoreDef>
+          <section>
+            <measure n="1">
+              <staff n="1">
+                <layer n="1">
+                  <note xml:id="s1" pname="c" oct="4" dur="4"/>
+                  <note xml:id="s2" pname="e" oct="4" dur="4"/>
+                  <slide startid="#s1" endid="#s2"/>
+                </layer>
+              </staff>
+            </measure>
+          </section>
+        </score>
+      </mdiv>
+    </body>
+  </music>
+</mei>`;
+    const xml = convertMeiToMusicXml(mei);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    const first = outDoc.querySelector("part > measure > note:nth-of-type(1)");
+    const second = outDoc.querySelector("part > measure > note:nth-of-type(2)");
+    expect(first?.querySelector(':scope > notations > slide[type="start"]')).not.toBeNull();
+    expect(second?.querySelector(':scope > notations > slide[type="stop"]')).not.toBeNull();
+  });
+
+  it("imports MEI octave via startid/endid as MusicXML octave-shift start/stop directions", () => {
+    const mei = `<?xml version="1.0" encoding="UTF-8"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
+  <music>
+    <body>
+      <mdiv>
+        <score>
+          <scoreDef meter.count="4" meter.unit="4" key.sig="0">
+            <staffGrp><staffDef n="1" label="Lead" clef.shape="G" clef.line="2"/></staffGrp>
+          </scoreDef>
+          <section>
+            <measure n="1">
+              <staff n="1">
+                <layer n="1">
+                  <note xml:id="o1" pname="c" oct="5" dur="4"/>
+                  <note xml:id="o2" pname="d" oct="5" dur="4"/>
+                  <octave startid="#o1" endid="#o2" dis="8" dis.place="above"/>
+                </layer>
+              </staff>
+            </measure>
+          </section>
+        </score>
+      </mdiv>
+    </body>
+  </music>
+</mei>`;
+    const xml = convertMeiToMusicXml(mei);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    const startDir = outDoc.querySelector("part > measure > direction:nth-of-type(1)");
+    const stopDir = outDoc.querySelector("part > measure > direction:nth-of-type(2)");
+    expect(startDir?.querySelector(':scope > direction-type > octave-shift[type="up"][size="8"]')).not.toBeNull();
+    expect(stopDir?.querySelector(':scope > direction-type > octave-shift[type="stop"][size="8"]')).not.toBeNull();
+    expect(stopDir?.querySelector(":scope > offset")?.textContent?.trim()).toBe("480");
+  });
+
+  it("imports MEI octave explicit stop event as single MusicXML octave-shift stop direction", () => {
+    const mei = `<?xml version="1.0" encoding="UTF-8"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
+  <music>
+    <body>
+      <mdiv>
+        <score>
+          <scoreDef meter.count="4" meter.unit="4" key.sig="0">
+            <staffGrp><staffDef n="1" label="Lead" clef.shape="G" clef.line="2"/></staffGrp>
+          </scoreDef>
+          <section>
+            <measure n="1">
+              <staff n="1">
+                <layer n="1">
+                  <note pname="a" oct="4" dur="4"/>
+                  <note pname="b" oct="4" dur="4"/>
+                  <octave type="stop" tstamp="2" dis="8"/>
+                </layer>
+              </staff>
+            </measure>
+          </section>
+        </score>
+      </mdiv>
+    </body>
+  </music>
+</mei>`;
+    const xml = convertMeiToMusicXml(mei);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    const dir = outDoc.querySelector("part > measure > direction");
+    expect(dir?.querySelector(':scope > direction-type > octave-shift[type="stop"][size="8"]')).not.toBeNull();
+    expect(dir?.querySelector(":scope > offset")?.textContent?.trim()).toBe("480");
+  });
+
+  it("imports MEI repeatMark segno/coda/fine into MusicXML directions", () => {
+    const mei = `<?xml version="1.0" encoding="UTF-8"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
+  <music>
+    <body>
+      <mdiv>
+        <score>
+          <scoreDef meter.count="4" meter.unit="4" key.sig="0">
+            <staffGrp><staffDef n="1" label="Lead" clef.shape="G" clef.line="2"/></staffGrp>
+          </scoreDef>
+          <section>
+            <measure n="1">
+              <staff n="1">
+                <layer n="1">
+                  <note pname="c" oct="4" dur="4"/>
+                  <note pname="d" oct="4" dur="4"/>
+                  <repeatMark tstamp="1">segno</repeatMark>
+                  <repeatMark tstamp="2">coda</repeatMark>
+                  <repeatMark>fine</repeatMark>
+                </layer>
+              </staff>
+            </measure>
+          </section>
+        </score>
+      </mdiv>
+    </body>
+  </music>
+</mei>`;
+    const xml = convertMeiToMusicXml(mei);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector("part > measure > direction > direction-type > segno")).not.toBeNull();
+    expect(outDoc.querySelector("part > measure > direction > direction-type > coda")).not.toBeNull();
+    const fineWords = Array.from(outDoc.querySelectorAll("part > measure > direction > direction-type > words"))
+      .map((node) => (node.textContent || "").trim().toLowerCase());
+    expect(fineWords.includes("fine")).toBe(true);
+  });
+
+  it("imports MEI turn/mordent control events into MusicXML ornament notations", () => {
+    const mei = `<?xml version="1.0" encoding="UTF-8"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
+  <music>
+    <body>
+      <mdiv>
+        <score>
+          <scoreDef meter.count="4" meter.unit="4" key.sig="0">
+            <staffGrp><staffDef n="1" label="Lead" clef.shape="G" clef.line="2"/></staffGrp>
+          </scoreDef>
+          <section>
+            <measure n="1">
+              <staff n="1">
+                <layer n="1">
+                  <note xml:id="orn1" pname="c" oct="4" dur="4"/>
+                  <note xml:id="orn2" pname="d" oct="4" dur="4"/>
+                  <turn startid="#orn1" type="inverted"/>
+                  <mordent startid="#orn2" type="upper"/>
+                </layer>
+              </staff>
+            </measure>
+          </section>
+        </score>
+      </mdiv>
+    </body>
+  </music>
+</mei>`;
+    const xml = convertMeiToMusicXml(mei);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    const first = outDoc.querySelector("part > measure > note:nth-of-type(1)");
+    const second = outDoc.querySelector("part > measure > note:nth-of-type(2)");
+    expect(first?.querySelector(":scope > notations > ornaments > inverted-turn")).not.toBeNull();
+    expect(second?.querySelector(":scope > notations > ornaments > mordent")).not.toBeNull();
+  });
+
+  it("imports MEI breath/caesura control events into MusicXML articulation notations", () => {
+    const mei = `<?xml version="1.0" encoding="UTF-8"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
+  <music>
+    <body>
+      <mdiv>
+        <score>
+          <scoreDef meter.count="4" meter.unit="4" key.sig="0">
+            <staffGrp><staffDef n="1" label="Lead" clef.shape="G" clef.line="2"/></staffGrp>
+          </scoreDef>
+          <section>
+            <measure n="1">
+              <staff n="1">
+                <layer n="1">
+                  <note pname="e" oct="4" dur="4"/>
+                  <note pname="f" oct="4" dur="4"/>
+                  <breath tstamp="1"/>
+                  <caesura tstamp="2"/>
+                </layer>
+              </staff>
+            </measure>
+          </section>
+        </score>
+      </mdiv>
+    </body>
+  </music>
+</mei>`;
+    const xml = convertMeiToMusicXml(mei);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    const first = outDoc.querySelector("part > measure > note:nth-of-type(1)");
+    const second = outDoc.querySelector("part > measure > note:nth-of-type(2)");
+    expect(first?.querySelector(":scope > notations > articulations > breath-mark")).not.toBeNull();
+    expect(second?.querySelector(":scope > notations > articulations > caesura")).not.toBeNull();
+  });
+
+  it("imports MEI tupletSpan via startid/endid as MusicXML tuplet start/stop notations", () => {
+    const mei = `<?xml version="1.0" encoding="UTF-8"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
+  <music>
+    <body>
+      <mdiv>
+        <score>
+          <scoreDef meter.count="4" meter.unit="4" key.sig="0">
+            <staffGrp><staffDef n="1" label="Lead" clef.shape="G" clef.line="2"/></staffGrp>
+          </scoreDef>
+          <section>
+            <measure n="1">
+              <staff n="1">
+                <layer n="1">
+                  <note xml:id="ts1" pname="c" oct="4" dur="8"/>
+                  <note xml:id="ts2" pname="d" oct="4" dur="8"/>
+                  <note xml:id="ts3" pname="e" oct="4" dur="8"/>
+                  <tupletSpan startid="#ts1" endid="#ts3"/>
+                </layer>
+              </staff>
+            </measure>
+          </section>
+        </score>
+      </mdiv>
+    </body>
+  </music>
+</mei>`;
+    const xml = convertMeiToMusicXml(mei);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    const first = outDoc.querySelector("part > measure > note:nth-of-type(1)");
+    const third = outDoc.querySelector("part > measure > note:nth-of-type(3)");
+    expect(first?.querySelector(':scope > notations > tuplet[type="start"]')).not.toBeNull();
+    expect(third?.querySelector(':scope > notations > tuplet[type="stop"]')).not.toBeNull();
+  });
+
+  it("imports MEI beamSpan via plist and applies beams only to listed notes", () => {
+    const mei = `<?xml version="1.0" encoding="UTF-8"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
+  <music>
+    <body>
+      <mdiv>
+        <score>
+          <scoreDef meter.count="4" meter.unit="4" key.sig="0">
+            <staffGrp><staffDef n="1" label="Lead" clef.shape="G" clef.line="2"/></staffGrp>
+          </scoreDef>
+          <section>
+            <measure n="1">
+              <staff n="1">
+                <layer n="1">
+                  <note xml:id="bs1" pname="c" oct="4" dur="8"/>
+                  <note xml:id="bs2" pname="d" oct="4" dur="8"/>
+                  <note xml:id="bs3" pname="e" oct="4" dur="8"/>
+                  <note xml:id="bs4" pname="f" oct="4" dur="8"/>
+                  <beamSpan startid="#bs1" endid="#bs4" plist="#bs1 #bs3 #bs4"/>
+                </layer>
+              </staff>
+            </measure>
+          </section>
+        </score>
+      </mdiv>
+    </body>
+  </music>
+</mei>`;
+    const xml = convertMeiToMusicXml(mei);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    const notes = Array.from(outDoc.querySelectorAll("part > measure > note"));
+    expect(notes.length).toBe(4);
+    expect(notes[0]?.querySelector(':scope > beam[number="1"]')?.textContent?.trim()).toBe("begin");
+    expect(notes[1]?.querySelector(':scope > beam[number="1"]')).toBeNull();
+    expect(notes[2]?.querySelector(':scope > beam[number="1"]')?.textContent?.trim()).toBe("continue");
+    expect(notes[3]?.querySelector(':scope > beam[number="1"]')?.textContent?.trim()).toBe("end");
+  });
+
+  it("imports MEI harm as MusicXML harmony (root/bass/kind/degrees)", () => {
+    const mei = `<?xml version="1.0" encoding="UTF-8"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
+  <music>
+    <body>
+      <mdiv>
+        <score>
+          <scoreDef meter.count="4" meter.unit="4" key.sig="0">
+            <staffGrp><staffDef n="1" label="Lead" clef.shape="G" clef.line="2"/></staffGrp>
+          </scoreDef>
+          <section>
+            <measure n="1">
+              <staff n="1">
+                <layer n="1">
+                  <note pname="c" oct="4" dur="4"/>
+                  <note pname="d" oct="4" dur="4"/>
+                  <harm tstamp="2">C7#11b9/G</harm>
+                </layer>
+              </staff>
+            </measure>
+          </section>
+        </score>
+      </mdiv>
+    </body>
+  </music>
+</mei>`;
+    const xml = convertMeiToMusicXml(mei);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    const harmony = outDoc.querySelector("part > measure > harmony");
+    expect(harmony).not.toBeNull();
+    expect(harmony?.querySelector(":scope > root > root-step")?.textContent?.trim()).toBe("C");
+    expect(harmony?.querySelector(":scope > kind")?.textContent?.trim()).toBe("other");
+    expect(harmony?.querySelector(":scope > kind")?.getAttribute("text")).toBe("7#11b9");
+    expect(harmony?.querySelector(":scope > bass > bass-step")?.textContent?.trim()).toBe("G");
+    const d1 = harmony?.querySelector(":scope > degree:nth-of-type(1) > degree-value")?.textContent?.trim();
+    const a1 = harmony?.querySelector(":scope > degree:nth-of-type(1) > degree-alter")?.textContent?.trim();
+    const d2 = harmony?.querySelector(":scope > degree:nth-of-type(2) > degree-value")?.textContent?.trim();
+    const a2 = harmony?.querySelector(":scope > degree:nth-of-type(2) > degree-alter")?.textContent?.trim();
+    expect([`${d1}:${a1}`, `${d2}:${a2}`].sort()).toEqual(["11:1", "9:-1"]);
+    expect(harmony?.querySelector(":scope > offset")?.textContent?.trim()).toBe("480");
+  });
+
   it("roundtrips miscellaneous-field via MEI annot", () => {
     const xml = `<?xml version="1.0" encoding="UTF-8"?>
 <score-partwise version="3.1">
@@ -138,6 +2231,291 @@ describe("MEI export", () => {
     );
     expect(field).not.toBeNull();
     expect(field?.textContent).toBe("hello");
+  });
+
+  it("roundtrips harmony as MEI <harm> with degree alterations", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>Part 1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>480</divisions>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <harmony>
+        <root><root-step>C</root-step></root>
+        <kind text="7#11b9">other</kind>
+        <bass><bass-step>G</bass-step></bass>
+        <degree><degree-value>11</degree-value><degree-alter>1</degree-alter><degree-type>add</degree-type></degree>
+        <degree><degree-value>9</degree-value><degree-alter>-1</degree-alter><degree-type>add</degree-type></degree>
+        <offset>480</offset>
+        <staff>1</staff>
+      </harmony>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>480</duration><voice>1</voice><type>quarter</type></note>
+      <note><pitch><step>D</step><octave>4</octave></pitch><duration>480</duration><voice>1</voice><type>quarter</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+    const mei = exportMusicXmlDomToMei(srcDoc);
+    expect(mei).toContain("<harm");
+    expect(mei).toContain("C7#11b9/G");
+    expect(mei).toContain('tstamp="2"');
+
+    const roundtripXml = convertMeiToMusicXml(mei);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    const harmony = outDoc.querySelector("part > measure > harmony");
+    expect(harmony).not.toBeNull();
+    expect(harmony?.querySelector(":scope > root > root-step")?.textContent?.trim()).toBe("C");
+    expect(harmony?.querySelector(":scope > bass > bass-step")?.textContent?.trim()).toBe("G");
+    const d1 = harmony?.querySelector(":scope > degree:nth-of-type(1) > degree-value")?.textContent?.trim();
+    const a1 = harmony?.querySelector(":scope > degree:nth-of-type(1) > degree-alter")?.textContent?.trim();
+    const d2 = harmony?.querySelector(":scope > degree:nth-of-type(2) > degree-value")?.textContent?.trim();
+    const a2 = harmony?.querySelector(":scope > degree:nth-of-type(2) > degree-alter")?.textContent?.trim();
+    expect([`${d1}:${a1}`, `${d2}:${a2}`].sort()).toEqual(["11:1", "9:-1"]);
+  });
+
+  it("exports MusicXML dynamics/wedge directions to MEI dynam/hairpin and roundtrips", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>Part 1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>480</divisions>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+      </attributes>
+      <direction placement="below">
+        <direction-type><dynamics><mf/></dynamics></direction-type>
+        <offset>480</offset>
+        <staff>1</staff>
+      </direction>
+      <direction placement="below">
+        <direction-type><wedge type="crescendo" number="1"/></direction-type>
+        <offset>0</offset>
+        <staff>1</staff>
+      </direction>
+      <direction placement="below">
+        <direction-type><wedge type="stop" number="1"/></direction-type>
+        <offset>480</offset>
+        <staff>1</staff>
+      </direction>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>480</duration><voice>1</voice><type>quarter</type></note>
+      <note><pitch><step>D</step><octave>4</octave></pitch><duration>480</duration><voice>1</voice><type>quarter</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+    const mei = exportMusicXmlDomToMei(srcDoc);
+    expect(mei).toContain("<dynam");
+    expect(mei).toContain(">mf</dynam>");
+    expect(mei).toContain("<hairpin");
+    expect(mei).toContain('form="cres"');
+    expect(mei).toContain('tstamp="1"');
+    expect(mei).toContain('tstamp2="2"');
+
+    const roundtripXml = convertMeiToMusicXml(mei);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector("part > measure > direction > direction-type > dynamics > mf")).not.toBeNull();
+    expect(outDoc.querySelector('part > measure > direction > direction-type > wedge[type="crescendo"]')).not.toBeNull();
+    expect(outDoc.querySelector('part > measure > direction > direction-type > wedge[type="stop"]')).not.toBeNull();
+  });
+
+  it("exports MusicXML pedal/octave-shift directions to MEI pedal/octave and roundtrips", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>Part 1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>480</divisions>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+      </attributes>
+      <direction placement="below">
+        <direction-type><pedal type="start" number="1" line="yes"/></direction-type>
+        <offset>0</offset><staff>1</staff>
+      </direction>
+      <direction placement="below">
+        <direction-type><pedal type="stop" number="1" line="yes"/></direction-type>
+        <offset>480</offset><staff>1</staff>
+      </direction>
+      <direction placement="above">
+        <direction-type><octave-shift type="up" size="8" number="1"/></direction-type>
+        <offset>0</offset><staff>1</staff>
+      </direction>
+      <direction placement="above">
+        <direction-type><octave-shift type="stop" size="8" number="1"/></direction-type>
+        <offset>480</offset><staff>1</staff>
+      </direction>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>480</duration><voice>1</voice><type>quarter</type></note>
+      <note><pitch><step>D</step><octave>4</octave></pitch><duration>480</duration><voice>1</voice><type>quarter</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+    const mei = exportMusicXmlDomToMei(srcDoc);
+    expect(mei).toContain("<pedal");
+    expect(mei).toContain('tstamp="1"');
+    expect(mei).toContain('tstamp2="2"');
+    expect(mei).toContain("<octave");
+    expect(mei).toContain('dis="8"');
+    expect(mei).toContain('dis.place="above"');
+
+    const roundtripXml = convertMeiToMusicXml(mei);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector('part > measure > direction > direction-type > pedal[type="start"]')).not.toBeNull();
+    expect(outDoc.querySelector('part > measure > direction > direction-type > pedal[type="stop"]')).not.toBeNull();
+    expect(outDoc.querySelector('part > measure > direction > direction-type > octave-shift[type="up"][size="8"]')).not.toBeNull();
+    expect(outDoc.querySelector('part > measure > direction > direction-type > octave-shift[type="stop"][size="8"]')).not.toBeNull();
+  });
+
+  it("exports MusicXML segno/coda/fine directions to MEI repeatMark and roundtrips", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>Part 1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>480</divisions>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+      </attributes>
+      <direction><direction-type><segno/></direction-type><staff>1</staff></direction>
+      <direction><direction-type><coda/></direction-type><offset>480</offset><staff>1</staff></direction>
+      <direction><direction-type><words>Fine</words></direction-type><offset>960</offset><staff>1</staff></direction>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>480</duration><voice>1</voice><type>quarter</type></note>
+      <note><pitch><step>D</step><octave>4</octave></pitch><duration>480</duration><voice>1</voice><type>quarter</type></note>
+      <note><pitch><step>E</step><octave>4</octave></pitch><duration>480</duration><voice>1</voice><type>quarter</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+    const mei = exportMusicXmlDomToMei(srcDoc);
+    expect(mei).toContain("<repeatMark");
+    expect(mei).toContain(">segno</repeatMark>");
+    expect(mei).toContain(">coda</repeatMark>");
+    expect(mei).toContain(">Fine</repeatMark>");
+
+    const roundtripXml = convertMeiToMusicXml(mei);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector("part > measure > direction > direction-type > segno")).not.toBeNull();
+    expect(outDoc.querySelector("part > measure > direction > direction-type > coda")).not.toBeNull();
+    const words = Array.from(outDoc.querySelectorAll("part > measure > direction > direction-type > words"))
+      .map((node) => (node.textContent || "").trim().toLowerCase());
+    expect(words.includes("fine")).toBe(true);
+  });
+
+  it("exports MusicXML note glissando/slide notations to MEI gliss/slide and roundtrips", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>Part 1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>480</divisions>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+      </attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>480</duration><voice>1</voice><type>quarter</type>
+        <notations><glissando type="start" number="1"/></notations>
+      </note>
+      <note>
+        <pitch><step>D</step><octave>4</octave></pitch>
+        <duration>480</duration><voice>1</voice><type>quarter</type>
+        <notations><glissando type="stop" number="1"/><slide type="start" number="2"/></notations>
+      </note>
+      <note>
+        <pitch><step>E</step><octave>4</octave></pitch>
+        <duration>480</duration><voice>1</voice><type>quarter</type>
+        <notations><slide type="stop" number="2"/></notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+    const mei = exportMusicXmlDomToMei(srcDoc);
+    expect(mei).toContain("<gliss ");
+    expect(mei).toContain("<slide ");
+    expect(mei).toContain('tstamp="1"');
+    expect(mei).toContain('tstamp2="2"');
+    expect(mei).toContain('tstamp2="3"');
+
+    const roundtripXml = convertMeiToMusicXml(mei);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector('part > measure > note:nth-of-type(1) > notations > glissando[type="start"]')).not.toBeNull();
+    expect(outDoc.querySelector('part > measure > note:nth-of-type(2) > notations > glissando[type="stop"]')).not.toBeNull();
+    expect(outDoc.querySelector('part > measure > note:nth-of-type(2) > notations > slide[type="start"]')).not.toBeNull();
+    expect(outDoc.querySelector('part > measure > note:nth-of-type(3) > notations > slide[type="stop"]')).not.toBeNull();
+  });
+
+  it("exports MusicXML ornaments/fermata/breath/caesura to MEI control events and roundtrips", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>Part 1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>480</divisions>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+      </attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch><duration>480</duration><voice>1</voice><type>quarter</type>
+        <notations><ornaments><trill-mark/></ornaments></notations>
+      </note>
+      <note>
+        <pitch><step>D</step><octave>4</octave></pitch><duration>480</duration><voice>1</voice><type>quarter</type>
+        <notations><ornaments><inverted-turn/></ornaments><fermata type="inverted"/></notations>
+      </note>
+      <note>
+        <pitch><step>E</step><octave>4</octave></pitch><duration>480</duration><voice>1</voice><type>quarter</type>
+        <notations><ornaments><mordent/></ornaments><articulations><breath-mark/><caesura/></articulations></notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+    const mei = exportMusicXmlDomToMei(srcDoc);
+    expect(mei).toContain("<trill ");
+    expect(mei).toContain("<turn ");
+    expect(mei).toContain("<mordent ");
+    expect(mei).toContain("<fermata ");
+    expect(mei).toContain("<breath ");
+    expect(mei).toContain("<caesura ");
+
+    const roundtripXml = convertMeiToMusicXml(mei);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector("part > measure > note:nth-of-type(1) > notations > ornaments > trill-mark")).not.toBeNull();
+    expect(outDoc.querySelector("part > measure > note:nth-of-type(2) > notations > ornaments > inverted-turn")).not.toBeNull();
+    expect(outDoc.querySelector("part > measure > note:nth-of-type(2) > notations > fermata[type=\"inverted\"]")).not.toBeNull();
+    expect(outDoc.querySelector("part > measure > note:nth-of-type(3) > notations > ornaments > mordent")).not.toBeNull();
+    expect(outDoc.querySelector("part > measure > note:nth-of-type(3) > notations > articulations > breath-mark")).not.toBeNull();
+    expect(outDoc.querySelector("part > measure > note:nth-of-type(3) > notations > articulations > caesura")).not.toBeNull();
   });
 
   it("maps non-namespaced MEI misc labels to src:mei:* namespace", () => {
@@ -225,6 +2603,39 @@ describe("MEI export", () => {
         'part > measure > attributes > miscellaneous > miscellaneous-field[name="diag:0001"]'
       )?.textContent
     ).toContain("code=OVERFULL_CLAMPED");
+  });
+
+  it("can fail on overfull note drop in strict mode", () => {
+    const mei = `<?xml version="1.0" encoding="UTF-8"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.1">
+  <music>
+    <body>
+      <mdiv>
+        <score>
+          <scoreDef meter.count="3" meter.unit="4" key.sig="0">
+            <staffGrp><staffDef n="1" label="Lead" clef.shape="G" clef.line="2" /></staffGrp>
+          </scoreDef>
+          <section>
+            <measure n="1">
+              <staff n="1">
+                <layer n="1">
+                  <rest dur="4"/>
+                  <rest dur="4"/>
+                  <note pname="d" oct="4" dur="8"/>
+                  <note pname="a" oct="3" dur="8"/>
+                  <note pname="f" oct="3" dur="8"/>
+                </layer>
+              </staff>
+            </measure>
+          </section>
+        </score>
+      </mdiv>
+    </body>
+  </music>
+</mei>`;
+    expect(() => convertMeiToMusicXml(mei, { failOnOverfullDrop: true })).toThrow(
+      /overfull would drop events/i
+    );
   });
 
   it("adds implicit beams on MEI import for short-note groups", () => {
@@ -347,6 +2758,53 @@ describe("MEI export", () => {
     expect(second?.querySelector(":scope > notations > articulations > accent")).not.toBeNull();
   });
 
+  it("roundtrips tie/slur from MusicXML note notation into MEI @tie/@slur and back", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>Part 1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>480</divisions><time><beats>2</beats><beat-type>4</beat-type></time></attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <tie type="start"/>
+        <duration>480</duration><voice>1</voice><type>quarter</type>
+        <notations><tied type="start"/><slur type="start" number="1"/></notations>
+      </note>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <tie type="stop"/>
+        <duration>480</duration><voice>1</voice><type>quarter</type>
+        <notations><tied type="stop"/><slur type="stop" number="1"/></notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+    const mei = exportMusicXmlDomToMei(srcDoc);
+    expect(mei).toContain('tie="i"');
+    expect(mei).toContain('tie="t"');
+    expect(mei).toContain('slur="i1"');
+    expect(mei).toContain('slur="t1"');
+    expect(mei).toContain("<tie ");
+    expect(mei).toContain('tstamp="1"');
+    expect(mei).toContain('tstamp2="2"');
+    expect(mei).toContain("<slur ");
+
+    const roundtripXml = convertMeiToMusicXml(mei);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    const first = outDoc.querySelector("part > measure > note:nth-of-type(1)");
+    const second = outDoc.querySelector("part > measure > note:nth-of-type(2)");
+    expect(first?.querySelector(':scope > tie[type="start"]')).not.toBeNull();
+    expect(first?.querySelector(':scope > notations > slur[type="start"][number="1"]')).not.toBeNull();
+    expect(second?.querySelector(':scope > tie[type="stop"]')).not.toBeNull();
+    expect(second?.querySelector(':scope > notations > slur[type="stop"][number="1"]')).not.toBeNull();
+  });
+
   it("roundtrips accidental display (natural/sharp/flat) between MusicXML and MEI", () => {
     const xml = `<?xml version="1.0" encoding="UTF-8"?>
 <score-partwise version="4.0">
@@ -378,6 +2836,9 @@ describe("MEI export", () => {
     expect(notes[0]?.querySelector(":scope > accidental")?.textContent?.trim()).toBe("natural");
     expect(notes[1]?.querySelector(":scope > accidental")?.textContent?.trim()).toBe("sharp");
     expect(notes[2]?.querySelector(":scope > accidental")?.textContent?.trim()).toBe("flat");
+    expect(notes[0]?.querySelector(":scope > pitch > alter")).toBeNull();
+    expect(notes[1]?.querySelector(":scope > pitch > alter")?.textContent?.trim()).toBe("1");
+    expect(notes[2]?.querySelector(":scope > pitch > alter")?.textContent?.trim()).toBe("-1");
   });
 
   it("roundtrips grace notes between MusicXML and MEI", () => {
@@ -397,7 +2858,7 @@ describe("MEI export", () => {
     expect(srcDoc).not.toBeNull();
     if (!srcDoc) return;
     const mei = exportMusicXmlDomToMei(srcDoc);
-    expect(mei).toContain('grace="acc"');
+    expect(mei.includes('grace="acc"') || mei.includes("<graceGrp")).toBe(true);
 
     const roundtripXml = convertMeiToMusicXml(mei);
     const outDoc = parseMusicXmlDocument(roundtripXml);
@@ -407,6 +2868,39 @@ describe("MEI export", () => {
     const second = outDoc.querySelector("part > measure > note:nth-of-type(2)");
     expect(first?.querySelector(":scope > grace")).not.toBeNull();
     expect(second?.querySelector(":scope > duration")?.textContent?.trim()).toBe("480");
+  });
+
+  it("exports consecutive grace notes as MEI graceGrp and roundtrips both grace notes", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>Part 1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>480</divisions><time><beats>2</beats><beat-type>4</beat-type></time></attributes>
+      <note><grace slash="yes"/><pitch><step>C</step><octave>5</octave></pitch><voice>1</voice><type>16th</type></note>
+      <note><grace/><pitch><step>D</step><octave>5</octave></pitch><voice>1</voice><type>16th</type></note>
+      <note><pitch><step>E</step><octave>5</octave></pitch><duration>960</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const mei = exportMusicXmlDomToMei(srcDoc);
+    expect(mei).toContain("<graceGrp");
+    expect(mei).toContain('slash="yes"');
+    expect(mei).not.toContain('grace="acc"');
+
+    const roundtripXml = convertMeiToMusicXml(mei);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    const notes = Array.from(outDoc.querySelectorAll("part > measure > note"));
+    expect(notes.length).toBeGreaterThanOrEqual(3);
+    expect(notes[0]?.querySelector(":scope > grace")).not.toBeNull();
+    expect(notes[1]?.querySelector(":scope > grace")).not.toBeNull();
+    expect(notes[2]?.querySelector(":scope > duration")?.textContent?.trim()).toBe("960");
   });
 
   it("roundtrips tuplet timing and start/stop markers between MusicXML and MEI", () => {
@@ -460,5 +2954,484 @@ describe("MEI export", () => {
     expect(first?.querySelector(":scope > time-modification > normal-notes")?.textContent?.trim()).toBe("2");
     expect(first?.querySelector(':scope > notations > tuplet[type="start"]')).not.toBeNull();
     expect(third?.querySelector(':scope > notations > tuplet[type="stop"]')).not.toBeNull();
+  });
+
+  it("preserves non-standard duration ticks via mks-dur-ticks metadata", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>Part 1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>480</divisions><time><beats>2</beats><beat-type>4</beat-type></time></attributes>
+      <note><pitch><step>C</step><alter>1</alter><octave>4</octave></pitch><duration>69</duration><voice>1</voice><type>16th</type></note>
+      <note><rest/><duration>891</duration><voice>1</voice><type>whole</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+    const mei = exportMusicXmlDomToMei(srcDoc);
+    expect(mei).toContain('mks-dur-ticks="69"');
+    expect(mei).toContain('mks-dur-ticks="891"');
+
+    const roundtripXml = convertMeiToMusicXml(mei);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector("part > measure > note:nth-of-type(1) > duration")?.textContent?.trim()).toBe("69");
+    expect(outDoc.querySelector("part > measure > note:nth-of-type(2) > duration")?.textContent?.trim()).toBe("891");
+    expect(outDoc.querySelector("part > measure > note:nth-of-type(1) > pitch > alter")?.textContent?.trim()).toBe("1");
+  });
+
+  it("does not clamp away notes when later measure capacity is larger (time change)", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>Part 1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>480</divisions><time><beats>2</beats><beat-type>4</beat-type></time></attributes>
+      <note><rest/><duration>960</duration><voice>1</voice><type>half</type></note>
+    </measure>
+    <measure number="2">
+      <attributes><time><beats>4</beats><beat-type>4</beat-type></time></attributes>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>480</duration><voice>1</voice><type>quarter</type></note>
+      <note><pitch><step>D</step><octave>4</octave></pitch><duration>480</duration><voice>1</voice><type>quarter</type></note>
+      <note><pitch><step>E</step><octave>4</octave></pitch><duration>480</duration><voice>1</voice><type>quarter</type></note>
+      <note><pitch><step>F</step><octave>4</octave></pitch><duration>480</duration><voice>1</voice><type>quarter</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+    const mei = exportMusicXmlDomToMei(srcDoc);
+    const roundtripXml = convertMeiToMusicXml(mei);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    const measure2Notes = outDoc.querySelectorAll("part > measure:nth-of-type(2) > note > pitch > step");
+    expect(measure2Notes.length).toBe(4);
+    expect(
+      outDoc.querySelector(
+        'part > measure:nth-of-type(2) > attributes > miscellaneous > miscellaneous-field[name="diag:0001"]'
+      )
+    ).toBeNull();
+  });
+
+  it("imports external-style MEI pitch/timing from dur/dots/chord without mks metadata", () => {
+    const mei = `<?xml version="1.0" encoding="UTF-8"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+  <music>
+    <body>
+      <mdiv>
+        <score>
+          <scoreDef meter.count="4" meter.unit="4" key.sig="0">
+            <staffGrp>
+              <staffDef n="1" label="Staff 1" lines="5" clef.shape="G" clef.line="2"/>
+            </staffGrp>
+          </scoreDef>
+          <section>
+            <measure n="1">
+              <staff n="1">
+                <layer n="1">
+                  <note pname="c" oct="4" dur="4"/>
+                  <rest dur="8"/>
+                  <note pname="d" oct="4" dur="8" dots="1"/>
+                  <chord dur="4">
+                    <note pname="e" oct="4"/>
+                    <note pname="g" oct="4"/>
+                  </chord>
+                </layer>
+              </staff>
+            </measure>
+          </section>
+        </score>
+      </mdiv>
+    </body>
+  </music>
+</mei>`;
+
+    const xml = convertMeiToMusicXml(mei);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    const notes = Array.from(outDoc.querySelectorAll("part > measure > note"));
+    expect(notes.length).toBe(5);
+
+    expect(notes[0]?.querySelector(":scope > pitch > step")?.textContent?.trim()).toBe("C");
+    expect(notes[0]?.querySelector(":scope > pitch > octave")?.textContent?.trim()).toBe("4");
+    expect(notes[0]?.querySelector(":scope > duration")?.textContent?.trim()).toBe("480");
+
+    expect(notes[1]?.querySelector(":scope > rest")).not.toBeNull();
+    expect(notes[1]?.querySelector(":scope > duration")?.textContent?.trim()).toBe("240");
+
+    expect(notes[2]?.querySelector(":scope > pitch > step")?.textContent?.trim()).toBe("D");
+    expect(notes[2]?.querySelector(":scope > duration")?.textContent?.trim()).toBe("360");
+    expect(notes[2]?.querySelectorAll(":scope > dot").length).toBe(1);
+
+    expect(notes[3]?.querySelector(":scope > pitch > step")?.textContent?.trim()).toBe("E");
+    expect(notes[3]?.querySelector(":scope > duration")?.textContent?.trim()).toBe("480");
+    expect(notes[3]?.querySelector(":scope > chord")).toBeNull();
+
+    expect(notes[4]?.querySelector(":scope > pitch > step")?.textContent?.trim()).toBe("G");
+    expect(notes[4]?.querySelector(":scope > chord")).not.toBeNull();
+    expect(notes[4]?.querySelector(":scope > duration")?.textContent?.trim()).toBe("480");
+  });
+
+  it("imports MEI mRest/mSpace/space as timing-preserving rests", () => {
+    const mei = `<?xml version="1.0" encoding="UTF-8"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
+  <music>
+    <body>
+      <mdiv>
+        <score>
+          <scoreDef meter.count="3" meter.unit="4">
+            <staffGrp><staffDef n="1" lines="5" clef.shape="G" clef.line="2"/></staffGrp>
+          </scoreDef>
+          <section>
+            <measure n="1">
+              <staff n="1">
+                <layer n="1">
+                  <mRest/>
+                </layer>
+              </staff>
+            </measure>
+            <measure n="2">
+              <staff n="1">
+                <layer n="1">
+                  <mSpace/>
+                </layer>
+              </staff>
+            </measure>
+            <measure n="3">
+              <staff n="1">
+                <layer n="1">
+                  <space dur="4"/>
+                  <space dur="2"/>
+                </layer>
+              </staff>
+            </measure>
+          </section>
+        </score>
+      </mdiv>
+    </body>
+  </music>
+</mei>`;
+
+    const xml = convertMeiToMusicXml(mei);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const m1n1 = outDoc.querySelector('part > measure[number="1"] > note:nth-of-type(1)');
+    const m2n1 = outDoc.querySelector('part > measure[number="2"] > note:nth-of-type(1)');
+    expect(m1n1?.querySelector(":scope > rest")).not.toBeNull();
+    expect(m2n1?.querySelector(":scope > rest")).not.toBeNull();
+    expect(Number(m1n1?.querySelector(":scope > duration")?.textContent || "0")).toBe(1440);
+    expect(Number(m2n1?.querySelector(":scope > duration")?.textContent || "0")).toBe(1440);
+    expect(m1n1?.querySelector(":scope > type")?.textContent?.trim()).toBe("half");
+    expect(m1n1?.querySelectorAll(":scope > dot").length).toBe(1);
+    expect(m2n1?.querySelector(":scope > type")?.textContent?.trim()).toBe("half");
+    expect(m2n1?.querySelectorAll(":scope > dot").length).toBe(1);
+
+    const m3Durations = Array.from(outDoc.querySelectorAll('part > measure[number="3"] > note > duration')).map((n) =>
+      Number(n.textContent || "0")
+    );
+    expect(m3Durations).toEqual([480, 960]);
+  });
+
+  it("imports official MEI fixture (CMN Listing 132 excerpt) with grace pitch/timing semantics", () => {
+    const mei = readFileSync(
+      resolve(process.cwd(), "tests/fixtures-local/mei-official/beam-grace/source-listing-132-snippet.mei"),
+      "utf8"
+    );
+
+    const xml = convertMeiToMusicXml(mei);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const notes = Array.from(outDoc.querySelectorAll("part > measure > note"));
+    expect(notes.length).toBe(6);
+
+    const stepOct = notes.map((n) => {
+      const step = n.querySelector(":scope > pitch > step")?.textContent?.trim() ?? "";
+      const octave = n.querySelector(":scope > pitch > octave")?.textContent?.trim() ?? "";
+      return `${step}${octave}`;
+    });
+    expect(stepOct).toEqual(["D5", "E5", "D5", "C5", "D5", "B4"]);
+
+    const graceIndexes = notes
+      .map((n, i) => (n.querySelector(":scope > grace") ? i : -1))
+      .filter((i) => i >= 0);
+    expect(graceIndexes).toEqual([1, 3]);
+
+    expect(notes[0].querySelector(":scope > duration")?.textContent?.trim()).toBe("240");
+    expect(notes[2].querySelector(":scope > duration")?.textContent?.trim()).toBe("240");
+    expect(notes[4].querySelector(":scope > duration")?.textContent?.trim()).toBe("240");
+    expect(notes[5].querySelector(":scope > duration")?.textContent?.trim()).toBe("240");
+    expect(notes[1].querySelector(":scope > duration")).toBeNull();
+    expect(notes[3].querySelector(":scope > duration")).toBeNull();
+
+    expect(notes[3].querySelector(":scope > pitch > alter")?.textContent?.trim()).toBe("1");
+    expect(notes[0].querySelector(":scope > stem")?.textContent?.trim()).toBe("down");
+    expect(notes[1].querySelector(":scope > stem")?.textContent?.trim()).toBe("up");
+    expect(notes[3].querySelector(":scope > stem")?.textContent?.trim()).toBe("up");
+    expect(notes[1].querySelector(":scope > grace")?.getAttribute("slash")).toBe("yes");
+    expect(notes[3].querySelector(":scope > grace")?.getAttribute("slash")).toBe("yes");
+    expect(notes[0].querySelector(':scope > beam[number="1"]')?.textContent?.trim()).toBe("begin");
+    expect(notes[1].querySelector(':scope > beam[number="1"]')?.textContent?.trim()).toBe("continue");
+    expect(notes[2].querySelector(':scope > beam[number="1"]')?.textContent?.trim()).toBe("continue");
+    expect(notes[3].querySelector(':scope > beam[number="1"]')?.textContent?.trim()).toBe("continue");
+    expect(notes[4].querySelector(':scope > beam[number="1"]')?.textContent?.trim()).toBe("continue");
+    expect(notes[5].querySelector(':scope > beam[number="1"]')?.textContent?.trim()).toBe("end");
+  });
+
+  it("imports official MEI fixture (CMN Listing 142 excerpt) with breaksec secondary-beam split semantics", () => {
+    const mei = readFileSync(
+      resolve(process.cwd(), "tests/fixtures-local/mei-official/beam-secondary/source-listing-142-snippet.mei"),
+      "utf8"
+    );
+
+    const xml = convertMeiToMusicXml(mei);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const notes = Array.from(outDoc.querySelectorAll("part > measure > note"));
+    expect(notes.length).toBe(9);
+
+    const typeSeq = notes.map((n) => n.querySelector(":scope > type")?.textContent?.trim());
+    expect(typeSeq).toEqual(["eighth", "16th", "32nd", "32nd", "16th", "32nd", "32nd", "32nd", "32nd"]);
+
+    // Primary beam remains continuous inside each explicit MEI <beam> container.
+    expect(notes[2].querySelector(':scope > beam[number="1"]')?.textContent?.trim()).toBe("begin");
+    expect(notes[8].querySelector(':scope > beam[number="1"]')?.textContent?.trim()).toBe("end");
+
+    // breaksec="1" on the 16th note splits secondary beam after that note.
+    expect(notes[2].querySelector(':scope > beam[number="2"]')?.textContent?.trim()).toBe("begin");
+    expect(notes[3].querySelector(':scope > beam[number="2"]')?.textContent?.trim()).toBe("continue");
+    expect(notes[4].querySelector(':scope > beam[number="2"]')?.textContent?.trim()).toBe("end");
+    expect(notes[5].querySelector(':scope > beam[number="2"]')?.textContent?.trim()).toBe("begin");
+    expect(notes[8].querySelector(':scope > beam[number="2"]')?.textContent?.trim()).toBe("end");
+
+    // Third-level beam naturally breaks at the 16th note and resumes on following 32nds.
+    expect(notes[2].querySelector(':scope > beam[number="3"]')?.textContent?.trim()).toBe("begin");
+    expect(notes[3].querySelector(':scope > beam[number="3"]')?.textContent?.trim()).toBe("end");
+    expect(notes[5].querySelector(':scope > beam[number="3"]')?.textContent?.trim()).toBe("begin");
+    expect(notes[8].querySelector(':scope > beam[number="3"]')?.textContent?.trim()).toBe("end");
+  });
+
+  it("imports Bach Brandenburg fixture and preserves first-measure key signature from keysig", () => {
+    const mei = readFileSync(
+      resolve(process.cwd(), "tests", "fixtures-local", "Bach-JS_BrandenburgConcert_No4_I_BWV1049.mei"),
+      "utf-8"
+    );
+    const xml = convertMeiToMusicXml(mei);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const keyFifthsNodes = Array.from(
+      outDoc.querySelectorAll('score-partwise > part > measure[number="1"] > attributes > key > fifths')
+    );
+    expect(keyFifthsNodes.length).toBeGreaterThan(0);
+    for (const node of keyFifthsNodes) {
+      expect(node.textContent?.trim()).toBe("1");
+    }
+  }, 15000);
+
+  it("imports Bach Brandenburg fixture and keeps viola clef as C3 on part 6", () => {
+    const mei = readFileSync(
+      resolve(process.cwd(), "tests", "fixtures-local", "Bach-JS_BrandenburgConcert_No4_I_BWV1049.mei"),
+      "utf-8"
+    );
+    const xml = convertMeiToMusicXml(mei);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const part6Measure1 = outDoc.querySelector('score-partwise > part[id="P6"] > measure[number="1"]');
+    expect(part6Measure1).not.toBeNull();
+    if (!part6Measure1) return;
+    expect(part6Measure1.querySelector(":scope > attributes > clef > sign")?.textContent?.trim()).toBe("C");
+    expect(part6Measure1.querySelector(":scope > attributes > clef > line")?.textContent?.trim()).toBe("3");
+  }, 15000);
+
+  it("imports beamSpan minimal fixture and keeps beam continuity on listed notes", () => {
+    const mei = readFileSync(
+      resolve(process.cwd(), "tests/fixtures-local/mei-official/beamspan-min/source-listing-147-inspired.mei"),
+      "utf8"
+    );
+    const xml = convertMeiToMusicXml(mei);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const m1n1 = outDoc.querySelector('part > measure[number="1"] > note:nth-of-type(1)');
+    const m1n2 = outDoc.querySelector('part > measure[number="1"] > note:nth-of-type(2)');
+    const m1n3 = outDoc.querySelector('part > measure[number="1"] > note:nth-of-type(3)');
+    const m1n4 = outDoc.querySelector('part > measure[number="1"] > note:nth-of-type(4)');
+    expect(m1n1?.querySelector(':scope > beam[number="1"]')?.textContent?.trim()).toBe("begin");
+    expect(m1n2?.querySelector(':scope > beam[number="1"]')?.textContent?.trim()).toBe("continue");
+    expect(m1n3?.querySelector(':scope > beam[number="1"]')?.textContent?.trim()).toBe("continue");
+    expect(m1n4?.querySelector(':scope > beam[number="1"]')?.textContent?.trim()).toBe("end");
+  });
+
+  it("imports tie-crossbar minimal fixture and keeps tie start/stop across measures", () => {
+    const mei = readFileSync(
+      resolve(process.cwd(), "tests/fixtures-local/mei-official/tie-crossbar-min/source-listing-148-inspired.mei"),
+      "utf8"
+    );
+    const xml = convertMeiToMusicXml(mei);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const m1 = outDoc.querySelector('part > measure[number="1"] > note:nth-of-type(1)');
+    const m2 = outDoc.querySelector('part > measure[number="2"] > note:nth-of-type(1)');
+    expect(m1?.querySelector(':scope > tie[type="start"]')).not.toBeNull();
+    expect(m1?.querySelector(':scope > notations > tied[type="start"]')).not.toBeNull();
+    expect(m2?.querySelector(':scope > tie[type="stop"]')).not.toBeNull();
+    expect(m2?.querySelector(':scope > notations > tied[type="stop"]')).not.toBeNull();
+  });
+
+  it("imports slur minimal fixture and maps i/m/t slur markers", () => {
+    const mei = readFileSync(
+      resolve(process.cwd(), "tests/fixtures-local/mei-official/slur-min/source-listing-152-inspired.mei"),
+      "utf8"
+    );
+    const xml = convertMeiToMusicXml(mei);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const n1 = outDoc.querySelector('part > measure[number="1"] > note:nth-of-type(1)');
+    const n2 = outDoc.querySelector('part > measure[number="1"] > note:nth-of-type(2)');
+    const n3 = outDoc.querySelector('part > measure[number="1"] > note:nth-of-type(3)');
+    expect(n1?.querySelector(':scope > notations > slur[type="start"][number="1"]')).not.toBeNull();
+    expect(n2?.querySelector(':scope > notations > slur[type="start"][number="1"]')).not.toBeNull();
+    expect(n2?.querySelector(':scope > notations > slur[type="stop"][number="1"]')).not.toBeNull();
+    expect(n3?.querySelector(':scope > notations > slur[type="stop"][number="1"]')).not.toBeNull();
+  });
+
+  it("imports hairpin minimal fixture and maps startid/endid to wedge start/stop", () => {
+    const mei = readFileSync(
+      resolve(process.cwd(), "tests/fixtures-local/mei-official/hairpin-min/source-hairpin-inspired.mei"),
+      "utf8"
+    );
+    const xml = convertMeiToMusicXml(mei);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const directions = Array.from(outDoc.querySelectorAll('part > measure[number="1"] > direction'));
+    const start = directions.find((d) => d.querySelector(':scope > direction-type > wedge[type="crescendo"]'));
+    const stop = directions.find((d) => d.querySelector(':scope > direction-type > wedge[type="stop"]'));
+    expect(start).toBeTruthy();
+    expect(stop).toBeTruthy();
+  });
+
+  it("resolves staff-level control-event ids across layers by tick (hairpin startid/endid)", () => {
+    const mei = `<?xml version="1.0" encoding="UTF-8"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
+  <music>
+    <body>
+      <mdiv>
+        <score>
+          <scoreDef meter.count="4" meter.unit="4" key.sig="0">
+            <staffGrp><staffDef n="1" lines="5" clef.shape="G" clef.line="2"/></staffGrp>
+          </scoreDef>
+          <section>
+            <measure n="1">
+              <staff n="1">
+                <hairpin form="cres" startid="#n1" endid="#n4"/>
+                <layer n="1">
+                  <note xml:id="n1" pname="c" oct="4" dur="4"/>
+                  <note xml:id="n2" pname="d" oct="4" dur="4"/>
+                </layer>
+                <layer n="2">
+                  <note xml:id="n3" pname="e" oct="4" dur="4"/>
+                  <note xml:id="n4" pname="f" oct="4" dur="4"/>
+                </layer>
+              </staff>
+            </measure>
+          </section>
+        </score>
+      </mdiv>
+    </body>
+  </music>
+</mei>`;
+    const xml = convertMeiToMusicXml(mei);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const dirs = Array.from(outDoc.querySelectorAll('part > measure[number="1"] > direction'));
+    const start = dirs.find((d) => d.querySelector(':scope > direction-type > wedge[type="crescendo"]'));
+    const stop = dirs.find((d) => d.querySelector(':scope > direction-type > wedge[type="stop"]'));
+    expect(start).toBeTruthy();
+    expect(stop).toBeTruthy();
+    expect(stop?.querySelector(":scope > offset")?.textContent?.trim()).toBe("480");
+  });
+
+  it("imports dynam minimal fixture and maps MEI dynam text to MusicXML dynamics mark", () => {
+    const mei = readFileSync(
+      resolve(process.cwd(), "tests/fixtures-local/mei-official/dynam-min/source-dynam-inspired.mei"),
+      "utf8"
+    );
+    const xml = convertMeiToMusicXml(mei);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const dynamics = outDoc.querySelector("part > measure:nth-of-type(1) > direction > direction-type > dynamics > mf");
+    expect(dynamics).not.toBeNull();
+  });
+
+  it("imports tuplet minimal fixture and keeps 3:2 time-modification on notes", () => {
+    const mei = readFileSync(
+      resolve(process.cwd(), "tests/fixtures-local/mei-official/tuplet-min/source-tuplet-inspired.mei"),
+      "utf8"
+    );
+    const xml = convertMeiToMusicXml(mei);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    const notes = Array.from(outDoc.querySelectorAll('part > measure[number="1"] > note')).slice(0, 3);
+    expect(notes.length).toBe(3);
+    for (const n of notes) {
+      expect(n.querySelector(":scope > time-modification > actual-notes")?.textContent?.trim()).toBe("3");
+      expect(n.querySelector(":scope > time-modification > normal-notes")?.textContent?.trim()).toBe("2");
+    }
+  });
+
+  it("imports fermata minimal fixture and maps to MusicXML fermata notation", () => {
+    const mei = readFileSync(
+      resolve(process.cwd(), "tests/fixtures-local/mei-official/fermata-min/source-fermata-inspired.mei"),
+      "utf8"
+    );
+    const xml = convertMeiToMusicXml(mei);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    const third = outDoc.querySelector('part > measure[number="1"] > note:nth-of-type(3)');
+    expect(third?.querySelector(":scope > notations > fermata")).not.toBeNull();
+  });
+
+  it("imports gliss minimal fixture and maps to MusicXML glissando start/stop", () => {
+    const mei = readFileSync(
+      resolve(process.cwd(), "tests/fixtures-local/mei-official/gliss-min/source-gliss-inspired.mei"),
+      "utf8"
+    );
+    const xml = convertMeiToMusicXml(mei);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    const first = outDoc.querySelector('part > measure[number="1"] > note:nth-of-type(1)');
+    const fourth = outDoc.querySelector('part > measure[number="1"] > note:nth-of-type(4)');
+    expect(first?.querySelector(':scope > notations > glissando[type="start"]')).not.toBeNull();
+    expect(fourth?.querySelector(':scope > notations > glissando[type="stop"]')).not.toBeNull();
   });
 });

--- a/tests/unit/musescore-io.spec.ts
+++ b/tests/unit/musescore-io.spec.ts
@@ -2118,5 +2118,5 @@ describe("musescore-io", () => {
     const dstNatural = dstEvents.find((e) => e.step === "B" && e.octave === "3" && e.accidental === "natural");
     expect(srcNatural).toBeDefined();
     expect(dstNatural).toBeDefined();
-  });
+  }, 15000);
 });


### PR DESCRIPTION
…充）+ ABCのclef自動判定改善

### 概要
MEI対応の信頼性を上げるため、`mei-io` を中心に仕様追従の実装を大きく拡張しました。
あわせて、MEI公式サンプルを使った spot/parity テストと比較補助スクリプトを追加し、継続検証の基盤を整備しています。 また、ABC取り込み時の clef 無指定ケースに対して、共通ポリシーを使う自動判定を追加しました。

### 主な変更点
- `src/ts/mei-io.ts`
- `tests/unit/mei-io.spec.ts`
- `tests/spot/local-mei-official-visual.spot.spec.ts`
- `tests/spot/local-mei-roundtrip-parity.spot.spec.ts`
- `scripts/compare-mei-official-reports.mjs`
- `src/ts/abc-io.ts`
- `tests/unit/abc-io.spec.ts`
- `README.md`
- `TODO.md`

### 実装内容（MEI）
- import/export オプションを拡張
- `meiCorpus` 読み込み対応（`meiCorpusIndex`）
- export `meiversion` の既定を `5.1` に変更し、オーバーライド可能化
- transposition (`trans.diat` / `trans.semi`) の import/export 対応を追加
- tie/slur の note属性・control event 取り込み強化
- tie継続時の accidental/alter 引き継ぎ補強
- `accid.ges` / `accid-ges` の実音反映（表示 accidental とは分離）
- 中間 `scoreDef` / `staffDef` の key/clef/transpose 変更反映を強化
- `mRest` / `mSpace` / `space` / `graceGrp` / beam/tuplet 系の取り扱いを強化
- overfull時の厳格化オプション（`failOnOverfullDrop`）を追加

### 実装内容（ABC）
- ABC取り込みで clef 無指定時に `staffClefPolicy`（`chooseSingleClefByKeys`）を使った G/F 自動判定を追加

### テスト・検証
- MEI unit テストを大幅に追加（transposition, meiversion, control events, key/clef変更, accid系など）
- MEI公式サンプル比較の spot テストを追加
- parity回帰テストを追加（既知欠落ケースの検証）
- レポート比較補助スクリプトを追加（`scripts/compare-mei-official-reports.mjs`）

### ドキュメント
- README に MEI公式サンプル参照先を追記
- TODO に MEIギャップ・進捗・今後対応項目を整理して追記

### 補足
- `mikuscore.html` と `src/js/main.js` はビルド生成物更新を含みます