### PR TITLE
MIDI I/O: 標準メタ優先の復元に改善し、mksテキストメタ出力を設定連動化

### DIFF
--- a/docs/spec/MIDI_IO.md
+++ b/docs/spec/MIDI_IO.md
@@ -186,6 +186,7 @@ The module includes a built-in raw SMF Type-1 writer path in addition to `midi-w
   - time signature meta (`FF 58`)
   - key signature meta (`FF 59`)
   - optional mikuscore SysEx chunks
+  - optional mikuscore text meta (`FF 01`, `mks:*`)
 - `MTrk #N` (note tracks by `trackId`):
   - program change per used channel (except ch10)
   - note-on / note-off events
@@ -215,6 +216,22 @@ For same-tick same-pitch situations, event ordering is configurable:
   - TPQ is fixed to `480`
   - raw writer path enabled
   - retrigger policy defaults to `off_before_on`
+
+#### `mks` metadata emission policy
+
+- `buildMidiBytesForPlayback(..., options)` supports:
+  - `embedMksSysEx?: boolean` (default: `true`)
+  - `emitMksTextMeta?: boolean` (default: `true`)
+- `embedMksSysEx` controls mikuscore SysEx payload emission on the meta track.
+- `emitMksTextMeta` controls text meta lines such as:
+  - `mks:meta-version:1`
+  - `mks:title:*`
+  - `mks:movement-title:*`
+  - `mks:composer:*`
+  - `mks:pickup-ticks:*`
+  - `mks:part-name-track:*`
+- In app export flow, `Keep roundtrip metadata (mks:meta:*)` controls `emitMksTextMeta`.
+- `Keep roundtrip metadata` does NOT disable `embedMksSysEx`; SysEx diagnostics/statistics remain enabled by default.
 
 #### Known constraints
 

--- a/mikuscore.html
+++ b/mikuscore.html
@@ -11770,7 +11770,7 @@ const onDownloadMidi = () => {
         failExport("MIDI", "No notes to export (MIDI events are empty).");
         return;
     }
