### PR TITLE
ZIPファイル入力対応を追加し、ルート直下エントリ選択とロード中オーバーレイ表示を実装

### DIFF
--- a/mikuscore-src.html
+++ b/mikuscore-src.html
@@ -167,7 +167,7 @@
             <div class="ms-file-meta">
               <span id="fileNameText" class="ms-file-name md-hidden">No file selected</span>
             </div>
-            <input id="fileInput" type="file" accept=".musicxml,.xml,.mxl,.abc,.mid,.midi,.vsqx,.mei,.ly,.mscx,.mscz,text/plain,text/xml,application/xml,application/mei+xml" hidden />
+            <input id="fileInput" type="file" accept=".musicxml,.xml,.mxl,.abc,.mid,.midi,.vsqx,.mei,.ly,.mscx,.mscz,.zip,application/vnd.recordare.musicxml+xml,application/vnd.recordare.musicxml,application/vnd.recordare.musicxml-container,application/mxl+xml,audio/midi,audio/x-midi,audio/mid,text/vnd.abc,application/abc,text/x-abc,application/mei+xml,text/x-vsqx,application/vsqx,text/x-lilypond,text/x-ly,application/vnd.musescore.mscx,application/vnd.musescore.mscz,application/zip,application/x-zip-compressed,text/plain,text/xml,application/xml" hidden />
           </div>
 
           <div id="sourceXmlInputBlock" class="ms-block md-hidden">
@@ -219,6 +219,9 @@
             </button>
             <button id="loadSampleBtn1" type="button" class="md-button md-button--tonal">Load sample 1</button>
             <button id="loadSample2Btn" type="button" class="md-button md-button--tonal">Load sample 2</button>
+          </div>
+          <div id="zipEntrySelectBlock" class="ms-block md-hidden">
+            <select id="zipEntrySelect" class="md-select"></select>
           </div>
           <div id="inputUiMessage" class="ms-ui-message ms-ui-message--inline md-hidden" role="status" aria-live="polite"></div>
           <div id="localDraftNotice" class="ms-local-draft md-hidden" role="status" aria-live="polite">
@@ -895,6 +898,12 @@
 
     </section>
   </main>
+  <div id="fileLoadOverlay" class="ms-loading-overlay md-hidden" role="status" aria-live="polite" aria-hidden="true">
+    <div class="ms-loading-dialog">
+      <div class="ms-loading-spinner" aria-hidden="true"></div>
+      <p class="ms-loading-text">Loading file...</p>
+    </div>
+  </div>
 
   <script src="src/js/verovio.js"></script>
   <script src="src/js/midi-writer.js"></script>

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -331,6 +331,52 @@ body {
   flex-wrap: wrap;
 }
 
+.ms-loading-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 70;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  background: rgba(17, 13, 27, 0.45);
+  backdrop-filter: blur(2px);
+}
+
+.ms-loading-dialog {
+  min-width: 13rem;
+  border-radius: 16px;
+  border: 1px solid #ded4ef;
+  background: #ffffff;
+  box-shadow: 0 18px 36px rgba(24, 18, 36, 0.24);
+  padding: 1rem 1.2rem;
+  display: grid;
+  justify-items: center;
+  gap: 0.65rem;
+}
+
+.ms-loading-spinner {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  border: 3px solid #d8caee;
+  border-top-color: #6200ee;
+  animation: ms-loading-spin 0.95s linear infinite;
+}
+
+.ms-loading-text {
+  margin: 0;
+  color: #383247;
+  font-size: 0.92rem;
+  font-weight: 600;
+}
+
+@keyframes ms-loading-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 .ms-file-select-button {
   background: #6200ee;
   color: #ffffff;
@@ -351,6 +397,10 @@ body {
 
 .ms-actions .md-button {
   width: auto;
+}
+
+#zipEntrySelectBlock {
+  margin-top: 0.5rem;
 }
 
 .ms-preview-actions {


### PR DESCRIPTION
## 概要
ファイル読み込みフローを拡張し、`.zip` を入力として受け付けられるようにしました。
ZIP内の対応ファイルは「ルート直下のみ」を候補表示し、選択後は既存の通常ロード経路に合流します。
あわせて、ファイルロード中のUIとして全画面オーバーレイ（スピナー）を追加しました。

## 主な変更点
- `accept` を拡張し、`.zip` と関連MIMEを追加
- ZIP読み込み時の候補選択UIを追加（`#zipEntrySelectBlock`）
  - ルート直下の対応拡張子のみ列挙
  - 候補1件は自動選択、複数件はユーザー選択
- ZIP内選択後、既存 `resolveLoadFlow` に仮想 `File` として渡す実装を追加
- ZIPユーティリティを `mxl-io.ts` に追加
  - `listZipRootEntryPathsByExtensions`
  - `extractZipEntryBytesByPath`
- ファイルロード中の全画面オーバーレイを追加
  - `Loading file...` + スピナー
  - ロード中は関連UIを非活性化
- ZIPユーティリティのユニットテストを追加

## 変更ファイル
- `mikuscore-src.html`
- `src/css/app.css`
- `src/ts/main.ts`
- `src/ts/mxl-io.ts`
- `tests/unit/download-flow.spec.ts`
- `src/js/main.js`（ビルド成果物）
- `mikuscore.html`（ビルド成果物）

## テスト
- `npm run typecheck` ✅
- `npm run test:unit -- tests/unit/download-flow.spec.ts` ✅
- `npm run build` ✅

## 影響範囲
- 入力画面のファイルロードUX
- ZIP経由の各フォーマット取り込み経路
- ビルド済み配布HTML / JS