### PR TITLE
MIDI/LilyPondラウンドトリップ時のメタデータ保持強化（Title/Composer/Part名）と関連UI・テスト更新

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -71,6 +71,11 @@
   - [x] MEI: articulation (`staccato` / `accent`) minimal roundtrip-equivalent test and preservation path.
 
 #### P3: Feature expansion
+- [ ] Investigation: add `lightweight playback mode` for dense-note scores (classified as design consideration):
+  - limit max simultaneous voices (e.g., 32-48) to avoid browser audio-node saturation.
+  - optionally drop/merge ultra-short or duplicate-nearby notes for stability-first playback.
+  - allow omitting ornaments/grace in lightweight mode with explicit UI toggle and policy.
+  - define quality vs stability presets and default behavior for large scores.
 - [ ] Decide whether to reintroduce `insert_note_after` in UI.
 - [ ] Reconfirm in-session `xml:id` strategy and operation rules.
 - [ ] Add chord editing support in core/editor commands (currently chord targets are read/play only in MVP).
@@ -406,6 +411,11 @@
   - [x] MEI: アーティキュレーション（`staccato` / `accent`）最小同等テストと保持経路。
 
 #### P3: 仕様拡張
+- [ ] 検討事項: ノート密度が高い譜面向けに `軽量再生モード` を追加する。
+  - ブラウザの音声ノード飽和を避けるため、同時発音数の上限（例: 32-48）を設ける。
+  - 安定再生優先として、極短音や近接重複音の間引き/マージを任意適用できるようにする。
+  - 軽量モードでは装飾音（trill/grace 等）を省略可能にし、UIトグルと方針を明示する。
+  - 大規模譜面向けに「音質優先/安定優先」プリセットと既定値を定義する。
 - [ ] `insert_note_after` の UI 再導入可否を仕様確定。
 - [ ] セッション内 `xml:id` 付与戦略を再確認（永続化しない方針の運用ルール化）。
 - [ ] 和音編集（chord）対応を core/editor コマンドに追加（現状はMVPで「読み込み/再生は可・直接編集は不可」）。

--- a/mikuscore-src.html
+++ b/mikuscore-src.html
@@ -276,6 +276,7 @@
               <span>Add Measure (End)</span>
             </button>
           </div>
+          <p id="scoreHeaderMetaText" class="ms-score-header-meta md-hidden" aria-live="polite"></p>
           <p id="playbackText" class="ms-playback-status" aria-live="polite">Playback: idle</p>
         </section>
 

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -379,6 +379,12 @@ body {
   color: var(--md-sys-color-on-surface-variant);
 }
 
+.ms-score-header-meta {
+  margin: -0.2rem 0 0.5rem;
+  font-size: 0.88rem;
+  color: var(--md-sys-color-on-surface-variant);
+}
+
 .ms-settings-card {
   margin-top: 2rem;
   padding-top: 1rem;

--- a/src/ts/download-flow.ts
+++ b/src/ts/download-flow.ts
@@ -328,6 +328,18 @@ export const createMidiDownloadPayload = (
 
   let midiBytes: Uint8Array;
   try {
+    const scoreTitle =
+      playbackDoc.querySelector("score-partwise > work > work-title")?.textContent?.trim() ??
+      playbackDoc.querySelector("score-partwise > movement-title")?.textContent?.trim() ??
+      "";
+    const movementTitle =
+      playbackDoc.querySelector("score-partwise > movement-title")?.textContent?.trim() ?? "";
+    const scoreComposer =
+      playbackDoc
+        .querySelector('score-partwise > identification > creator[type="composer"]')
+        ?.textContent?.trim() ??
+      playbackDoc.querySelector("score-partwise > identification > creator")?.textContent?.trim() ??
+      "";
     midiBytes = buildMidiBytesForPlayback(
       parsedPlayback.events,
       parsedPlayback.tempo,
@@ -343,6 +355,11 @@ export const createMidiDownloadPayload = (
         normalizeForParity: runtime.normalizeForParity,
         rawWriter: runtime.rawWriter,
         rawRetriggerPolicy: runtime.rawRetriggerPolicy,
+        metadata: {
+          title: scoreTitle,
+          movementTitle,
+          composer: scoreComposer,
+        },
       }
     );
   } catch {

--- a/src/ts/playback-flow.ts
+++ b/src/ts/playback-flow.ts
@@ -539,6 +539,18 @@ export const startPlayback = async (
 
   let midiBytes: Uint8Array;
   try {
+    const scoreTitle =
+      playbackDoc.querySelector("score-partwise > work > work-title")?.textContent?.trim() ??
+      playbackDoc.querySelector("score-partwise > movement-title")?.textContent?.trim() ??
+      "";
+    const movementTitle =
+      playbackDoc.querySelector("score-partwise > movement-title")?.textContent?.trim() ?? "";
+    const scoreComposer =
+      playbackDoc
+        .querySelector('score-partwise > identification > creator[type="composer"]')
+        ?.textContent?.trim() ??
+      playbackDoc.querySelector("score-partwise > identification > creator")?.textContent?.trim() ??
+      "";
     midiBytes = buildMidiBytesForPlayback(
       events,
       effectiveParsedPlayback.tempo,
@@ -547,7 +559,14 @@ export const startPlayback = async (
       effectiveControlEvents,
       effectiveTempoEvents,
       timeSignatureEvents,
-      keySignatureEvents
+      keySignatureEvents,
+      {
+        metadata: {
+          title: scoreTitle,
+          movementTitle,
+          composer: scoreComposer,
+        },
+      }
     );
   } catch (error) {
     options.setPlaybackText(


### PR DESCRIPTION
### 背景

`MusicXML -> MIDI -> MusicXML` および `MusicXML -> LilyPond -> MusicXML` の往復で、以下のメタデータが失われる課題がありました。

- 曲名（Title）
- 作曲者（Composer）
- パート名（Part name）

また、Score画面の情報表示や関連実装の整合性も合わせて改善対象でした。

### 変更内容

1. MIDIラウンドトリップでのメタデータ保持を追加
- MIDI Track 0 のテキストメタイベントに `mks:` プレフィックスでメタデータを退避する仕組みを追加。
- 取り込み時に `mks:` メタデータを読み戻し、MusicXML側の `title/composer/movement-title/part-name` へ復元。
- MIDI出力フロー（ダウンロード/再生経路）でメタデータを渡すよう接続を更新。

2. LilyPondラウンドトリップでのパート名保持を強化
- LilyPond出力で `\with { instrumentName = "..." }` を活用してパート名を埋め込み。
- LilyPond入力で `instrumentName`（および関連設定）を読み取り、MusicXML `part-name` に復元。

3. UI/周辺整備
- Score画面のメタ情報表示に関する関連更新。
- 生成物（`mikuscore.html`, `src/js/main.js`）をビルド反映。
- TODO更新。

### テスト

- `tests/unit/midi-io.spec.ts` を更新し、MIDIメタデータの往復保持を検証。
- `tests/unit/lilypond-io.spec.ts` を更新し、LilyPond経由のパート名保持を検証。

### 影響範囲

- MIDI I/O
- LilyPond I/O
- ダウンロード/再生フローのメタデータ受け渡し
- Score画面の表示（関連部分）
- ビルド済みHTML/JS成果物