### PR TITLE
Unify `miscellaneous-field` namespaces under `mks:*` (`meta/diag/src/…

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Its primary goal is reliability, not feature volume: edit while preserving exist
 - `docs/spec/MIDI_IO.md`
 - `docs/spec/PLAYBACK.md`
 - `docs/spec/ABC_IO.md`
+- `docs/spec/MISCELLANEOUS_FIELDS.md`
 - `docs/spec/TEST_MATRIX.md`
 - `docs/spec/LOCAL_WORKFLOW.md`
 - `docs/spec/BUILD_PROCESS.md`
@@ -157,6 +158,7 @@ mikuscore は、MusicXML、MuseScore、MIDI、VSQX、ABC、MEI、LilyPond の入
 - `docs/spec/MIDI_IO.md`
 - `docs/spec/PLAYBACK.md`
 - `docs/spec/ABC_IO.md`
+- `docs/spec/MISCELLANEOUS_FIELDS.md`
 - `docs/spec/TEST_MATRIX.md`
 - `docs/spec/LOCAL_WORKFLOW.md`
 - `docs/spec/BUILD_PROCESS.md`

--- a/docs/spec/FORMAT_IO_CHECKLIST.md
+++ b/docs/spec/FORMAT_IO_CHECKLIST.md
@@ -95,26 +95,26 @@ When adding a new format (e.g. ABC / MEI / future formats), use this checklist t
 - [ ] Warn vs error boundary is documented
 - [ ] Console diagnostics and UI diagnostics are consistent
 - [ ] For bug investigation, preserve and utilize debug metadata through `miscellaneous-field` (or format-equivalent mapping) whenever possible.
-- [ ] When conversion applies degradation/auto-fix (e.g. overfull clamped), record it as structured diagnostics in `miscellaneous-field` using `diag:*`.
+- [ ] When conversion applies degradation/auto-fix (e.g. overfull clamped), record it as structured diagnostics in `miscellaneous-field` using `mks:diag:*`.
 
 ### `miscellaneous-field` Usage Patterns (MUST classify explicitly)
 
 - [ ] Classify each `miscellaneous-field` mapping into one of the following:
-  - **Source-preservation metadata** (`src:*` recommended):
-    - Purpose: preserve source-format-only information when importing `Format -> MusicXML`.
-    - Example: fields needed to reconstruct/trace original MEI/ABC semantics not directly representable in core MusicXML path.
-  - **mikuscore extension metadata** (`mks:*`):
+  - **mikuscore extension metadata** (`mks:meta:*`):
     - Purpose: preserve mikuscore-specific semantics/provenance when a target format cannot represent them natively (not debug-only).
     - Example: mikuscore extension comments/hints and restoration metadata required for compatible roundtrip behavior.
-  - **Optional debug-only metadata** (`dbg:*` recommended if separated):
-    - Purpose: investigation/tracing only.
-    - Example: event-level conversion traces used for incident analysis.
-  - **Structured conversion diagnostics** (`diag:*`):
+  - **Structured conversion diagnostics** (`mks:diag:*`):
     - Purpose: record warnings/repair actions that occurred during conversion, so issues are not silently hidden.
-    - Example: `diag:0001 = level=warn;code=OVERFULL_CLAMPED;fmt=mei;measure=8;staff=1;action=clamped;droppedTicks=240`.
-    - Recommended key order inside `diag:NNNN` payload:
+    - Example: `mks:diag:0001 = level=warn;code=OVERFULL_CLAMPED;fmt=mei;measure=8;staff=1;action=clamped;droppedTicks=240`.
+    - Recommended key order inside `mks:diag:NNNN` payload:
       - `level;code;fmt;measure;staff;voice;action;message;sourceTicks;capacityTicks;movedEvents;droppedEvents;droppedTicks`
       - Omit keys that do not apply, but keep relative order for diff/readability.
+  - **Source-preservation metadata** (`mks:src:*` recommended):
+    - Purpose: preserve source-format-only information when importing `Format -> MusicXML`.
+    - Example: fields needed to reconstruct/trace original MEI/ABC semantics not directly representable in core MusicXML path.
+  - **Optional debug-only metadata** (`mks:dbg:*`):
+    - Purpose: investigation/tracing only.
+    - Example: event-level conversion traces used for incident analysis.
 - [ ] For each format, document retention policy for both categories:
   - preserve as-is / transform / drop
   - roundtrip expectations (`MusicXML -> Format -> MusicXML`, `Format -> MusicXML -> Format`)
@@ -123,7 +123,8 @@ When adding a new format (e.g. ABC / MEI / future formats), use this checklist t
   - event addressing key (`voice + measure + event`)
   - fallback when hint is absent or invalid
   - safety against conflicts with existing source comments
-- [ ] Keep namespace separation strict (`src:*` vs `mks:*` vs `diag:*` vs optional `dbg:*`) to avoid mixing source data, functional extension metadata, diagnostics, and debug traces.
+- [ ] Keep namespace separation strict (`mks:src:*` vs `mks:meta:*` vs `mks:diag:*` vs `mks:dbg:*`) to avoid mixing source data, functional extension metadata, diagnostics, and debug traces.
+  - During migration, allow legacy names (`src:*`, `diag:*`, old `mks:*`) only via dual-write/dual-read compatibility paths.
 
 ### LilyPond Note (Current `mks` usage)
 

--- a/docs/spec/MISCELLANEOUS_FIELDS.md
+++ b/docs/spec/MISCELLANEOUS_FIELDS.md
@@ -1,0 +1,141 @@
+# miscellaneous-field Metadata (mikuscore)
+
+このドキュメントは、mikuscore が MusicXML の
+`attributes > miscellaneous > miscellaneous-field` に付与する情報を整理したものです。
+
+## Scope
+
+- 対象: mikuscore が生成・追記する `miscellaneous-field`
+- 非対象: 外部ツールが独自に付与したフィールド仕様
+
+## Namespace Policy
+
+新規実装の目標は、mikuscore 付与情報を `mks:` 配下に集約すること。
+
+- `mks:meta:*`: ラウンドトリップ復元に使う安定メタデータ
+- `mks:diag:*`: 変換時の警告/劣化情報
+- `mks:src:*`: 元データ退避（raw payload 断片や由来情報。`mks:dbg:*` に位置付けが近い）
+- `mks:dbg:*`: 調査用デバッグ情報（変更されやすい）
+
+補足:
+
+- 現行実装には legacy 名（`src:*`, `diag:*`, `mks:...` 旧形式）が混在する。
+- 移行期間は **dual-write + dual-read** を採用し、段階的に新命名へ寄せる。
+
+## mks:dbg:* Fields (Target)
+
+### MEI import debug
+
+- `mks:dbg:mei:notes:count`
+- `mks:dbg:mei:notes:0001` ... `mks:dbg:mei:notes:####`
+
+Payload keys:
+
+- 共通: `idx,m,stf,ly,li,k,du,dt`
+- `note` のとき: `pn,oc`（必要時 `ac`）
+- `chord` のとき: `cn`
+
+### ABC import debug
+
+- `mks:dbg:abc:meta:count`
+- `mks:dbg:abc:meta:0001` ... `mks:dbg:abc:meta:####`
+
+Payload keys:
+
+- `idx,m,v,r,g,ch,st,al,oc,dd,tp`
+
+### MIDI import debug
+
+- `mks:dbg:midi:meta:count`
+- `mks:dbg:midi:meta:0001` ... `mks:dbg:midi:meta:####`
+
+Payload keys:
+
+- `idx,tr,ch,v,stf,key,vel,sd,dd,tk0,tk1`
+
+## mks:meta:* Fields (Target)
+
+### MIDI SysEx metadata (roundtrip restore)
+
+- `mks:meta:midi:sysex:count`
+- `mks:meta:midi:sysex:0001` ... `mks:meta:midi:sysex:####`
+- `mks:meta:midi:sysex:<key>`（要約キー）
+
+代表的な `<key>`:
+
+- `schema,namespace,app,source,tpq`
+- `track-count,event-count,tempo-event-count,timesig-event-count`
+- `keysig-event-count,control-event-count,channel-count`
+- `fingerprint-fnv1a32`
+
+## mks:src:* Fields (Target)
+
+### ABC raw source
+
+- `mks:src:abc:raw-encoding`
+- `mks:src:abc:raw-length`
+- `mks:src:abc:raw-encoded-length`
+- `mks:src:abc:raw-chunks`
+- `mks:src:abc:raw-truncated`
+- `mks:src:abc:raw-0001` ... `mks:src:abc:raw-####`
+
+### MIDI raw bytes
+
+- `mks:src:midi:raw-encoding`
+- `mks:src:midi:raw-bytes`
+- `mks:src:midi:raw-hex-length`
+- `mks:src:midi:raw-chunks`
+- `mks:src:midi:raw-truncated`
+- `mks:src:midi:raw-0001` ... `mks:src:midi:raw-####`
+
+### MuseScore raw source
+
+- `mks:src:musescore:raw-encoding`
+- `mks:src:musescore:raw-length`
+- `mks:src:musescore:raw-encoded-length`
+- `mks:src:musescore:raw-chunks`
+- `mks:src:musescore:raw-0001` ... `mks:src:musescore:raw-####`
+- `mks:src:musescore:version`
+
+### MEI-derived source annotations
+
+- `mks:src:mei:*`
+  - MEI 側 annot から取り込まれた名称を `mks:src:mei:` プレフィクス化
+
+## mks:diag:* Fields (Target)
+
+- `mks:diag:count`
+- `mks:diag:0001` ... `mks:diag:####`
+
+`mks:diag:0001` 以降は `;` 区切りの構造化文字列。
+例:
+
+- `level=warn;code=OVERFULL_CLAMPED;fmt=mei;...`
+- `level=warn;code=...;fmt=abc;...`
+- `level=warn;code=...;fmt=midi;...`
+- `level=warn;code=...;fmt=lilypond;...`
+- `level=warn;code=...;fmt=musescore;...`
+
+## Legacy Names (Current)
+
+現行の実装・既存データで使われる名称:
+
+- debug:
+  - `mks:mei-debug-*`
+  - `mks:abc-meta-*`
+  - `mks:midi-meta-*`
+  - `mks:midi-sysex-*`
+- source:
+  - `src:abc:*`
+  - `src:midi:*`
+  - `src:musescore:*`
+  - `src:mei:*`
+- diagnostics:
+  - `diag:*`
+
+## Notes
+
+- `*-count` は対応する連番フィールド数を示す。
+- 連番は `0001` 形式（4桁ゼロ埋め）。
+- `mks:meta:*` は長期互換を優先する。
+- `mks:dbg:*` は将来変更される可能性がある。

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -376,10 +376,10 @@ const summarizeImportedDiagWarnings = (xml) => {
         return "";
     let overfullReflowCount = 0;
     let parserWarningCount = 0;
-    const fields = Array.from(doc.querySelectorAll('miscellaneous-field[name^="diag:"]'));
+    const fields = Array.from(doc.querySelectorAll('miscellaneous-field[name^="mks:diag:"]'));
     for (const field of fields) {
         const name = (field.getAttribute("name") || "").trim().toLowerCase();
-        if (name === "diag:count")
+        if (name === "mks:diag:count")
             continue;
         const payload = (_b = (_a = field.textContent) === null || _a === void 0 ? void 0 : _a.trim()) !== null && _b !== void 0 ? _b : "";
         const m = payload.match(/(?:^|;)code=([^;]+)/);
@@ -4437,7 +4437,7 @@ const buildMeasureMidiMetaMiscXml = (measureSegments) => {
             : a.midi - b.midi
         : a.startDiv - b.startDiv);
     let xml = "<attributes><miscellaneous>";
-    xml += `<miscellaneous-field name="mks:midi-meta-count">${toHex(sorted.length, 4)}</miscellaneous-field>`;
+    xml += `<miscellaneous-field name="mks:dbg:midi:meta:count">${toHex(sorted.length, 4)}</miscellaneous-field>`;
     for (let i = 0; i < sorted.length; i += 1) {
         const seg = sorted[i];
         const payload = [
@@ -4453,7 +4453,7 @@ const buildMeasureMidiMetaMiscXml = (measureSegments) => {
             `tk0=${toHex(seg.startTick, 6)}`,
             `tk1=${toHex(seg.endTick, 6)}`,
         ].join(";");
-        xml += `<miscellaneous-field name="mks:midi-meta-${String(i + 1).padStart(4, "0")}">${payload}</miscellaneous-field>`;
+        xml += `<miscellaneous-field name="mks:dbg:midi:meta:${String(i + 1).padStart(4, "0")}">${payload}</miscellaneous-field>`;
     }
     xml += "</miscellaneous></attributes>";
     return xml;
@@ -4473,13 +4473,13 @@ const buildMidiSourceMiscXml = (midiBytes) => {
     }
     const truncated = chunks.join("").length < hex.length;
     let xml = "<attributes><miscellaneous>";
-    xml += `<miscellaneous-field name="src:midi:raw-encoding">hex-v1</miscellaneous-field>`;
-    xml += `<miscellaneous-field name="src:midi:raw-bytes">${bytes.length}</miscellaneous-field>`;
-    xml += `<miscellaneous-field name="src:midi:raw-hex-length">${hex.length}</miscellaneous-field>`;
-    xml += `<miscellaneous-field name="src:midi:raw-chunks">${chunks.length}</miscellaneous-field>`;
-    xml += `<miscellaneous-field name="src:midi:raw-truncated">${truncated ? "1" : "0"}</miscellaneous-field>`;
+    xml += `<miscellaneous-field name="mks:src:midi:raw-encoding">hex-v1</miscellaneous-field>`;
+    xml += `<miscellaneous-field name="mks:src:midi:raw-bytes">${bytes.length}</miscellaneous-field>`;
+    xml += `<miscellaneous-field name="mks:src:midi:raw-hex-length">${hex.length}</miscellaneous-field>`;
+    xml += `<miscellaneous-field name="mks:src:midi:raw-chunks">${chunks.length}</miscellaneous-field>`;
+    xml += `<miscellaneous-field name="mks:src:midi:raw-truncated">${truncated ? "1" : "0"}</miscellaneous-field>`;
     for (let i = 0; i < chunks.length; i += 1) {
-        xml += `<miscellaneous-field name="src:midi:raw-${String(i + 1).padStart(4, "0")}">${chunks[i]}</miscellaneous-field>`;
+        xml += `<miscellaneous-field name="mks:src:midi:raw-${String(i + 1).padStart(4, "0")}">${chunks[i]}</miscellaneous-field>`;
     }
     xml += "</miscellaneous></attributes>";
     return xml;
@@ -4509,9 +4509,9 @@ const buildMidiSysExMiscXml = (payloads) => {
         map.set(key, value);
     }
     let xml = "<attributes><miscellaneous>";
-    xml += `<miscellaneous-field name="mks:midi-sysex-count">${toHex(lines.length, 4)}</miscellaneous-field>`;
+    xml += `<miscellaneous-field name="mks:meta:midi:sysex:count">${toHex(lines.length, 4)}</miscellaneous-field>`;
     for (let i = 0; i < lines.length; i += 1) {
-        xml += `<miscellaneous-field name="mks:midi-sysex-${String(i + 1).padStart(4, "0")}">${xmlEscape(lines[i])}</miscellaneous-field>`;
+        xml += `<miscellaneous-field name="mks:meta:midi:sysex:${String(i + 1).padStart(4, "0")}">${xmlEscape(lines[i])}</miscellaneous-field>`;
     }
     const preferred = [
         "schema",
@@ -4532,7 +4532,7 @@ const buildMidiSysExMiscXml = (payloads) => {
         const value = map.get(key);
         if (!value)
             continue;
-        xml += `<miscellaneous-field name="mks:midi-sysex:${key}">${xmlEscape(value)}</miscellaneous-field>`;
+        xml += `<miscellaneous-field name="mks:meta:midi:sysex:${key}">${xmlEscape(value)}</miscellaneous-field>`;
     }
     xml += "</miscellaneous></attributes>";
     return xml;
@@ -4542,7 +4542,7 @@ const buildMidiDiagMiscXml = (warnings) => {
         return "";
     const maxEntries = Math.min(256, warnings.length);
     let xml = "<attributes><miscellaneous>";
-    xml += `<miscellaneous-field name="diag:count">${maxEntries}</miscellaneous-field>`;
+    xml += `<miscellaneous-field name="mks:diag:count">${maxEntries}</miscellaneous-field>`;
     for (let i = 0; i < maxEntries; i += 1) {
         const warning = warnings[i];
         const payload = [
@@ -4551,7 +4551,7 @@ const buildMidiDiagMiscXml = (warnings) => {
             "fmt=midi",
             `message=${xmlEscape(warning.message)}`,
         ].join(";");
-        xml += `<miscellaneous-field name="diag:${String(i + 1).padStart(4, "0")}">${payload}</miscellaneous-field>`;
+        xml += `<miscellaneous-field name="mks:diag:${String(i + 1).padStart(4, "0")}">${payload}</miscellaneous-field>`;
     }
     xml += "</miscellaneous></attributes>";
     return xml;
@@ -9510,7 +9510,7 @@ const buildWarningMiscXml = (warnings) => {
     if (!warnings.length)
         return "";
     const maxEntries = Math.min(256, warnings.length);
-    let xml = `<miscellaneous-field name="diag:count">${maxEntries}</miscellaneous-field>`;
+    let xml = `<miscellaneous-field name="mks:diag:count">${maxEntries}</miscellaneous-field>`;
     for (let i = 0; i < maxEntries; i += 1) {
         const warning = warnings[i];
         const attrs = [
@@ -9538,7 +9538,7 @@ const buildWarningMiscXml = (warnings) => {
         if (warning.capacityDiv !== undefined)
             attrs.push(`capacityDiv=${warning.capacityDiv}`);
         const payload = attrs.join(";");
-        xml += `<miscellaneous-field name="diag:${String(i + 1).padStart(4, "0")}">${xmlEscape(payload)}</miscellaneous-field>`;
+        xml += `<miscellaneous-field name="mks:diag:${String(i + 1).padStart(4, "0")}">${xmlEscape(payload)}</miscellaneous-field>`;
     }
     return xml;
 };
@@ -9546,12 +9546,12 @@ const buildSourceMiscXml = (source) => {
     const encoded = encodeURIComponent(source);
     const chunks = chunkString(encoded, 800);
     let xml = "";
-    xml += '<miscellaneous-field name="src:musescore:raw-encoding">uri-v1</miscellaneous-field>';
-    xml += `<miscellaneous-field name="src:musescore:raw-length">${source.length}</miscellaneous-field>`;
-    xml += `<miscellaneous-field name="src:musescore:raw-encoded-length">${encoded.length}</miscellaneous-field>`;
-    xml += `<miscellaneous-field name="src:musescore:raw-chunks">${chunks.length}</miscellaneous-field>`;
+    xml += '<miscellaneous-field name="mks:src:musescore:raw-encoding">uri-v1</miscellaneous-field>';
+    xml += `<miscellaneous-field name="mks:src:musescore:raw-length">${source.length}</miscellaneous-field>`;
+    xml += `<miscellaneous-field name="mks:src:musescore:raw-encoded-length">${encoded.length}</miscellaneous-field>`;
+    xml += `<miscellaneous-field name="mks:src:musescore:raw-chunks">${chunks.length}</miscellaneous-field>`;
     for (let i = 0; i < chunks.length; i += 1) {
-        xml += `<miscellaneous-field name="src:musescore:raw-${String(i + 1).padStart(4, "0")}">${xmlEscape(chunks[i])}</miscellaneous-field>`;
+        xml += `<miscellaneous-field name="mks:src:musescore:raw-${String(i + 1).padStart(4, "0")}">${xmlEscape(chunks[i])}</miscellaneous-field>`;
     }
     return xml;
 };
@@ -10882,7 +10882,7 @@ const convertMuseScoreToMusicXml = (mscxSource, options = {}) => {
     if (sourceMetadata) {
         sourceMiscXml = buildSourceMiscXml(mscxSource);
         if (sourceVersion) {
-            sourceMiscXml += `<miscellaneous-field name="src:musescore:version">${xmlEscape(sourceVersion)}</miscellaneous-field>`;
+            sourceMiscXml += `<miscellaneous-field name="mks:src:musescore:version">${xmlEscape(sourceVersion)}</miscellaneous-field>`;
         }
     }
     const miscXml = `${debugMetadata ? buildWarningMiscXml(warnings) : ""}${sourceMiscXml}`;
@@ -14675,15 +14675,15 @@ const buildLilySourceMiscFields = (source) => {
     }
     const truncated = chunks.join("").length < encoded.length;
     const fields = [
-        { name: "src:lilypond:raw-encoding", value: "escape-v1" },
-        { name: "src:lilypond:raw-length", value: String(raw.length) },
-        { name: "src:lilypond:raw-encoded-length", value: String(encoded.length) },
-        { name: "src:lilypond:raw-chunks", value: String(chunks.length) },
-        { name: "src:lilypond:raw-truncated", value: truncated ? "1" : "0" },
+        { name: "mks:src:lilypond:raw-encoding", value: "escape-v1" },
+        { name: "mks:src:lilypond:raw-length", value: String(raw.length) },
+        { name: "mks:src:lilypond:raw-encoded-length", value: String(encoded.length) },
+        { name: "mks:src:lilypond:raw-chunks", value: String(chunks.length) },
+        { name: "mks:src:lilypond:raw-truncated", value: truncated ? "1" : "0" },
     ];
     for (let i = 0; i < chunks.length; i += 1) {
         fields.push({
-            name: `src:lilypond:raw-${String(i + 1).padStart(4, "0")}`,
+            name: `mks:src:lilypond:raw-${String(i + 1).padStart(4, "0")}`,
             value: chunks[i],
         });
     }
@@ -14693,11 +14693,14 @@ const buildLilyDiagMiscFields = (warnings) => {
     if (!warnings.length)
         return [];
     const maxEntries = Math.min(256, warnings.length);
-    const fields = [{ name: "diag:count", value: String(maxEntries) }];
+    const fields = [
+        { name: "mks:diag:count", value: String(maxEntries) },
+    ];
     for (let i = 0; i < maxEntries; i += 1) {
+        const payload = `level=warn;code=LILYPOND_IMPORT_WARNING;fmt=lilypond;message=${warnings[i]}`;
         fields.push({
-            name: `diag:${String(i + 1).padStart(4, "0")}`,
-            value: `level=warn;code=LILYPOND_IMPORT_WARNING;fmt=lilypond;message=${warnings[i]}`,
+            name: `mks:diag:${String(i + 1).padStart(4, "0")}`,
+            value: payload,
         });
     }
     return fields;
@@ -15287,7 +15290,7 @@ const exportMusicXmlDomToLilyPond = (doc) => {
     const diagComments = [];
     for (const measure of Array.from(doc.querySelectorAll("score-partwise > part > measure"))) {
         const measureNo = (measure.getAttribute("number") || "").trim() || "1";
-        for (const field of Array.from(measure.querySelectorAll(':scope > attributes > miscellaneous > miscellaneous-field[name^="diag:"]'))) {
+        for (const field of Array.from(measure.querySelectorAll(':scope > attributes > miscellaneous > miscellaneous-field[name^="mks:diag:"]'))) {
             const name = ((_u = field.getAttribute("name")) === null || _u === void 0 ? void 0 : _u.trim()) || "";
             if (!name)
                 continue;
@@ -18084,8 +18087,10 @@ const extractMiscFieldsFromMeiStaff = (staff) => {
         if (name.startsWith("mks:"))
             return name;
         if (name.startsWith("src:"))
-            return name;
-        return `src:mei:${name}`;
+            return `mks:${name}`;
+        if (name.startsWith("diag:"))
+            return `mks:${name}`;
+        return `mks:src:mei:${name}`;
     };
     for (const child of Array.from(staff.children)) {
         if (localNameOf(child) !== "annot")
@@ -18198,11 +18203,11 @@ const buildMeiDebugFieldsFromStaff = (staff, measureNo, divisions) => {
     if (entries.length === 0)
         return [];
     const fields = [
-        { name: "mks:mei-debug-count", value: toHex(entries.length, 4) },
+        { name: "mks:dbg:mei:notes:count", value: toHex(entries.length, 4) },
     ];
     for (let i = 0; i < entries.length; i += 1) {
         fields.push({
-            name: `mks:mei-debug-${String(i + 1).padStart(4, "0")}`,
+            name: `mks:dbg:mei:notes:${String(i + 1).padStart(4, "0")}`,
             value: entries[i],
         });
     }
@@ -18419,9 +18424,9 @@ const convertMeiToMusicXml = (meiSource, options = {}) => {
             }
             const overflowFields = overfullDetected
                 ? [
-                    { name: "diag:count", value: "1" },
+                    { name: "mks:diag:count", value: "1" },
                     {
-                        name: "diag:0001",
+                        name: "mks:diag:0001",
                         value: `level=warn;code=OVERFULL_CLAMPED;fmt=mei;measure=${measureNo};staff=${staffNo};action=clamped;sourceTicks=${sourceTotalTicks};capacityTicks=${measureTicks};droppedEvents=${droppedEvents};droppedTicks=${droppedTicks};trimmedEvents=${trimmedEvents};trimmedTicks=${trimmedTicks}`,
                     },
                 ]
@@ -19839,7 +19844,7 @@ const exportMusicXmlDomToAbc = (doc) => {
     const metaLines = [];
     const emittedKeyMetaByVoiceMeasure = new Set();
     const emitDiagMetaForMeasure = (normalizedVoiceId, measure, safeMeasureNumber) => {
-        const fields = Array.from(measure.querySelectorAll(':scope > attributes > miscellaneous > miscellaneous-field[name^="diag:"]'));
+        const fields = Array.from(measure.querySelectorAll(':scope > attributes > miscellaneous > miscellaneous-field[name^="mks:diag:"]'));
         if (!fields.length)
             return;
         const byName = new Map();
@@ -19851,9 +19856,11 @@ const exportMusicXmlDomToAbc = (doc) => {
             byName.set(name, value);
         }
         const orderedNames = Array.from(byName.keys()).sort((a, b) => {
-            if (a === "diag:count")
+            const isCountA = a === "mks:diag:count";
+            const isCountB = b === "mks:diag:count";
+            if (isCountA && !isCountB)
                 return -1;
-            if (b === "diag:count")
+            if (!isCountA && isCountB)
                 return 1;
             return a.localeCompare(b);
         });
@@ -20294,7 +20301,7 @@ const buildAbcMeasureDebugMiscXml = (notes, measureNo) => {
     if (!notes.length)
         return "";
     let xml = "<attributes><miscellaneous>";
-    xml += `<miscellaneous-field name="mks:abc-meta-count">${toHex(notes.length, 4)}</miscellaneous-field>`;
+    xml += `<miscellaneous-field name="mks:dbg:abc:meta:count">${toHex(notes.length, 4)}</miscellaneous-field>`;
     for (let i = 0; i < notes.length; i += 1) {
         const note = notes[i];
         const voice = normalizeVoiceForMusicXml(note.voice);
@@ -20315,7 +20322,7 @@ const buildAbcMeasureDebugMiscXml = (notes, measureNo) => {
             `dd=${toHex(dur, 4)}`,
             `tp=${xmlEscape(normalizeTypeForMusicXml(note.type))}`,
         ].join(";");
-        xml += `<miscellaneous-field name="mks:abc-meta-${String(i + 1).padStart(4, "0")}">${payload}</miscellaneous-field>`;
+        xml += `<miscellaneous-field name="mks:dbg:abc:meta:${String(i + 1).padStart(4, "0")}">${payload}</miscellaneous-field>`;
     }
     xml += "</miscellaneous></attributes>";
     return xml;
@@ -20336,13 +20343,13 @@ const buildAbcSourceMiscXml = (abcSource) => {
     }
     const truncated = chunks.join("").length < encoded.length;
     let xml = "<attributes><miscellaneous>";
-    xml += `<miscellaneous-field name="src:abc:raw-encoding">escape-v1</miscellaneous-field>`;
-    xml += `<miscellaneous-field name="src:abc:raw-length">${xmlEscape(String(source.length))}</miscellaneous-field>`;
-    xml += `<miscellaneous-field name="src:abc:raw-encoded-length">${xmlEscape(String(encoded.length))}</miscellaneous-field>`;
-    xml += `<miscellaneous-field name="src:abc:raw-chunks">${xmlEscape(String(chunks.length))}</miscellaneous-field>`;
-    xml += `<miscellaneous-field name="src:abc:raw-truncated">${truncated ? "1" : "0"}</miscellaneous-field>`;
+    xml += `<miscellaneous-field name="mks:src:abc:raw-encoding">escape-v1</miscellaneous-field>`;
+    xml += `<miscellaneous-field name="mks:src:abc:raw-length">${xmlEscape(String(source.length))}</miscellaneous-field>`;
+    xml += `<miscellaneous-field name="mks:src:abc:raw-encoded-length">${xmlEscape(String(encoded.length))}</miscellaneous-field>`;
+    xml += `<miscellaneous-field name="mks:src:abc:raw-chunks">${xmlEscape(String(chunks.length))}</miscellaneous-field>`;
+    xml += `<miscellaneous-field name="mks:src:abc:raw-truncated">${truncated ? "1" : "0"}</miscellaneous-field>`;
     for (let i = 0; i < chunks.length; i += 1) {
-        xml += `<miscellaneous-field name="src:abc:raw-${String(i + 1).padStart(4, "0")}">${xmlEscape(chunks[i])}</miscellaneous-field>`;
+        xml += `<miscellaneous-field name="mks:src:abc:raw-${String(i + 1).padStart(4, "0")}">${xmlEscape(chunks[i])}</miscellaneous-field>`;
     }
     xml += "</miscellaneous></attributes>";
     return xml;
@@ -20352,7 +20359,7 @@ const buildAbcDiagMiscXml = (diagnostics) => {
         return "";
     const maxEntries = Math.min(256, diagnostics.length);
     let xml = "<attributes><miscellaneous>";
-    xml += `<miscellaneous-field name="diag:count">${maxEntries}</miscellaneous-field>`;
+    xml += `<miscellaneous-field name="mks:diag:count">${maxEntries}</miscellaneous-field>`;
     for (let i = 0; i < maxEntries; i += 1) {
         const item = diagnostics[i];
         const payload = [
@@ -20367,7 +20374,7 @@ const buildAbcDiagMiscXml = (diagnostics) => {
         ]
             .filter(Boolean)
             .join(";");
-        xml += `<miscellaneous-field name="diag:${String(i + 1).padStart(4, "0")}">${payload}</miscellaneous-field>`;
+        xml += `<miscellaneous-field name="mks:diag:${String(i + 1).padStart(4, "0")}">${payload}</miscellaneous-field>`;
     }
     xml += "</miscellaneous></attributes>";
     return xml;

--- a/src/ts/abc-io.ts
+++ b/src/ts/abc-io.ts
@@ -1477,7 +1477,7 @@ export const exportMusicXmlDomToAbc = (doc: Document): string => {
   ): void => {
     const fields = Array.from(
       measure.querySelectorAll(
-        ':scope > attributes > miscellaneous > miscellaneous-field[name^="diag:"]'
+        ':scope > attributes > miscellaneous > miscellaneous-field[name^="mks:diag:"]'
       )
     );
     if (!fields.length) return;
@@ -1489,8 +1489,10 @@ export const exportMusicXmlDomToAbc = (doc: Document): string => {
       byName.set(name, value);
     }
     const orderedNames = Array.from(byName.keys()).sort((a, b) => {
-      if (a === "diag:count") return -1;
-      if (b === "diag:count") return 1;
+      const isCountA = a === "mks:diag:count";
+      const isCountB = b === "mks:diag:count";
+      if (isCountA && !isCountB) return -1;
+      if (!isCountA && isCountB) return 1;
       return a.localeCompare(b);
     });
     for (const name of orderedNames) {
@@ -2004,7 +2006,7 @@ const toHex = (value: number, width = 2): string => {
 const buildAbcMeasureDebugMiscXml = (notes: AbcParsedNote[], measureNo: number): string => {
   if (!notes.length) return "";
   let xml = "<attributes><miscellaneous>";
-  xml += `<miscellaneous-field name="mks:abc-meta-count">${toHex(notes.length, 4)}</miscellaneous-field>`;
+  xml += `<miscellaneous-field name="mks:dbg:abc:meta:count">${toHex(notes.length, 4)}</miscellaneous-field>`;
   for (let i = 0; i < notes.length; i += 1) {
     const note = notes[i];
     const voice = normalizeVoiceForMusicXml(note.voice);
@@ -2025,7 +2027,7 @@ const buildAbcMeasureDebugMiscXml = (notes: AbcParsedNote[], measureNo: number):
       `dd=${toHex(dur, 4)}`,
       `tp=${xmlEscape(normalizeTypeForMusicXml(note.type))}`,
     ].join(";");
-    xml += `<miscellaneous-field name="mks:abc-meta-${String(i + 1).padStart(4, "0")}">${payload}</miscellaneous-field>`;
+    xml += `<miscellaneous-field name="mks:dbg:abc:meta:${String(i + 1).padStart(4, "0")}">${payload}</miscellaneous-field>`;
   }
   xml += "</miscellaneous></attributes>";
   return xml;
@@ -2046,13 +2048,13 @@ const buildAbcSourceMiscXml = (abcSource: string): string => {
   }
   const truncated = chunks.join("").length < encoded.length;
   let xml = "<attributes><miscellaneous>";
-  xml += `<miscellaneous-field name="src:abc:raw-encoding">escape-v1</miscellaneous-field>`;
-  xml += `<miscellaneous-field name="src:abc:raw-length">${xmlEscape(String(source.length))}</miscellaneous-field>`;
-  xml += `<miscellaneous-field name="src:abc:raw-encoded-length">${xmlEscape(String(encoded.length))}</miscellaneous-field>`;
-  xml += `<miscellaneous-field name="src:abc:raw-chunks">${xmlEscape(String(chunks.length))}</miscellaneous-field>`;
-  xml += `<miscellaneous-field name="src:abc:raw-truncated">${truncated ? "1" : "0"}</miscellaneous-field>`;
+  xml += `<miscellaneous-field name="mks:src:abc:raw-encoding">escape-v1</miscellaneous-field>`;
+  xml += `<miscellaneous-field name="mks:src:abc:raw-length">${xmlEscape(String(source.length))}</miscellaneous-field>`;
+  xml += `<miscellaneous-field name="mks:src:abc:raw-encoded-length">${xmlEscape(String(encoded.length))}</miscellaneous-field>`;
+  xml += `<miscellaneous-field name="mks:src:abc:raw-chunks">${xmlEscape(String(chunks.length))}</miscellaneous-field>`;
+  xml += `<miscellaneous-field name="mks:src:abc:raw-truncated">${truncated ? "1" : "0"}</miscellaneous-field>`;
   for (let i = 0; i < chunks.length; i += 1) {
-    xml += `<miscellaneous-field name="src:abc:raw-${String(i + 1).padStart(4, "0")}">${xmlEscape(chunks[i])}</miscellaneous-field>`;
+    xml += `<miscellaneous-field name="mks:src:abc:raw-${String(i + 1).padStart(4, "0")}">${xmlEscape(chunks[i])}</miscellaneous-field>`;
   }
   xml += "</miscellaneous></attributes>";
   return xml;
@@ -2073,7 +2075,7 @@ const buildAbcDiagMiscXml = (
   if (!diagnostics.length) return "";
   const maxEntries = Math.min(256, diagnostics.length);
   let xml = "<attributes><miscellaneous>";
-  xml += `<miscellaneous-field name="diag:count">${maxEntries}</miscellaneous-field>`;
+  xml += `<miscellaneous-field name="mks:diag:count">${maxEntries}</miscellaneous-field>`;
   for (let i = 0; i < maxEntries; i += 1) {
     const item = diagnostics[i];
     const payload = [
@@ -2088,7 +2090,7 @@ const buildAbcDiagMiscXml = (
     ]
       .filter(Boolean)
       .join(";");
-    xml += `<miscellaneous-field name="diag:${String(i + 1).padStart(4, "0")}">${payload}</miscellaneous-field>`;
+    xml += `<miscellaneous-field name="mks:diag:${String(i + 1).padStart(4, "0")}">${payload}</miscellaneous-field>`;
   }
   xml += "</miscellaneous></attributes>";
   return xml;

--- a/src/ts/lilypond-io.ts
+++ b/src/ts/lilypond-io.ts
@@ -2611,15 +2611,15 @@ const buildLilySourceMiscFields = (source: string): Array<{ name: string; value:
   }
   const truncated = chunks.join("").length < encoded.length;
   const fields: Array<{ name: string; value: string }> = [
-    { name: "src:lilypond:raw-encoding", value: "escape-v1" },
-    { name: "src:lilypond:raw-length", value: String(raw.length) },
-    { name: "src:lilypond:raw-encoded-length", value: String(encoded.length) },
-    { name: "src:lilypond:raw-chunks", value: String(chunks.length) },
-    { name: "src:lilypond:raw-truncated", value: truncated ? "1" : "0" },
+    { name: "mks:src:lilypond:raw-encoding", value: "escape-v1" },
+    { name: "mks:src:lilypond:raw-length", value: String(raw.length) },
+    { name: "mks:src:lilypond:raw-encoded-length", value: String(encoded.length) },
+    { name: "mks:src:lilypond:raw-chunks", value: String(chunks.length) },
+    { name: "mks:src:lilypond:raw-truncated", value: truncated ? "1" : "0" },
   ];
   for (let i = 0; i < chunks.length; i += 1) {
     fields.push({
-      name: `src:lilypond:raw-${String(i + 1).padStart(4, "0")}`,
+      name: `mks:src:lilypond:raw-${String(i + 1).padStart(4, "0")}`,
       value: chunks[i],
     });
   }
@@ -2629,11 +2629,14 @@ const buildLilySourceMiscFields = (source: string): Array<{ name: string; value:
 const buildLilyDiagMiscFields = (warnings: string[]): Array<{ name: string; value: string }> => {
   if (!warnings.length) return [];
   const maxEntries = Math.min(256, warnings.length);
-  const fields: Array<{ name: string; value: string }> = [{ name: "diag:count", value: String(maxEntries) }];
+  const fields: Array<{ name: string; value: string }> = [
+    { name: "mks:diag:count", value: String(maxEntries) },
+  ];
   for (let i = 0; i < maxEntries; i += 1) {
+    const payload = `level=warn;code=LILYPOND_IMPORT_WARNING;fmt=lilypond;message=${warnings[i]}`;
     fields.push({
-      name: `diag:${String(i + 1).padStart(4, "0")}`,
-      value: `level=warn;code=LILYPOND_IMPORT_WARNING;fmt=lilypond;message=${warnings[i]}`,
+      name: `mks:diag:${String(i + 1).padStart(4, "0")}`,
+      value: payload,
     });
   }
   return fields;
@@ -3197,7 +3200,7 @@ export const exportMusicXmlDomToLilyPond = (doc: Document): string => {
   const diagComments: string[] = [];
   for (const measure of Array.from(doc.querySelectorAll("score-partwise > part > measure"))) {
     const measureNo = (measure.getAttribute("number") || "").trim() || "1";
-    for (const field of Array.from(measure.querySelectorAll(':scope > attributes > miscellaneous > miscellaneous-field[name^="diag:"]'))) {
+    for (const field of Array.from(measure.querySelectorAll(':scope > attributes > miscellaneous > miscellaneous-field[name^="mks:diag:"]'))) {
       const name = field.getAttribute("name")?.trim() || "";
       if (!name) continue;
       const value = field.textContent?.trim() || "";

--- a/src/ts/main.ts
+++ b/src/ts/main.ts
@@ -471,10 +471,10 @@ const summarizeImportedDiagWarnings = (xml: string): string => {
   if (!doc) return "";
   let overfullReflowCount = 0;
   let parserWarningCount = 0;
-  const fields = Array.from(doc.querySelectorAll('miscellaneous-field[name^="diag:"]'));
+  const fields = Array.from(doc.querySelectorAll('miscellaneous-field[name^="mks:diag:"]'));
   for (const field of fields) {
     const name = (field.getAttribute("name") || "").trim().toLowerCase();
-    if (name === "diag:count") continue;
+    if (name === "mks:diag:count") continue;
     const payload = field.textContent?.trim() ?? "";
     const m = payload.match(/(?:^|;)code=([^;]+)/);
     const code = (m?.[1] ?? "").trim().toUpperCase();

--- a/src/ts/mei-io.ts
+++ b/src/ts/mei-io.ts
@@ -3240,8 +3240,9 @@ const extractMiscFieldsFromMeiStaff = (staff: Element): Array<{ name: string; va
     const name = rawName.trim();
     if (!name) return "";
     if (name.startsWith("mks:")) return name;
-    if (name.startsWith("src:")) return name;
-    return `src:mei:${name}`;
+    if (name.startsWith("src:")) return `mks:${name}`;
+    if (name.startsWith("diag:")) return `mks:${name}`;
+    return `mks:src:mei:${name}`;
   };
   for (const child of Array.from(staff.children)) {
     if (localNameOf(child) !== "annot") continue;
@@ -3357,11 +3358,11 @@ const buildMeiDebugFieldsFromStaff = (
 
   if (entries.length === 0) return [];
   const fields: Array<{ name: string; value: string }> = [
-    { name: "mks:mei-debug-count", value: toHex(entries.length, 4) },
+    { name: "mks:dbg:mei:notes:count", value: toHex(entries.length, 4) },
   ];
   for (let i = 0; i < entries.length; i += 1) {
     fields.push({
-      name: `mks:mei-debug-${String(i + 1).padStart(4, "0")}`,
+      name: `mks:dbg:mei:notes:${String(i + 1).padStart(4, "0")}`,
       value: entries[i],
     });
   }
@@ -3632,9 +3633,9 @@ export const convertMeiToMusicXml = (meiSource: string, options: MeiImportOption
           const overflowFields: Array<{ name: string; value: string }> =
             overfullDetected
               ? [
-                  { name: "diag:count", value: "1" },
+                  { name: "mks:diag:count", value: "1" },
                   {
-                    name: "diag:0001",
+                    name: "mks:diag:0001",
                     value: `level=warn;code=OVERFULL_CLAMPED;fmt=mei;measure=${measureNo};staff=${staffNo};action=clamped;sourceTicks=${sourceTotalTicks};capacityTicks=${measureTicks};droppedEvents=${droppedEvents};droppedTicks=${droppedTicks};trimmedEvents=${trimmedEvents};trimmedTicks=${trimmedTicks}`,
                   },
                 ]

--- a/src/ts/midi-io.ts
+++ b/src/ts/midi-io.ts
@@ -1806,7 +1806,7 @@ const buildMeasureMidiMetaMiscXml = (measureSegments: ImportedVoiceNoteSegment[]
         : a.startDiv - b.startDiv
     );
   let xml = "<attributes><miscellaneous>";
-  xml += `<miscellaneous-field name="mks:midi-meta-count">${toHex(sorted.length, 4)}</miscellaneous-field>`;
+  xml += `<miscellaneous-field name="mks:dbg:midi:meta:count">${toHex(sorted.length, 4)}</miscellaneous-field>`;
   for (let i = 0; i < sorted.length; i += 1) {
     const seg = sorted[i];
     const payload = [
@@ -1822,7 +1822,7 @@ const buildMeasureMidiMetaMiscXml = (measureSegments: ImportedVoiceNoteSegment[]
       `tk0=${toHex(seg.startTick, 6)}`,
       `tk1=${toHex(seg.endTick, 6)}`,
     ].join(";");
-    xml += `<miscellaneous-field name="mks:midi-meta-${String(i + 1).padStart(4, "0")}">${payload}</miscellaneous-field>`;
+    xml += `<miscellaneous-field name="mks:dbg:midi:meta:${String(i + 1).padStart(4, "0")}">${payload}</miscellaneous-field>`;
   }
   xml += "</miscellaneous></attributes>";
   return xml;
@@ -1842,13 +1842,13 @@ const buildMidiSourceMiscXml = (midiBytes: Uint8Array): string => {
   }
   const truncated = chunks.join("").length < hex.length;
   let xml = "<attributes><miscellaneous>";
-  xml += `<miscellaneous-field name="src:midi:raw-encoding">hex-v1</miscellaneous-field>`;
-  xml += `<miscellaneous-field name="src:midi:raw-bytes">${bytes.length}</miscellaneous-field>`;
-  xml += `<miscellaneous-field name="src:midi:raw-hex-length">${hex.length}</miscellaneous-field>`;
-  xml += `<miscellaneous-field name="src:midi:raw-chunks">${chunks.length}</miscellaneous-field>`;
-  xml += `<miscellaneous-field name="src:midi:raw-truncated">${truncated ? "1" : "0"}</miscellaneous-field>`;
+  xml += `<miscellaneous-field name="mks:src:midi:raw-encoding">hex-v1</miscellaneous-field>`;
+  xml += `<miscellaneous-field name="mks:src:midi:raw-bytes">${bytes.length}</miscellaneous-field>`;
+  xml += `<miscellaneous-field name="mks:src:midi:raw-hex-length">${hex.length}</miscellaneous-field>`;
+  xml += `<miscellaneous-field name="mks:src:midi:raw-chunks">${chunks.length}</miscellaneous-field>`;
+  xml += `<miscellaneous-field name="mks:src:midi:raw-truncated">${truncated ? "1" : "0"}</miscellaneous-field>`;
   for (let i = 0; i < chunks.length; i += 1) {
-    xml += `<miscellaneous-field name="src:midi:raw-${String(i + 1).padStart(4, "0")}">${chunks[i]}</miscellaneous-field>`;
+    xml += `<miscellaneous-field name="mks:src:midi:raw-${String(i + 1).padStart(4, "0")}">${chunks[i]}</miscellaneous-field>`;
   }
   xml += "</miscellaneous></attributes>";
   return xml;
@@ -1875,9 +1875,9 @@ const buildMidiSysExMiscXml = (payloads: string[]): string => {
     map.set(key, value);
   }
   let xml = "<attributes><miscellaneous>";
-  xml += `<miscellaneous-field name="mks:midi-sysex-count">${toHex(lines.length, 4)}</miscellaneous-field>`;
+  xml += `<miscellaneous-field name="mks:meta:midi:sysex:count">${toHex(lines.length, 4)}</miscellaneous-field>`;
   for (let i = 0; i < lines.length; i += 1) {
-    xml += `<miscellaneous-field name="mks:midi-sysex-${String(i + 1).padStart(4, "0")}">${xmlEscape(
+    xml += `<miscellaneous-field name="mks:meta:midi:sysex:${String(i + 1).padStart(4, "0")}">${xmlEscape(
       lines[i]
     )}</miscellaneous-field>`;
   }
@@ -1899,7 +1899,7 @@ const buildMidiSysExMiscXml = (payloads: string[]): string => {
   for (const key of preferred) {
     const value = map.get(key);
     if (!value) continue;
-    xml += `<miscellaneous-field name="mks:midi-sysex:${key}">${xmlEscape(value)}</miscellaneous-field>`;
+    xml += `<miscellaneous-field name="mks:meta:midi:sysex:${key}">${xmlEscape(value)}</miscellaneous-field>`;
   }
   xml += "</miscellaneous></attributes>";
   return xml;
@@ -1909,7 +1909,7 @@ const buildMidiDiagMiscXml = (warnings: MidiImportDiagnostic[]): string => {
   if (!warnings.length) return "";
   const maxEntries = Math.min(256, warnings.length);
   let xml = "<attributes><miscellaneous>";
-  xml += `<miscellaneous-field name="diag:count">${maxEntries}</miscellaneous-field>`;
+  xml += `<miscellaneous-field name="mks:diag:count">${maxEntries}</miscellaneous-field>`;
   for (let i = 0; i < maxEntries; i += 1) {
     const warning = warnings[i];
     const payload = [
@@ -1918,7 +1918,7 @@ const buildMidiDiagMiscXml = (warnings: MidiImportDiagnostic[]): string => {
       "fmt=midi",
       `message=${xmlEscape(warning.message)}`,
     ].join(";");
-    xml += `<miscellaneous-field name="diag:${String(i + 1).padStart(4, "0")}">${payload}</miscellaneous-field>`;
+    xml += `<miscellaneous-field name="mks:diag:${String(i + 1).padStart(4, "0")}">${payload}</miscellaneous-field>`;
   }
   xml += "</miscellaneous></attributes>";
   return xml;

--- a/src/ts/musescore-io.ts
+++ b/src/ts/musescore-io.ts
@@ -198,7 +198,7 @@ const chunkString = (value: string, maxChunk: number): string[] => {
 const buildWarningMiscXml = (warnings: MuseScoreWarning[]): string => {
   if (!warnings.length) return "";
   const maxEntries = Math.min(256, warnings.length);
-  let xml = `<miscellaneous-field name="diag:count">${maxEntries}</miscellaneous-field>`;
+  let xml = `<miscellaneous-field name="mks:diag:count">${maxEntries}</miscellaneous-field>`;
   for (let i = 0; i < maxEntries; i += 1) {
     const warning = warnings[i];
     const attrs: string[] = [
@@ -217,7 +217,7 @@ const buildWarningMiscXml = (warnings: MuseScoreWarning[]): string => {
     if (warning.occupiedDiv !== undefined) attrs.push(`occupiedDiv=${warning.occupiedDiv}`);
     if (warning.capacityDiv !== undefined) attrs.push(`capacityDiv=${warning.capacityDiv}`);
     const payload = attrs.join(";");
-    xml += `<miscellaneous-field name="diag:${String(i + 1).padStart(4, "0")}">${xmlEscape(payload)}</miscellaneous-field>`;
+    xml += `<miscellaneous-field name="mks:diag:${String(i + 1).padStart(4, "0")}">${xmlEscape(payload)}</miscellaneous-field>`;
   }
   return xml;
 };
@@ -226,12 +226,12 @@ const buildSourceMiscXml = (source: string): string => {
   const encoded = encodeURIComponent(source);
   const chunks = chunkString(encoded, 800);
   let xml = "";
-  xml += '<miscellaneous-field name="src:musescore:raw-encoding">uri-v1</miscellaneous-field>';
-  xml += `<miscellaneous-field name="src:musescore:raw-length">${source.length}</miscellaneous-field>`;
-  xml += `<miscellaneous-field name="src:musescore:raw-encoded-length">${encoded.length}</miscellaneous-field>`;
-  xml += `<miscellaneous-field name="src:musescore:raw-chunks">${chunks.length}</miscellaneous-field>`;
+  xml += '<miscellaneous-field name="mks:src:musescore:raw-encoding">uri-v1</miscellaneous-field>';
+  xml += `<miscellaneous-field name="mks:src:musescore:raw-length">${source.length}</miscellaneous-field>`;
+  xml += `<miscellaneous-field name="mks:src:musescore:raw-encoded-length">${encoded.length}</miscellaneous-field>`;
+  xml += `<miscellaneous-field name="mks:src:musescore:raw-chunks">${chunks.length}</miscellaneous-field>`;
   for (let i = 0; i < chunks.length; i += 1) {
-    xml += `<miscellaneous-field name="src:musescore:raw-${String(i + 1).padStart(4, "0")}">${xmlEscape(chunks[i])}</miscellaneous-field>`;
+    xml += `<miscellaneous-field name="mks:src:musescore:raw-${String(i + 1).padStart(4, "0")}">${xmlEscape(chunks[i])}</miscellaneous-field>`;
   }
   return xml;
 };
@@ -1629,7 +1629,7 @@ export const convertMuseScoreToMusicXml = (
   if (sourceMetadata) {
     sourceMiscXml = buildSourceMiscXml(mscxSource);
     if (sourceVersion) {
-      sourceMiscXml += `<miscellaneous-field name="src:musescore:version">${xmlEscape(sourceVersion)}</miscellaneous-field>`;
+      sourceMiscXml += `<miscellaneous-field name="mks:src:musescore:version">${xmlEscape(sourceVersion)}</miscellaneous-field>`;
     }
   }
   const miscXml = `${debugMetadata ? buildWarningMiscXml(warnings) : ""}${sourceMiscXml}`;

--- a/tests/unit/abc-io.spec.ts
+++ b/tests/unit/abc-io.spec.ts
@@ -39,7 +39,7 @@ describe("ABC I/O compatibility", () => {
     expect(voices.every((v) => /^[1-9]\d*$/.test(v))).toBe(true);
   });
 
-  it("ABC->MusicXML writes mks:abc-meta miscellaneous fields by default", () => {
+  it("ABC->MusicXML writes mks:dbg:abc:meta miscellaneous fields by default", () => {
     const abc = `X:1
 T:Debug test
 M:4/4
@@ -51,21 +51,21 @@ C D E F |`;
     expect(outDoc).not.toBeNull();
     if (!outDoc) return;
     const fields = Array.from(
-      outDoc.querySelectorAll('part > measure > attributes > miscellaneous > miscellaneous-field[name^="mks:abc-meta"]')
+      outDoc.querySelectorAll('part > measure > attributes > miscellaneous > miscellaneous-field[name^="mks:dbg:abc:meta"]')
     );
     expect(fields.length).toBeGreaterThan(0);
     expect(fields.some((field) => (field.textContent || "").includes("st=C"))).toBe(true);
     expect(
-      outDoc.querySelector('part > measure > attributes > miscellaneous > miscellaneous-field[name="src:abc:raw-truncated"]')
+      outDoc.querySelector('part > measure > attributes > miscellaneous > miscellaneous-field[name="mks:src:abc:raw-truncated"]')
         ?.textContent
     ).toBe("0");
     expect(
-      outDoc.querySelector('part > measure > attributes > miscellaneous > miscellaneous-field[name="src:abc:raw-0001"]')
+      outDoc.querySelector('part > measure > attributes > miscellaneous > miscellaneous-field[name="mks:src:abc:raw-0001"]')
         ?.textContent
     ).toContain("X:1");
   });
 
-  it("ABC->MusicXML can disable mks:abc-meta miscellaneous fields", () => {
+  it("ABC->MusicXML can disable mks:dbg:abc:meta miscellaneous fields", () => {
     const abc = `X:1
 T:Debug test
 M:4/4
@@ -77,7 +77,7 @@ C D E F |`;
     expect(outDoc).not.toBeNull();
     if (!outDoc) return;
     expect(
-      outDoc.querySelector('part > measure > attributes > miscellaneous > miscellaneous-field[name^="mks:abc-meta"]')
+      outDoc.querySelector('part > measure > attributes > miscellaneous > miscellaneous-field[name^="mks:dbg:abc:meta"]')
     ).toBeNull();
   });
 
@@ -258,12 +258,12 @@ C D E F G A B c d |`;
     expect(measureCount).toBeGreaterThanOrEqual(2);
     expect(
       outDoc.querySelector(
-        'part > measure > attributes > miscellaneous > miscellaneous-field[name="diag:count"]'
+        'part > measure > attributes > miscellaneous > miscellaneous-field[name="mks:diag:count"]'
       )?.textContent
     ).toBe("1");
     expect(
       outDoc.querySelector(
-        'part > measure > attributes > miscellaneous > miscellaneous-field[name="diag:0001"]'
+        'part > measure > attributes > miscellaneous > miscellaneous-field[name="mks:diag:0001"]'
       )?.textContent
     ).toContain("code=OVERFULL_REFLOWED");
   });
@@ -280,7 +280,7 @@ C D E F G A B c d |`;
     const outDoc = parseMusicXmlDocument(xml);
     expect(outDoc).not.toBeNull();
     if (!outDoc) return;
-    expect(outDoc.querySelector('miscellaneous-field[name="diag:count"]')).toBeNull();
+    expect(outDoc.querySelector('miscellaneous-field[name="mks:diag:count"]')).toBeNull();
 
     const core = new ScoreCore();
     core.load(xml);
@@ -301,8 +301,8 @@ C D E F |`;
     const outDoc = parseMusicXmlDocument(xml);
     expect(outDoc).not.toBeNull();
     if (!outDoc) return;
-    expect(outDoc.querySelector('miscellaneous-field[name="diag:count"]')).not.toBeNull();
-    expect(outDoc.querySelector('miscellaneous-field[name="diag:0001"]')?.textContent).toContain(
+    expect(outDoc.querySelector('miscellaneous-field[name="mks:diag:count"]')).not.toBeNull();
+    expect(outDoc.querySelector('miscellaneous-field[name="mks:diag:0001"]')?.textContent).toContain(
       "code=ABC_IMPORT_WARNING"
     );
   });
@@ -427,7 +427,7 @@ V:1
     const outDoc = parseMusicXmlDocument(xml);
     expect(outDoc).not.toBeNull();
     if (!outDoc) return;
-    const overfullDiag = Array.from(outDoc.querySelectorAll('miscellaneous-field[name^="diag:"]'))
+    const overfullDiag = Array.from(outDoc.querySelectorAll('miscellaneous-field[name^="mks:diag:"]'))
       .map((node) => node.textContent?.trim() ?? "")
       .find((text) => text.includes("code=OVERFULL_REFLOWED"));
     expect(overfullDiag).toBeUndefined();
@@ -451,8 +451,8 @@ V:1
         <time><beats>4</beats><beat-type>4</beat-type></time>
         <clef><sign>G</sign><line>2</line></clef>
         <miscellaneous>
-          <miscellaneous-field name="diag:count">1</miscellaneous-field>
-          <miscellaneous-field name="diag:0001">level=warn;code=OVERFULL_CLAMPED;fmt=mei;measure=1</miscellaneous-field>
+          <miscellaneous-field name="mks:diag:count">1</miscellaneous-field>
+          <miscellaneous-field name="mks:diag:0001">level=warn;code=OVERFULL_CLAMPED;fmt=mei;measure=1</miscellaneous-field>
         </miscellaneous>
       </attributes>
       <note><rest/><duration>3840</duration><voice>1</voice><type>whole</type></note>
@@ -464,8 +464,8 @@ V:1
     if (!doc) return;
     const abc = exportMusicXmlDomToAbc(doc);
     expect(abc).toContain("%@mks diag");
-    expect(abc).toContain("name=diag:count");
-    expect(abc).toContain("name=diag:0001");
+    expect(abc).toContain("name=mks:diag:count");
+    expect(abc).toContain("name=mks:diag:0001");
     expect(abc).toContain("enc=uri-v1");
   });
 

--- a/tests/unit/lilypond-io.spec.ts
+++ b/tests/unit/lilypond-io.spec.ts
@@ -106,8 +106,8 @@ describe("LilyPond I/O", () => {
     const doc = parseMusicXmlDocument(xml);
     expect(doc).not.toBeNull();
     if (!doc) return;
-    expect(doc.querySelector('miscellaneous-field[name="diag:count"]')).not.toBeNull();
-    expect(doc.querySelector('miscellaneous-field[name="diag:0001"]')?.textContent).toContain(
+    expect(doc.querySelector('miscellaneous-field[name="mks:diag:count"]')).not.toBeNull();
+    expect(doc.querySelector('miscellaneous-field[name="mks:diag:0001"]')?.textContent).toContain(
       "code=LILYPOND_IMPORT_WARNING"
     );
   });
@@ -944,7 +944,7 @@ PedalOrganMusic = \\relative {
     const doc = parseMusicXmlDocument(xml);
     expect(doc).not.toBeNull();
     if (!doc) return;
-    expect(doc.querySelector('miscellaneous-field[name="diag:count"]')).not.toBeNull();
+    expect(doc.querySelector('miscellaneous-field[name="mks:diag:count"]')).not.toBeNull();
     const core = new ScoreCore();
     core.load(xml);
     const saved = core.save();

--- a/tests/unit/mei-io.spec.ts
+++ b/tests/unit/mei-io.spec.ts
@@ -223,12 +223,12 @@ describe("MEI export", () => {
     expect(outDoc.querySelector("part > measure > note > pitch > step")?.textContent).toBe("C");
     expect(
       outDoc.querySelector(
-        'part > measure > attributes > miscellaneous > miscellaneous-field[name="mks:mei-debug-count"]'
+        'part > measure > attributes > miscellaneous > miscellaneous-field[name="mks:dbg:mei:notes:count"]'
       )?.textContent
     ).toBe("0x0003");
     expect(
       outDoc.querySelector(
-        'part > measure > attributes > miscellaneous > miscellaneous-field[name="mks:mei-debug-0001"]'
+        'part > measure > attributes > miscellaneous > miscellaneous-field[name="mks:dbg:mei:notes:0001"]'
       )?.textContent
     ).toContain("k=note");
   });
@@ -2601,7 +2601,7 @@ describe("MEI export", () => {
     expect(outDoc.querySelector("part > measure > note:nth-of-type(3) > notations > articulations > caesura")).not.toBeNull();
   });
 
-  it("maps non-namespaced MEI misc labels to src:mei:* namespace", () => {
+  it("maps non-namespaced MEI misc labels to mks:src:mei:* namespace", () => {
     const mei = `<?xml version="1.0" encoding="UTF-8"?>
 <mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.1">
   <music>
@@ -2633,7 +2633,7 @@ describe("MEI export", () => {
     expect(outDoc).not.toBeNull();
     if (!outDoc) return;
     const field = outDoc.querySelector(
-      'part > measure > attributes > miscellaneous > miscellaneous-field[name="src:mei:legacy-token"]'
+      'part > measure > attributes > miscellaneous > miscellaneous-field[name="mks:src:mei:legacy-token"]'
     );
     expect(field).not.toBeNull();
     expect(field?.textContent).toBe("abc123");
@@ -2678,12 +2678,12 @@ describe("MEI export", () => {
     expect(total).toBe(1440);
     expect(
       outDoc.querySelector(
-        'part > measure > attributes > miscellaneous > miscellaneous-field[name="diag:count"]'
+        'part > measure > attributes > miscellaneous > miscellaneous-field[name="mks:diag:count"]'
       )?.textContent
     ).toBe("1");
     expect(
       outDoc.querySelector(
-        'part > measure > attributes > miscellaneous > miscellaneous-field[name="diag:0001"]'
+        'part > measure > attributes > miscellaneous > miscellaneous-field[name="mks:diag:0001"]'
       )?.textContent
     ).toContain("code=OVERFULL_CLAMPED");
   });
@@ -3097,7 +3097,7 @@ describe("MEI export", () => {
     expect(measure2Notes.length).toBe(4);
     expect(
       outDoc.querySelector(
-        'part > measure:nth-of-type(2) > attributes > miscellaneous > miscellaneous-field[name="diag:0001"]'
+        'part > measure:nth-of-type(2) > attributes > miscellaneous > miscellaneous-field[name="mks:diag:0001"]'
       )
     ).toBeNull();
   });

--- a/tests/unit/midi-io.spec.ts
+++ b/tests/unit/midi-io.spec.ts
@@ -768,7 +768,7 @@ describe("midi-io MIDI import MVP", () => {
     );
     expect(drumPart).toBeDefined();
     expect(result.warnings.some((warning) => warning.code === "MIDI_DRUM_CHANNEL_SEPARATED")).toBe(true);
-    expect(doc.querySelector('miscellaneous-field[name="diag:0001"]')?.textContent).toContain(
+    expect(doc.querySelector('miscellaneous-field[name="mks:diag:0001"]')?.textContent).toContain(
       "MIDI_DRUM_CHANNEL_SEPARATED"
     );
   });
@@ -1092,11 +1092,11 @@ describe("midi-io MIDI import MVP", () => {
     expect(result.ok).toBe(true);
     const doc = parseDoc(result.xml);
     const metaFields = Array.from(
-      doc.querySelectorAll('part > measure > attributes > miscellaneous > miscellaneous-field[name^="mks:midi-meta"]')
+      doc.querySelectorAll('part > measure > attributes > miscellaneous > miscellaneous-field[name^="mks:dbg:midi:meta"]')
     );
     expect(metaFields.length).toBeGreaterThan(0);
     const firstPayload = metaFields.find((node) =>
-      /^mks:midi-meta-\d{4}$/.test(node.getAttribute("name") ?? "")
+      /^mks:dbg:midi:meta:\d{4}$/.test(node.getAttribute("name") ?? "")
     )?.textContent;
     expect(firstPayload ?? "").toContain("key=0x3C");
     expect(firstPayload ?? "").toContain("vel=0x60");
@@ -1111,16 +1111,16 @@ describe("midi-io MIDI import MVP", () => {
     expect(result.ok).toBe(true);
     const doc = parseDoc(result.xml);
     expect(
-      doc.querySelector('part > measure > attributes > miscellaneous > miscellaneous-field[name="src:midi:raw-encoding"]')
+      doc.querySelector('part > measure > attributes > miscellaneous > miscellaneous-field[name="mks:src:midi:raw-encoding"]')
         ?.textContent
     ).toBe("hex-v1");
     expect(
-      doc.querySelector('part > measure > attributes > miscellaneous > miscellaneous-field[name="src:midi:raw-0001"]')
+      doc.querySelector('part > measure > attributes > miscellaneous > miscellaneous-field[name="mks:src:midi:raw-0001"]')
         ?.textContent
     ).toMatch(/^[0-9A-F]+$/);
   });
 
-  it("reads mikuscore SysEx metadata into mks:midi-sysex miscellaneous fields", () => {
+  it("reads mikuscore SysEx metadata into mks:meta:midi:sysex miscellaneous fields", () => {
     const payloadText =
       "mks|v=1|m=0001|i=0001|n=0001|d=" +
       encodeURIComponent("schema=mks-sysex-v1\napp=mikuscore\nsource=musicxml");
@@ -1145,12 +1145,12 @@ describe("midi-io MIDI import MVP", () => {
     const doc = parseDoc(result.xml);
     expect(
       doc.querySelector(
-        'part > measure > attributes > miscellaneous > miscellaneous-field[name="mks:midi-sysex:schema"]'
+        'part > measure > attributes > miscellaneous > miscellaneous-field[name="mks:meta:midi:sysex:schema"]'
       )?.textContent
     ).toBe("mks-sysex-v1");
     expect(
       doc.querySelector(
-        'part > measure > attributes > miscellaneous > miscellaneous-field[name="mks:midi-sysex:app"]'
+        'part > measure > attributes > miscellaneous > miscellaneous-field[name="mks:meta:midi:sysex:app"]'
       )?.textContent
     ).toBe("mikuscore");
   });
@@ -1184,7 +1184,7 @@ describe("midi-io MIDI import MVP", () => {
     expect(result.ok).toBe(true);
     const doc = parseDoc(result.xml);
     expect(
-      doc.querySelector('part > measure > attributes > miscellaneous > miscellaneous-field[name^="mks:midi-meta"]')
+      doc.querySelector('part > measure > attributes > miscellaneous > miscellaneous-field[name^="mks:dbg:midi:meta"]')
     ).toBeNull();
   });
 
@@ -1199,8 +1199,8 @@ describe("midi-io MIDI import MVP", () => {
     expect(result.ok).toBe(true);
     expect(result.warnings.some((warning) => warning.code === "MIDI_POLYPHONY_VOICE_ASSIGNED")).toBe(true);
     const doc = parseDoc(result.xml);
-    expect(doc.querySelector('miscellaneous-field[name="diag:count"]')?.textContent).toBe("1");
-    expect(doc.querySelector('miscellaneous-field[name="diag:0001"]')?.textContent).toContain(
+    expect(doc.querySelector('miscellaneous-field[name="mks:diag:count"]')?.textContent).toBe("1");
+    expect(doc.querySelector('miscellaneous-field[name="mks:diag:0001"]')?.textContent).toContain(
       "code=MIDI_POLYPHONY_VOICE_ASSIGNED"
     );
   });

--- a/tests/unit/musescore-io.spec.ts
+++ b/tests/unit/musescore-io.spec.ts
@@ -92,7 +92,7 @@ describe("musescore-io", () => {
     expect(doc.querySelector("work > work-title")?.textContent?.trim()).toBe("MS Test");
     expect(doc.querySelector("part-list > score-part[id=\"P1\"]")).not.toBeNull();
     expect(doc.querySelector("part > measure > note > pitch > step")?.textContent?.trim()).toBe("C");
-    expect(doc.querySelector("miscellaneous-field[name=\"src:musescore:raw-encoding\"]")).not.toBeNull();
+    expect(doc.querySelector("miscellaneous-field[name=\"mks:src:musescore:raw-encoding\"]")).not.toBeNull();
   });
 
   it("imports tempo/time/key changes, repeats, and dynamics", () => {
@@ -136,7 +136,7 @@ describe("musescore-io", () => {
     expect(doc.querySelector("measure:nth-of-type(2) dynamics > p")).not.toBeNull();
     expect(doc.querySelector("measure:nth-of-type(1) direction > sound[dynamics=\"100.00\"]")).not.toBeNull();
     expect(doc.querySelector("measure:nth-of-type(2) direction > sound[dynamics=\"54.44\"]")).not.toBeNull();
-    expect(doc.querySelector("miscellaneous-field[name=\"src:musescore:version\"]")?.textContent?.trim()).toBe("4.0");
+    expect(doc.querySelector("miscellaneous-field[name=\"mks:src:musescore:version\"]")?.textContent?.trim()).toBe("4.0");
   });
 
   it("imports MuseScore cut-time symbol as MusicXML time symbol", () => {
@@ -1382,7 +1382,7 @@ describe("musescore-io", () => {
     expect(doc).not.toBeNull();
     if (!doc) return;
 
-    const diag = doc.querySelector("miscellaneous-field[name=\"diag:0001\"]")?.textContent ?? "";
+    const diag = doc.querySelector("miscellaneous-field[name=\"mks:diag:0001\"]")?.textContent ?? "";
     expect(diag).toContain("reason=unknown-duration");
     expect(diag).toContain("action=dropped");
     expect(diag).toContain("measure=1");


### PR DESCRIPTION
…dbg`) and update related docs/tests

### Summary

This PR standardizes `MusicXML miscellaneous-field` keys to the new `mks:*` namespace structure and updates docs/tests accordingly.

- `mks:meta:*` for roundtrip restoration metadata
- `mks:diag:*` for structured conversion diagnostics
- `mks:src:*` for source-preservation payloads
- `mks:dbg:*` for debug-only traces

### What Changed

1. Namespace migration in format I/O implementations
- `diag:*` -> `mks:diag:*`
- `src:*` -> `mks:src:*`
- legacy debug keys migrated to `mks:dbg:*`
  - `mks:abc-meta-*` -> `mks:dbg:abc:meta:*`
  - `mks:midi-meta-*` -> `mks:dbg:midi:meta:*`
  - `mks:mei-debug-*` -> `mks:dbg:mei:notes:*`
- MIDI SysEx roundtrip metadata moved to `mks:meta:*`
  - `mks:midi-sysex-*` -> `mks:meta:midi:sysex:*`

2. Behavior alignment in readers/consumers
- Diagnostic scanning/export paths now target `mks:diag:*` (ABC/LilyPond/UI summary path in `main.ts`)
- MEI misc label mapping now normalizes into `mks:*` namespace (`mks:src:mei:*` etc.)

3. Documentation updates
- Added new spec: `docs/spec/MISCELLANEOUS_FIELDS.md`
- Updated `docs/spec/FORMAT_IO_CHECKLIST.md` to the new classification/order:
  - `mks:meta` -> `mks:diag` -> `mks:src` -> `mks:dbg`
- Added `MISCELLANEOUS_FIELDS.md` links in `README.md`

4. Test updates
- Updated unit tests across ABC/MIDI/MEI/MuseScore/LilyPond to assert new key names.

### Impact

- Output key names are now based on the new namespace policy.
- Any downstream tooling that depends on legacy names (`diag:*`, `src:*`, old `mks:*` variants) must be updated to the new keys.

### Files in Scope (main)

- `src/ts/abc-io.ts`
- `src/ts/midi-io.ts`
- `src/ts/mei-io.ts`
- `src/ts/musescore-io.ts`
- `src/ts/lilypond-io.ts`
- `src/ts/main.ts`
- `docs/spec/MISCELLANEOUS_FIELDS.md` (new)
- `docs/spec/FORMAT_IO_CHECKLIST.md`
- `README.md`
- `tests/unit/*-io.spec.ts`
- generated artifacts: `src/js/main.js`, `mikuscore.html`