### PR TITLE
Align `miscellaneous-field` policy to `mks:*` only and remove legacy …

### DIFF
--- a/docs/spec/ABC_IO.md
+++ b/docs/spec/ABC_IO.md
@@ -155,20 +155,20 @@ Generation policy:
 - restores tuplet semantics using both `<time-modification>` and `<notations><tuplet>`
 - restores measure metadata (`number`, `implicit`) and repeat barlines from `%@mks measure`
 - restores transpose (`chromatic`, `diatonic`) from `%@mks transpose`
-- emits metadata to `attributes/miscellaneous-field` (`mks:abc-meta-*`) by default; disable with `debugMetadata:false`
+- emits metadata to `attributes/miscellaneous-field` (`mks:dbg:abc:meta:*`) by default; disable with `debugMetadata:false`
 - inserts a fallback whole-rest note for empty measures
 
 ### Incident analysis using `miscellaneous-field`
 
 For ABC import troubleshooting, inspect:
 
-- `part > measure > attributes > miscellaneous > miscellaneous-field[name="mks:abc-meta-count"]`
-- `part > measure > attributes > miscellaneous > miscellaneous-field[name^="mks:abc-meta-"]`
+- `part > measure > attributes > miscellaneous > miscellaneous-field[name="mks:dbg:abc:meta:count"]`
+- `part > measure > attributes > miscellaneous > miscellaneous-field[name^="mks:dbg:abc:meta:"]`
 
 Recommended flow:
 
 1. identify the problematic measure/event in the rendered score.
-2. inspect corresponding `mks:abc-meta-*` rows in MusicXML.
+2. inspect corresponding `mks:dbg:abc:meta:*` rows in MusicXML.
 3. compare parsed note facts (`r`, `g`, `ch`, `st`, `al`, `oc`, `dd`, `tp`) against expected ABC intent.
 
 ---

--- a/docs/spec/FORMAT_IO_CHECKLIST.md
+++ b/docs/spec/FORMAT_IO_CHECKLIST.md
@@ -124,7 +124,6 @@ When adding a new format (e.g. ABC / MEI / future formats), use this checklist t
   - fallback when hint is absent or invalid
   - safety against conflicts with existing source comments
 - [ ] Keep namespace separation strict (`mks:src:*` vs `mks:meta:*` vs `mks:diag:*` vs `mks:dbg:*`) to avoid mixing source data, functional extension metadata, diagnostics, and debug traces.
-  - During migration, allow legacy names (`src:*`, `diag:*`, old `mks:*`) only via dual-write/dual-read compatibility paths.
 
 ### LilyPond Note (Current `mks` usage)
 

--- a/docs/spec/MIDI_IO.md
+++ b/docs/spec/MIDI_IO.md
@@ -298,13 +298,13 @@ Rules:
 
 When analyzing rendering/import issues, inspect:
 
-- `part > measure > attributes > miscellaneous > miscellaneous-field[name="mks:midi-meta-count"]`
-- `part > measure > attributes > miscellaneous > miscellaneous-field[name^="mks:midi-meta-"]`
+- `part > measure > attributes > miscellaneous > miscellaneous-field[name="mks:dbg:midi:meta:count"]`
+- `part > measure > attributes > miscellaneous > miscellaneous-field[name^="mks:dbg:midi:meta:"]`
 
 Recommended flow:
 
 1. identify the problematic measure and note on screen.
-2. open the same measure in MusicXML and read `mks:midi-meta-*`.
+2. open the same measure in MusicXML and read `mks:dbg:midi:meta:*`.
 3. compare note duration/type and debug payload (`key`, `vel`, `sd`, `dd`, `tk0`, `tk1`) to detect where conversion diverged.
 
 ### Drum note rendering

--- a/docs/spec/MISCELLANEOUS_FIELDS.md
+++ b/docs/spec/MISCELLANEOUS_FIELDS.md
@@ -19,8 +19,7 @@
 
 補足:
 