-    const payload = (0, download_flow_1.createMidiDownloadPayload)(xmlText, playback_flow_1.PLAYBACK_TICKS_PER_QUARTER, normalizeMidiProgram(midiProgramSelect.value), forceMidiProgramOverride.checked, normalizeGraceTimingMode(graceTimingModeSelect.value), metricAccentEnabledInput.checked, normalizeMetricAccentProfile(metricAccentProfileSelect.value), (0, midi_musescore_io_1.normalizeMidiExportProfile)(midiExportProfileSelect.value));
+    const payload = (0, download_flow_1.createMidiDownloadPayload)(xmlText, playback_flow_1.PLAYBACK_TICKS_PER_QUARTER, normalizeMidiProgram(midiProgramSelect.value), forceMidiProgramOverride.checked, normalizeGraceTimingMode(graceTimingModeSelect.value), metricAccentEnabledInput.checked, normalizeMetricAccentProfile(metricAccentProfileSelect.value), (0, midi_musescore_io_1.normalizeMidiExportProfile)(midiExportProfileSelect.value), keepMksMetaMetadataInMusicXml.checked);
     if (!payload) {
         failExport("MIDI", "Could not build MIDI payload from current MusicXML.");
         return;
@@ -11894,7 +11894,7 @@ const onDownloadAll = async () => {
             failExport("All", "Could not build MuseScore payload from current MusicXML.");
             return;
         }
-        const midiPayload = (0, download_flow_1.createMidiDownloadPayload)(xmlText, playback_flow_1.PLAYBACK_TICKS_PER_QUARTER, normalizeMidiProgram(midiProgramSelect.value), forceMidiProgramOverride.checked, normalizeGraceTimingMode(graceTimingModeSelect.value), metricAccentEnabledInput.checked, normalizeMetricAccentProfile(metricAccentProfileSelect.value), (0, midi_musescore_io_1.normalizeMidiExportProfile)(midiExportProfileSelect.value));
+        const midiPayload = (0, download_flow_1.createMidiDownloadPayload)(xmlText, playback_flow_1.PLAYBACK_TICKS_PER_QUARTER, normalizeMidiProgram(midiProgramSelect.value), forceMidiProgramOverride.checked, normalizeGraceTimingMode(graceTimingModeSelect.value), metricAccentEnabledInput.checked, normalizeMetricAccentProfile(metricAccentProfileSelect.value), (0, midi_musescore_io_1.normalizeMidiExportProfile)(midiExportProfileSelect.value), keepMksMetaMetadataInMusicXml.checked);
         if (!midiPayload) {
             failExport("All", "Could not build MIDI payload from current MusicXML.");
             return;
@@ -12000,7 +12000,7 @@ const onDownloadMeasureMidi = () => {
         failExport("MIDI", "No notes to export (MIDI events are empty).");
         return;
     }
-    const payload = (0, download_flow_1.createMidiDownloadPayload)(xmlText, playback_flow_1.PLAYBACK_TICKS_PER_QUARTER, normalizeMidiProgram(midiProgramSelect.value), forceMidiProgramOverride.checked, normalizeGraceTimingMode(graceTimingModeSelect.value), metricAccentEnabledInput.checked, normalizeMetricAccentProfile(metricAccentProfileSelect.value), (0, midi_musescore_io_1.normalizeMidiExportProfile)(midiExportProfileSelect.value));
+    const payload = (0, download_flow_1.createMidiDownloadPayload)(xmlText, playback_flow_1.PLAYBACK_TICKS_PER_QUARTER, normalizeMidiProgram(midiProgramSelect.value), forceMidiProgramOverride.checked, normalizeGraceTimingMode(graceTimingModeSelect.value), metricAccentEnabledInput.checked, normalizeMetricAccentProfile(metricAccentProfileSelect.value), (0, midi_musescore_io_1.normalizeMidiExportProfile)(midiExportProfileSelect.value), keepMksMetaMetadataInMusicXml.checked);
     if (!payload) {
         failExport("MIDI", "Could not build MIDI payload from current measure MusicXML.");
         return;
@@ -12499,6 +12499,30 @@ const METRIC_ACCENT_PROFILE_DELTAS = {
     subtle: { strong: 2, medium: 1 },
     balanced: { strong: 4, medium: 2 },
     strong: { strong: 6, medium: 3 },
+};
+const isGenericMidiTrackName = (value) => {
+    const text = value.trim();
+    if (!text)
+        return true;
+    return /^(track|trk)\s*\d+(\s*ch(?:annel)?\s*\d+)?$/i.test(text);
+};
+const parseStandardTitleFromMetaText = (value) => {
+    const text = value.trim();
+    if (!text)
+        return "";
+    const prefixed = text.match(/^(title|piece|movement)\s*[:=]\s*(.+)$/i);
+    if (prefixed && prefixed[2])
+        return prefixed[2].trim();
+    return "";
+};
+const parseStandardComposerFromMetaText = (value) => {
+    const text = value.trim();
+    if (!text)
+        return "";
+    const prefixed = text.match(/^(composer|comp)\s*[:=]\s*(.+)$/i);
+    if (prefixed && prefixed[2])
+        return prefixed[2].trim();
+    return "";
 };
 const normalizeMetricAccentProfile = (value) => {
     if (value === "balanced" || value === "strong")
@@ -13198,6 +13222,8 @@ const parseTrackSummary = (trackData, trackIndex) => {
     const notes = [];
     const channels = new Set();
     let trackName = null;
+    const standardTitleCandidates = [];
+    const standardComposerCandidates = [];
     const programByTrackChannel = new Map();
     const controllerEvents = [];
     const timeSignatureEvents = [];
@@ -13280,7 +13306,7 @@ const parseTrackSummary = (trackData, trackIndex) => {
                     tempoEvents.push({ tick: absTick, bpm });
                 }
             }
-            else if (metaType === 0x01 || metaType === 0x03) {
+            else if (metaType === 0x01 || metaType === 0x02 || metaType === 0x03) {
                 const payloadBytes = trackData.slice(payloadStart, payloadEnd);
                 const text = decodeMetaTextBytes(payloadBytes).trim();
                 if (metaType === 0x03 && text && !trackName) {
@@ -13288,6 +13314,21 @@ const parseTrackSummary = (trackData, trackIndex) => {
                 }
                 if (text.startsWith("mks:")) {
                     mksTextMetaLines.push(text);
+                }
+                else if (text) {
+                    if (metaType === 0x01) {
+                        const parsedTitle = parseStandardTitleFromMetaText(text);
+                        if (parsedTitle)
+                            standardTitleCandidates.push(parsedTitle);
+                        const parsedComposer = parseStandardComposerFromMetaText(text);
+                        if (parsedComposer)
+                            standardComposerCandidates.push(parsedComposer);
+                    }
+                    if (metaType === 0x02) {
+                        const parsedComposer = parseStandardComposerFromMetaText(text);
+                        if (parsedComposer)
+                            standardComposerCandidates.push(parsedComposer);
+                    }
                 }
             }
             cursor = payloadEnd;
@@ -13399,6 +13440,8 @@ const parseTrackSummary = (trackData, trackIndex) => {
         notes,
         channels,
         trackName,
+        standardTitleCandidates,
+        standardComposerCandidates,
         programByTrackChannel,
         controllerEvents,
         timeSignatureEvents,
@@ -14428,7 +14471,7 @@ const buildImportSkeletonMusicXml = (params) => {
                 var _a, _b, _c, _d, _e;
                 const mksName = (_b = (_a = mksTextMetadata === null || mksTextMetadata === void 0 ? void 0 : mksTextMetadata.partNameByTrackIndex.get(group.trackIndex)) === null || _a === void 0 ? void 0 : _a.trim()) !== null && _b !== void 0 ? _b : "";
                 const trackName = (_d = (_c = trackNameByIndex.get(group.trackIndex)) === null || _c === void 0 ? void 0 : _c.trim()) !== null && _d !== void 0 ? _d : "";
-                const preferred = mksName || trackName;
+                const preferred = !isGenericMidiTrackName(trackName) ? trackName : (mksName || trackName);
                 if (preferred) {
                     const channelCount = (_e = channelCountByTrackIndex.get(group.trackIndex)) !== null && _e !== void 0 ? _e : 1;
                     return channelCount > 1 ? `${preferred} Ch ${group.channel}` : preferred;
@@ -15537,27 +15580,30 @@ const buildMidiBytesForPlayback = (events, tempo, programPreset = "electric_pian
     }
     const midiTracks = [];
     const sortedTrackIds = Array.from(tracksById.keys()).sort((a, b) => a.localeCompare(b));
-    const mksTextMetaLines = ["mks:meta-version:1"];
+    const emitMksTextMeta = options.emitMksTextMeta !== false;
+    const mksTextMetaLines = emitMksTextMeta ? ["mks:meta-version:1"] : [];
     const metaTitle = String((_d = (_c = options.metadata) === null || _c === void 0 ? void 0 : _c.title) !== null && _d !== void 0 ? _d : "").trim();
     const metaMovementTitle = String((_f = (_e = options.metadata) === null || _e === void 0 ? void 0 : _e.movementTitle) !== null && _f !== void 0 ? _f : "").trim();
     const metaComposer = String((_h = (_g = options.metadata) === null || _g === void 0 ? void 0 : _g.composer) !== null && _h !== void 0 ? _h : "").trim();
     const metaPickupTicks = Math.max(0, Math.round((_k = (_j = options.metadata) === null || _j === void 0 ? void 0 : _j.pickupTicks) !== null && _k !== void 0 ? _k : 0));
-    if (metaTitle)
-        mksTextMetaLines.push(`mks:title:${encodeURIComponent(metaTitle)}`);
-    if (metaMovementTitle) {
-        mksTextMetaLines.push(`mks:movement-title:${encodeURIComponent(metaMovementTitle)}`);
-    }
-    if (metaComposer)
-        mksTextMetaLines.push(`mks:composer:${encodeURIComponent(metaComposer)}`);
-    if (metaPickupTicks > 0)
-        mksTextMetaLines.push(`mks:pickup-ticks:${metaPickupTicks}`);
-    for (let index = 0; index < sortedTrackIds.length; index += 1) {
-        const trackId = sortedTrackIds[index];
-        const trackEvents = (_l = tracksById.get(trackId)) !== null && _l !== void 0 ? _l : [];
-        const trackName = (_p = (_o = (_m = trackEvents[0]) === null || _m === void 0 ? void 0 : _m.trackName) === null || _o === void 0 ? void 0 : _o.trim()) !== null && _p !== void 0 ? _p : "";
-        if (!trackName)
-            continue;
-        mksTextMetaLines.push(`mks:part-name-track:${index + 1}:${encodeURIComponent(trackName)}`);
+    if (emitMksTextMeta) {
+        if (metaTitle)
+            mksTextMetaLines.push(`mks:title:${encodeURIComponent(metaTitle)}`);
+        if (metaMovementTitle) {
+            mksTextMetaLines.push(`mks:movement-title:${encodeURIComponent(metaMovementTitle)}`);
+        }
+        if (metaComposer)
+            mksTextMetaLines.push(`mks:composer:${encodeURIComponent(metaComposer)}`);
+        if (metaPickupTicks > 0)
+            mksTextMetaLines.push(`mks:pickup-ticks:${metaPickupTicks}`);
+        for (let index = 0; index < sortedTrackIds.length; index += 1) {
+            const trackId = sortedTrackIds[index];
+            const trackEvents = (_l = tracksById.get(trackId)) !== null && _l !== void 0 ? _l : [];
+            const trackName = (_p = (_o = (_m = trackEvents[0]) === null || _m === void 0 ? void 0 : _m.trackName) === null || _o === void 0 ? void 0 : _o.trim()) !== null && _p !== void 0 ? _p : "";
+            if (!trackName)
+                continue;
+            mksTextMetaLines.push(`mks:part-name-track:${index + 1}:${encodeURIComponent(trackName)}`);
+        }
     }
     const normalizedTempoEvents = (tempoEvents.length ? tempoEvents : [{ startTicks: 0, bpm: tempo }])
         .map((event) => ({
@@ -15775,7 +15821,7 @@ const buildMidiBytesForPlayback = (events, tempo, programPreset = "electric_pian
 };
 exports.buildMidiBytesForPlayback = buildMidiBytesForPlayback;
 const convertMidiToMusicXml = (midiBytes, options = {}) => {
-    var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k;
+    var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p;
     const diagnostics = [];
     const warnings = [];
     const quantizeGridOption = normalizeMidiImportQuantizeGridOption(options.quantizeGrid);
@@ -15805,6 +15851,9 @@ const convertMidiToMusicXml = (midiBytes, options = {}) => {
     const tempoMetaEvents = [];
     const mksSysExPayloads = [];
     const mksTextMetaLines = [];
+    const standardTitleCandidates = [];
+    const standardComposerCandidates = [];
+    let singleTrackTitleCandidate = "";
     const trackNameByIndex = new Map();
     for (let i = 0; i < header.trackCount; i += 1) {
         if (offset + 8 > midiBytes.length) {
@@ -15831,10 +15880,19 @@ const convertMidiToMusicXml = (midiBytes, options = {}) => {
         }
         const trackData = midiBytes.slice(offset + 8, offset + 8 + trackLength);
         const summary = parseTrackSummary(trackData, i);
+        if (header.trackCount === 1 &&
+            i === 0 &&
+            !singleTrackTitleCandidate &&
+            summary.trackName &&
+            !isGenericMidiTrackName(summary.trackName)) {
+            singleTrackTitleCandidate = summary.trackName.trim();
+        }
         if (summary.trackName) {
             trackNameByIndex.set(i, summary.trackName);
         }
         collectedNotes.push(...summary.notes);
+        standardTitleCandidates.push(...summary.standardTitleCandidates);
+        standardComposerCandidates.push(...summary.standardComposerCandidates);
         controllerEvents.push(...summary.controllerEvents.map((event) => ({ ...event, trackIndex: i })));
         timeSignatureEvents.push(...summary.timeSignatureEvents);
         keySignatureEvents.push(...summary.keySignatureEvents);
@@ -15852,8 +15910,11 @@ const convertMidiToMusicXml = (midiBytes, options = {}) => {
         offset += 8 + trackLength;
     }
     const parsedMksTextMetadata = parseMksMidiTextMetadata(mksTextMetaLines);
-    const title = ((_c = parsedMksTextMetadata.title) === null || _c === void 0 ? void 0 : _c.trim()) ||
-        String((_d = options.title) !== null && _d !== void 0 ? _d : "").trim() ||
+    const standardTitle = (_d = (_c = standardTitleCandidates.find((entry) => String(entry || "").trim().length > 0)) === null || _c === void 0 ? void 0 : _c.trim()) !== null && _d !== void 0 ? _d : singleTrackTitleCandidate;
+    const standardComposer = (_f = (_e = standardComposerCandidates.find((entry) => String(entry || "").trim().length > 0)) === null || _e === void 0 ? void 0 : _e.trim()) !== null && _f !== void 0 ? _f : "";
+    const title = standardTitle ||
+        ((_g = parsedMksTextMetadata.title) === null || _g === void 0 ? void 0 : _g.trim()) ||
+        String((_h = options.title) !== null && _h !== void 0 ? _h : "").trim() ||
         "Imported MIDI";
     const quantizeGrid = quantizeGridOption === "auto"
         ? chooseBestImportQuantizeGrid(collectedNotes, header.ticksPerQuarter, tripletAwareQuantize)
@@ -15864,7 +15925,7 @@ const convertMidiToMusicXml = (midiBytes, options = {}) => {
     const notesByTrackChannel = new Map();
     for (const note of velocityScaledNotes) {
         const key = `${note.trackIndex}:${note.channel}`;
-        const bucket = (_e = notesByTrackChannel.get(key)) !== null && _e !== void 0 ? _e : [];
+        const bucket = (_j = notesByTrackChannel.get(key)) !== null && _j !== void 0 ? _j : [];
         bucket.push(note);
         notesByTrackChannel.set(key, bucket);
     }
@@ -15875,21 +15936,21 @@ const convertMidiToMusicXml = (midiBytes, options = {}) => {
             message: "Normalized leading pickup time signature (e.g. 1/8 at tick 0 followed by full meter).",
         });
     }
-    const firstTimeSignature = (_f = normalizedTimeSignature.events[0]) !== null && _f !== void 0 ? _f : { tick: 0, beats: 4, beatType: 4 };
+    const firstTimeSignature = (_k = normalizedTimeSignature.events[0]) !== null && _k !== void 0 ? _k : { tick: 0, beats: 4, beatType: 4 };
     const inferredKeySignature = keySignatureEvents.length
         ? null
         : inferKeySignatureFromImportedNotes(velocityScaledNotes);
-    const firstKeySignature = (_g = keySignatureEvents
+    const firstKeySignature = (_l = keySignatureEvents
         .slice()
-        .sort((a, b) => a.tick - b.tick)[0]) !== null && _g !== void 0 ? _g : {
+        .sort((a, b) => a.tick - b.tick)[0]) !== null && _l !== void 0 ? _l : {
         tick: 0,
-        fifths: (_h = inferredKeySignature === null || inferredKeySignature === void 0 ? void 0 : inferredKeySignature.fifths) !== null && _h !== void 0 ? _h : 0,
-        mode: (_j = inferredKeySignature === null || inferredKeySignature === void 0 ? void 0 : inferredKeySignature.mode) !== null && _j !== void 0 ? _j : "major",
+        fifths: (_m = inferredKeySignature === null || inferredKeySignature === void 0 ? void 0 : inferredKeySignature.fifths) !== null && _m !== void 0 ? _m : 0,
+        mode: (_o = inferredKeySignature === null || inferredKeySignature === void 0 ? void 0 : inferredKeySignature.mode) !== null && _o !== void 0 ? _o : "major",
     };
     const beats = Math.max(1, Math.round(firstTimeSignature.beats));
     const beatType = Math.max(1, Math.round(firstTimeSignature.beatType));
     const measureTicks = Math.max(1, Math.round((header.ticksPerQuarter * 4 * beats) / beatType));
-    const metadataPickupTicks = Math.max(0, Math.min(measureTicks - 1, Math.round((_k = parsedMksTextMetadata.pickupTicks) !== null && _k !== void 0 ? _k : 0)));
+    const metadataPickupTicks = Math.max(0, Math.min(measureTicks - 1, Math.round((_p = parsedMksTextMetadata.pickupTicks) !== null && _p !== void 0 ? _p : 0)));
     const resolvedPickupTicks = normalizedTimeSignature.pickupTicks > 0
         ? normalizedTimeSignature.pickupTicks
         : metadataPickupTicks;
@@ -15933,7 +15994,7 @@ const convertMidiToMusicXml = (midiBytes, options = {}) => {
     const xml = buildImportSkeletonMusicXml({
         title,
         movementTitle: parsedMksTextMetadata.movementTitle,
-        composer: parsedMksTextMetadata.composer,
+        composer: standardComposer || parsedMksTextMetadata.composer,
         quantizeGrid,
         divisionsOverride: quantized.divisions,
         ticksPerQuarter: header.ticksPerQuarter,
@@ -18977,7 +19038,7 @@ const createVsqxDownloadPayload = (vsqxText) => {
     };
 };
 exports.createVsqxDownloadPayload = createVsqxDownloadPayload;
-const createMidiDownloadPayload = (xmlText, ticksPerQuarter, programPreset = "electric_piano_2", forceProgramPreset = false, graceTimingMode = "before_beat", metricAccentEnabled = false, metricAccentProfile = "subtle", exportProfile = "safe") => {
+const createMidiDownloadPayload = (xmlText, ticksPerQuarter, programPreset = "electric_piano_2", forceProgramPreset = false, graceTimingMode = "before_beat", metricAccentEnabled = false, metricAccentProfile = "subtle", exportProfile = "safe", keepRoundtripMetadata = true) => {
     var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p, _q;
     const playbackDoc = (0, musicxml_io_1.parseMusicXmlDocument)(xmlText);
     if (!playbackDoc)
@@ -19012,6 +19073,7 @@ const createMidiDownloadPayload = (xmlText, ticksPerQuarter, programPreset = "el
         const pickupTicks = (0, midi_io_1.collectLeadingPickupTicksFromMusicXmlDoc)(playbackDoc, exportTicksPerQuarter);
         midiBytes = (0, midi_io_1.buildMidiBytesForPlayback)(parsedPlayback.events, parsedPlayback.tempo, programPreset, midiProgramOverrides, midiControlEvents, midiTempoEvents, midiTimeSignatureEvents, midiKeySignatureEvents, {
             embedMksSysEx: true,
+            emitMksTextMeta: keepRoundtripMetadata,
             ticksPerQuarter: exportTicksPerQuarter,
             normalizeForParity: runtime.normalizeForParity,
             rawWriter: runtime.rawWriter,

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -2851,7 +2851,7 @@ const onDownloadMidi = () => {
         failExport("MIDI", "No notes to export (MIDI events are empty).");
         return;
     }
-    const payload = (0, download_flow_1.createMidiDownloadPayload)(xmlText, playback_flow_1.PLAYBACK_TICKS_PER_QUARTER, normalizeMidiProgram(midiProgramSelect.value), forceMidiProgramOverride.checked, normalizeGraceTimingMode(graceTimingModeSelect.value), metricAccentEnabledInput.checked, normalizeMetricAccentProfile(metricAccentProfileSelect.value), (0, midi_musescore_io_1.normalizeMidiExportProfile)(midiExportProfileSelect.value));
+    const payload = (0, download_flow_1.createMidiDownloadPayload)(xmlText, playback_flow_1.PLAYBACK_TICKS_PER_QUARTER, normalizeMidiProgram(midiProgramSelect.value), forceMidiProgramOverride.checked, normalizeGraceTimingMode(graceTimingModeSelect.value), metricAccentEnabledInput.checked, normalizeMetricAccentProfile(metricAccentProfileSelect.value), (0, midi_musescore_io_1.normalizeMidiExportProfile)(midiExportProfileSelect.value), keepMksMetaMetadataInMusicXml.checked);
     if (!payload) {
         failExport("MIDI", "Could not build MIDI payload from current MusicXML.");
         return;
@@ -2975,7 +2975,7 @@ const onDownloadAll = async () => {
             failExport("All", "Could not build MuseScore payload from current MusicXML.");
             return;
         }
-        const midiPayload = (0, download_flow_1.createMidiDownloadPayload)(xmlText, playback_flow_1.PLAYBACK_TICKS_PER_QUARTER, normalizeMidiProgram(midiProgramSelect.value), forceMidiProgramOverride.checked, normalizeGraceTimingMode(graceTimingModeSelect.value), metricAccentEnabledInput.checked, normalizeMetricAccentProfile(metricAccentProfileSelect.value), (0, midi_musescore_io_1.normalizeMidiExportProfile)(midiExportProfileSelect.value));
+        const midiPayload = (0, download_flow_1.createMidiDownloadPayload)(xmlText, playback_flow_1.PLAYBACK_TICKS_PER_QUARTER, normalizeMidiProgram(midiProgramSelect.value), forceMidiProgramOverride.checked, normalizeGraceTimingMode(graceTimingModeSelect.value), metricAccentEnabledInput.checked, normalizeMetricAccentProfile(metricAccentProfileSelect.value), (0, midi_musescore_io_1.normalizeMidiExportProfile)(midiExportProfileSelect.value), keepMksMetaMetadataInMusicXml.checked);
         if (!midiPayload) {
             failExport("All", "Could not build MIDI payload from current MusicXML.");
             return;
@@ -3081,7 +3081,7 @@ const onDownloadMeasureMidi = () => {
         failExport("MIDI", "No notes to export (MIDI events are empty).");
         return;
     }
-    const payload = (0, download_flow_1.createMidiDownloadPayload)(xmlText, playback_flow_1.PLAYBACK_TICKS_PER_QUARTER, normalizeMidiProgram(midiProgramSelect.value), forceMidiProgramOverride.checked, normalizeGraceTimingMode(graceTimingModeSelect.value), metricAccentEnabledInput.checked, normalizeMetricAccentProfile(metricAccentProfileSelect.value), (0, midi_musescore_io_1.normalizeMidiExportProfile)(midiExportProfileSelect.value));
+    const payload = (0, download_flow_1.createMidiDownloadPayload)(xmlText, playback_flow_1.PLAYBACK_TICKS_PER_QUARTER, normalizeMidiProgram(midiProgramSelect.value), forceMidiProgramOverride.checked, normalizeGraceTimingMode(graceTimingModeSelect.value), metricAccentEnabledInput.checked, normalizeMetricAccentProfile(metricAccentProfileSelect.value), (0, midi_musescore_io_1.normalizeMidiExportProfile)(midiExportProfileSelect.value), keepMksMetaMetadataInMusicXml.checked);
     if (!payload) {
         failExport("MIDI", "Could not build MIDI payload from current measure MusicXML.");
         return;
@@ -3580,6 +3580,30 @@ const METRIC_ACCENT_PROFILE_DELTAS = {
     subtle: { strong: 2, medium: 1 },
     balanced: { strong: 4, medium: 2 },
     strong: { strong: 6, medium: 3 },
+};
+const isGenericMidiTrackName = (value) => {
+    const text = value.trim();
+    if (!text)
+        return true;
+    return /^(track|trk)\s*\d+(\s*ch(?:annel)?\s*\d+)?$/i.test(text);
+};
+const parseStandardTitleFromMetaText = (value) => {
+    const text = value.trim();
+    if (!text)
+        return "";
+    const prefixed = text.match(/^(title|piece|movement)\s*[:=]\s*(.+)$/i);
+    if (prefixed && prefixed[2])
+        return prefixed[2].trim();
+    return "";
+};
+const parseStandardComposerFromMetaText = (value) => {
+    const text = value.trim();
+    if (!text)
+        return "";
+    const prefixed = text.match(/^(composer|comp)\s*[:=]\s*(.+)$/i);
+    if (prefixed && prefixed[2])
+        return prefixed[2].trim();
+    return "";
 };
 const normalizeMetricAccentProfile = (value) => {
     if (value === "balanced" || value === "strong")
@@ -4279,6 +4303,8 @@ const parseTrackSummary = (trackData, trackIndex) => {
     const notes = [];
     const channels = new Set();
     let trackName = null;
+    const standardTitleCandidates = [];
+    const standardComposerCandidates = [];
     const programByTrackChannel = new Map();
     const controllerEvents = [];
     const timeSignatureEvents = [];
@@ -4361,7 +4387,7 @@ const parseTrackSummary = (trackData, trackIndex) => {
                     tempoEvents.push({ tick: absTick, bpm });
                 }
             }
-            else if (metaType === 0x01 || metaType === 0x03) {
+            else if (metaType === 0x01 || metaType === 0x02 || metaType === 0x03) {
                 const payloadBytes = trackData.slice(payloadStart, payloadEnd);
                 const text = decodeMetaTextBytes(payloadBytes).trim();
                 if (metaType === 0x03 && text && !trackName) {
@@ -4369,6 +4395,21 @@ const parseTrackSummary = (trackData, trackIndex) => {
                 }
                 if (text.startsWith("mks:")) {
                     mksTextMetaLines.push(text);
+                }
+                else if (text) {
+                    if (metaType === 0x01) {
+                        const parsedTitle = parseStandardTitleFromMetaText(text);
+                        if (parsedTitle)
+                            standardTitleCandidates.push(parsedTitle);
+                        const parsedComposer = parseStandardComposerFromMetaText(text);
+                        if (parsedComposer)
+                            standardComposerCandidates.push(parsedComposer);
+                    }
+                    if (metaType === 0x02) {
+                        const parsedComposer = parseStandardComposerFromMetaText(text);
+                        if (parsedComposer)
+                            standardComposerCandidates.push(parsedComposer);
+                    }
                 }
             }
             cursor = payloadEnd;
@@ -4480,6 +4521,8 @@ const parseTrackSummary = (trackData, trackIndex) => {
         notes,
         channels,
         trackName,
+        standardTitleCandidates,
+        standardComposerCandidates,
         programByTrackChannel,
         controllerEvents,
         timeSignatureEvents,
@@ -5509,7 +5552,7 @@ const buildImportSkeletonMusicXml = (params) => {
                 var _a, _b, _c, _d, _e;
                 const mksName = (_b = (_a = mksTextMetadata === null || mksTextMetadata === void 0 ? void 0 : mksTextMetadata.partNameByTrackIndex.get(group.trackIndex)) === null || _a === void 0 ? void 0 : _a.trim()) !== null && _b !== void 0 ? _b : "";
                 const trackName = (_d = (_c = trackNameByIndex.get(group.trackIndex)) === null || _c === void 0 ? void 0 : _c.trim()) !== null && _d !== void 0 ? _d : "";
-                const preferred = mksName || trackName;
+                const preferred = !isGenericMidiTrackName(trackName) ? trackName : (mksName || trackName);
                 if (preferred) {
                     const channelCount = (_e = channelCountByTrackIndex.get(group.trackIndex)) !== null && _e !== void 0 ? _e : 1;
                     return channelCount > 1 ? `${preferred} Ch ${group.channel}` : preferred;
@@ -6618,27 +6661,30 @@ const buildMidiBytesForPlayback = (events, tempo, programPreset = "electric_pian
     }
     const midiTracks = [];
     const sortedTrackIds = Array.from(tracksById.keys()).sort((a, b) => a.localeCompare(b));
-    const mksTextMetaLines = ["mks:meta-version:1"];
+    const emitMksTextMeta = options.emitMksTextMeta !== false;
+    const mksTextMetaLines = emitMksTextMeta ? ["mks:meta-version:1"] : [];
     const metaTitle = String((_d = (_c = options.metadata) === null || _c === void 0 ? void 0 : _c.title) !== null && _d !== void 0 ? _d : "").trim();
     const metaMovementTitle = String((_f = (_e = options.metadata) === null || _e === void 0 ? void 0 : _e.movementTitle) !== null && _f !== void 0 ? _f : "").trim();
     const metaComposer = String((_h = (_g = options.metadata) === null || _g === void 0 ? void 0 : _g.composer) !== null && _h !== void 0 ? _h : "").trim();
     const metaPickupTicks = Math.max(0, Math.round((_k = (_j = options.metadata) === null || _j === void 0 ? void 0 : _j.pickupTicks) !== null && _k !== void 0 ? _k : 0));
-    if (metaTitle)
-        mksTextMetaLines.push(`mks:title:${encodeURIComponent(metaTitle)}`);
-    if (metaMovementTitle) {
-        mksTextMetaLines.push(`mks:movement-title:${encodeURIComponent(metaMovementTitle)}`);
-    }
-    if (metaComposer)
-        mksTextMetaLines.push(`mks:composer:${encodeURIComponent(metaComposer)}`);
-    if (metaPickupTicks > 0)
-        mksTextMetaLines.push(`mks:pickup-ticks:${metaPickupTicks}`);
-    for (let index = 0; index < sortedTrackIds.length; index += 1) {
-        const trackId = sortedTrackIds[index];
-        const trackEvents = (_l = tracksById.get(trackId)) !== null && _l !== void 0 ? _l : [];
-        const trackName = (_p = (_o = (_m = trackEvents[0]) === null || _m === void 0 ? void 0 : _m.trackName) === null || _o === void 0 ? void 0 : _o.trim()) !== null && _p !== void 0 ? _p : "";
-        if (!trackName)
-            continue;
-        mksTextMetaLines.push(`mks:part-name-track:${index + 1}:${encodeURIComponent(trackName)}`);
+    if (emitMksTextMeta) {
+        if (metaTitle)
+            mksTextMetaLines.push(`mks:title:${encodeURIComponent(metaTitle)}`);
+        if (metaMovementTitle) {
+            mksTextMetaLines.push(`mks:movement-title:${encodeURIComponent(metaMovementTitle)}`);
+        }
+        if (metaComposer)
+            mksTextMetaLines.push(`mks:composer:${encodeURIComponent(metaComposer)}`);
+        if (metaPickupTicks > 0)
+            mksTextMetaLines.push(`mks:pickup-ticks:${metaPickupTicks}`);
+        for (let index = 0; index < sortedTrackIds.length; index += 1) {
+            const trackId = sortedTrackIds[index];
+            const trackEvents = (_l = tracksById.get(trackId)) !== null && _l !== void 0 ? _l : [];
+            const trackName = (_p = (_o = (_m = trackEvents[0]) === null || _m === void 0 ? void 0 : _m.trackName) === null || _o === void 0 ? void 0 : _o.trim()) !== null && _p !== void 0 ? _p : "";
+            if (!trackName)
+                continue;
+            mksTextMetaLines.push(`mks:part-name-track:${index + 1}:${encodeURIComponent(trackName)}`);
+        }
     }
     const normalizedTempoEvents = (tempoEvents.length ? tempoEvents : [{ startTicks: 0, bpm: tempo }])
         .map((event) => ({
@@ -6856,7 +6902,7 @@ const buildMidiBytesForPlayback = (events, tempo, programPreset = "electric_pian
 };
 exports.buildMidiBytesForPlayback = buildMidiBytesForPlayback;
 const convertMidiToMusicXml = (midiBytes, options = {}) => {
-    var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k;
+    var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p;
     const diagnostics = [];
     const warnings = [];
     const quantizeGridOption = normalizeMidiImportQuantizeGridOption(options.quantizeGrid);
@@ -6886,6 +6932,9 @@ const convertMidiToMusicXml = (midiBytes, options = {}) => {
     const tempoMetaEvents = [];
     const mksSysExPayloads = [];
     const mksTextMetaLines = [];
+    const standardTitleCandidates = [];
+    const standardComposerCandidates = [];
+    let singleTrackTitleCandidate = "";
     const trackNameByIndex = new Map();
     for (let i = 0; i < header.trackCount; i += 1) {
         if (offset + 8 > midiBytes.length) {
@@ -6912,10 +6961,19 @@ const convertMidiToMusicXml = (midiBytes, options = {}) => {
         }
         const trackData = midiBytes.slice(offset + 8, offset + 8 + trackLength);
         const summary = parseTrackSummary(trackData, i);
+        if (header.trackCount === 1 &&
+            i === 0 &&
+            !singleTrackTitleCandidate &&
+            summary.trackName &&
+            !isGenericMidiTrackName(summary.trackName)) {
+            singleTrackTitleCandidate = summary.trackName.trim();
+        }
         if (summary.trackName) {
             trackNameByIndex.set(i, summary.trackName);
         }
         collectedNotes.push(...summary.notes);
+        standardTitleCandidates.push(...summary.standardTitleCandidates);
+        standardComposerCandidates.push(...summary.standardComposerCandidates);
         controllerEvents.push(...summary.controllerEvents.map((event) => ({ ...event, trackIndex: i })));
         timeSignatureEvents.push(...summary.timeSignatureEvents);
         keySignatureEvents.push(...summary.keySignatureEvents);
@@ -6933,8 +6991,11 @@ const convertMidiToMusicXml = (midiBytes, options = {}) => {
         offset += 8 + trackLength;
     }
     const parsedMksTextMetadata = parseMksMidiTextMetadata(mksTextMetaLines);
-    const title = ((_c = parsedMksTextMetadata.title) === null || _c === void 0 ? void 0 : _c.trim()) ||
-        String((_d = options.title) !== null && _d !== void 0 ? _d : "").trim() ||
+    const standardTitle = (_d = (_c = standardTitleCandidates.find((entry) => String(entry || "").trim().length > 0)) === null || _c === void 0 ? void 0 : _c.trim()) !== null && _d !== void 0 ? _d : singleTrackTitleCandidate;
+    const standardComposer = (_f = (_e = standardComposerCandidates.find((entry) => String(entry || "").trim().length > 0)) === null || _e === void 0 ? void 0 : _e.trim()) !== null && _f !== void 0 ? _f : "";
+    const title = standardTitle ||
+        ((_g = parsedMksTextMetadata.title) === null || _g === void 0 ? void 0 : _g.trim()) ||
+        String((_h = options.title) !== null && _h !== void 0 ? _h : "").trim() ||
         "Imported MIDI";
     const quantizeGrid = quantizeGridOption === "auto"
         ? chooseBestImportQuantizeGrid(collectedNotes, header.ticksPerQuarter, tripletAwareQuantize)
@@ -6945,7 +7006,7 @@ const convertMidiToMusicXml = (midiBytes, options = {}) => {
     const notesByTrackChannel = new Map();
     for (const note of velocityScaledNotes) {
         const key = `${note.trackIndex}:${note.channel}`;
-        const bucket = (_e = notesByTrackChannel.get(key)) !== null && _e !== void 0 ? _e : [];
+        const bucket = (_j = notesByTrackChannel.get(key)) !== null && _j !== void 0 ? _j : [];
         bucket.push(note);
         notesByTrackChannel.set(key, bucket);
     }
@@ -6956,21 +7017,21 @@ const convertMidiToMusicXml = (midiBytes, options = {}) => {
             message: "Normalized leading pickup time signature (e.g. 1/8 at tick 0 followed by full meter).",
         });
     }
-    const firstTimeSignature = (_f = normalizedTimeSignature.events[0]) !== null && _f !== void 0 ? _f : { tick: 0, beats: 4, beatType: 4 };
+    const firstTimeSignature = (_k = normalizedTimeSignature.events[0]) !== null && _k !== void 0 ? _k : { tick: 0, beats: 4, beatType: 4 };
     const inferredKeySignature = keySignatureEvents.length
         ? null
         : inferKeySignatureFromImportedNotes(velocityScaledNotes);
-    const firstKeySignature = (_g = keySignatureEvents
+    const firstKeySignature = (_l = keySignatureEvents
         .slice()
-        .sort((a, b) => a.tick - b.tick)[0]) !== null && _g !== void 0 ? _g : {
+        .sort((a, b) => a.tick - b.tick)[0]) !== null && _l !== void 0 ? _l : {
         tick: 0,
-        fifths: (_h = inferredKeySignature === null || inferredKeySignature === void 0 ? void 0 : inferredKeySignature.fifths) !== null && _h !== void 0 ? _h : 0,
-        mode: (_j = inferredKeySignature === null || inferredKeySignature === void 0 ? void 0 : inferredKeySignature.mode) !== null && _j !== void 0 ? _j : "major",
+        fifths: (_m = inferredKeySignature === null || inferredKeySignature === void 0 ? void 0 : inferredKeySignature.fifths) !== null && _m !== void 0 ? _m : 0,
+        mode: (_o = inferredKeySignature === null || inferredKeySignature === void 0 ? void 0 : inferredKeySignature.mode) !== null && _o !== void 0 ? _o : "major",
     };
     const beats = Math.max(1, Math.round(firstTimeSignature.beats));
     const beatType = Math.max(1, Math.round(firstTimeSignature.beatType));
     const measureTicks = Math.max(1, Math.round((header.ticksPerQuarter * 4 * beats) / beatType));
-    const metadataPickupTicks = Math.max(0, Math.min(measureTicks - 1, Math.round((_k = parsedMksTextMetadata.pickupTicks) !== null && _k !== void 0 ? _k : 0)));
+    const metadataPickupTicks = Math.max(0, Math.min(measureTicks - 1, Math.round((_p = parsedMksTextMetadata.pickupTicks) !== null && _p !== void 0 ? _p : 0)));
     const resolvedPickupTicks = normalizedTimeSignature.pickupTicks > 0
         ? normalizedTimeSignature.pickupTicks
         : metadataPickupTicks;
@@ -7014,7 +7075,7 @@ const convertMidiToMusicXml = (midiBytes, options = {}) => {
     const xml = buildImportSkeletonMusicXml({
         title,
         movementTitle: parsedMksTextMetadata.movementTitle,
-        composer: parsedMksTextMetadata.composer,
+        composer: standardComposer || parsedMksTextMetadata.composer,
         quantizeGrid,
         divisionsOverride: quantized.divisions,
         ticksPerQuarter: header.ticksPerQuarter,
@@ -10058,7 +10119,7 @@ const createVsqxDownloadPayload = (vsqxText) => {
     };
 };
 exports.createVsqxDownloadPayload = createVsqxDownloadPayload;
-const createMidiDownloadPayload = (xmlText, ticksPerQuarter, programPreset = "electric_piano_2", forceProgramPreset = false, graceTimingMode = "before_beat", metricAccentEnabled = false, metricAccentProfile = "subtle", exportProfile = "safe") => {
+const createMidiDownloadPayload = (xmlText, ticksPerQuarter, programPreset = "electric_piano_2", forceProgramPreset = false, graceTimingMode = "before_beat", metricAccentEnabled = false, metricAccentProfile = "subtle", exportProfile = "safe", keepRoundtripMetadata = true) => {
     var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p, _q;
     const playbackDoc = (0, musicxml_io_1.parseMusicXmlDocument)(xmlText);
     if (!playbackDoc)
@@ -10093,6 +10154,7 @@ const createMidiDownloadPayload = (xmlText, ticksPerQuarter, programPreset = "el
         const pickupTicks = (0, midi_io_1.collectLeadingPickupTicksFromMusicXmlDoc)(playbackDoc, exportTicksPerQuarter);
         midiBytes = (0, midi_io_1.buildMidiBytesForPlayback)(parsedPlayback.events, parsedPlayback.tempo, programPreset, midiProgramOverrides, midiControlEvents, midiTempoEvents, midiTimeSignatureEvents, midiKeySignatureEvents, {
             embedMksSysEx: true,
+            emitMksTextMeta: keepRoundtripMetadata,
             ticksPerQuarter: exportTicksPerQuarter,
             normalizeForParity: runtime.normalizeForParity,
             rawWriter: runtime.rawWriter,

--- a/src/ts/download-flow.ts
+++ b/src/ts/download-flow.ts
@@ -301,7 +301,8 @@ export const createMidiDownloadPayload = (
   graceTimingMode: GraceTimingMode = "before_beat",
   metricAccentEnabled = false,
   metricAccentProfile: MetricAccentProfile = "subtle",
-  exportProfile: MidiExportProfile = "safe"
+  exportProfile: MidiExportProfile = "safe",
+  keepRoundtripMetadata = true
 ): DownloadFilePayload | null => {
   const playbackDoc = parseMusicXmlDocument(xmlText);
   if (!playbackDoc) return null;
@@ -353,6 +354,7 @@ export const createMidiDownloadPayload = (
       midiKeySignatureEvents,
       {
         embedMksSysEx: true,
+        emitMksTextMeta: keepRoundtripMetadata,
         ticksPerQuarter: exportTicksPerQuarter,
         normalizeForParity: runtime.normalizeForParity,
         rawWriter: runtime.rawWriter,

--- a/src/ts/main.ts
+++ b/src/ts/main.ts
@@ -3039,7 +3039,8 @@ const onDownloadMidi = (): void => {
     normalizeGraceTimingMode(graceTimingModeSelect.value),
     metricAccentEnabledInput.checked,
     normalizeMetricAccentProfile(metricAccentProfileSelect.value),
-    normalizeMidiExportProfile(midiExportProfileSelect.value)
+    normalizeMidiExportProfile(midiExportProfileSelect.value),
+    keepMksMetaMetadataInMusicXml.checked
   );
   if (!payload) {
     failExport("MIDI", "Could not build MIDI payload from current MusicXML.");
@@ -3172,7 +3173,8 @@ const onDownloadAll = async (): Promise<void> => {
       normalizeGraceTimingMode(graceTimingModeSelect.value),
       metricAccentEnabledInput.checked,
       normalizeMetricAccentProfile(metricAccentProfileSelect.value),
-      normalizeMidiExportProfile(midiExportProfileSelect.value)
+      normalizeMidiExportProfile(midiExportProfileSelect.value),
+      keepMksMetaMetadataInMusicXml.checked
     );
     if (!midiPayload) {
       failExport("All", "Could not build MIDI payload from current MusicXML.");
@@ -3285,7 +3287,8 @@ const onDownloadMeasureMidi = (): void => {
     normalizeGraceTimingMode(graceTimingModeSelect.value),
     metricAccentEnabledInput.checked,
     normalizeMetricAccentProfile(metricAccentProfileSelect.value),
-    normalizeMidiExportProfile(midiExportProfileSelect.value)
+    normalizeMidiExportProfile(midiExportProfileSelect.value),
+    keepMksMetaMetadataInMusicXml.checked
   );
   if (!payload) {
     failExport("MIDI", "Could not build MIDI payload from current measure MusicXML.");

--- a/src/ts/midi-io.ts
+++ b/src/ts/midi-io.ts
@@ -379,6 +379,8 @@ type SmfParseSummary = {
   notes: SmfImportedNote[];
   channels: Set<number>;
   trackName: string | null;
+  standardTitleCandidates: string[];
+  standardComposerCandidates: string[];
   programByTrackChannel: Map<TrackChannelKey, number>;
   controllerEvents: Array<{ tick: number; channel: number; controllerNumber: number; controllerValue: number }>;
   timeSignatureEvents: Array<{ tick: number; beats: number; beatType: number }>;
@@ -402,6 +404,28 @@ type MksSysExChunk = {
   chunkIndex: number;
   totalChunks: number;
   data: string;
+};
+
+const isGenericMidiTrackName = (value: string): boolean => {
+  const text = value.trim();
+  if (!text) return true;
+  return /^(track|trk)\s*\d+(\s*ch(?:annel)?\s*\d+)?$/i.test(text);
+};
+
+const parseStandardTitleFromMetaText = (value: string): string => {
+  const text = value.trim();
+  if (!text) return "";
+  const prefixed = text.match(/^(title|piece|movement)\s*[:=]\s*(.+)$/i);
+  if (prefixed && prefixed[2]) return prefixed[2].trim();
+  return "";
+};
+
+const parseStandardComposerFromMetaText = (value: string): string => {
+  const text = value.trim();
+  if (!text) return "";
+  const prefixed = text.match(/^(composer|comp)\s*[:=]\s*(.+)$/i);
+  if (prefixed && prefixed[2]) return prefixed[2].trim();
+  return "";
 };
 
 const normalizeMetricAccentProfile = (value: unknown): MetricAccentProfile => {
@@ -1147,6 +1171,8 @@ const parseTrackSummary = (trackData: Uint8Array, trackIndex: number): SmfParseS
   const notes: SmfImportedNote[] = [];
   const channels = new Set<number>();
   let trackName: string | null = null;
+  const standardTitleCandidates: string[] = [];
+  const standardComposerCandidates: string[] = [];
   const programByTrackChannel = new Map<TrackChannelKey, number>();
   const controllerEvents: Array<{
     tick: number;
@@ -1231,7 +1257,7 @@ const parseTrackSummary = (trackData: Uint8Array, trackIndex: number): SmfParseS
           const bpm = clampTempo(60000000 / microsPerQuarter);
           tempoEvents.push({ tick: absTick, bpm });
         }
-      } else if (metaType === 0x01 || metaType === 0x03) {
+      } else if (metaType === 0x01 || metaType === 0x02 || metaType === 0x03) {
         const payloadBytes = trackData.slice(payloadStart, payloadEnd);
         const text = decodeMetaTextBytes(payloadBytes).trim();
         if (metaType === 0x03 && text && !trackName) {
@@ -1239,6 +1265,17 @@ const parseTrackSummary = (trackData: Uint8Array, trackIndex: number): SmfParseS
         }
         if (text.startsWith("mks:")) {
           mksTextMetaLines.push(text);
+        } else if (text) {
+          if (metaType === 0x01) {
+            const parsedTitle = parseStandardTitleFromMetaText(text);
+            if (parsedTitle) standardTitleCandidates.push(parsedTitle);
+            const parsedComposer = parseStandardComposerFromMetaText(text);
+            if (parsedComposer) standardComposerCandidates.push(parsedComposer);
+          }
+          if (metaType === 0x02) {
+            const parsedComposer = parseStandardComposerFromMetaText(text);
+            if (parsedComposer) standardComposerCandidates.push(parsedComposer);
+          }
         }
       }
       cursor = payloadEnd;
@@ -1352,6 +1389,8 @@ const parseTrackSummary = (trackData: Uint8Array, trackIndex: number): SmfParseS
     notes,
     channels,
     trackName,
+    standardTitleCandidates,
+    standardComposerCandidates,
     programByTrackChannel,
     controllerEvents,
     timeSignatureEvents,
@@ -2559,7 +2598,7 @@ const buildImportSkeletonMusicXml = (params: {
       name: (() => {
         const mksName = mksTextMetadata?.partNameByTrackIndex.get(group.trackIndex)?.trim() ?? "";
         const trackName = trackNameByIndex.get(group.trackIndex)?.trim() ?? "";
-        const preferred = mksName || trackName;
+        const preferred = !isGenericMidiTrackName(trackName) ? trackName : (mksName || trackName);
         if (preferred) {
           const channelCount = channelCountByTrackIndex.get(group.trackIndex) ?? 1;
           return channelCount > 1 ? `${preferred} Ch ${group.channel}` : preferred;
@@ -3796,6 +3835,7 @@ export const buildMidiBytesForPlayback = (
   keySignatureEvents: MidiKeySignatureEvent[] = [],
   options: {
     embedMksSysEx?: boolean;
+    emitMksTextMeta?: boolean;
     ticksPerQuarter?: number;
     diagnostics?: string[];
     normalizeForParity?: boolean;
@@ -3831,23 +3871,26 @@ export const buildMidiBytesForPlayback = (
 
   const midiTracks: unknown[] = [];
   const sortedTrackIds = Array.from(tracksById.keys()).sort((a, b) => a.localeCompare(b));
-  const mksTextMetaLines: string[] = ["mks:meta-version:1"];
+  const emitMksTextMeta = options.emitMksTextMeta !== false;
+  const mksTextMetaLines: string[] = emitMksTextMeta ? ["mks:meta-version:1"] : [];
   const metaTitle = String(options.metadata?.title ?? "").trim();
   const metaMovementTitle = String(options.metadata?.movementTitle ?? "").trim();
   const metaComposer = String(options.metadata?.composer ?? "").trim();
   const metaPickupTicks = Math.max(0, Math.round(options.metadata?.pickupTicks ?? 0));
-  if (metaTitle) mksTextMetaLines.push(`mks:title:${encodeURIComponent(metaTitle)}`);
-  if (metaMovementTitle) {
-    mksTextMetaLines.push(`mks:movement-title:${encodeURIComponent(metaMovementTitle)}`);
-  }
-  if (metaComposer) mksTextMetaLines.push(`mks:composer:${encodeURIComponent(metaComposer)}`);
-  if (metaPickupTicks > 0) mksTextMetaLines.push(`mks:pickup-ticks:${metaPickupTicks}`);
-  for (let index = 0; index < sortedTrackIds.length; index += 1) {
-    const trackId = sortedTrackIds[index];
-    const trackEvents = tracksById.get(trackId) ?? [];
-    const trackName = trackEvents[0]?.trackName?.trim() ?? "";
-    if (!trackName) continue;
-    mksTextMetaLines.push(`mks:part-name-track:${index + 1}:${encodeURIComponent(trackName)}`);
+  if (emitMksTextMeta) {
+    if (metaTitle) mksTextMetaLines.push(`mks:title:${encodeURIComponent(metaTitle)}`);
+    if (metaMovementTitle) {
+      mksTextMetaLines.push(`mks:movement-title:${encodeURIComponent(metaMovementTitle)}`);
+    }
+    if (metaComposer) mksTextMetaLines.push(`mks:composer:${encodeURIComponent(metaComposer)}`);
+    if (metaPickupTicks > 0) mksTextMetaLines.push(`mks:pickup-ticks:${metaPickupTicks}`);
+    for (let index = 0; index < sortedTrackIds.length; index += 1) {
+      const trackId = sortedTrackIds[index];
+      const trackEvents = tracksById.get(trackId) ?? [];
+      const trackName = trackEvents[0]?.trackName?.trim() ?? "";
+      if (!trackName) continue;
+      mksTextMetaLines.push(`mks:part-name-track:${index + 1}:${encodeURIComponent(trackName)}`);
+    }
   }
   const normalizedTempoEvents = (tempoEvents.length ? tempoEvents : [{ startTicks: 0, bpm: tempo }])
     .map((event) => ({
@@ -4149,6 +4192,9 @@ export const convertMidiToMusicXml = (
   const tempoMetaEvents: Array<{ tick: number; bpm: number }> = [];
   const mksSysExPayloads: string[] = [];
   const mksTextMetaLines: string[] = [];
+  const standardTitleCandidates: string[] = [];
+  const standardComposerCandidates: string[] = [];
+  let singleTrackTitleCandidate = "";
   const trackNameByIndex = new Map<number, string>();
 
   for (let i = 0; i < header.trackCount; i += 1) {
@@ -4176,10 +4222,21 @@ export const convertMidiToMusicXml = (
     }
     const trackData = midiBytes.slice(offset + 8, offset + 8 + trackLength);
     const summary = parseTrackSummary(trackData, i);
+    if (
+      header.trackCount === 1 &&
+      i === 0 &&
+      !singleTrackTitleCandidate &&
+      summary.trackName &&
+      !isGenericMidiTrackName(summary.trackName)
+    ) {
+      singleTrackTitleCandidate = summary.trackName.trim();
+    }
     if (summary.trackName) {
       trackNameByIndex.set(i, summary.trackName);
     }
     collectedNotes.push(...summary.notes);
+    standardTitleCandidates.push(...summary.standardTitleCandidates);
+    standardComposerCandidates.push(...summary.standardComposerCandidates);
     controllerEvents.push(
       ...summary.controllerEvents.map((event) => ({ ...event, trackIndex: i }))
     );
@@ -4198,7 +4255,13 @@ export const convertMidiToMusicXml = (
     offset += 8 + trackLength;
   }
   const parsedMksTextMetadata = parseMksMidiTextMetadata(mksTextMetaLines);
+  const standardTitle =
+    standardTitleCandidates.find((entry) => String(entry || "").trim().length > 0)?.trim() ??
+    singleTrackTitleCandidate;
+  const standardComposer =
+    standardComposerCandidates.find((entry) => String(entry || "").trim().length > 0)?.trim() ?? "";
   const title =
+    standardTitle ||
     parsedMksTextMetadata.title?.trim() ||
     String(options.title ?? "").trim() ||
     "Imported MIDI";
@@ -4296,7 +4359,7 @@ export const convertMidiToMusicXml = (
   const xml = buildImportSkeletonMusicXml({
     title,
     movementTitle: parsedMksTextMetadata.movementTitle,
-    composer: parsedMksTextMetadata.composer,
+    composer: standardComposer || parsedMksTextMetadata.composer,
     quantizeGrid,
     divisionsOverride: quantized.divisions,
     ticksPerQuarter: header.ticksPerQuarter,

--- a/tests/unit/midi-io.spec.ts
+++ b/tests/unit/midi-io.spec.ts
@@ -163,6 +163,62 @@ const collectTimeSignatureMetaFromMidi = (midi: Uint8Array): Array<{ tick: numbe
   return out.sort((a, b) => a.tick - b.tick);
 };
 
+const collectTextMetaFromMidi = (midi: Uint8Array): string[] => {
+  if (String.fromCharCode(...Array.from(midi.slice(0, 4))) !== "MThd") return [];
+  const headerLen = readU32Be(midi, 4);
+  const trackCount = readU16Be(midi, 10);
+  let offset = 8 + headerLen;
+  const out: string[] = [];
+
+  for (let t = 0; t < trackCount; t += 1) {
+    if (String.fromCharCode(...Array.from(midi.slice(offset, offset + 4))) !== "MTrk") break;
+    const trackLen = readU32Be(midi, offset + 4);
+    const track = midi.slice(offset + 8, offset + 8 + trackLen);
+    offset += 8 + trackLen;
+    let cursor = 0;
+    let runningStatus: number | null = null;
+    while (cursor < track.length) {
+      const delta = readVlqAt(track, cursor);
+      if (!delta) break;
+      cursor = delta.next;
+      const first = track[cursor];
+      if (first === undefined) break;
+      let status = first;
+      if (status < 0x80) {
+        if (runningStatus === null) break;
+        status = runningStatus;
+      } else {
+        cursor += 1;
+        if (status < 0xf0) runningStatus = status;
+        else runningStatus = null;
+      }
+      if (status === 0xff) {
+        const metaType = track[cursor];
+        cursor += 1;
+        const len = readVlqAt(track, cursor);
+        if (!len) break;
+        cursor = len.next;
+        if ((metaType === 0x01 || metaType === 0x03) && len.value > 0) {
+          const payload = track.slice(cursor, cursor + len.value);
+          out.push(String.fromCharCode(...Array.from(payload)));
+        }
+        cursor += len.value;
+        continue;
+      }
+      if (status === 0xf0 || status === 0xf7) {
+        const len = readVlqAt(track, cursor);
+        if (!len) break;
+        cursor = len.next + len.value;
+        continue;
+      }
+      const msg = status & 0xf0;
+      const dataLen = msg === 0xc0 || msg === 0xd0 ? 1 : 2;
+      cursor += dataLen;
+    }
+  }
+  return out;
+};
+
 describe("midi-io MIDI nuance regressions", () => {
   it("keeps full non-implicit measure length for playback timeline", () => {
     const xml = `<?xml version="1.0" encoding="UTF-8"?>
@@ -1731,6 +1787,35 @@ describe("midi-io MIDI import MVP", () => {
     expect(timeSigs[1]).toEqual({ tick: 240, beats: 6, beatType: 8 });
   });
 
+  it("does not emit mks text metadata when emitMksTextMeta is false", () => {
+    const midi = buildMidiBytesForPlayback(
+      [{ midiNumber: 69, startTicks: 0, durTicks: 240, channel: 1, velocity: 90, trackId: "P1", trackName: "P1" }],
+      120,
+      "electric_piano_2",
+      new Map<string, number>(),
+      [],
+      [{ startTicks: 0, bpm: 120 }],
+      [{ startTicks: 0, beats: 6, beatType: 8 }],
+      [{ startTicks: 0, fifths: -1, mode: "major" }],
+      {
+        ticksPerQuarter: 480,
+        rawWriter: true,
+        emitMksTextMeta: false,
+        metadata: {
+          title: "Title",
+          composer: "Composer",
+          pickupTicks: 240,
+        },
+      }
+    );
+    const texts = collectTextMetaFromMidi(midi);
+    expect(texts.some((text) => text.startsWith("mks:"))).toBe(false);
+    const timeSigs = collectTimeSignatureMetaFromMidi(midi);
+    expect(timeSigs.length).toBeGreaterThanOrEqual(2);
+    expect(timeSigs[0]).toEqual({ tick: 0, beats: 1, beatType: 8 });
+    expect(timeSigs[1]).toEqual({ tick: 240, beats: 6, beatType: 8 });
+  });
+
   it("keeps stable triplet-eighth timing in MusicXML playback extraction", () => {
     const xml = `<?xml version="1.0" encoding="UTF-8"?>
 <score-partwise version="4.0">
@@ -1859,6 +1944,60 @@ describe("midi-io MIDI import MVP", () => {
       "Roundtrip Composer"
     );
     expect(doc.querySelector("part-list > score-part > part-name")?.textContent?.trim()).toBe("Violin Solo");
+  });
+
+  it("prefers standard MIDI meta title/composer over mks text meta", () => {
+    const track0 = [
+      ...metaTextEvent(0, "title:Concert Overture", 0x01),
+      ...metaTextEvent(0, "composer:Standard Composer", 0x01),
+      ...metaTextEvent(0, "mks:meta-version:1"),
+      ...metaTextEvent(0, "mks:title:Roundtrip%20Title"),
+      ...metaTextEvent(0, "mks:composer:Roundtrip%20Composer"),
+      ...vlq(0),
+      0xff,
+      0x51,
+      0x03,
+      0x07,
+      0xa1,
+      0x20,
+    ];
+    const track1 = [
+      ...metaTextEvent(0, "Track 1", 0x03),
+      ...vlq(0),
+      0x90,
+      60,
+      100,
+      ...vlq(480),
+      0x80,
+      60,
+      0,
+    ];
+    const midi = buildSmfFormat1([track0, track1], 480);
+    const result = convertMidiToMusicXml(midi);
+    expect(result.ok).toBe(true);
+    const doc = parseDoc(result.xml);
+    expect(doc.querySelector("work > work-title")?.textContent?.trim()).toBe("Concert Overture");
+    expect(doc.querySelector('identification > creator[type="composer"]')?.textContent?.trim()).toBe(
+      "Standard Composer"
+    );
+  });
+
+  it("prefers explicit track-name over mks part-name-track when naming parts", () => {
+    const track0 = [
+      ...metaTextEvent(0, "mks:meta-version:1"),
+      ...metaTextEvent(0, "mks:part-name-track:1:Viola"),
+      ...vlq(0), 0xff, 0x51, 0x03, 0x07, 0xa1, 0x20,
+    ];
+    const track1 = [
+      ...metaTextEvent(0, "Solo Violin", 0x03),
+      ...vlq(0), 0x90, 60, 100,
+      ...vlq(480), 0x80, 60, 0,
+    ];
+    const midi = buildSmfFormat1([track0, track1], 480);
+    const result = convertMidiToMusicXml(midi);
+    expect(result.ok).toBe(true);
+    const doc = parseDoc(result.xml);
+    expect(doc.querySelector("part-list > score-part > part-name")?.textContent?.trim()).toBe("Solo Violin");
   });
 
   it("uses alto clef when imported MIDI part-name includes Viola/Vla", () => {


### PR DESCRIPTION
## 背景
MIDIインポート時に `mks:*` が標準MIDIメタより優先されるケースがあり、Title/Composerやパート名が不自然に復元される問題がありました。 また、`Keep roundtrip metadata (mks:meta:*)` のON/OFFと、MIDI出力時の `mks:*` テキストメタ出力の連動が不足していました。

## 変更内容

### 1. MIDIインポートの優先順位改善（標準メタ優先）
- `title:` / `piece:` / `movement:` を標準テキストメタから抽出してタイトル候補化。
- `composer:` / `comp:` を標準テキストメタから抽出して作曲者候補化。
- 復元時は標準候補を優先し、`mks:title` / `mks:composer` はフォールバックに変更。
- 単一トラックMIDIでは、汎用名でない Track Name をタイトル候補として利用。
- パート名は `mks:part-name-track` より実トラック名を優先（ただし `Track 1` など汎用名は除外）。

### 2. MIDI出力の `mks` テキストメタ制御を追加
- `buildMidiBytesForPlayback` に `emitMksTextMeta?: boolean` を追加（既定値 `true`）。
- `false` の場合、以下の `FF 01` テキストメタを出力しない:
  - `mks:meta-version`
  - `mks:title`
  - `mks:movement-title`
  - `mks:composer`
  - `mks:pickup-ticks`
  - `mks:part-name-track:*`
- `download-flow` / `main` で `Keep roundtrip metadata (mks:meta:*)` の値を `emitMksTextMeta` に連動。

### 3. 仕様ドキュメント更新
- `docs/spec/MIDI_IO.md` に以下を明記:
  - メタトラック上の `mks` テキストメタ（`FF 01`）の扱い
  - `embedMksSysEx` と `emitMksTextMeta` の役割
  - `Keep roundtrip metadata` は `emitMksTextMeta` を制御し、SysExは既定で維持されること

### 4. テスト追加/更新
- `emitMksTextMeta=false` で `mks:*` テキストメタが出力されないことを追加検証。
- 標準MIDIメタの Title/Composer が `mks:*` より優先されることを検証。
- 明示トラック名が `mks:part-name-track` より優先されることを検証。

## 影響範囲
- MIDI import/export（`src/ts/midi-io.ts`, `src/ts/download-flow.ts`）
- UI連携（`src/ts/main.ts`）
- 仕様書（`docs/spec/MIDI_IO.md`）
- 単体テスト（`tests/unit/midi-io.spec.ts`）
- 生成物更新（`mikuscore.html`, `src/js/main.js`）

## 期待効果
- 外部アプリ編集後の再インポートで、`mks:*` 過信による不自然な復元を抑制。
- ユーザー設定とMIDI出力結果（`mks` テキストメタ）の整合性向上。
- MIDI I/O仕様の明確化による運用・保守性の向上。