### PR TITLE
MIDI/Playbackの同音連結ロジックを再設計し、tie/slur境界とアーティキュレーション表現を保持

### DIFF
--- a/mikuscore.html
+++ b/mikuscore.html
@@ -12496,6 +12496,9 @@ const getNoteArticulationAdjustments = (noteNode) => {
     }
     return { velocityDelta, durationRatio, hasTenuto };
 };
+const hasExplicitArticulation = (noteNode) => {
+    return noteNode.querySelector("notations > articulations > *") !== null;
+};
 const getTieFlags = (noteNode) => {
     var _a;
     const directTieNodes = Array.from(noteNode.children).filter((child) => child.tagName === "tie");
@@ -15795,6 +15798,7 @@ const buildPlaybackEventsFromMusicXmlDoc = (doc, ticksPerQuarter, options = {}) 
     const includeGraceProcessing = applyMidiNuance || options.includeGraceInPlaybackLikeMode === true;
     const includeOrnamentExpansion = applyMidiNuance || options.includeOrnamentInPlaybackLikeMode === true;
     const includeTieProcessing = applyMidiNuance || options.includeTieInPlaybackLikeMode === true;
+    const includeSlurProcessing = applyMidiNuance || includeTieProcessing;
     const applyDefaultDetache = applyMidiNuance || options.applyDefaultDetacheInPlaybackLikeMode === true;
     const graceTimingMode = (_b = options.graceTimingMode) !== null && _b !== void 0 ? _b : DEFAULT_GRACE_TIMING_MODE;
     const metricAccentEnabled = options.metricAccentEnabled === true;
@@ -15827,7 +15831,7 @@ const buildPlaybackEventsFromMusicXmlDoc = (doc, ticksPerQuarter, options = {}) 
     const tempo = clampTempo((_k = getFirstNumber(doc, "sound[tempo]")) !== null && _k !== void 0 ? _k : defaultTempo);
     const events = [];
     partNodes.forEach((part, partIndex) => {
-        var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p, _q, _r, _s, _t, _u, _v, _w, _x, _y, _z, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18;
+        var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p, _q, _r, _s, _t, _u, _v, _w, _x, _y, _z, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19;
         const partId = (_a = part.getAttribute("id")) !== null && _a !== void 0 ? _a : "";
         const fallbackChannel = (partIndex % 16) + 1 === 10 ? 11 : (partIndex % 16) + 1;
         const channel = (_b = channelMap.get(partId)) !== null && _b !== void 0 ? _b : fallbackChannel;
@@ -15839,10 +15843,27 @@ const buildPlaybackEventsFromMusicXmlDoc = (doc, ticksPerQuarter, options = {}) 
         let currentVelocity = 80;
         let timelineDiv = 0;
         const tieChainByKey = new Map();
+        const resolveFallbackTieChainKey = (voice, midiChannel, midiNumber) => {
+            const suffix = `|${midiChannel}|${midiNumber}`;
+            const exact = `${voice}${suffix}`;
+            if (tieChainByKey.has(exact))
+                return exact;
+            let candidate = null;
+            for (const key of tieChainByKey.keys()) {
+                if (!key.endsWith(suffix))
+                    continue;
+                if (candidate !== null)
+                    return null; // ambiguous
+                candidate = key;
+            }
+            return candidate;
+        };
         const activeWedgeByNumber = new Map();
         const pendingGraceByVoice = new Map();
         const activeSlurByVoice = new Map();
         const voiceTimeShiftTicks = new Map();
+        const lastEventByVoiceChannelPitch = new Map();
+        const lastEventAllowsRepeatedSlurMergeByVoiceChannelPitch = new Map();
         const measures = Array.from(part.querySelectorAll(":scope > measure"));
         for (let measureIndex = 0; measureIndex < measures.length; measureIndex += 1) {
             const measure = measures[measureIndex];
@@ -15990,9 +16011,15 @@ const buildPlaybackEventsFromMusicXmlDoc = (doc, ticksPerQuarter, options = {}) 
                         if (soundingMidi < 0 || soundingMidi > 127) {
                             continue;
                         }
+                        const parsedArticulation = getNoteArticulationAdjustments(child);
                         const articulation = applyMidiNuance
-                            ? getNoteArticulationAdjustments(child)
+                            ? parsedArticulation
                             : { velocityDelta: 0, durationRatio: 1, hasTenuto: false };
+                        const hasAnyExplicitArticulation = hasExplicitArticulation(child);
+                        const allowsRepeatedSlurMergeForCurrent = !hasAnyExplicitArticulation &&
+                            parsedArticulation.durationRatio >= 1 &&
+                            !parsedArticulation.hasTenuto &&
+                            parsedArticulation.velocityDelta === 0;
                         const metricAccentDelta = applyMidiNuance && metricAccentEnabled
                             ? getMetricAccentVelocityDelta(startDiv, currentDivisions, currentBeats, currentBeatType, metricAccentProfile)
                             : 0;
@@ -16002,10 +16029,18 @@ const buildPlaybackEventsFromMusicXmlDoc = (doc, ticksPerQuarter, options = {}) 
                         const baseDurTicks = Math.max(1, Math.round(((durationDiv !== null && durationDiv !== void 0 ? durationDiv : 1) / currentDivisions) * normalizedTicksPerQuarter));
                         const slurNumbers = applyMidiNuance
                             ? getSlurNumbers(child)
-                            : { starts: [], stops: [] };
+                            : includeSlurProcessing
+                                ? getSlurNumbers(child)
+                                : { starts: [], stops: [] };
                         const activeSlurSet = (_8 = activeSlurByVoice.get(voice)) !== null && _8 !== void 0 ? _8 : new Set();
-                        const noteUnderSlur = applyMidiNuance &&
+                        const noteUnderSlur = includeSlurProcessing &&
                             (activeSlurSet.size > 0 || slurNumbers.starts.length > 0 || slurNumbers.stops.length > 0);
+                        const hasForwardSlurConnection = includeSlurProcessing &&
+                            (slurNumbers.starts.length > 0 || activeSlurSet.size > slurNumbers.stops.length);
+                        const isInsideOngoingSlurOnly = includeSlurProcessing &&
+                            activeSlurSet.size > 0 &&
+                            slurNumbers.starts.length === 0 &&
+                            slurNumbers.stops.length === 0;
                         const tieFlags = includeTieProcessing ? getTieFlags(child) : { start: false, stop: false };
                         const shouldApplyDefaultDetache = applyDefaultDetache &&
                             !isGrace &&
@@ -16032,7 +16067,7 @@ const buildPlaybackEventsFromMusicXmlDoc = (doc, ticksPerQuarter, options = {}) 
                             pendingGraceByVoice.set(voice, pending);
                             continue;
                         }
-                        const legatoOverlapTicks = applyMidiNuance && !isChord && (noteUnderSlur || articulation.hasTenuto)
+                        const legatoOverlapTicks = applyMidiNuance && !isChord && (hasForwardSlurConnection || articulation.hasTenuto)
                             ? Math.max(1, Math.round(normalizedTicksPerQuarter / 32))
                             : 0;
                         const temporalAdjustments = applyMidiNuance && !isGrace
@@ -16109,29 +16144,64 @@ const buildPlaybackEventsFromMusicXmlDoc = (doc, ticksPerQuarter, options = {}) 
                         const primaryEvent = generatedEvents[0];
                         if (!primaryEvent)
                             continue;
+                        const voiceChannelPitchKey = `${voice}|${channel}|${soundingMidi}`;
+                        const priorSamePitchEvent = (_18 = lastEventByVoiceChannelPitch.get(voiceChannelPitchKey)) !== null && _18 !== void 0 ? _18 : null;
+                        const shouldMergeRepeatedSlurSamePitch = includeSlurProcessing &&
+                            !isChord &&
+                            !isGrace &&
+                            !tieFlags.start &&
+                            !tieFlags.stop &&
+                            isInsideOngoingSlurOnly &&
+                            generatedEvents.length === 1 &&
+                            priorSamePitchEvent !== null &&
+                            allowsRepeatedSlurMergeForCurrent &&
+                            Boolean(lastEventAllowsRepeatedSlurMergeByVoiceChannelPitch.get(voiceChannelPitchKey)) &&
+                            priorSamePitchEvent.startTicks < startTicks &&
+                            priorSamePitchEvent.startTicks + priorSamePitchEvent.durTicks >= startTicks;
                         for (const wedgeKind of activeWedgeByNumber.values()) {
                             currentVelocity = clampVelocity(currentVelocity + (wedgeKind === "crescendo" ? 4 : -4));
                         }
-                        if (includeTieProcessing) {
-                            const tieKey = `${voice}|${channel}|${soundingMidi}`;
+                        if (shouldMergeRepeatedSlurSamePitch && priorSamePitchEvent) {
+                            const priorEndTick = priorSamePitchEvent.startTicks + priorSamePitchEvent.durTicks;
+                            const currentEndTick = primaryEvent.startTicks + primaryEvent.durTicks;
+                            priorSamePitchEvent.durTicks = Math.max(1, Math.max(priorEndTick, currentEndTick) - priorSamePitchEvent.startTicks);
+                            priorSamePitchEvent.velocity = Math.max(priorSamePitchEvent.velocity, velocity);
+                            lastEventByVoiceChannelPitch.set(voiceChannelPitchKey, priorSamePitchEvent);
+                        }
+                        else if (includeTieProcessing) {
+                            const tieKey = voiceChannelPitchKey;
                             if (tieFlags.stop) {
-                                const chained = tieChainByKey.get(tieKey);
+                                const chainedKey = resolveFallbackTieChainKey(voice, channel, soundingMidi);
+                                const chained = chainedKey ? tieChainByKey.get(chainedKey) : null;
                                 if (chained) {
                                     chained.durTicks += primaryEvent.durTicks;
                                     chained.velocity = Math.max(chained.velocity, velocity);
+                                    lastEventByVoiceChannelPitch.set(chainedKey !== null && chainedKey !== void 0 ? chainedKey : tieKey, chained);
+                                    lastEventAllowsRepeatedSlurMergeByVoiceChannelPitch.set(chainedKey !== null && chainedKey !== void 0 ? chainedKey : tieKey, allowsRepeatedSlurMergeForCurrent);
                                 }
                                 else {
                                     events.push(primaryEvent);
+                                    lastEventByVoiceChannelPitch.set(tieKey, primaryEvent);
+                                    lastEventAllowsRepeatedSlurMergeByVoiceChannelPitch.set(tieKey, allowsRepeatedSlurMergeForCurrent);
                                 }
                                 if (!tieFlags.start) {
-                                    tieChainByKey.delete(tieKey);
+                                    if (chainedKey)
+                                        tieChainByKey.delete(chainedKey);
                                 }
                                 else {
-                                    tieChainByKey.set(tieKey, chained !== null && chained !== void 0 ? chained : primaryEvent);
+                                    const chainedOrPrimary = chained !== null && chained !== void 0 ? chained : primaryEvent;
+                                    tieChainByKey.set(chainedKey !== null && chainedKey !== void 0 ? chainedKey : tieKey, chainedOrPrimary);
+                                    lastEventByVoiceChannelPitch.set(chainedKey !== null && chainedKey !== void 0 ? chainedKey : tieKey, chainedOrPrimary);
+                                    lastEventAllowsRepeatedSlurMergeByVoiceChannelPitch.set(chainedKey !== null && chainedKey !== void 0 ? chainedKey : tieKey, allowsRepeatedSlurMergeForCurrent);
                                 }
                             }
                             else {
                                 events.push(...generatedEvents);
+                                for (const generated of generatedEvents) {
+                                    const generatedKey = `${voice}|${channel}|${generated.midiNumber}`;
+                                    lastEventByVoiceChannelPitch.set(generatedKey, generated);
+                                    lastEventAllowsRepeatedSlurMergeByVoiceChannelPitch.set(generatedKey, allowsRepeatedSlurMergeForCurrent);
+                                }
                                 if (tieFlags.start) {
                                     tieChainByKey.set(tieKey, primaryEvent);
                                 }
@@ -16142,8 +16212,13 @@ const buildPlaybackEventsFromMusicXmlDoc = (doc, ticksPerQuarter, options = {}) 
                         }
                         else {
                             events.push(...generatedEvents);
+                            for (const generated of generatedEvents) {
+                                const generatedKey = `${voice}|${channel}|${generated.midiNumber}`;
+                                lastEventByVoiceChannelPitch.set(generatedKey, generated);
+                                lastEventAllowsRepeatedSlurMergeByVoiceChannelPitch.set(generatedKey, allowsRepeatedSlurMergeForCurrent);
+                            }
                         }
-                        if (applyMidiNuance) {
+                        if (includeSlurProcessing || applyMidiNuance) {
                             const nextSlurSet = new Set(activeSlurSet);
                             for (const slurStart of slurNumbers.starts)
                                 nextSlurSet.add(slurStart);
@@ -16155,8 +16230,10 @@ const buildPlaybackEventsFromMusicXmlDoc = (doc, ticksPerQuarter, options = {}) 
                             else {
                                 activeSlurByVoice.delete(voice);
                             }
+                        }
+                        if (applyMidiNuance) {
                             if (!isChord && temporalAdjustments.postPauseTicks > 0) {
-                                const shiftedTicks = ((_18 = voiceTimeShiftTicks.get(voice)) !== null && _18 !== void 0 ? _18 : 0) + temporalAdjustments.postPauseTicks;
+                                const shiftedTicks = ((_19 = voiceTimeShiftTicks.get(voice)) !== null && _19 !== void 0 ? _19 : 0) + temporalAdjustments.postPauseTicks;
                                 voiceTimeShiftTicks.set(voice, shiftedTicks);
                             }
                         }
@@ -17281,11 +17358,11 @@ const createBasicWaveSynthEngine = (options) => {
         }
         return context;
     };
-    const scheduleBasicWaveNote = (event, startAt, bodyDuration, waveform, sustainHoldSeconds = 0) => {
+    const scheduleBasicWaveNote = (event, startAt, bodyDuration, waveform, sustainHoldSeconds = 0, legatoFromOverlap = false) => {
         if (!audioContext)
             return startAt;
-        const attack = 0.005;
-        const release = 0.03;
+        const attack = legatoFromOverlap ? 0.0015 : 0.005;
+        const release = legatoFromOverlap ? 0.03 : 0.01;
         const endAt = startAt + bodyDuration;
         const heldEndAt = endAt + Math.max(0, sustainHoldSeconds);
         const oscillator = audioContext.createOscillator();
@@ -17293,8 +17370,14 @@ const createBasicWaveSynthEngine = (options) => {
         oscillator.frequency.setValueAtTime(midiToHz(event.midiNumber), startAt);
         const gainNode = audioContext.createGain();
         const gainLevel = event.channel === 10 ? 0.06 : 0.1;
-        gainNode.gain.setValueAtTime(0.0001, startAt);
-        gainNode.gain.linearRampToValueAtTime(gainLevel, startAt + attack);
+        if (legatoFromOverlap) {
+            gainNode.gain.setValueAtTime(gainLevel * 0.75, startAt);
+            gainNode.gain.linearRampToValueAtTime(gainLevel, startAt + attack);
+        }
+        else {
+            gainNode.gain.setValueAtTime(0.0001, startAt);
+            gainNode.gain.linearRampToValueAtTime(gainLevel, startAt + attack);
+        }
         gainNode.gain.setValueAtTime(gainLevel, heldEndAt);
         gainNode.gain.linearRampToValueAtTime(0.0001, heldEndAt + release);
         oscillator.connect(gainNode);
@@ -17368,7 +17451,7 @@ const createBasicWaveSynthEngine = (options) => {
         }
     };
     const playSchedule = async (schedule, waveform, onEnded) => {
-        var _a, _b;
+        var _a, _b, _c, _d, _e, _f, _g;
         if (!schedule || !Array.isArray(schedule.events) || schedule.events.length === 0) {
             throw new Error("Please convert first.");
         }
@@ -17427,12 +17510,57 @@ const createBasicWaveSynthEngine = (options) => {
         const isPedalHeldAt = (channel, tick) => {
             return pedalRanges.some((range) => range.channel === channel && tick >= range.startTick && tick < range.endTick);
         };
+        const laneStarts = new Map();
         for (const event of schedule.events) {
+            const laneKey = `${event.channel}|${(_c = event.trackId) !== null && _c !== void 0 ? _c : ""}`;
+            const starts = (_d = laneStarts.get(laneKey)) !== null && _d !== void 0 ? _d : [];
+            starts.push(event.start);
+            laneStarts.set(laneKey, starts);
+        }
+        for (const [laneKey, starts] of laneStarts.entries()) {
+            const uniqSorted = Array.from(new Set(starts)).sort((a, b) => a - b);
+            laneStarts.set(laneKey, uniqSorted);
+        }
+        const findNextStartTickOnLane = (laneKey, startTick) => {
+            var _a, _b;
+            const starts = laneStarts.get(laneKey);
+            if (!starts || starts.length === 0)
+                return null;
+            let lo = 0;
+            let hi = starts.length - 1;
+            let ans = -1;
+            while (lo <= hi) {
+                const mid = (lo + hi) >> 1;
+                if (((_a = starts[mid]) !== null && _a !== void 0 ? _a : 0) > startTick) {
+                    ans = (_b = starts[mid]) !== null && _b !== void 0 ? _b : -1;
+                    hi = mid - 1;
+                }
+                else {
+                    lo = mid + 1;
+                }
+            }
+            return ans >= 0 ? ans : null;
+        };
+        const lastNoteByLane = new Map();
+        for (const event of schedule.events) {
+            const laneKey = `${event.channel}|${(_e = event.trackId) !== null && _e !== void 0 ? _e : ""}`;
+            const prevInLane = lastNoteByLane.get(laneKey);
+            const legatoFromOverlap = ((_f = prevInLane === null || prevInLane === void 0 ? void 0 : prevInLane.startTick) !== null && _f !== void 0 ? _f : -1) < event.start && ((_g = prevInLane === null || prevInLane === void 0 ? void 0 : prevInLane.endTick) !== null && _g !== void 0 ? _g : -1) > event.start;
             const startAt = baseTime + tickToSeconds(event.start);
             const endAt = baseTime + tickToSeconds(event.start + event.ticks);
-            const bodyDuration = Math.max(0.04, endAt - startAt);
+            let bodyDuration = Math.max(0.04, endAt - startAt);
+            const nextStartTick = findNextStartTickOnLane(laneKey, event.start);
+            if (!legatoFromOverlap && nextStartTick !== null && nextStartTick > event.start) {
+                const hasForwardOverlapIntent = event.start + event.ticks > nextStartTick;
+                if (!hasForwardOverlapIntent) {
+                    const nextStartAt = baseTime + tickToSeconds(nextStartTick);
+                    const separatedEndAt = Math.max(startAt + 0.02, nextStartAt - 0.006);
+                    bodyDuration = Math.max(0.02, Math.min(bodyDuration, separatedEndAt - startAt));
+                }
+            }
             const sustainHoldSeconds = isPedalHeldAt(event.channel, event.start) ? 0.18 : 0;
-            latestEndTime = Math.max(latestEndTime, scheduleBasicWaveNote(event, startAt, bodyDuration, normalizedWaveform, sustainHoldSeconds));
+            latestEndTime = Math.max(latestEndTime, scheduleBasicWaveNote(event, startAt, bodyDuration, normalizedWaveform, sustainHoldSeconds, legatoFromOverlap));
+            lastNoteByLane.set(laneKey, { startTick: event.start, endTick: event.start + event.ticks });
         }
         const waitMs = Math.max(0, Math.ceil((latestEndTime - runningContext.currentTime) * 1000));
         synthStopTimer = window.setTimeout(() => {
@@ -17496,6 +17624,7 @@ const toSynthSchedule = (tempo, events, tempoEvents = [], controlEvents = []) =>
             start: event.startTicks,
             ticks: event.durTicks,
             channel: event.channel,
+            trackId: event.trackId,
         })),
     };
 };
@@ -17609,6 +17738,8 @@ const startPlayback = async (options, params) => {
         graceTimingMode: options.getGraceTimingMode(),
         metricAccentEnabled: options.getMetricAccentEnabled(),
         metricAccentProfile: options.getMetricAccentProfile(),
+        includeTieInPlaybackLikeMode: !useMidiLikePlayback,
+        applyDefaultDetacheInPlaybackLikeMode: !useMidiLikePlayback,
     });
     let effectiveParsedPlayback = parsedPlayback;
     let effectiveTempoEvents = useMidiLikePlayback
@@ -17704,6 +17835,8 @@ const startMeasurePlayback = async (options, params) => {
         graceTimingMode: options.getGraceTimingMode(),
         metricAccentEnabled: options.getMetricAccentEnabled(),
         metricAccentProfile: options.getMetricAccentProfile(),
+        includeTieInPlaybackLikeMode: !useMidiLikePlayback,
+        applyDefaultDetacheInPlaybackLikeMode: !useMidiLikePlayback,
     });
     const events = parsedPlayback.events;
     if (events.length === 0) {

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -3577,6 +3577,9 @@ const getNoteArticulationAdjustments = (noteNode) => {
     }
     return { velocityDelta, durationRatio, hasTenuto };
 };
+const hasExplicitArticulation = (noteNode) => {
+    return noteNode.querySelector("notations > articulations > *") !== null;
+};
 const getTieFlags = (noteNode) => {
     var _a;
     const directTieNodes = Array.from(noteNode.children).filter((child) => child.tagName === "tie");
@@ -6876,6 +6879,7 @@ const buildPlaybackEventsFromMusicXmlDoc = (doc, ticksPerQuarter, options = {}) 
     const includeGraceProcessing = applyMidiNuance || options.includeGraceInPlaybackLikeMode === true;
     const includeOrnamentExpansion = applyMidiNuance || options.includeOrnamentInPlaybackLikeMode === true;
     const includeTieProcessing = applyMidiNuance || options.includeTieInPlaybackLikeMode === true;
+    const includeSlurProcessing = applyMidiNuance || includeTieProcessing;
     const applyDefaultDetache = applyMidiNuance || options.applyDefaultDetacheInPlaybackLikeMode === true;
     const graceTimingMode = (_b = options.graceTimingMode) !== null && _b !== void 0 ? _b : DEFAULT_GRACE_TIMING_MODE;
     const metricAccentEnabled = options.metricAccentEnabled === true;
@@ -6908,7 +6912,7 @@ const buildPlaybackEventsFromMusicXmlDoc = (doc, ticksPerQuarter, options = {}) 
     const tempo = clampTempo((_k = getFirstNumber(doc, "sound[tempo]")) !== null && _k !== void 0 ? _k : defaultTempo);
     const events = [];
     partNodes.forEach((part, partIndex) => {
-        var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p, _q, _r, _s, _t, _u, _v, _w, _x, _y, _z, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18;
+        var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p, _q, _r, _s, _t, _u, _v, _w, _x, _y, _z, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19;
         const partId = (_a = part.getAttribute("id")) !== null && _a !== void 0 ? _a : "";
         const fallbackChannel = (partIndex % 16) + 1 === 10 ? 11 : (partIndex % 16) + 1;
         const channel = (_b = channelMap.get(partId)) !== null && _b !== void 0 ? _b : fallbackChannel;
@@ -6920,10 +6924,27 @@ const buildPlaybackEventsFromMusicXmlDoc = (doc, ticksPerQuarter, options = {}) 
         let currentVelocity = 80;
         let timelineDiv = 0;
         const tieChainByKey = new Map();
+        const resolveFallbackTieChainKey = (voice, midiChannel, midiNumber) => {
+            const suffix = `|${midiChannel}|${midiNumber}`;
+            const exact = `${voice}${suffix}`;
+            if (tieChainByKey.has(exact))
+                return exact;
+            let candidate = null;
+            for (const key of tieChainByKey.keys()) {
+                if (!key.endsWith(suffix))
+                    continue;
+                if (candidate !== null)
+                    return null; // ambiguous
+                candidate = key;
+            }
+            return candidate;
+        };
         const activeWedgeByNumber = new Map();
         const pendingGraceByVoice = new Map();
         const activeSlurByVoice = new Map();
         const voiceTimeShiftTicks = new Map();
+        const lastEventByVoiceChannelPitch = new Map();
+        const lastEventAllowsRepeatedSlurMergeByVoiceChannelPitch = new Map();
         const measures = Array.from(part.querySelectorAll(":scope > measure"));
         for (let measureIndex = 0; measureIndex < measures.length; measureIndex += 1) {
             const measure = measures[measureIndex];
@@ -7071,9 +7092,15 @@ const buildPlaybackEventsFromMusicXmlDoc = (doc, ticksPerQuarter, options = {}) 
                         if (soundingMidi < 0 || soundingMidi > 127) {
                             continue;
                         }
+                        const parsedArticulation = getNoteArticulationAdjustments(child);
                         const articulation = applyMidiNuance
-                            ? getNoteArticulationAdjustments(child)
+                            ? parsedArticulation
                             : { velocityDelta: 0, durationRatio: 1, hasTenuto: false };
+                        const hasAnyExplicitArticulation = hasExplicitArticulation(child);
+                        const allowsRepeatedSlurMergeForCurrent = !hasAnyExplicitArticulation &&
+                            parsedArticulation.durationRatio >= 1 &&
+                            !parsedArticulation.hasTenuto &&
+                            parsedArticulation.velocityDelta === 0;
                         const metricAccentDelta = applyMidiNuance && metricAccentEnabled
                             ? getMetricAccentVelocityDelta(startDiv, currentDivisions, currentBeats, currentBeatType, metricAccentProfile)
                             : 0;
@@ -7083,10 +7110,18 @@ const buildPlaybackEventsFromMusicXmlDoc = (doc, ticksPerQuarter, options = {}) 
                         const baseDurTicks = Math.max(1, Math.round(((durationDiv !== null && durationDiv !== void 0 ? durationDiv : 1) / currentDivisions) * normalizedTicksPerQuarter));
                         const slurNumbers = applyMidiNuance
                             ? getSlurNumbers(child)
-                            : { starts: [], stops: [] };
+                            : includeSlurProcessing
+                                ? getSlurNumbers(child)
+                                : { starts: [], stops: [] };
                         const activeSlurSet = (_8 = activeSlurByVoice.get(voice)) !== null && _8 !== void 0 ? _8 : new Set();
-                        const noteUnderSlur = applyMidiNuance &&
+                        const noteUnderSlur = includeSlurProcessing &&
                             (activeSlurSet.size > 0 || slurNumbers.starts.length > 0 || slurNumbers.stops.length > 0);
+                        const hasForwardSlurConnection = includeSlurProcessing &&
+                            (slurNumbers.starts.length > 0 || activeSlurSet.size > slurNumbers.stops.length);
+                        const isInsideOngoingSlurOnly = includeSlurProcessing &&
+                            activeSlurSet.size > 0 &&
+                            slurNumbers.starts.length === 0 &&
+                            slurNumbers.stops.length === 0;
                         const tieFlags = includeTieProcessing ? getTieFlags(child) : { start: false, stop: false };
                         const shouldApplyDefaultDetache = applyDefaultDetache &&
                             !isGrace &&
@@ -7113,7 +7148,7 @@ const buildPlaybackEventsFromMusicXmlDoc = (doc, ticksPerQuarter, options = {}) 
                             pendingGraceByVoice.set(voice, pending);
                             continue;
                         }
-                        const legatoOverlapTicks = applyMidiNuance && !isChord && (noteUnderSlur || articulation.hasTenuto)
+                        const legatoOverlapTicks = applyMidiNuance && !isChord && (hasForwardSlurConnection || articulation.hasTenuto)
                             ? Math.max(1, Math.round(normalizedTicksPerQuarter / 32))
                             : 0;
                         const temporalAdjustments = applyMidiNuance && !isGrace
@@ -7190,29 +7225,64 @@ const buildPlaybackEventsFromMusicXmlDoc = (doc, ticksPerQuarter, options = {}) 
                         const primaryEvent = generatedEvents[0];
                         if (!primaryEvent)
                             continue;
+                        const voiceChannelPitchKey = `${voice}|${channel}|${soundingMidi}`;
+                        const priorSamePitchEvent = (_18 = lastEventByVoiceChannelPitch.get(voiceChannelPitchKey)) !== null && _18 !== void 0 ? _18 : null;
+                        const shouldMergeRepeatedSlurSamePitch = includeSlurProcessing &&
+                            !isChord &&
+                            !isGrace &&
+                            !tieFlags.start &&
+                            !tieFlags.stop &&
+                            isInsideOngoingSlurOnly &&
+                            generatedEvents.length === 1 &&
+                            priorSamePitchEvent !== null &&
+                            allowsRepeatedSlurMergeForCurrent &&
+                            Boolean(lastEventAllowsRepeatedSlurMergeByVoiceChannelPitch.get(voiceChannelPitchKey)) &&
+                            priorSamePitchEvent.startTicks < startTicks &&
+                            priorSamePitchEvent.startTicks + priorSamePitchEvent.durTicks >= startTicks;
                         for (const wedgeKind of activeWedgeByNumber.values()) {
                             currentVelocity = clampVelocity(currentVelocity + (wedgeKind === "crescendo" ? 4 : -4));
                         }
-                        if (includeTieProcessing) {
-                            const tieKey = `${voice}|${channel}|${soundingMidi}`;
+                        if (shouldMergeRepeatedSlurSamePitch && priorSamePitchEvent) {
+                            const priorEndTick = priorSamePitchEvent.startTicks + priorSamePitchEvent.durTicks;
+                            const currentEndTick = primaryEvent.startTicks + primaryEvent.durTicks;
+                            priorSamePitchEvent.durTicks = Math.max(1, Math.max(priorEndTick, currentEndTick) - priorSamePitchEvent.startTicks);
+                            priorSamePitchEvent.velocity = Math.max(priorSamePitchEvent.velocity, velocity);
+                            lastEventByVoiceChannelPitch.set(voiceChannelPitchKey, priorSamePitchEvent);
+                        }
+                        else if (includeTieProcessing) {
+                            const tieKey = voiceChannelPitchKey;
                             if (tieFlags.stop) {
-                                const chained = tieChainByKey.get(tieKey);
+                                const chainedKey = resolveFallbackTieChainKey(voice, channel, soundingMidi);
+                                const chained = chainedKey ? tieChainByKey.get(chainedKey) : null;
                                 if (chained) {
                                     chained.durTicks += primaryEvent.durTicks;
                                     chained.velocity = Math.max(chained.velocity, velocity);
+                                    lastEventByVoiceChannelPitch.set(chainedKey !== null && chainedKey !== void 0 ? chainedKey : tieKey, chained);
+                                    lastEventAllowsRepeatedSlurMergeByVoiceChannelPitch.set(chainedKey !== null && chainedKey !== void 0 ? chainedKey : tieKey, allowsRepeatedSlurMergeForCurrent);
                                 }
                                 else {
                                     events.push(primaryEvent);
+                                    lastEventByVoiceChannelPitch.set(tieKey, primaryEvent);
+                                    lastEventAllowsRepeatedSlurMergeByVoiceChannelPitch.set(tieKey, allowsRepeatedSlurMergeForCurrent);
                                 }
                                 if (!tieFlags.start) {
-                                    tieChainByKey.delete(tieKey);
+                                    if (chainedKey)
+                                        tieChainByKey.delete(chainedKey);
                                 }
                                 else {
-                                    tieChainByKey.set(tieKey, chained !== null && chained !== void 0 ? chained : primaryEvent);
+                                    const chainedOrPrimary = chained !== null && chained !== void 0 ? chained : primaryEvent;
+                                    tieChainByKey.set(chainedKey !== null && chainedKey !== void 0 ? chainedKey : tieKey, chainedOrPrimary);
+                                    lastEventByVoiceChannelPitch.set(chainedKey !== null && chainedKey !== void 0 ? chainedKey : tieKey, chainedOrPrimary);
+                                    lastEventAllowsRepeatedSlurMergeByVoiceChannelPitch.set(chainedKey !== null && chainedKey !== void 0 ? chainedKey : tieKey, allowsRepeatedSlurMergeForCurrent);
                                 }
                             }
                             else {
                                 events.push(...generatedEvents);
+                                for (const generated of generatedEvents) {
+                                    const generatedKey = `${voice}|${channel}|${generated.midiNumber}`;
+                                    lastEventByVoiceChannelPitch.set(generatedKey, generated);
+                                    lastEventAllowsRepeatedSlurMergeByVoiceChannelPitch.set(generatedKey, allowsRepeatedSlurMergeForCurrent);
+                                }
                                 if (tieFlags.start) {
                                     tieChainByKey.set(tieKey, primaryEvent);
                                 }
@@ -7223,8 +7293,13 @@ const buildPlaybackEventsFromMusicXmlDoc = (doc, ticksPerQuarter, options = {}) 
                         }
                         else {
                             events.push(...generatedEvents);
+                            for (const generated of generatedEvents) {
+                                const generatedKey = `${voice}|${channel}|${generated.midiNumber}`;
+                                lastEventByVoiceChannelPitch.set(generatedKey, generated);
+                                lastEventAllowsRepeatedSlurMergeByVoiceChannelPitch.set(generatedKey, allowsRepeatedSlurMergeForCurrent);
+                            }
                         }
-                        if (applyMidiNuance) {
+                        if (includeSlurProcessing || applyMidiNuance) {
                             const nextSlurSet = new Set(activeSlurSet);
                             for (const slurStart of slurNumbers.starts)
                                 nextSlurSet.add(slurStart);
@@ -7236,8 +7311,10 @@ const buildPlaybackEventsFromMusicXmlDoc = (doc, ticksPerQuarter, options = {}) 
                             else {
                                 activeSlurByVoice.delete(voice);
                             }
+                        }
+                        if (applyMidiNuance) {
                             if (!isChord && temporalAdjustments.postPauseTicks > 0) {
-                                const shiftedTicks = ((_18 = voiceTimeShiftTicks.get(voice)) !== null && _18 !== void 0 ? _18 : 0) + temporalAdjustments.postPauseTicks;
+                                const shiftedTicks = ((_19 = voiceTimeShiftTicks.get(voice)) !== null && _19 !== void 0 ? _19 : 0) + temporalAdjustments.postPauseTicks;
                                 voiceTimeShiftTicks.set(voice, shiftedTicks);
                             }
                         }
@@ -8362,11 +8439,11 @@ const createBasicWaveSynthEngine = (options) => {
         }
         return context;
     };
-    const scheduleBasicWaveNote = (event, startAt, bodyDuration, waveform, sustainHoldSeconds = 0) => {
+    const scheduleBasicWaveNote = (event, startAt, bodyDuration, waveform, sustainHoldSeconds = 0, legatoFromOverlap = false) => {
         if (!audioContext)
             return startAt;
-        const attack = 0.005;
-        const release = 0.03;
+        const attack = legatoFromOverlap ? 0.0015 : 0.005;
+        const release = legatoFromOverlap ? 0.03 : 0.01;
         const endAt = startAt + bodyDuration;
         const heldEndAt = endAt + Math.max(0, sustainHoldSeconds);
         const oscillator = audioContext.createOscillator();
@@ -8374,8 +8451,14 @@ const createBasicWaveSynthEngine = (options) => {
         oscillator.frequency.setValueAtTime(midiToHz(event.midiNumber), startAt);
         const gainNode = audioContext.createGain();
         const gainLevel = event.channel === 10 ? 0.06 : 0.1;
-        gainNode.gain.setValueAtTime(0.0001, startAt);
-        gainNode.gain.linearRampToValueAtTime(gainLevel, startAt + attack);
+        if (legatoFromOverlap) {
+            gainNode.gain.setValueAtTime(gainLevel * 0.75, startAt);
+            gainNode.gain.linearRampToValueAtTime(gainLevel, startAt + attack);
+        }
+        else {
+            gainNode.gain.setValueAtTime(0.0001, startAt);
+            gainNode.gain.linearRampToValueAtTime(gainLevel, startAt + attack);
+        }
         gainNode.gain.setValueAtTime(gainLevel, heldEndAt);
         gainNode.gain.linearRampToValueAtTime(0.0001, heldEndAt + release);
         oscillator.connect(gainNode);
@@ -8449,7 +8532,7 @@ const createBasicWaveSynthEngine = (options) => {
         }
     };
     const playSchedule = async (schedule, waveform, onEnded) => {
-        var _a, _b;
+        var _a, _b, _c, _d, _e, _f, _g;
         if (!schedule || !Array.isArray(schedule.events) || schedule.events.length === 0) {
             throw new Error("Please convert first.");
         }
@@ -8508,12 +8591,57 @@ const createBasicWaveSynthEngine = (options) => {
         const isPedalHeldAt = (channel, tick) => {
             return pedalRanges.some((range) => range.channel === channel && tick >= range.startTick && tick < range.endTick);
         };
+        const laneStarts = new Map();
         for (const event of schedule.events) {
+            const laneKey = `${event.channel}|${(_c = event.trackId) !== null && _c !== void 0 ? _c : ""}`;
+            const starts = (_d = laneStarts.get(laneKey)) !== null && _d !== void 0 ? _d : [];
+            starts.push(event.start);
+            laneStarts.set(laneKey, starts);
+        }
+        for (const [laneKey, starts] of laneStarts.entries()) {
+            const uniqSorted = Array.from(new Set(starts)).sort((a, b) => a - b);
+            laneStarts.set(laneKey, uniqSorted);
+        }
+        const findNextStartTickOnLane = (laneKey, startTick) => {
+            var _a, _b;
+            const starts = laneStarts.get(laneKey);
+            if (!starts || starts.length === 0)
+                return null;
+            let lo = 0;
+            let hi = starts.length - 1;
+            let ans = -1;
+            while (lo <= hi) {
+                const mid = (lo + hi) >> 1;
+                if (((_a = starts[mid]) !== null && _a !== void 0 ? _a : 0) > startTick) {
+                    ans = (_b = starts[mid]) !== null && _b !== void 0 ? _b : -1;
+                    hi = mid - 1;
+                }
+                else {
+                    lo = mid + 1;
+                }
+            }
+            return ans >= 0 ? ans : null;
+        };
+        const lastNoteByLane = new Map();
+        for (const event of schedule.events) {
+            const laneKey = `${event.channel}|${(_e = event.trackId) !== null && _e !== void 0 ? _e : ""}`;
+            const prevInLane = lastNoteByLane.get(laneKey);
+            const legatoFromOverlap = ((_f = prevInLane === null || prevInLane === void 0 ? void 0 : prevInLane.startTick) !== null && _f !== void 0 ? _f : -1) < event.start && ((_g = prevInLane === null || prevInLane === void 0 ? void 0 : prevInLane.endTick) !== null && _g !== void 0 ? _g : -1) > event.start;
             const startAt = baseTime + tickToSeconds(event.start);
             const endAt = baseTime + tickToSeconds(event.start + event.ticks);
-            const bodyDuration = Math.max(0.04, endAt - startAt);
+            let bodyDuration = Math.max(0.04, endAt - startAt);
+            const nextStartTick = findNextStartTickOnLane(laneKey, event.start);
+            if (!legatoFromOverlap && nextStartTick !== null && nextStartTick > event.start) {
+                const hasForwardOverlapIntent = event.start + event.ticks > nextStartTick;
+                if (!hasForwardOverlapIntent) {
+                    const nextStartAt = baseTime + tickToSeconds(nextStartTick);
+                    const separatedEndAt = Math.max(startAt + 0.02, nextStartAt - 0.006);
+                    bodyDuration = Math.max(0.02, Math.min(bodyDuration, separatedEndAt - startAt));
+                }
+            }
             const sustainHoldSeconds = isPedalHeldAt(event.channel, event.start) ? 0.18 : 0;
-            latestEndTime = Math.max(latestEndTime, scheduleBasicWaveNote(event, startAt, bodyDuration, normalizedWaveform, sustainHoldSeconds));
+            latestEndTime = Math.max(latestEndTime, scheduleBasicWaveNote(event, startAt, bodyDuration, normalizedWaveform, sustainHoldSeconds, legatoFromOverlap));
+            lastNoteByLane.set(laneKey, { startTick: event.start, endTick: event.start + event.ticks });
         }
         const waitMs = Math.max(0, Math.ceil((latestEndTime - runningContext.currentTime) * 1000));
         synthStopTimer = window.setTimeout(() => {
@@ -8577,6 +8705,7 @@ const toSynthSchedule = (tempo, events, tempoEvents = [], controlEvents = []) =>
             start: event.startTicks,
             ticks: event.durTicks,
             channel: event.channel,
+            trackId: event.trackId,
         })),
     };
 };
@@ -8690,6 +8819,8 @@ const startPlayback = async (options, params) => {
         graceTimingMode: options.getGraceTimingMode(),
         metricAccentEnabled: options.getMetricAccentEnabled(),
         metricAccentProfile: options.getMetricAccentProfile(),
+        includeTieInPlaybackLikeMode: !useMidiLikePlayback,
+        applyDefaultDetacheInPlaybackLikeMode: !useMidiLikePlayback,
     });
     let effectiveParsedPlayback = parsedPlayback;
     let effectiveTempoEvents = useMidiLikePlayback
@@ -8785,6 +8916,8 @@ const startMeasurePlayback = async (options, params) => {
         graceTimingMode: options.getGraceTimingMode(),
         metricAccentEnabled: options.getMetricAccentEnabled(),
         metricAccentProfile: options.getMetricAccentProfile(),
+        includeTieInPlaybackLikeMode: !useMidiLikePlayback,
+        applyDefaultDetacheInPlaybackLikeMode: !useMidiLikePlayback,
     });
     const events = parsedPlayback.events;
     if (events.length === 0) {

--- a/src/ts/midi-io.ts
+++ b/src/ts/midi-io.ts
@@ -389,6 +389,10 @@ const getNoteArticulationAdjustments = (noteNode: Element): {
   return { velocityDelta, durationRatio, hasTenuto };
 };
 
+const hasExplicitArticulation = (noteNode: Element): boolean => {
+  return noteNode.querySelector("notations > articulations > *") !== null;
+};
+
 const getTieFlags = (noteNode: Element): { start: boolean; stop: boolean } => {
   const directTieNodes = Array.from(noteNode.children).filter((child) => child.tagName === "tie");
   const notationTieNodes = Array.from(noteNode.querySelectorAll("notations > tied"));
@@ -4142,6 +4146,7 @@ export const buildPlaybackEventsFromMusicXmlDoc = (
   const includeGraceProcessing = applyMidiNuance || options.includeGraceInPlaybackLikeMode === true;
   const includeOrnamentExpansion = applyMidiNuance || options.includeOrnamentInPlaybackLikeMode === true;
   const includeTieProcessing = applyMidiNuance || options.includeTieInPlaybackLikeMode === true;
+  const includeSlurProcessing = applyMidiNuance || includeTieProcessing;
   const applyDefaultDetache = applyMidiNuance || options.applyDefaultDetacheInPlaybackLikeMode === true;
   const graceTimingMode = options.graceTimingMode ?? DEFAULT_GRACE_TIMING_MODE;
   const metricAccentEnabled = options.metricAccentEnabled === true;
@@ -4186,10 +4191,24 @@ export const buildPlaybackEventsFromMusicXmlDoc = (
     let currentVelocity = 80;
     let timelineDiv = 0;
     const tieChainByKey = new Map<string, PlaybackEvent>();
+    const resolveFallbackTieChainKey = (voice: string, midiChannel: number, midiNumber: number): string | null => {
+      const suffix = `|${midiChannel}|${midiNumber}`;
+      const exact = `${voice}${suffix}`;
+      if (tieChainByKey.has(exact)) return exact;
+      let candidate: string | null = null;
+      for (const key of tieChainByKey.keys()) {
+        if (!key.endsWith(suffix)) continue;
+        if (candidate !== null) return null; // ambiguous
+        candidate = key;
+      }
+      return candidate;
+    };
     const activeWedgeByNumber = new Map<string, WedgeKind>();
     const pendingGraceByVoice = new Map<string, Array<{ midiNumber: number; velocity: number; weight: number }>>();
     const activeSlurByVoice = new Map<string, Set<string>>();
     const voiceTimeShiftTicks = new Map<string, number>();
+    const lastEventByVoiceChannelPitch = new Map<string, PlaybackEvent>();
+    const lastEventAllowsRepeatedSlurMergeByVoiceChannelPitch = new Map<string, boolean>();
 
     const measures = Array.from(part.querySelectorAll(":scope > measure"));
     for (let measureIndex = 0; measureIndex < measures.length; measureIndex += 1) {
@@ -4345,9 +4364,16 @@ export const buildPlaybackEventsFromMusicXmlDoc = (
             if (soundingMidi < 0 || soundingMidi > 127) {
               continue;
             }
+            const parsedArticulation = getNoteArticulationAdjustments(child);
             const articulation = applyMidiNuance
-              ? getNoteArticulationAdjustments(child)
+              ? parsedArticulation
               : { velocityDelta: 0, durationRatio: 1, hasTenuto: false };
+            const hasAnyExplicitArticulation = hasExplicitArticulation(child);
+            const allowsRepeatedSlurMergeForCurrent =
+              !hasAnyExplicitArticulation &&
+              parsedArticulation.durationRatio >= 1 &&
+              !parsedArticulation.hasTenuto &&
+              parsedArticulation.velocityDelta === 0;
             const metricAccentDelta =
               applyMidiNuance && metricAccentEnabled
                 ? getMetricAccentVelocityDelta(
@@ -4370,11 +4396,21 @@ export const buildPlaybackEventsFromMusicXmlDoc = (
             );
             const slurNumbers = applyMidiNuance
               ? getSlurNumbers(child)
+              : includeSlurProcessing
+              ? getSlurNumbers(child)
               : { starts: [] as string[], stops: [] as string[] };
             const activeSlurSet = activeSlurByVoice.get(voice) ?? new Set<string>();
             const noteUnderSlur =
-              applyMidiNuance &&
+              includeSlurProcessing &&
               (activeSlurSet.size > 0 || slurNumbers.starts.length > 0 || slurNumbers.stops.length > 0);
+            const hasForwardSlurConnection =
+              includeSlurProcessing &&
+              (slurNumbers.starts.length > 0 || activeSlurSet.size > slurNumbers.stops.length);
+            const isInsideOngoingSlurOnly =
+              includeSlurProcessing &&
+              activeSlurSet.size > 0 &&
+              slurNumbers.starts.length === 0 &&
+              slurNumbers.stops.length === 0;
             const tieFlags = includeTieProcessing ? getTieFlags(child) : { start: false, stop: false };
             const shouldApplyDefaultDetache =
               applyDefaultDetache &&
@@ -4404,7 +4440,7 @@ export const buildPlaybackEventsFromMusicXmlDoc = (
               continue;
             }
             const legatoOverlapTicks =
-              applyMidiNuance && !isChord && (noteUnderSlur || articulation.hasTenuto)
+              applyMidiNuance && !isChord && (hasForwardSlurConnection || articulation.hasTenuto)
                 ? Math.max(1, Math.round(normalizedTicksPerQuarter / 32))
                 : 0;
             const temporalAdjustments =
@@ -4500,27 +4536,73 @@ export const buildPlaybackEventsFromMusicXmlDoc = (
             }
             const primaryEvent = generatedEvents[0];
             if (!primaryEvent) continue;
+            const voiceChannelPitchKey = `${voice}|${channel}|${soundingMidi}`;
+            const priorSamePitchEvent = lastEventByVoiceChannelPitch.get(voiceChannelPitchKey) ?? null;
+            const shouldMergeRepeatedSlurSamePitch =
+              includeSlurProcessing &&
+              !isChord &&
+              !isGrace &&
+              !tieFlags.start &&
+              !tieFlags.stop &&
+              isInsideOngoingSlurOnly &&
+              generatedEvents.length === 1 &&
+              priorSamePitchEvent !== null &&
+              allowsRepeatedSlurMergeForCurrent &&
+              Boolean(lastEventAllowsRepeatedSlurMergeByVoiceChannelPitch.get(voiceChannelPitchKey)) &&
+              priorSamePitchEvent.startTicks < startTicks &&
+              priorSamePitchEvent.startTicks + priorSamePitchEvent.durTicks >= startTicks;
 
             for (const wedgeKind of activeWedgeByNumber.values()) {
               currentVelocity = clampVelocity(currentVelocity + (wedgeKind === "crescendo" ? 4 : -4));
             }
-            if (includeTieProcessing) {
-              const tieKey = `${voice}|${channel}|${soundingMidi}`;
+            if (shouldMergeRepeatedSlurSamePitch && priorSamePitchEvent) {
+              const priorEndTick = priorSamePitchEvent.startTicks + priorSamePitchEvent.durTicks;
+              const currentEndTick = primaryEvent.startTicks + primaryEvent.durTicks;
+              priorSamePitchEvent.durTicks = Math.max(1, Math.max(priorEndTick, currentEndTick) - priorSamePitchEvent.startTicks);
+              priorSamePitchEvent.velocity = Math.max(priorSamePitchEvent.velocity, velocity);
+              lastEventByVoiceChannelPitch.set(voiceChannelPitchKey, priorSamePitchEvent);
+            } else if (includeTieProcessing) {
+              const tieKey = voiceChannelPitchKey;
               if (tieFlags.stop) {
-                const chained = tieChainByKey.get(tieKey);
+                const chainedKey = resolveFallbackTieChainKey(voice, channel, soundingMidi);
+                const chained = chainedKey ? tieChainByKey.get(chainedKey) : null;
                 if (chained) {
                   chained.durTicks += primaryEvent.durTicks;
                   chained.velocity = Math.max(chained.velocity, velocity);
+                  lastEventByVoiceChannelPitch.set(chainedKey ?? tieKey, chained);
+                  lastEventAllowsRepeatedSlurMergeByVoiceChannelPitch.set(
+                    chainedKey ?? tieKey,
+                    allowsRepeatedSlurMergeForCurrent
+                  );
                 } else {
                   events.push(primaryEvent);
+                  lastEventByVoiceChannelPitch.set(tieKey, primaryEvent);
+                  lastEventAllowsRepeatedSlurMergeByVoiceChannelPitch.set(
+                    tieKey,
+                    allowsRepeatedSlurMergeForCurrent
+                  );
                 }
                 if (!tieFlags.start) {
-                  tieChainByKey.delete(tieKey);
+                  if (chainedKey) tieChainByKey.delete(chainedKey);
                 } else {
-                  tieChainByKey.set(tieKey, chained ?? primaryEvent);
+                  const chainedOrPrimary = chained ?? primaryEvent;
+                  tieChainByKey.set(chainedKey ?? tieKey, chainedOrPrimary);
+                  lastEventByVoiceChannelPitch.set(chainedKey ?? tieKey, chainedOrPrimary);
+                  lastEventAllowsRepeatedSlurMergeByVoiceChannelPitch.set(
+                    chainedKey ?? tieKey,
+                    allowsRepeatedSlurMergeForCurrent
+                  );
                 }
               } else {
                 events.push(...generatedEvents);
+                for (const generated of generatedEvents) {
+                  const generatedKey = `${voice}|${channel}|${generated.midiNumber}`;
+                  lastEventByVoiceChannelPitch.set(generatedKey, generated);
+                  lastEventAllowsRepeatedSlurMergeByVoiceChannelPitch.set(
+                    generatedKey,
+                    allowsRepeatedSlurMergeForCurrent
+                  );
+                }
                 if (tieFlags.start) {
                   tieChainByKey.set(tieKey, primaryEvent);
                 } else {
@@ -4529,8 +4611,16 @@ export const buildPlaybackEventsFromMusicXmlDoc = (
               }
             } else {
               events.push(...generatedEvents);
+              for (const generated of generatedEvents) {
+                const generatedKey = `${voice}|${channel}|${generated.midiNumber}`;
+                lastEventByVoiceChannelPitch.set(generatedKey, generated);
+                lastEventAllowsRepeatedSlurMergeByVoiceChannelPitch.set(
+                  generatedKey,
+                  allowsRepeatedSlurMergeForCurrent
+                );
+              }
             }
-            if (applyMidiNuance) {
+            if (includeSlurProcessing || applyMidiNuance) {
               const nextSlurSet = new Set(activeSlurSet);
               for (const slurStart of slurNumbers.starts) nextSlurSet.add(slurStart);
               for (const slurStop of slurNumbers.stops) nextSlurSet.delete(slurStop);
@@ -4539,6 +4629,8 @@ export const buildPlaybackEventsFromMusicXmlDoc = (
               } else {
                 activeSlurByVoice.delete(voice);
               }
+            }
+            if (applyMidiNuance) {
               if (!isChord && temporalAdjustments.postPauseTicks > 0) {
                 const shiftedTicks = (voiceTimeShiftTicks.get(voice) ?? 0) + temporalAdjustments.postPauseTicks;
                 voiceTimeShiftTicks.set(voice, shiftedTicks);

--- a/src/ts/playback-flow.ts
+++ b/src/ts/playback-flow.ts
@@ -23,6 +23,7 @@ export type SynthSchedule = {
     start: number;
     ticks: number;
     channel: number;
+    trackId?: string;
   }>;
 };
 
@@ -101,11 +102,12 @@ export const createBasicWaveSynthEngine = (options: { ticksPerQuarter: number })
     startAt: number,
     bodyDuration: number,
     waveform: OscillatorType,
-    sustainHoldSeconds = 0
+    sustainHoldSeconds = 0,
+    legatoFromOverlap = false
   ): number => {
     if (!audioContext) return startAt;
-    const attack = 0.005;
-    const release = 0.03;
+    const attack = legatoFromOverlap ? 0.0015 : 0.005;
+    const release = legatoFromOverlap ? 0.03 : 0.01;
     const endAt = startAt + bodyDuration;
     const heldEndAt = endAt + Math.max(0, sustainHoldSeconds);
     const oscillator = audioContext.createOscillator();
@@ -114,8 +116,13 @@ export const createBasicWaveSynthEngine = (options: { ticksPerQuarter: number })
 
     const gainNode = audioContext.createGain();
     const gainLevel = event.channel === 10 ? 0.06 : 0.1;
-    gainNode.gain.setValueAtTime(0.0001, startAt);
-    gainNode.gain.linearRampToValueAtTime(gainLevel, startAt + attack);
+    if (legatoFromOverlap) {
+      gainNode.gain.setValueAtTime(gainLevel * 0.75, startAt);
+      gainNode.gain.linearRampToValueAtTime(gainLevel, startAt + attack);
+    } else {
+      gainNode.gain.setValueAtTime(0.0001, startAt);
+      gainNode.gain.linearRampToValueAtTime(gainLevel, startAt + attack);
+    }
     gainNode.gain.setValueAtTime(gainLevel, heldEndAt);
     gainNode.gain.linearRampToValueAtTime(0.0001, heldEndAt + release);
 
@@ -248,16 +255,66 @@ export const createBasicWaveSynthEngine = (options: { ticksPerQuarter: number })
     const isPedalHeldAt = (channel: number, tick: number): boolean => {
       return pedalRanges.some((range) => range.channel === channel && tick >= range.startTick && tick < range.endTick);
     };
+    const laneStarts = new Map<string, number[]>();
+    for (const event of schedule.events) {
+      const laneKey = `${event.channel}|${event.trackId ?? ""}`;
+      const starts = laneStarts.get(laneKey) ?? [];
+      starts.push(event.start);
+      laneStarts.set(laneKey, starts);
+    }
+    for (const [laneKey, starts] of laneStarts.entries()) {
+      const uniqSorted = Array.from(new Set(starts)).sort((a, b) => a - b);
+      laneStarts.set(laneKey, uniqSorted);
+    }
+    const findNextStartTickOnLane = (laneKey: string, startTick: number): number | null => {
+      const starts = laneStarts.get(laneKey);
+      if (!starts || starts.length === 0) return null;
+      let lo = 0;
+      let hi = starts.length - 1;
+      let ans = -1;
+      while (lo <= hi) {
+        const mid = (lo + hi) >> 1;
+        if ((starts[mid] ?? 0) > startTick) {
+          ans = starts[mid] ?? -1;
+          hi = mid - 1;
+        } else {
+          lo = mid + 1;
+        }
+      }
+      return ans >= 0 ? ans : null;
+    };
+    const lastNoteByLane = new Map<string, { startTick: number; endTick: number }>();
 
     for (const event of schedule.events) {
+      const laneKey = `${event.channel}|${event.trackId ?? ""}`;
+      const prevInLane = lastNoteByLane.get(laneKey);
+      const legatoFromOverlap =
+        (prevInLane?.startTick ?? -1) < event.start && (prevInLane?.endTick ?? -1) > event.start;
       const startAt = baseTime + tickToSeconds(event.start);
       const endAt = baseTime + tickToSeconds(event.start + event.ticks);
-      const bodyDuration = Math.max(0.04, endAt - startAt);
+      let bodyDuration = Math.max(0.04, endAt - startAt);
+      const nextStartTick = findNextStartTickOnLane(laneKey, event.start);
+      if (!legatoFromOverlap && nextStartTick !== null && nextStartTick > event.start) {
+        const hasForwardOverlapIntent = event.start + event.ticks > nextStartTick;
+        if (!hasForwardOverlapIntent) {
+          const nextStartAt = baseTime + tickToSeconds(nextStartTick);
+          const separatedEndAt = Math.max(startAt + 0.02, nextStartAt - 0.006);
+          bodyDuration = Math.max(0.02, Math.min(bodyDuration, separatedEndAt - startAt));
+        }
+      }
       const sustainHoldSeconds = isPedalHeldAt(event.channel, event.start) ? 0.18 : 0;
       latestEndTime = Math.max(
         latestEndTime,
-        scheduleBasicWaveNote(event, startAt, bodyDuration, normalizedWaveform, sustainHoldSeconds)
+        scheduleBasicWaveNote(
+          event,
+          startAt,
+          bodyDuration,
+          normalizedWaveform,
+          sustainHoldSeconds,
+          legatoFromOverlap
+        )
       );
+      lastNoteByLane.set(laneKey, { startTick: event.start, endTick: event.start + event.ticks });
     }
 
     const waitMs = Math.max(0, Math.ceil((latestEndTime - runningContext.currentTime) * 1000));
@@ -274,7 +331,7 @@ export const createBasicWaveSynthEngine = (options: { ticksPerQuarter: number })
 
 const toSynthSchedule = (
   tempo: number,
-  events: Array<{ midiNumber: number; startTicks: number; durTicks: number; channel: number }>,
+  events: Array<{ midiNumber: number; startTicks: number; durTicks: number; channel: number; trackId?: string }>,
   tempoEvents: Array<{ startTicks: number; bpm: number }> = [],
   controlEvents: Array<{ channel: number; startTicks: number; controllerNumber: number; controllerValue: number }> = []
 ): SynthSchedule => {
@@ -333,6 +390,7 @@ const toSynthSchedule = (
         start: event.startTicks,
         ticks: event.durTicks,
         channel: event.channel,
+        trackId: event.trackId,
       })),
   };
 };
@@ -500,6 +558,8 @@ export const startPlayback = async (
     graceTimingMode: options.getGraceTimingMode(),
     metricAccentEnabled: options.getMetricAccentEnabled(),
     metricAccentProfile: options.getMetricAccentProfile(),
+    includeTieInPlaybackLikeMode: !useMidiLikePlayback,
+    applyDefaultDetacheInPlaybackLikeMode: !useMidiLikePlayback,
   });
   let effectiveParsedPlayback = parsedPlayback;
   let effectiveTempoEvents = useMidiLikePlayback
@@ -637,6 +697,8 @@ export const startMeasurePlayback = async (
     graceTimingMode: options.getGraceTimingMode(),
     metricAccentEnabled: options.getMetricAccentEnabled(),
     metricAccentProfile: options.getMetricAccentProfile(),
+    includeTieInPlaybackLikeMode: !useMidiLikePlayback,
+    applyDefaultDetacheInPlaybackLikeMode: !useMidiLikePlayback,
   });
   const events = parsedPlayback.events;
   if (events.length === 0) {

--- a/tests/unit/midi-io.spec.ts
+++ b/tests/unit/midi-io.spec.ts
@@ -301,6 +301,46 @@ describe("midi-io MIDI nuance regressions", () => {
     expect(c4Events[0]?.durTicks).toBeGreaterThanOrEqual(256);
   });
 
+  it("merges tied notes even when continuation note omits voice (fallback by channel/pitch)", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>Music</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>480</divisions>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+      </attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>480</duration><voice>2</voice><type>quarter</type>
+        <tie type="start"/><notations><tied type="start"/></notations>
+      </note>
+      <backup><duration>480</duration></backup>
+      <note>
+        <pitch><step>E</step><octave>4</octave></pitch>
+        <duration>480</duration><voice>1</voice><type>quarter</type>
+      </note>
+    </measure>
+    <measure number="2">
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>480</duration><type>quarter</type>
+        <tie type="stop"/><notations><tied type="stop"/></notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const doc = parseDoc(xml);
+    const midiMode = buildPlaybackEventsFromMusicXmlDoc(doc, 128, { mode: "midi" });
+    const c4Events = midiMode.events
+      .filter((e) => e.midiNumber === 60)
+      .sort((a, b) => a.startTicks - b.startTicks);
+    expect(c4Events.length).toBe(1);
+    expect(c4Events[0]?.startTicks).toBe(0);
+    expect(c4Events[0]?.durTicks).toBeGreaterThanOrEqual(256);
+  });
+
   it("keeps slurred notes longer than detached notes in MIDI mode", () => {
     const baseXml = `<?xml version="1.0" encoding="UTF-8"?>
 <score-partwise version="4.0">
@@ -338,6 +378,248 @@ describe("midi-io MIDI nuance regressions", () => {
     expect(slurred.length).toBe(2);
     expect(slurred[0]?.durTicks ?? 0).toBeGreaterThan(plain[0]?.durTicks ?? 0);
     expect(slurred[1]?.durTicks ?? 0).toBeGreaterThan(plain[1]?.durTicks ?? 0);
+  });
+
+  it("does not retrigger repeated same-pitch note inside slur in MIDI mode", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>Music</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>480</divisions>
+        <time><beats>1</beats><beat-type>1</beat-type></time>
+      </attributes>
+      <note>
+        <pitch><step>F</step><octave>5</octave></pitch>
+        <duration>480</duration><voice>1</voice><type>quarter</type>
+        <notations><slur type="start" number="1"/></notations>
+      </note>
+      <note>
+        <pitch><step>F</step><octave>5</octave></pitch>
+        <duration>120</duration><voice>1</voice><type>16th</type>
+      </note>
+      <note>
+        <pitch><step>E</step><octave>5</octave></pitch>
+        <duration>120</duration><voice>1</voice><type>16th</type>
+        <notations><slur type="stop" number="1"/></notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const doc = parseDoc(xml);
+    const midiMode = buildPlaybackEventsFromMusicXmlDoc(doc, 128, { mode: "midi" });
+    const f5Events = midiMode.events
+      .filter((e) => e.midiNumber === 77)
+      .sort((a, b) => a.startTicks - b.startTicks);
+    expect(f5Events.length).toBe(1);
+    expect(f5Events[0]?.startTicks).toBe(0);
+    expect(f5Events[0]?.durTicks ?? 0).toBeGreaterThan(128);
+  });
+
+  it("does not retrigger repeated same-pitch note inside slur in playback-like mode with tie processing", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>Music</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>480</divisions>
+        <time><beats>1</beats><beat-type>1</beat-type></time>
+      </attributes>
+      <note>
+        <pitch><step>F</step><octave>5</octave></pitch>
+        <duration>480</duration><voice>1</voice><type>quarter</type>
+        <notations><slur type="start" number="1"/></notations>
+      </note>
+      <note>
+        <pitch><step>F</step><octave>5</octave></pitch>
+        <duration>120</duration><voice>1</voice><type>16th</type>
+      </note>
+      <note>
+        <pitch><step>E</step><octave>5</octave></pitch>
+        <duration>120</duration><voice>1</voice><type>16th</type>
+        <notations><slur type="stop" number="1"/></notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const doc = parseDoc(xml);
+    const playbackLike = buildPlaybackEventsFromMusicXmlDoc(doc, 128, {
+      mode: "playback",
+      includeTieInPlaybackLikeMode: true,
+    });
+    const f5Events = playbackLike.events
+      .filter((e) => e.midiNumber === 77)
+      .sort((a, b) => a.startTicks - b.startTicks);
+    expect(f5Events.length).toBe(1);
+    expect(f5Events[0]?.startTicks).toBe(0);
+    expect(f5Events[0]?.durTicks ?? 0).toBeGreaterThan(120);
+  });
+
+  it("keeps retrigger when repeated same-pitch note is slur-start boundary", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>Music</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>480</divisions>
+        <time><beats>1</beats><beat-type>1</beat-type></time>
+      </attributes>
+      <note>
+        <pitch><step>D</step><octave>4</octave></pitch>
+        <duration>240</duration><voice>1</voice><type>eighth</type>
+      </note>
+      <note>
+        <pitch><step>D</step><octave>4</octave></pitch>
+        <duration>240</duration><voice>1</voice><type>eighth</type>
+        <notations><slur type="start" number="1"/></notations>
+      </note>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>480</duration><voice>1</voice><type>quarter</type>
+        <notations><slur type="stop" number="1"/></notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const doc = parseDoc(xml);
+    const midiMode = buildPlaybackEventsFromMusicXmlDoc(doc, 128, { mode: "midi" });
+    const d4Midi = midiMode.events.filter((e) => e.midiNumber === 62).sort((a, b) => a.startTicks - b.startTicks);
+    expect(d4Midi.length).toBe(2);
+    expect(d4Midi[0]?.startTicks).toBe(0);
+    expect(d4Midi[1]?.startTicks ?? 0).toBeGreaterThan(0);
+
+    const playbackLike = buildPlaybackEventsFromMusicXmlDoc(doc, 128, {
+      mode: "playback",
+      includeTieInPlaybackLikeMode: true,
+    });
+    const d4Playback = playbackLike.events
+      .filter((e) => e.midiNumber === 62)
+      .sort((a, b) => a.startTicks - b.startTicks);
+    expect(d4Playback.length).toBe(2);
+    expect(d4Playback[1]?.startTicks ?? 0).toBeGreaterThan(0);
+  });
+
+  it("does not extend slur-stop note into following same pitch", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>Music</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>480</divisions>
+        <time><beats>2</beats><beat-type>4</beat-type></time>
+      </attributes>
+      <note>
+        <pitch><step>D</step><octave>4</octave></pitch>
+        <duration>480</duration><voice>1</voice><type>quarter</type>
+        <notations><slur type="start" number="1"/></notations>
+      </note>
+      <note>
+        <pitch><step>D</step><octave>4</octave></pitch>
+        <duration>480</duration><voice>1</voice><type>quarter</type>
+        <notations><slur type="stop" number="1"/></notations>
+      </note>
+    </measure>
+    <measure number="2">
+      <note>
+        <pitch><step>D</step><octave>4</octave></pitch>
+        <duration>480</duration><voice>1</voice><type>quarter</type>
+      </note>
+      <note><rest/><duration>480</duration><voice>1</voice><type>quarter</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const doc = parseDoc(xml);
+    const midiMode = buildPlaybackEventsFromMusicXmlDoc(doc, 128, { mode: "midi" });
+    const d4 = midiMode.events.filter((e) => e.midiNumber === 62).sort((a, b) => a.startTicks - b.startTicks);
+    expect(d4.length).toBe(3);
+    expect(d4[1]?.startTicks).toBe(128);
+    expect((d4[1]?.durTicks ?? 0) + (d4[1]?.startTicks ?? 0)).toBeLessThanOrEqual(d4[2]?.startTicks ?? 0);
+  });
+
+  it("keeps retrigger for repeated same-pitch slur when staccato is present in playback-like mode", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>Music</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>480</divisions>
+        <time><beats>1</beats><beat-type>1</beat-type></time>
+      </attributes>
+      <note>
+        <pitch><step>F</step><octave>5</octave></pitch>
+        <duration>480</duration><voice>1</voice><type>quarter</type>
+        <notations><slur type="start" number="1"/></notations>
+      </note>
+      <note>
+        <pitch><step>F</step><octave>5</octave></pitch>
+        <duration>120</duration><voice>1</voice><type>16th</type>
+        <notations><articulations><staccato/></articulations></notations>
+      </note>
+      <note>
+        <pitch><step>E</step><octave>5</octave></pitch>
+        <duration>120</duration><voice>1</voice><type>16th</type>
+        <notations><slur type="stop" number="1"/></notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const doc = parseDoc(xml);
+    const playbackLike = buildPlaybackEventsFromMusicXmlDoc(doc, 128, {
+      mode: "playback",
+      includeTieInPlaybackLikeMode: true,
+    });
+    const f5Events = playbackLike.events
+      .filter((e) => e.midiNumber === 77)
+      .sort((a, b) => a.startTicks - b.startTicks);
+    expect(f5Events.length).toBe(2);
+    expect(f5Events[0]?.startTicks).toBe(0);
+    expect(f5Events[1]?.startTicks ?? 0).toBeGreaterThan(0);
+  });
+
+  it("keeps retrigger for repeated same-pitch slur when tenuto is present in playback-like mode", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>Music</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>480</divisions>
+        <time><beats>1</beats><beat-type>1</beat-type></time>
+      </attributes>
+      <note>
+        <pitch><step>F</step><octave>5</octave></pitch>
+        <duration>480</duration><voice>1</voice><type>quarter</type>
+        <notations><slur type="start" number="1"/></notations>
+      </note>
+      <note>
+        <pitch><step>F</step><octave>5</octave></pitch>
+        <duration>120</duration><voice>1</voice><type>16th</type>
+        <notations><articulations><tenuto/></articulations></notations>
+      </note>
+      <note>
+        <pitch><step>E</step><octave>5</octave></pitch>
+        <duration>120</duration><voice>1</voice><type>16th</type>
+        <notations><slur type="stop" number="1"/></notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const doc = parseDoc(xml);
+    const playbackLike = buildPlaybackEventsFromMusicXmlDoc(doc, 128, {
+      mode: "playback",
+      includeTieInPlaybackLikeMode: true,
+    });
+    const f5Events = playbackLike.events
+      .filter((e) => e.midiNumber === 77)
+      .sort((a, b) => a.startTicks - b.startTicks);
+    expect(f5Events.length).toBe(2);
+    expect(f5Events[0]?.startTicks).toBe(0);
+    expect(f5Events[1]?.startTicks ?? 0).toBeGreaterThan(0);
   });
 
   it("keeps timeline stable for underfull + implicit + regular-underfull sequence", () => {

--- a/tests/unit/playback-flow.spec.ts
+++ b/tests/unit/playback-flow.spec.ts
@@ -195,6 +195,6 @@ describe("playback-flow midi-like scheduling", () => {
     );
 
     expect(oscillators).toHaveLength(1);
-    expect(oscillators[0].stop).toHaveBeenCalledWith(expect.closeTo(0.51, 6));
+    expect(oscillators[0].stop).toHaveBeenCalledWith(expect.closeTo(0.49, 6));
   });
 });


### PR DESCRIPTION
### 概要
MIDI出力およびPlaybackで発生していた「同音が不自然に連結される／逆に必要な表現が消える」問題を修正しました。 特に `tie` / `slur` / `staccato` / `tenuto` の組み合わせでの挙動を整理し、境界音の再発音と持続のバランスを改善しています。

### 背景
- tie継続音が再発音されるケースがあった
- 同音+slurで連結しすぎて、表現（特に slur start/stop 境界や staccato/tenuto）が消えるケースがあった
- PlaybackでMIDIより「つながって聞こえる」差があった

### 変更内容
#### `src/ts/midi-io.ts`
- tie連結キーにフォールバック解決を追加（`voice` 欠落/不一致時でも `channel+pitch` で連結可能）
- slur処理を `includeTieInPlaybackLikeMode` 時にも有効化
- 同音slurマージを厳格化
  - slur内部音のみ対象（`slur start/stop` 境界は対象外）
  - 明示アーティキュレーション付き音（staccato/tenuto/accent等）は対象外
- `slur stop` 音が次音へ食い込む問題を抑止
  - forward connection がある場合のみ legato overlap を付与

#### `src/ts/playback-flow.ts`
- SynthScheduleに `trackId` を持たせ、レーン単位で再生制御
- レガート時と非レガート時でエンベロープを分離
  - attack/release を条件分岐
- 非レガート時、同レーン次音の直前で明示的に打ち切る制御を追加
- Playback通常モードでも必要な playback-like オプションを有効化
  - `includeTieInPlaybackLikeMode`
  - `applyDefaultDetacheInPlaybackLikeMode`

### テスト
#### 追加・更新
- `tests/unit/midi-io.spec.ts`
  - voice欠落時のtie連結
  - 同音slur内部の非再発音
  - slur start/stop 境界での再発音維持
  - staccato/tenuto付き同音slurの再発音維持
  - slur-stop後の同音への不正延長防止
- `tests/unit/playback-flow.spec.ts`
  - release変更に伴う期待値更新

#### 実行結果
- `npm run test:unit -- tests/unit/midi-io.spec.ts` ✅
- `npm run test:unit -- tests/unit/playback-flow.spec.ts` ✅
- `npm run build` ✅

### 影響範囲
- MIDIイベント生成（export/playback両経路）
- WebAudio簡易再生のノート接続感
- `mikuscore.html`, `src/js/main.js` はビルド成果物更新のみ

### 期待される改善
- tieの二度打ち抑止
- slur境界やアーティキュレーション表現の保持
- PlaybackとMIDI出力の体感差の縮小