-- 現行実装には legacy 名（`src:*`, `diag:*`, `mks:...` 旧形式）が混在する。
-- 移行期間は **dual-write + dual-read** を採用し、段階的に新命名へ寄せる。
+- 出力時の `miscellaneous-field` は本ドキュメントの `mks:*` 命名を基準とする。
 
 ## mks:dbg:* Fields (Target)
 
@@ -115,23 +114,6 @@ Payload keys:
 - `level=warn;code=...;fmt=midi;...`
 - `level=warn;code=...;fmt=lilypond;...`
 - `level=warn;code=...;fmt=musescore;...`
-
-## Legacy Names (Current)
-
-現行の実装・既存データで使われる名称:
-
-- debug:
-  - `mks:mei-debug-*`
-  - `mks:abc-meta-*`
-  - `mks:midi-meta-*`
-  - `mks:midi-sysex-*`
-- source:
-  - `src:abc:*`
-  - `src:midi:*`
-  - `src:musescore:*`
-  - `src:mei:*`
-- diagnostics:
-  - `diag:*`
 
 ## Notes
 

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -353,7 +353,7 @@ const stripMetadataFromMusicXml = (xml, keepMetadata) => {
     const doc = (0, musicxml_io_1.parseMusicXmlDocument)(xml);
     if (!doc)
         return xml;
-    const fields = Array.from(doc.querySelectorAll('part > measure > attributes > miscellaneous > miscellaneous-field[name^="src:"], part > measure > attributes > miscellaneous > miscellaneous-field[name^="mks:"]'));
+    const fields = Array.from(doc.querySelectorAll('part > measure > attributes > miscellaneous > miscellaneous-field[name^="mks:"]'));
     for (const field of fields) {
         field.remove();
     }

--- a/src/ts/main.ts
+++ b/src/ts/main.ts
@@ -449,7 +449,7 @@ const stripMetadataFromMusicXml = (xml: string, keepMetadata: boolean): string =
   if (!doc) return xml;
   const fields = Array.from(
     doc.querySelectorAll(
-      'part > measure > attributes > miscellaneous > miscellaneous-field[name^="src:"], part > measure > attributes > miscellaneous > miscellaneous-field[name^="mks:"]'
+      'part > measure > attributes > miscellaneous > miscellaneous-field[name^="mks:"]'
     )
   );
   for (const field of fields) {


### PR DESCRIPTION
…namespace references

### Summary

This PR finalizes the documentation and runtime behavior for `miscellaneous-field` naming by treating `mks:*` as the canonical output namespace and removing legacy-output guidance.

### Changes

- Updated ABC debug metadata references in docs:
  - `mks:abc-meta-*` -> `mks:dbg:abc:meta:*`
  - File: `docs/spec/ABC_IO.md`

- Updated MIDI debug metadata references in docs:
  - `mks:midi-meta-*` -> `mks:dbg:midi:meta:*`
  - File: `docs/spec/MIDI_IO.md`

- Removed migration note that allowed legacy dual-write/dual-read from checklist:
  - File: `docs/spec/FORMAT_IO_CHECKLIST.md`

- Simplified `miscellaneous-field` spec to new canonical policy:
  - Explicitly states output should follow `mks:*`
  - Removed `Legacy Names (Current)` section
  - File: `docs/spec/MISCELLANEOUS_FIELDS.md`

- Updated metadata stripping selector in app code to target only `mks:*` fields:
  - `name^="src:"` fallback removed
  - File: `src/ts/main.ts`

- Regenerated build artifacts:
  - `src/js/main.js`
  - `mikuscore.html`

### Impact

- Runtime metadata handling now assumes `mks:*` namespace for stripping/export-side treatment.
- Documentation no longer describes legacy output naming as an active behavior.
- This change helps keep implementation and specs consistent with the new namespace policy.