### PR TITLE
MEI/MuseScore互換性の改善: スラー・強弱時刻・テンポ・パート名/アーティキュレーション出力を修正し回帰テストを追加

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -671,6 +671,9 @@
       - [x] import 側で中間 `scoreDef` の拍子・調号・clef 変更を反映（measure属性へ出力）する最小対応とunit追加。
     - [ ] 出力 `meiversion=\"4.0.1\"` 固定を見直し、v5互換方針と互換契約を明文化する。
       - [x] 出力の既定 `meiversion` を `5.1` に変更し、互換目的で明示上書き（`MeiExportOptions.meiVersion`）を追加。
+    - [x] MEI export profile 分離の試行（`strict` / `musescore`）を実施。
+      - [x] 結果: `strict` は実運用で不足が多く、2026-03-04 時点で廃止して `musescore` 一本化に戻した。
+      - [x] 記録: `strict` で抑制していた要素（helper tempo / measure-level control duplication）は、MuseScore互換のため常時有効に復帰。
     - [ ] `annot type=\"musicxml-misc-field\"` への意味情報退避を補助用途に限定し、コア意味は標準MEI要素で保持する。
 - [ ] MuseScore形式（`.mscz` / `.mscx`）の入出力対応を追加。
 - [ ] VSQX 形式の入出力対応を追加。

--- a/mikuscore.html
+++ b/mikuscore.html
@@ -19136,13 +19136,13 @@ const createAbcDownloadPayload = (xmlText, convertMusicXmlToAbc) => {
     };
 };
 exports.createAbcDownloadPayload = createAbcDownloadPayload;
-const createMeiDownloadPayload = (xmlText, convertMusicXmlToMei) => {
+const createMeiDownloadPayload = (xmlText, convertMusicXmlToMei, options = {}) => {
     const musicXmlDoc = (0, musicxml_io_1.parseMusicXmlDocument)(xmlText);
     if (!musicXmlDoc)
         return null;
     let meiText = "";
     try {
-        meiText = convertMusicXmlToMei(musicXmlDoc);
+        meiText = convertMusicXmlToMei(musicXmlDoc, options);
     }
     catch (_a) {
         return null;
@@ -21391,7 +21391,7 @@ const divisionsToMuseDurationType = (divisions, durationDiv) => {
             return { durationType: "quarter", dots: 0 };
     }
 };
-const makeMuseChordXml = (durationDiv, displayDurationDiv, divisions, notes, slurStarts, slurStops, articulationSubtypes, trillMarkOnly, trillStarts, trillStops, tupletRefId, ottavaStartSubtypes, ottavaStopCount, grace, graceSlash) => {
+const makeMuseChordXml = (durationDiv, displayDurationDiv, divisions, notes, slurStartFractions, slurStopFractions, articulationSubtypes, trillMarkOnly, trillStarts, trillStops, tupletRefId, ottavaStartSubtypes, ottavaStopCount, grace, graceSlash) => {
     var _a;
     const duration = divisionsToMuseDurationType(divisions, displayDurationDiv > 0 ? displayDurationDiv : (durationDiv > 0 ? durationDiv : Math.max(1, Math.round(divisions / 4))));
     let xml = "<Chord>";
@@ -21419,13 +21419,13 @@ const makeMuseChordXml = (durationDiv, displayDurationDiv, divisions, notes, slu
     if (trillMarkOnly && ((_a = trillStarts === null || trillStarts === void 0 ? void 0 : trillStarts.length) !== null && _a !== void 0 ? _a : 0) === 0) {
         xml += "<Ornament><subtype>ornamentTrill</subtype></Ornament>";
     }
-    const slurSpanDiv = Math.max(1, Math.round(displayDurationDiv > 0 ? displayDurationDiv : durationDiv));
-    const slurSpanFraction = fractionFromDivisions(slurSpanDiv, divisions);
-    for (const _no of slurStops !== null && slurStops !== void 0 ? slurStops : []) {
-        xml += `<Spanner type="Slur"><prev><location><fractions>-${slurSpanFraction}</fractions></location></prev></Spanner>`;
+    for (const span of slurStopFractions !== null && slurStopFractions !== void 0 ? slurStopFractions : []) {
+        const normalized = String(span || "").trim() || fractionFromDivisions(Math.max(1, Math.round(displayDurationDiv > 0 ? displayDurationDiv : durationDiv)), divisions);
+        xml += `<Spanner type="Slur"><prev><location><fractions>-${normalized}</fractions></location></prev></Spanner>`;
     }
-    for (const _no of slurStarts !== null && slurStarts !== void 0 ? slurStarts : []) {
-        xml += `<Spanner type="Slur"><Slur/><next><location><fractions>${slurSpanFraction}</fractions></location></next></Spanner>`;
+    for (const span of slurStartFractions !== null && slurStartFractions !== void 0 ? slurStartFractions : []) {
+        const normalized = String(span || "").trim() || fractionFromDivisions(Math.max(1, Math.round(displayDurationDiv > 0 ? displayDurationDiv : durationDiv)), divisions);
+        xml += `<Spanner type="Slur"><Slur/><next><location><fractions>${normalized}</fractions></location></next></Spanner>`;
     }
     for (const subtype of articulationSubtypes !== null && articulationSubtypes !== void 0 ? articulationSubtypes : []) {
         xml += `<Articulation><subtype>${xmlEscape(subtype)}</subtype></Articulation>`;
@@ -22382,9 +22382,10 @@ const exportMusicXmlDomToMuseScore = (doc, options = {}) => {
         let currentTimeSymbol = null;
         let currentFifths = Math.max(-7, Math.min(7, Math.round((_6 = firstNumber(part, ":scope > measure > attributes > key > fifths")) !== null && _6 !== void 0 ? _6 : 0)));
         const staffXmlByLane = Array.from({ length: laneCount }, (_unused, laneIndex) => {
-            var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p, _q, _r, _s, _t, _u;
+            var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p, _q, _r, _s, _t, _u, _v;
             const staffNo = laneIndex + 1;
             let currentClef = (_a = initialClefByStaff.get(staffNo)) !== null && _a !== void 0 ? _a : "G";
+            const activeSlurSpanFractionByVoice = new Map();
             let staffXml = `<Staff id="${staffIds[laneIndex]}">`;
             for (let mi = 0; mi < measures.length; mi += 1) {
                 const measure = measures[mi];
@@ -22490,6 +22491,8 @@ const exportMusicXmlDomToMuseScore = (doc, options = {}) => {
                     let cursorDiv = 0;
                     let nextTupletRefNo = 1;
                     const activeTupletRefByNumber = new Map();
+                    const activeSlurSpanFractionById = (_r = activeSlurSpanFractionByVoice.get(voiceNo)) !== null && _r !== void 0 ? _r : new Map();
+                    activeSlurSpanFractionByVoice.set(voiceNo, activeSlurSpanFractionById);
                     for (const event of events) {
                         if (event.atDiv > cursorDiv) {
                             const gap = Math.min(event.atDiv, renderCapacityDiv) - cursorDiv;
@@ -22509,14 +22512,14 @@ const exportMusicXmlDomToMuseScore = (doc, options = {}) => {
                             if (subtype)
                                 voiceXml += `<BarLine><subtype>${subtype}</subtype></BarLine>`;
                         }
-                        const startNumbers = (_r = event.tupletStarts) !== null && _r !== void 0 ? _r : [];
-                        const stopNumbers = (_s = event.tupletStops) !== null && _s !== void 0 ? _s : [];
+                        const startNumbers = (_s = event.tupletStarts) !== null && _s !== void 0 ? _s : [];
+                        const stopNumbers = (_t = event.tupletStops) !== null && _t !== void 0 ? _t : [];
                         const hasTupletTiming = Boolean(event.tupletTimeModification);
                         for (const number of startNumbers) {
                             const normalized = Math.max(1, Math.round(number));
                             const refId = `T${nextTupletRefNo}`;
                             nextTupletRefNo += 1;
-                            const tm = (_t = event.tupletTimeModification) !== null && _t !== void 0 ? _t : { actualNotes: 3, normalNotes: 2 };
+                            const tm = (_u = event.tupletTimeModification) !== null && _u !== void 0 ? _u : { actualNotes: 3, normalNotes: 2 };
                             voiceXml += `<Tuplet id="${refId}"><normalNotes>${tm.normalNotes}</normalNotes><actualNotes>${tm.actualNotes}</actualNotes></Tuplet>`;
                             activeTupletRefByNumber.set(normalized, refId);
                         }
@@ -22527,7 +22530,7 @@ const exportMusicXmlDomToMuseScore = (doc, options = {}) => {
                             const implicitNumber = 1000000 + nextTupletRefNo;
                             const refId = `T${nextTupletRefNo}`;
                             nextTupletRefNo += 1;
-                            const tm = (_u = event.tupletTimeModification) !== null && _u !== void 0 ? _u : { actualNotes: 3, normalNotes: 2 };
+                            const tm = (_v = event.tupletTimeModification) !== null && _v !== void 0 ? _v : { actualNotes: 3, normalNotes: 2 };
                             voiceXml += `<Tuplet id="${refId}"><normalNotes>${tm.normalNotes}</normalNotes><actualNotes>${tm.actualNotes}</actualNotes></Tuplet>`;
                             activeTupletRefByNumber.set(implicitNumber, refId);
                         }
@@ -22545,9 +22548,20 @@ const exportMusicXmlDomToMuseScore = (doc, options = {}) => {
                             voiceXml += makeMuseRestXml(event.durationDiv, tupletDisplayDurationDiv, divisions, tupletRefId);
                         }
                         else {
+                            const defaultSlurSpanFraction = fractionFromDivisions(Math.max(1, Math.round(tupletDisplayDurationDiv > 0 ? tupletDisplayDurationDiv : event.durationDiv)), divisions);
                             const resolvedSlurStops = resolveSlurIds(event.slurStops, staffNo, voiceNo, false);
                             const resolvedSlurStarts = resolveSlurIds(event.slurStarts, staffNo, voiceNo, true);
-                            voiceXml += makeMuseChordXml(event.durationDiv, tupletDisplayDurationDiv, divisions, event.pitches, resolvedSlurStarts, resolvedSlurStops, event.articulationSubtypes, event.trillMarkOnly, event.trillStarts, event.trillStops, tupletRefId, event.ottavaStartSubtypes, event.ottavaStopCount, event.grace, event.graceSlash);
+                            const slurStopFractions = resolvedSlurStops.map((slurId) => {
+                                var _a;
+                                const span = (_a = activeSlurSpanFractionById.get(slurId)) !== null && _a !== void 0 ? _a : defaultSlurSpanFraction;
+                                activeSlurSpanFractionById.delete(slurId);
+                                return span;
+                            });
+                            const slurStartFractions = resolvedSlurStarts.map((slurId) => {
+                                activeSlurSpanFractionById.set(slurId, defaultSlurSpanFraction);
+                                return defaultSlurSpanFraction;
+                            });
+                            voiceXml += makeMuseChordXml(event.durationDiv, tupletDisplayDurationDiv, divisions, event.pitches, slurStartFractions, slurStopFractions, event.articulationSubtypes, event.trillMarkOnly, event.trillStarts, event.trillStops, tupletRefId, event.ottavaStartSubtypes, event.ottavaStopCount, event.grace, event.graceSlash);
                         }
                         for (const number of stopNumbers) {
                             activeTupletRefByNumber.delete(Math.max(1, Math.round(number)));
@@ -26067,21 +26081,6 @@ const extractMeiTieFromMusicXmlNote = (note) => {
         return "t";
     return "";
 };
-const extractMeiSlurFromMusicXmlNote = (note) => {
-    const slurNodes = Array.from(note.querySelectorAll(":scope > notations > slur"));
-    if (slurNodes.length === 0)
-        return "";
-    const tokens = [];
-    for (const slur of slurNodes) {
-        const type = (slur.getAttribute("type") || "").trim().toLowerCase();
-        const number = Math.max(1, parseIntSafe(slur.getAttribute("number"), 1));
-        if (type === "start")
-            tokens.push(`i${number}`);
-        if (type === "stop")
-            tokens.push(`t${number}`);
-    }
-    return tokens.join(" ");
-};
 const extractMeiArticulationTokensFromMusicXmlNote = (note) => {
     const arts = note.querySelector(":scope > notations > articulations");
     if (!arts)
@@ -26101,7 +26100,12 @@ const extractMeiArticulationTokensFromMusicXmlNote = (note) => {
         out.push("marc");
     return Array.from(new Set(out));
 };
-const buildSimplePitchNote = (note, sourceDivisions, includeGraceAttr = true) => {
+const buildMeiArticulationChildren = (tokens) => {
+    if (!tokens.length)
+        return "";
+    return tokens.map((token) => `<artic artic="${esc(token)}"/>`).join("");
+};
+const buildSimplePitchNote = (note, sourceDivisions, includeGraceAttr = true, xmlId) => {
     var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p, _q, _r, _s, _t;
     const typeText = (_c = (_b = (_a = note.querySelector(":scope > type")) === null || _a === void 0 ? void 0 : _a.textContent) === null || _b === void 0 ? void 0 : _b.trim()) !== null && _c !== void 0 ? _c : "quarter";
     const dur = noteTypeToDur(typeText);
@@ -26116,6 +26120,8 @@ const buildSimplePitchNote = (note, sourceDivisions, includeGraceAttr = true) =>
         `oct="${esc(octaveText)}"`,
         `dur="${esc(dur)}"`,
     ];
+    if (xmlId)
+        attrs.push(`xml:id="${esc(xmlId)}"`);
     const durationTicks = parseIntSafe((_p = note.querySelector(":scope > duration")) === null || _p === void 0 ? void 0 : _p.textContent, NaN);
     if (Number.isFinite(durationTicks) && durationTicks > 0) {
         attrs.push(`mks-dur-480="${toMksDur480(durationTicks, sourceDivisions)}"`);
@@ -26146,16 +26152,19 @@ const buildSimplePitchNote = (note, sourceDivisions, includeGraceAttr = true) =>
     const tieAttr = extractMeiTieFromMusicXmlNote(note);
     if (tieAttr)
         attrs.push(`tie="${esc(tieAttr)}"`);
-    const slurAttr = extractMeiSlurFromMusicXmlNote(note);
-    if (slurAttr)
-        attrs.push(`slur="${esc(slurAttr)}"`);
-    if (arts.length)
-        attrs.push(`artic="${esc(arts.join(" "))}"`);
+    const articulationXml = buildMeiArticulationChildren(arts);
     const lyric = extractMusicXmlLyric(note);
-    if (lyric) {
-        const wordpos = lyricWordposFromSyllabic(lyric.syllabic);
-        const wordposAttr = wordpos ? ` wordpos="${esc(wordpos)}"` : "";
-        return `<note ${attrs.join(" ")}><verse n="1"><syl${wordposAttr}>${esc(lyric.text)}</syl></verse></note>`;
+    if (lyric || articulationXml) {
+        const parts = [];
+        if (lyric) {
+            const wordpos = lyricWordposFromSyllabic(lyric.syllabic);
+            const wordposAttr = wordpos ? ` wordpos="${esc(wordpos)}"` : "";
+            parts.push(`<verse n="1"><syl${wordposAttr}>${esc(lyric.text)}</syl></verse>`);
+        }
+        if (articulationXml) {
+            parts.push(articulationXml);
+        }
+        return `<note ${attrs.join(" ")}>${parts.join("")}</note>`;
     }
     return `<note ${attrs.join(" ")}/>`;
 };
@@ -26176,6 +26185,11 @@ const buildSimpleRest = (note, sourceDivisions) => {
     const isInvisible = (note.getAttribute("print-object") || "").trim().toLowerCase() === "no";
     return `<${isInvisible ? "space" : "rest"} ${attrs.join(" ")}/>`;
 };
+const withStaffAttr = (nodeXml, staffNo) => {
+    if (/\bstaff="[^"]+"/.test(nodeXml))
+        return nodeXml;
+    return nodeXml.replace(/^<([A-Za-z][\w.-]*)(\s|>)/, `<$1 staff="${Math.max(1, Math.round(staffNo))}"$2`);
+};
 const gatherMeasureNumbers = (parts) => {
     var _a;
     const out = [];
@@ -26195,7 +26209,7 @@ const voiceSort = (a, b) => {
         return ai - bi;
     return a.localeCompare(b);
 };
-const buildLayerContent = (notes, sourceDivisions, measureTicks) => {
+const buildLayerContent = (notes, sourceDivisions, measureTicks, noteIdBySource, allocateNoteId) => {
     var _a, _b, _c, _d, _e, _f, _g, _h, _j;
     const pitchNotes = notes.filter((n) => !n.querySelector(":scope > rest"));
     const simpleRests = notes.filter((n) => n.querySelector(":scope > rest"));
@@ -26218,6 +26232,8 @@ const buildLayerContent = (notes, sourceDivisions, measureTicks) => {
         const hasChordFlag = Boolean(note.querySelector(":scope > chord"));
         const isGracePitchNote = !isRest && !hasChordFlag && note.querySelector(":scope > grace") !== null;
         if (isGracePitchNote) {
+            if (!noteIdBySource.has(note))
+                noteIdBySource.set(note, allocateNoteId());
             const graceGroup = [note];
             let hasSlash = ((_c = (_b = note.querySelector(":scope > grace")) === null || _b === void 0 ? void 0 : _b.getAttribute("slash")) !== null && _c !== void 0 ? _c : "").trim().toLowerCase() === "yes";
             for (let j = i + 1; j < notes.length; j += 1) {
@@ -26227,19 +26243,26 @@ const buildLayerContent = (notes, sourceDivisions, measureTicks) => {
                 const nextIsGracePitch = !nextIsRest && !nextHasChordFlag && next.querySelector(":scope > grace") !== null;
                 if (!nextIsGracePitch)
                     break;
+                if (!noteIdBySource.has(next))
+                    noteIdBySource.set(next, allocateNoteId());
                 graceGroup.push(next);
                 hasSlash = hasSlash || ((_e = (_d = next.querySelector(":scope > grace")) === null || _d === void 0 ? void 0 : _d.getAttribute("slash")) !== null && _e !== void 0 ? _e : "").trim().toLowerCase() === "yes";
                 i = j;
             }
-            const members = graceGroup.map((g) => buildSimplePitchNote(g, sourceDivisions, false)).join("");
+            const members = graceGroup
+                .map((g) => buildSimplePitchNote(g, sourceDivisions, false, noteIdBySource.get(g)))
+                .join("");
             out.push(`<graceGrp slash="${hasSlash ? "yes" : "no"}">${members}</graceGrp>`);
             continue;
         }
         if (isRest || hasChordFlag) {
             if (isRest)
                 out.push(buildSimpleRest(note, sourceDivisions));
-            else
-                out.push(buildSimplePitchNote(note, sourceDivisions));
+            else {
+                if (!noteIdBySource.has(note))
+                    noteIdBySource.set(note, allocateNoteId());
+                out.push(buildSimplePitchNote(note, sourceDivisions, true, noteIdBySource.get(note)));
+            }
             continue;
         }
         const chordNotes = [note];
@@ -26251,7 +26274,9 @@ const buildLayerContent = (notes, sourceDivisions, measureTicks) => {
             i = j;
         }
         if (chordNotes.length === 1) {
-            out.push(buildSimplePitchNote(note, sourceDivisions));
+            if (!noteIdBySource.has(note))
+                noteIdBySource.set(note, allocateNoteId());
+            out.push(buildSimplePitchNote(note, sourceDivisions, true, noteIdBySource.get(note)));
             continue;
         }
         const typeText = (_h = (_g = (_f = note.querySelector(":scope > type")) === null || _f === void 0 ? void 0 : _f.textContent) === null || _g === void 0 ? void 0 : _g.trim()) !== null && _h !== void 0 ? _h : "quarter";
@@ -26267,13 +26292,16 @@ const buildLayerContent = (notes, sourceDivisions, measureTicks) => {
         if (dots > 0)
             chordAttrs.push(`dots="${dots}"`);
         const members = chordNotes.map((n) => {
-            var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k;
+            var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l;
+            if (!noteIdBySource.has(n))
+                noteIdBySource.set(n, allocateNoteId());
             const step = (_c = (_b = (_a = n.querySelector(":scope > pitch > step")) === null || _a === void 0 ? void 0 : _a.textContent) === null || _b === void 0 ? void 0 : _b.trim()) !== null && _c !== void 0 ? _c : "C";
             const octaveText = (_f = (_e = (_d = n.querySelector(":scope > pitch > octave")) === null || _d === void 0 ? void 0 : _d.textContent) === null || _e === void 0 ? void 0 : _e.trim()) !== null && _f !== void 0 ? _f : "4";
             const alterText = (_h = (_g = n.querySelector(":scope > pitch > alter")) === null || _g === void 0 ? void 0 : _g.textContent) !== null && _h !== void 0 ? _h : null;
             const explicitAccid = musicXmlAccidentalToAccid((_k = (_j = n.querySelector(":scope > accidental")) === null || _j === void 0 ? void 0 : _j.textContent) !== null && _k !== void 0 ? _k : null);
             const accid = explicitAccid !== null && explicitAccid !== void 0 ? explicitAccid : alterToAccid(alterText);
             const noteAttrs = [
+                `xml:id="${esc((_l = noteIdBySource.get(n)) !== null && _l !== void 0 ? _l : allocateNoteId())}"`,
                 `pname="${esc(toPname(step))}"`,
                 `oct="${esc(octaveText)}"`,
             ];
@@ -26282,17 +26310,20 @@ const buildLayerContent = (notes, sourceDivisions, measureTicks) => {
             const tieAttr = extractMeiTieFromMusicXmlNote(n);
             if (tieAttr)
                 noteAttrs.push(`tie="${esc(tieAttr)}"`);
-            const slurAttr = extractMeiSlurFromMusicXmlNote(n);
-            if (slurAttr)
-                noteAttrs.push(`slur="${esc(slurAttr)}"`);
             const arts = extractMeiArticulationTokensFromMusicXmlNote(n);
-            if (arts.length)
-                noteAttrs.push(`artic="${esc(arts.join(" "))}"`);
+            const articulationXml = buildMeiArticulationChildren(arts);
             const lyric = extractMusicXmlLyric(n);
-            if (lyric) {
-                const wordpos = lyricWordposFromSyllabic(lyric.syllabic);
-                const wordposAttr = wordpos ? ` wordpos="${esc(wordpos)}"` : "";
-                return `<note ${noteAttrs.join(" ")}><verse n="1"><syl${wordposAttr}>${esc(lyric.text)}</syl></verse></note>`;
+            if (lyric || articulationXml) {
+                const parts = [];
+                if (lyric) {
+                    const wordpos = lyricWordposFromSyllabic(lyric.syllabic);
+                    const wordposAttr = wordpos ? ` wordpos="${esc(wordpos)}"` : "";
+                    parts.push(`<verse n="1"><syl${wordposAttr}>${esc(lyric.text)}</syl></verse>`);
+                }
+                if (articulationXml) {
+                    parts.push(articulationXml);
+                }
+                return `<note ${noteAttrs.join(" ")}>${parts.join("")}</note>`;
             }
             return `<note ${noteAttrs.join(" ")}/>`;
         });
@@ -26439,12 +26470,54 @@ const collectMeiHarmsForStaff = (measure, localStaff, sourceDivisions, beatType)
     }
     return out;
 };
-const directionOffsetTicks = (direction) => {
+const collectDirectionOnsetTicksInMeasure = (measure) => {
+    var _a, _b, _c, _d;
+    const out = new Map();
+    let cursor = 0;
+    for (const child of Array.from(measure.children)) {
+        if (!(child instanceof Element))
+            continue;
+        const kind = localNameOf(child);
+        if (kind === "backup") {
+            const dur = Math.max(0, parseIntSafe((_a = child.querySelector(":scope > duration")) === null || _a === void 0 ? void 0 : _a.textContent, 0));
+            cursor = Math.max(0, cursor - dur);
+            continue;
+        }
+        if (kind === "forward") {
+            const dur = Math.max(0, parseIntSafe((_b = child.querySelector(":scope > duration")) === null || _b === void 0 ? void 0 : _b.textContent, 0));
+            cursor += dur;
+            continue;
+        }
+        if (kind === "note") {
+            const isChord = child.querySelector(":scope > chord") !== null;
+            const isGrace = child.querySelector(":scope > grace") !== null;
+            if (!isChord && !isGrace) {
+                const dur = Math.max(0, parseIntSafe((_c = child.querySelector(":scope > duration")) === null || _c === void 0 ? void 0 : _c.textContent, 0));
+                cursor += dur;
+            }
+            continue;
+        }
+        if (kind === "direction") {
+            const offsetNode = child.querySelector(":scope > offset");
+            let onset = cursor;
+            if (offsetNode && String((_d = offsetNode.textContent) !== null && _d !== void 0 ? _d : "").trim() !== "") {
+                const rel = parseIntSafe(offsetNode.textContent, 0);
+                onset = Math.max(0, cursor + rel);
+            }
+            out.set(child, onset);
+        }
+    }
+    return out;
+};
+const directionOffsetTicks = (direction, onsetTicksByDirection) => {
     var _a;
+    const mapped = onsetTicksByDirection === null || onsetTicksByDirection === void 0 ? void 0 : onsetTicksByDirection.get(direction);
+    if (Number.isFinite(mapped))
+        return Math.max(0, Math.round(mapped));
     return Math.max(0, parseIntSafe((_a = direction.querySelector(":scope > offset")) === null || _a === void 0 ? void 0 : _a.textContent, 0));
 };
-const directionTstamp = (direction, divisions, beatType) => {
-    return offsetTicksToTstamp(directionOffsetTicks(direction), divisions, beatType);
+const directionTstamp = (direction, divisions, beatType, onsetTicksByDirection) => {
+    return offsetTicksToTstamp(directionOffsetTicks(direction, onsetTicksByDirection), divisions, beatType);
 };
 const directionStaffMatches = (direction, localStaff) => {
     var _a;
@@ -26452,13 +26525,14 @@ const directionStaffMatches = (direction, localStaff) => {
     return staffNo === localStaff;
 };
 const collectMeiDirectionControlsForStaff = (measure, localStaff, sourceDivisions, beatType) => {
-    var _a, _b;
+    var _a, _b, _c;
     const out = [];
+    const onsetTicksByDirection = collectDirectionOnsetTicksInMeasure(measure);
     const directions = Array.from(measure.querySelectorAll(":scope > direction")).filter((direction) => directionStaffMatches(direction, localStaff));
     for (const direction of directions) {
         const placement = (direction.getAttribute("placement") || "").trim().toLowerCase();
         const placeAttr = placement === "above" || placement === "below" ? ` place="${esc(placement)}"` : "";
-        const tstamp = directionTstamp(direction, sourceDivisions, beatType);
+        const tstamp = directionTstamp(direction, sourceDivisions, beatType, onsetTicksByDirection);
         const dynamicsNode = direction.querySelector(":scope > direction-type > dynamics");
         if (dynamicsNode) {
             const symbol = Array.from(dynamicsNode.children)
@@ -26469,9 +26543,30 @@ const collectMeiDirectionControlsForStaff = (measure, localStaff, sourceDivision
                 continue;
             }
         }
-        const words = (((_a = direction.querySelector(":scope > direction-type > words")) === null || _a === void 0 ? void 0 : _a.textContent) || "").trim();
+        const tempoRaw = (((_a = direction.querySelector(":scope > sound")) === null || _a === void 0 ? void 0 : _a.getAttribute("tempo")) || "").trim();
+        const tempo = Number.parseFloat(tempoRaw);
+        const words = (((_b = direction.querySelector(":scope > direction-type > words")) === null || _b === void 0 ? void 0 : _b.textContent) || "").trim();
+        if (words && Number.isFinite(tempo) && tempo > 0) {
+            out.push(`<tempo tstamp="${esc(tstamp)}" midi.bpm="${esc(String(tempo))}"${placeAttr}>${esc(words)}</tempo>`);
+            continue;
+        }
         if (words) {
             out.push(`<dynam tstamp="${esc(tstamp)}"${placeAttr}>${esc(words)}</dynam>`);
+        }
+    }
+    if (localStaff === 1) {
+        const measureSounds = Array.from(measure.querySelectorAll(":scope > sound"));
+        for (const sound of measureSounds) {
+            const tempoRaw = (sound.getAttribute("tempo") || "").trim();
+            const tempo = Number.parseFloat(tempoRaw);
+            if (!Number.isFinite(tempo) || tempo <= 0)
+                continue;
+            const offsetTicks = Math.max(0, parseIntSafe(sound.getAttribute("offset"), 0));
+            const tstamp = offsetTicksToTstamp(offsetTicks, sourceDivisions, beatType);
+            const bpm = Number.isInteger(tempo)
+                ? String(Math.round(tempo))
+                : tempo.toFixed(2).replace(/\.00$/, "").replace(/(\.\d)0$/, "$1");
+            out.push(`<tempo type="mscore-infer-from-text" tstamp="${esc(tstamp)}" midi.bpm="${esc(bpm)}">♩ = ${esc(bpm)}</tempo>`);
         }
     }
     const pendingByNumber = new Map();
@@ -26481,7 +26576,7 @@ const collectMeiDirectionControlsForStaff = (measure, localStaff, sourceDivision
             continue;
         const type = (wedge.getAttribute("type") || "").trim().toLowerCase();
         const number = (wedge.getAttribute("number") || "1").trim() || "1";
-        const tstamp = directionTstamp(direction, sourceDivisions, beatType);
+        const tstamp = directionTstamp(direction, sourceDivisions, beatType, onsetTicksByDirection);
         const placement = (direction.getAttribute("placement") || "").trim().toLowerCase();
         const placeAttr = placement === "above" || placement === "below" ? ` place="${esc(placement)}"` : "";
         if (type === "crescendo" || type === "diminuendo") {
@@ -26506,7 +26601,7 @@ const collectMeiDirectionControlsForStaff = (measure, localStaff, sourceDivision
             continue;
         const type = (pedal.getAttribute("type") || "").trim().toLowerCase();
         const number = (pedal.getAttribute("number") || "1").trim() || "1";
-        const tstamp = directionTstamp(direction, sourceDivisions, beatType);
+        const tstamp = directionTstamp(direction, sourceDivisions, beatType, onsetTicksByDirection);
         const placement = (direction.getAttribute("placement") || "").trim().toLowerCase();
         const placeAttr = placement === "above" || placement === "below" ? ` place="${esc(placement)}"` : "";
         if (type === "start" || type === "resume" || type === "change") {
@@ -26537,7 +26632,7 @@ const collectMeiDirectionControlsForStaff = (measure, localStaff, sourceDivision
         const size = parseIntSafe(octave.getAttribute("size"), 8);
         const dis = Math.max(1, Math.round(size));
         const disPlace = type === "down" ? "below" : "above";
-        const tstamp = directionTstamp(direction, sourceDivisions, beatType);
+        const tstamp = directionTstamp(direction, sourceDivisions, beatType, onsetTicksByDirection);
         const placement = (direction.getAttribute("placement") || "").trim().toLowerCase();
         const placeAttr = placement === "above" || placement === "below" ? ` place="${esc(placement)}"` : "";
         if (type === "up" || type === "down") {
@@ -26559,7 +26654,7 @@ const collectMeiDirectionControlsForStaff = (measure, localStaff, sourceDivision
         out.push(`<octave dis="${pending.dis}" dis.place="${pending.disPlace}" tstamp="${esc(pending.tstamp)}"${pending.placeAttr}/>`);
     }
     for (const direction of directions) {
-        const tstamp = directionTstamp(direction, sourceDivisions, beatType);
+        const tstamp = directionTstamp(direction, sourceDivisions, beatType, onsetTicksByDirection);
         const placement = (direction.getAttribute("placement") || "").trim().toLowerCase();
         const placeAttr = placement === "above" || placement === "below" ? ` place="${esc(placement)}"` : "";
         const segno = direction.querySelector(":scope > direction-type > segno");
@@ -26572,7 +26667,7 @@ const collectMeiDirectionControlsForStaff = (measure, localStaff, sourceDivision
             out.push(`<repeatMark tstamp="${esc(tstamp)}"${placeAttr}>coda</repeatMark>`);
             continue;
         }
-        const words = (((_b = direction.querySelector(":scope > direction-type > words")) === null || _b === void 0 ? void 0 : _b.textContent) || "").trim();
+        const words = (((_c = direction.querySelector(":scope > direction-type > words")) === null || _c === void 0 ? void 0 : _c.textContent) || "").trim();
         if (!words)
             continue;
         const lowered = words.toLowerCase();
@@ -26586,7 +26681,7 @@ const collectMeiDirectionControlsForStaff = (measure, localStaff, sourceDivision
     }
     return out;
 };
-const collectStaffTimelineForExport = (measure, localStaff, divisions) => {
+const collectStaffTimelineForExport = (measure, localStaff, divisions, noteIdBySource) => {
     var _a, _b, _c, _d;
     const out = [];
     let cursor = 0;
@@ -26609,7 +26704,7 @@ const collectStaffTimelineForExport = (measure, localStaff, divisions) => {
         const isChordContinuation = note.querySelector(":scope > chord") !== null;
         const dur = parseIntSafe((_d = note.querySelector(":scope > duration")) === null || _d === void 0 ? void 0 : _d.textContent, 0);
         if (staffNo === localStaff) {
-            out.push({ note, onset: cursor });
+            out.push({ note, onset: cursor, noteId: noteIdBySource === null || noteIdBySource === void 0 ? void 0 : noteIdBySource.get(note) });
         }
         if (!isChordContinuation) {
             cursor += Math.max(0, dur);
@@ -26663,11 +26758,12 @@ const tiePitchKeyFromMusicXmlNote = (note) => {
     const voice = (((_d = note.querySelector(":scope > voice")) === null || _d === void 0 ? void 0 : _d.textContent) || "1").trim() || "1";
     return `${step}:${alter}:${octave}:v${voice}`;
 };
-const collectMeiTieSlurControlsForStaff = (measure, localStaff, divisions, beatType) => {
+const collectMeiTieSlurControlsForStaff = (measure, localStaff, divisions, beatType, noteIdBySource, carryState) => {
+    var _a, _b;
     const out = [];
-    const timeline = collectStaffTimelineForExport(measure, localStaff, divisions);
-    const pendingSlurByNumber = new Map();
-    const pendingTieByPitch = new Map();
+    const timeline = collectStaffTimelineForExport(measure, localStaff, divisions, noteIdBySource);
+    const pendingSlurByNumber = (_a = carryState === null || carryState === void 0 ? void 0 : carryState.pendingSlurByNumber) !== null && _a !== void 0 ? _a : new Map();
+    const pendingTieByPitch = (_b = carryState === null || carryState === void 0 ? void 0 : carryState.pendingTieByPitch) !== null && _b !== void 0 ? _b : new Map();
     for (const item of timeline) {
         const note = item.note;
         const tstamp = offsetTicksToTstamp(item.onset, divisions, beatType);
@@ -26676,13 +26772,18 @@ const collectMeiTieSlurControlsForStaff = (measure, localStaff, divisions, beatT
             const type = (slur.getAttribute("type") || "").trim().toLowerCase();
             const number = String(Math.max(1, parseIntSafe(slur.getAttribute("number"), 1)));
             if (type === "start") {
-                pendingSlurByNumber.set(number, { tstamp });
+                pendingSlurByNumber.set(number, { tstamp, noteId: item.noteId });
                 continue;
             }
             if (type === "stop") {
                 const pending = pendingSlurByNumber.get(number);
                 if (pending) {
-                    out.push(`<slur tstamp="${esc(pending.tstamp)}" tstamp2="${esc(tstamp)}"/>`);
+                    if (pending.noteId && item.noteId) {
+                        out.push(`<slur startid="#${esc(pending.noteId)}" endid="#${esc(item.noteId)}"/>`);
+                    }
+                    else {
+                        out.push(`<slur tstamp="${esc(pending.tstamp)}" tstamp2="${esc(tstamp)}"/>`);
+                    }
                     pendingSlurByNumber.delete(number);
                 }
             }
@@ -26698,12 +26799,17 @@ const collectMeiTieSlurControlsForStaff = (measure, localStaff, divisions, beatT
                 if (hasStop) {
                     const pending = pendingTieByPitch.get(pitchKey);
                     if (pending) {
-                        out.push(`<tie tstamp="${esc(pending.tstamp)}" tstamp2="${esc(tstamp)}"/>`);
+                        if (pending.noteId && item.noteId) {
+                            out.push(`<tie startid="#${esc(pending.noteId)}" endid="#${esc(item.noteId)}"/>`);
+                        }
+                        else {
+                            out.push(`<tie tstamp="${esc(pending.tstamp)}" tstamp2="${esc(tstamp)}"/>`);
+                        }
                         pendingTieByPitch.delete(pitchKey);
                     }
                 }
                 if (hasStart) {
-                    pendingTieByPitch.set(pitchKey, { tstamp });
+                    pendingTieByPitch.set(pitchKey, { tstamp, noteId: item.noteId });
                 }
             }
         }
@@ -26754,13 +26860,19 @@ const collectMeiOrnamentAndBreathControlsForStaff = (measure, localStaff, divisi
 };
 const normalizeMeiVersion = (raw) => {
     const v = String(raw !== null && raw !== void 0 ? raw : "").trim();
-    if (/^\d+\.\d+(\.\d+)?$/.test(v))
+    if (/^\d+\.\d+(\.\d+)?(\+[A-Za-z0-9._-]+)?$/.test(v))
         return v;
-    return "5.1";
+    return "5.1+basic";
 };
 const exportMusicXmlDomToMei = (doc, options = {}) => {
     var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p, _q, _r, _s, _t, _u, _v;
     const meiVersion = normalizeMeiVersion(options.meiVersion);
+    let nextGeneratedNoteId = 1;
+    const allocateNoteId = () => {
+        const id = `mkN${nextGeneratedNoteId}`;
+        nextGeneratedNoteId += 1;
+        return id;
+    };
     const parts = Array.from(doc.querySelectorAll("score-partwise > part"));
     if (parts.length === 0) {
         throw new Error("MusicXML part is missing.");
@@ -26788,13 +26900,17 @@ const exportMusicXmlDomToMei = (doc, options = {}) => {
             Number.isFinite(transpose === null || transpose === void 0 ? void 0 : transpose.diatonic) ? ` trans.diat="${Math.round(Number(transpose === null || transpose === void 0 ? void 0 : transpose.diatonic))}"` : "",
             Number.isFinite(transpose === null || transpose === void 0 ? void 0 : transpose.chromatic) ? ` trans.semi="${Math.round(Number(transpose === null || transpose === void 0 ? void 0 : transpose.chromatic))}"` : "",
         ].join("");
-        scoreDefLines.push(`<staffDef n="${slot.globalStaff}" label="${esc(slot.label)}" lines="5" clef.shape="${esc(clef.shape)}" clef.line="${clef.line}"${transposeAttrs}/>`);
+        scoreDefLines.push(`<staffDef n="${slot.globalStaff}" label="${esc(slot.label)}" lines="5" clef.shape="${esc(clef.shape)}" clef.line="${clef.line}"${transposeAttrs}>` +
+            `<label>${esc(slot.label)}</label>` +
+            `<clef shape="${esc(clef.shape)}" line="${clef.line}"/>` +
+            `</staffDef>`);
     }
     scoreDefLines.push("</staffGrp>");
     scoreDefLines.push("</scoreDef>");
     const measuresOut = [];
     const measureNumbers = gatherMeasureNumbers(parts);
     const currentDivisionsByPart = new Map();
+    const tieSlurStateByStaffKey = new Map();
     for (const part of parts) {
         const partId = ((_j = part.getAttribute("id")) !== null && _j !== void 0 ? _j : "").trim();
         if (!partId)
@@ -26804,6 +26920,7 @@ const exportMusicXmlDomToMei = (doc, options = {}) => {
     }
     for (const number of measureNumbers) {
         const measureLines = [];
+        const measureControlNodes = [];
         measureLines.push(`<measure n="${esc(number)}">`);
         for (const slot of slots) {
             const part = parts.find((candidate) => { var _a; return ((_a = candidate.getAttribute("id")) !== null && _a !== void 0 ? _a : "") === slot.partId; });
@@ -26832,6 +26949,17 @@ const exportMusicXmlDomToMei = (doc, options = {}) => {
             if (voiceMap.size === 0)
                 continue;
             measureLines.push(`<staff n="${slot.globalStaff}">`);
+            const noteIdBySource = new Map();
+            const tieSlurCarryState = (() => {
+                const key = `${slot.partId}:${slot.localStaff}`;
+                if (!tieSlurStateByStaffKey.has(key)) {
+                    tieSlurStateByStaffKey.set(key, {
+                        pendingSlurByNumber: new Map(),
+                        pendingTieByPitch: new Map(),
+                    });
+                }
+                return tieSlurStateByStaffKey.get(key);
+            })();
             const miscFields = extractMiscellaneousFieldsFromMeasure(measure);
             for (const field of miscFields) {
                 measureLines.push(`<annot type="musicxml-misc-field" label="${esc(field.name)}">${esc(field.value)}</annot>`);
@@ -26840,35 +26968,41 @@ const exportMusicXmlDomToMei = (doc, options = {}) => {
             if (measureMeta) {
                 measureLines.push(`<annot type="musicxml-measure-meta" label="mks:measure-meta">${esc(measureMeta)}</annot>`);
             }
-            const controlNodes = collectMeiDirectionControlsForStaff(measure, slot.localStaff, sourceDivisions, beatType);
-            for (const controlNode of controlNodes) {
-                measureLines.push(controlNode);
-            }
-            const glissSlideNodes = collectMeiGlissSlideControlsForStaff(measure, slot.localStaff, sourceDivisions, beatType);
-            for (const node of glissSlideNodes) {
-                measureLines.push(node);
-            }
-            const tieSlurNodes = collectMeiTieSlurControlsForStaff(measure, slot.localStaff, sourceDivisions, beatType);
-            for (const node of tieSlurNodes) {
-                measureLines.push(node);
-            }
-            const ornamentNodes = collectMeiOrnamentAndBreathControlsForStaff(measure, slot.localStaff, sourceDivisions, beatType);
-            for (const node of ornamentNodes) {
-                measureLines.push(node);
-            }
-            const harmNodes = collectMeiHarmsForStaff(measure, slot.localStaff, sourceDivisions, beatType);
-            for (const harmNode of harmNodes) {
-                measureLines.push(harmNode);
-            }
             for (const voice of Array.from(voiceMap.keys()).sort(voiceSort)) {
                 const notes = (_u = voiceMap.get(voice)) !== null && _u !== void 0 ? _u : [];
                 const measureBeats = parseIntSafe((_v = measure.querySelector(":scope > attributes > time > beats")) === null || _v === void 0 ? void 0 : _v.textContent, meterCount);
                 const measureTicks = Math.max(1, Math.round((measureBeats * 4 * sourceDivisions) / Math.max(1, beatType)));
-                const layer = buildLayerContent(notes, sourceDivisions, measureTicks);
+                const layer = buildLayerContent(notes, sourceDivisions, measureTicks, noteIdBySource, allocateNoteId);
                 measureLines.push(`<layer n="${esc(voice)}">${layer}</layer>`);
+            }
+            const controlNodes = collectMeiDirectionControlsForStaff(measure, slot.localStaff, sourceDivisions, beatType);
+            for (const controlNode of controlNodes) {
+                measureLines.push(controlNode);
+                measureControlNodes.push(withStaffAttr(controlNode, slot.globalStaff));
+            }
+            const glissSlideNodes = collectMeiGlissSlideControlsForStaff(measure, slot.localStaff, sourceDivisions, beatType);
+            for (const node of glissSlideNodes) {
+                measureLines.push(node);
+                measureControlNodes.push(withStaffAttr(node, slot.globalStaff));
+            }
+            const tieSlurNodes = collectMeiTieSlurControlsForStaff(measure, slot.localStaff, sourceDivisions, beatType, noteIdBySource, tieSlurCarryState);
+            for (const node of tieSlurNodes) {
+                measureLines.push(node);
+                measureControlNodes.push(withStaffAttr(node, slot.globalStaff));
+            }
+            const ornamentNodes = collectMeiOrnamentAndBreathControlsForStaff(measure, slot.localStaff, sourceDivisions, beatType);
+            for (const node of ornamentNodes) {
+                measureLines.push(node);
+                measureControlNodes.push(withStaffAttr(node, slot.globalStaff));
+            }
+            const harmNodes = collectMeiHarmsForStaff(measure, slot.localStaff, sourceDivisions, beatType);
+            for (const harmNode of harmNodes) {
+                measureLines.push(harmNode);
+                measureControlNodes.push(withStaffAttr(harmNode, slot.globalStaff));
             }
             measureLines.push("</staff>");
         }
+        measureLines.push(...measureControlNodes);
         measureLines.push("</measure>");
         measuresOut.push(measureLines.join(""));
     }

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -10217,13 +10217,13 @@ const createAbcDownloadPayload = (xmlText, convertMusicXmlToAbc) => {
     };
 };
 exports.createAbcDownloadPayload = createAbcDownloadPayload;
-const createMeiDownloadPayload = (xmlText, convertMusicXmlToMei) => {
+const createMeiDownloadPayload = (xmlText, convertMusicXmlToMei, options = {}) => {
     const musicXmlDoc = (0, musicxml_io_1.parseMusicXmlDocument)(xmlText);
     if (!musicXmlDoc)
         return null;
     let meiText = "";
     try {
-        meiText = convertMusicXmlToMei(musicXmlDoc);
+        meiText = convertMusicXmlToMei(musicXmlDoc, options);
     }
     catch (_a) {
         return null;
@@ -12472,7 +12472,7 @@ const divisionsToMuseDurationType = (divisions, durationDiv) => {
             return { durationType: "quarter", dots: 0 };
     }
 };
-const makeMuseChordXml = (durationDiv, displayDurationDiv, divisions, notes, slurStarts, slurStops, articulationSubtypes, trillMarkOnly, trillStarts, trillStops, tupletRefId, ottavaStartSubtypes, ottavaStopCount, grace, graceSlash) => {
+const makeMuseChordXml = (durationDiv, displayDurationDiv, divisions, notes, slurStartFractions, slurStopFractions, articulationSubtypes, trillMarkOnly, trillStarts, trillStops, tupletRefId, ottavaStartSubtypes, ottavaStopCount, grace, graceSlash) => {
     var _a;
     const duration = divisionsToMuseDurationType(divisions, displayDurationDiv > 0 ? displayDurationDiv : (durationDiv > 0 ? durationDiv : Math.max(1, Math.round(divisions / 4))));
     let xml = "<Chord>";
@@ -12500,13 +12500,13 @@ const makeMuseChordXml = (durationDiv, displayDurationDiv, divisions, notes, slu
     if (trillMarkOnly && ((_a = trillStarts === null || trillStarts === void 0 ? void 0 : trillStarts.length) !== null && _a !== void 0 ? _a : 0) === 0) {
         xml += "<Ornament><subtype>ornamentTrill</subtype></Ornament>";
     }
-    const slurSpanDiv = Math.max(1, Math.round(displayDurationDiv > 0 ? displayDurationDiv : durationDiv));
-    const slurSpanFraction = fractionFromDivisions(slurSpanDiv, divisions);
-    for (const _no of slurStops !== null && slurStops !== void 0 ? slurStops : []) {
-        xml += `<Spanner type="Slur"><prev><location><fractions>-${slurSpanFraction}</fractions></location></prev></Spanner>`;
+    for (const span of slurStopFractions !== null && slurStopFractions !== void 0 ? slurStopFractions : []) {
+        const normalized = String(span || "").trim() || fractionFromDivisions(Math.max(1, Math.round(displayDurationDiv > 0 ? displayDurationDiv : durationDiv)), divisions);
+        xml += `<Spanner type="Slur"><prev><location><fractions>-${normalized}</fractions></location></prev></Spanner>`;
     }
-    for (const _no of slurStarts !== null && slurStarts !== void 0 ? slurStarts : []) {
-        xml += `<Spanner type="Slur"><Slur/><next><location><fractions>${slurSpanFraction}</fractions></location></next></Spanner>`;
+    for (const span of slurStartFractions !== null && slurStartFractions !== void 0 ? slurStartFractions : []) {
+        const normalized = String(span || "").trim() || fractionFromDivisions(Math.max(1, Math.round(displayDurationDiv > 0 ? displayDurationDiv : durationDiv)), divisions);
+        xml += `<Spanner type="Slur"><Slur/><next><location><fractions>${normalized}</fractions></location></next></Spanner>`;
     }
     for (const subtype of articulationSubtypes !== null && articulationSubtypes !== void 0 ? articulationSubtypes : []) {
         xml += `<Articulation><subtype>${xmlEscape(subtype)}</subtype></Articulation>`;
@@ -13463,9 +13463,10 @@ const exportMusicXmlDomToMuseScore = (doc, options = {}) => {
         let currentTimeSymbol = null;
         let currentFifths = Math.max(-7, Math.min(7, Math.round((_6 = firstNumber(part, ":scope > measure > attributes > key > fifths")) !== null && _6 !== void 0 ? _6 : 0)));
         const staffXmlByLane = Array.from({ length: laneCount }, (_unused, laneIndex) => {
-            var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p, _q, _r, _s, _t, _u;
+            var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p, _q, _r, _s, _t, _u, _v;
             const staffNo = laneIndex + 1;
             let currentClef = (_a = initialClefByStaff.get(staffNo)) !== null && _a !== void 0 ? _a : "G";
+            const activeSlurSpanFractionByVoice = new Map();
             let staffXml = `<Staff id="${staffIds[laneIndex]}">`;
             for (let mi = 0; mi < measures.length; mi += 1) {
                 const measure = measures[mi];
@@ -13571,6 +13572,8 @@ const exportMusicXmlDomToMuseScore = (doc, options = {}) => {
                     let cursorDiv = 0;
                     let nextTupletRefNo = 1;
                     const activeTupletRefByNumber = new Map();
+                    const activeSlurSpanFractionById = (_r = activeSlurSpanFractionByVoice.get(voiceNo)) !== null && _r !== void 0 ? _r : new Map();
+                    activeSlurSpanFractionByVoice.set(voiceNo, activeSlurSpanFractionById);
                     for (const event of events) {
                         if (event.atDiv > cursorDiv) {
                             const gap = Math.min(event.atDiv, renderCapacityDiv) - cursorDiv;
@@ -13590,14 +13593,14 @@ const exportMusicXmlDomToMuseScore = (doc, options = {}) => {
                             if (subtype)
                                 voiceXml += `<BarLine><subtype>${subtype}</subtype></BarLine>`;
                         }
-                        const startNumbers = (_r = event.tupletStarts) !== null && _r !== void 0 ? _r : [];
-                        const stopNumbers = (_s = event.tupletStops) !== null && _s !== void 0 ? _s : [];
+                        const startNumbers = (_s = event.tupletStarts) !== null && _s !== void 0 ? _s : [];
+                        const stopNumbers = (_t = event.tupletStops) !== null && _t !== void 0 ? _t : [];
                         const hasTupletTiming = Boolean(event.tupletTimeModification);
                         for (const number of startNumbers) {
                             const normalized = Math.max(1, Math.round(number));
                             const refId = `T${nextTupletRefNo}`;
                             nextTupletRefNo += 1;
-                            const tm = (_t = event.tupletTimeModification) !== null && _t !== void 0 ? _t : { actualNotes: 3, normalNotes: 2 };
+                            const tm = (_u = event.tupletTimeModification) !== null && _u !== void 0 ? _u : { actualNotes: 3, normalNotes: 2 };
                             voiceXml += `<Tuplet id="${refId}"><normalNotes>${tm.normalNotes}</normalNotes><actualNotes>${tm.actualNotes}</actualNotes></Tuplet>`;
                             activeTupletRefByNumber.set(normalized, refId);
                         }
@@ -13608,7 +13611,7 @@ const exportMusicXmlDomToMuseScore = (doc, options = {}) => {
                             const implicitNumber = 1000000 + nextTupletRefNo;
                             const refId = `T${nextTupletRefNo}`;
                             nextTupletRefNo += 1;
-                            const tm = (_u = event.tupletTimeModification) !== null && _u !== void 0 ? _u : { actualNotes: 3, normalNotes: 2 };
+                            const tm = (_v = event.tupletTimeModification) !== null && _v !== void 0 ? _v : { actualNotes: 3, normalNotes: 2 };
                             voiceXml += `<Tuplet id="${refId}"><normalNotes>${tm.normalNotes}</normalNotes><actualNotes>${tm.actualNotes}</actualNotes></Tuplet>`;
                             activeTupletRefByNumber.set(implicitNumber, refId);
                         }
@@ -13626,9 +13629,20 @@ const exportMusicXmlDomToMuseScore = (doc, options = {}) => {
                             voiceXml += makeMuseRestXml(event.durationDiv, tupletDisplayDurationDiv, divisions, tupletRefId);
                         }
                         else {
+                            const defaultSlurSpanFraction = fractionFromDivisions(Math.max(1, Math.round(tupletDisplayDurationDiv > 0 ? tupletDisplayDurationDiv : event.durationDiv)), divisions);
                             const resolvedSlurStops = resolveSlurIds(event.slurStops, staffNo, voiceNo, false);
                             const resolvedSlurStarts = resolveSlurIds(event.slurStarts, staffNo, voiceNo, true);
-                            voiceXml += makeMuseChordXml(event.durationDiv, tupletDisplayDurationDiv, divisions, event.pitches, resolvedSlurStarts, resolvedSlurStops, event.articulationSubtypes, event.trillMarkOnly, event.trillStarts, event.trillStops, tupletRefId, event.ottavaStartSubtypes, event.ottavaStopCount, event.grace, event.graceSlash);
+                            const slurStopFractions = resolvedSlurStops.map((slurId) => {
+                                var _a;
+                                const span = (_a = activeSlurSpanFractionById.get(slurId)) !== null && _a !== void 0 ? _a : defaultSlurSpanFraction;
+                                activeSlurSpanFractionById.delete(slurId);
+                                return span;
+                            });
+                            const slurStartFractions = resolvedSlurStarts.map((slurId) => {
+                                activeSlurSpanFractionById.set(slurId, defaultSlurSpanFraction);
+                                return defaultSlurSpanFraction;
+                            });
+                            voiceXml += makeMuseChordXml(event.durationDiv, tupletDisplayDurationDiv, divisions, event.pitches, slurStartFractions, slurStopFractions, event.articulationSubtypes, event.trillMarkOnly, event.trillStarts, event.trillStops, tupletRefId, event.ottavaStartSubtypes, event.ottavaStopCount, event.grace, event.graceSlash);
                         }
                         for (const number of stopNumbers) {
                             activeTupletRefByNumber.delete(Math.max(1, Math.round(number)));
@@ -17148,21 +17162,6 @@ const extractMeiTieFromMusicXmlNote = (note) => {
         return "t";
     return "";
 };
-const extractMeiSlurFromMusicXmlNote = (note) => {
-    const slurNodes = Array.from(note.querySelectorAll(":scope > notations > slur"));
-    if (slurNodes.length === 0)
-        return "";
-    const tokens = [];
-    for (const slur of slurNodes) {
-        const type = (slur.getAttribute("type") || "").trim().toLowerCase();
-        const number = Math.max(1, parseIntSafe(slur.getAttribute("number"), 1));
-        if (type === "start")
-            tokens.push(`i${number}`);
-        if (type === "stop")
-            tokens.push(`t${number}`);
-    }
-    return tokens.join(" ");
-};
 const extractMeiArticulationTokensFromMusicXmlNote = (note) => {
     const arts = note.querySelector(":scope > notations > articulations");
     if (!arts)
@@ -17182,7 +17181,12 @@ const extractMeiArticulationTokensFromMusicXmlNote = (note) => {
         out.push("marc");
     return Array.from(new Set(out));
 };
-const buildSimplePitchNote = (note, sourceDivisions, includeGraceAttr = true) => {
+const buildMeiArticulationChildren = (tokens) => {
+    if (!tokens.length)
+        return "";
+    return tokens.map((token) => `<artic artic="${esc(token)}"/>`).join("");
+};
+const buildSimplePitchNote = (note, sourceDivisions, includeGraceAttr = true, xmlId) => {
     var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p, _q, _r, _s, _t;
     const typeText = (_c = (_b = (_a = note.querySelector(":scope > type")) === null || _a === void 0 ? void 0 : _a.textContent) === null || _b === void 0 ? void 0 : _b.trim()) !== null && _c !== void 0 ? _c : "quarter";
     const dur = noteTypeToDur(typeText);
@@ -17197,6 +17201,8 @@ const buildSimplePitchNote = (note, sourceDivisions, includeGraceAttr = true) =>
         `oct="${esc(octaveText)}"`,
         `dur="${esc(dur)}"`,
     ];
+    if (xmlId)
+        attrs.push(`xml:id="${esc(xmlId)}"`);
     const durationTicks = parseIntSafe((_p = note.querySelector(":scope > duration")) === null || _p === void 0 ? void 0 : _p.textContent, NaN);
     if (Number.isFinite(durationTicks) && durationTicks > 0) {
         attrs.push(`mks-dur-480="${toMksDur480(durationTicks, sourceDivisions)}"`);
@@ -17227,16 +17233,19 @@ const buildSimplePitchNote = (note, sourceDivisions, includeGraceAttr = true) =>
     const tieAttr = extractMeiTieFromMusicXmlNote(note);
     if (tieAttr)
         attrs.push(`tie="${esc(tieAttr)}"`);
-    const slurAttr = extractMeiSlurFromMusicXmlNote(note);
-    if (slurAttr)
-        attrs.push(`slur="${esc(slurAttr)}"`);
-    if (arts.length)
-        attrs.push(`artic="${esc(arts.join(" "))}"`);
+    const articulationXml = buildMeiArticulationChildren(arts);
     const lyric = extractMusicXmlLyric(note);
-    if (lyric) {
-        const wordpos = lyricWordposFromSyllabic(lyric.syllabic);
-        const wordposAttr = wordpos ? ` wordpos="${esc(wordpos)}"` : "";
-        return `<note ${attrs.join(" ")}><verse n="1"><syl${wordposAttr}>${esc(lyric.text)}</syl></verse></note>`;
+    if (lyric || articulationXml) {
+        const parts = [];
+        if (lyric) {
+            const wordpos = lyricWordposFromSyllabic(lyric.syllabic);
+            const wordposAttr = wordpos ? ` wordpos="${esc(wordpos)}"` : "";
+            parts.push(`<verse n="1"><syl${wordposAttr}>${esc(lyric.text)}</syl></verse>`);
+        }
+        if (articulationXml) {
+            parts.push(articulationXml);
+        }
+        return `<note ${attrs.join(" ")}>${parts.join("")}</note>`;
     }
     return `<note ${attrs.join(" ")}/>`;
 };
@@ -17257,6 +17266,11 @@ const buildSimpleRest = (note, sourceDivisions) => {
     const isInvisible = (note.getAttribute("print-object") || "").trim().toLowerCase() === "no";
     return `<${isInvisible ? "space" : "rest"} ${attrs.join(" ")}/>`;
 };
+const withStaffAttr = (nodeXml, staffNo) => {
+    if (/\bstaff="[^"]+"/.test(nodeXml))
+        return nodeXml;
+    return nodeXml.replace(/^<([A-Za-z][\w.-]*)(\s|>)/, `<$1 staff="${Math.max(1, Math.round(staffNo))}"$2`);
+};
 const gatherMeasureNumbers = (parts) => {
     var _a;
     const out = [];
@@ -17276,7 +17290,7 @@ const voiceSort = (a, b) => {
         return ai - bi;
     return a.localeCompare(b);
 };
-const buildLayerContent = (notes, sourceDivisions, measureTicks) => {
+const buildLayerContent = (notes, sourceDivisions, measureTicks, noteIdBySource, allocateNoteId) => {
     var _a, _b, _c, _d, _e, _f, _g, _h, _j;
     const pitchNotes = notes.filter((n) => !n.querySelector(":scope > rest"));
     const simpleRests = notes.filter((n) => n.querySelector(":scope > rest"));
@@ -17299,6 +17313,8 @@ const buildLayerContent = (notes, sourceDivisions, measureTicks) => {
         const hasChordFlag = Boolean(note.querySelector(":scope > chord"));
         const isGracePitchNote = !isRest && !hasChordFlag && note.querySelector(":scope > grace") !== null;
         if (isGracePitchNote) {
+            if (!noteIdBySource.has(note))
+                noteIdBySource.set(note, allocateNoteId());
             const graceGroup = [note];
             let hasSlash = ((_c = (_b = note.querySelector(":scope > grace")) === null || _b === void 0 ? void 0 : _b.getAttribute("slash")) !== null && _c !== void 0 ? _c : "").trim().toLowerCase() === "yes";
             for (let j = i + 1; j < notes.length; j += 1) {
@@ -17308,19 +17324,26 @@ const buildLayerContent = (notes, sourceDivisions, measureTicks) => {
                 const nextIsGracePitch = !nextIsRest && !nextHasChordFlag && next.querySelector(":scope > grace") !== null;
                 if (!nextIsGracePitch)
                     break;
+                if (!noteIdBySource.has(next))
+                    noteIdBySource.set(next, allocateNoteId());
                 graceGroup.push(next);
                 hasSlash = hasSlash || ((_e = (_d = next.querySelector(":scope > grace")) === null || _d === void 0 ? void 0 : _d.getAttribute("slash")) !== null && _e !== void 0 ? _e : "").trim().toLowerCase() === "yes";
                 i = j;
             }
-            const members = graceGroup.map((g) => buildSimplePitchNote(g, sourceDivisions, false)).join("");
+            const members = graceGroup
+                .map((g) => buildSimplePitchNote(g, sourceDivisions, false, noteIdBySource.get(g)))
+                .join("");
             out.push(`<graceGrp slash="${hasSlash ? "yes" : "no"}">${members}</graceGrp>`);
             continue;
         }
         if (isRest || hasChordFlag) {
             if (isRest)
                 out.push(buildSimpleRest(note, sourceDivisions));
-            else
-                out.push(buildSimplePitchNote(note, sourceDivisions));
+            else {
+                if (!noteIdBySource.has(note))
+                    noteIdBySource.set(note, allocateNoteId());
+                out.push(buildSimplePitchNote(note, sourceDivisions, true, noteIdBySource.get(note)));
+            }
             continue;
         }
         const chordNotes = [note];
@@ -17332,7 +17355,9 @@ const buildLayerContent = (notes, sourceDivisions, measureTicks) => {
             i = j;
         }
         if (chordNotes.length === 1) {
-            out.push(buildSimplePitchNote(note, sourceDivisions));
+            if (!noteIdBySource.has(note))
+                noteIdBySource.set(note, allocateNoteId());
+            out.push(buildSimplePitchNote(note, sourceDivisions, true, noteIdBySource.get(note)));
             continue;
         }
         const typeText = (_h = (_g = (_f = note.querySelector(":scope > type")) === null || _f === void 0 ? void 0 : _f.textContent) === null || _g === void 0 ? void 0 : _g.trim()) !== null && _h !== void 0 ? _h : "quarter";
@@ -17348,13 +17373,16 @@ const buildLayerContent = (notes, sourceDivisions, measureTicks) => {
         if (dots > 0)
             chordAttrs.push(`dots="${dots}"`);
         const members = chordNotes.map((n) => {
-            var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k;
+            var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l;
+            if (!noteIdBySource.has(n))
+                noteIdBySource.set(n, allocateNoteId());
             const step = (_c = (_b = (_a = n.querySelector(":scope > pitch > step")) === null || _a === void 0 ? void 0 : _a.textContent) === null || _b === void 0 ? void 0 : _b.trim()) !== null && _c !== void 0 ? _c : "C";
             const octaveText = (_f = (_e = (_d = n.querySelector(":scope > pitch > octave")) === null || _d === void 0 ? void 0 : _d.textContent) === null || _e === void 0 ? void 0 : _e.trim()) !== null && _f !== void 0 ? _f : "4";
             const alterText = (_h = (_g = n.querySelector(":scope > pitch > alter")) === null || _g === void 0 ? void 0 : _g.textContent) !== null && _h !== void 0 ? _h : null;
             const explicitAccid = musicXmlAccidentalToAccid((_k = (_j = n.querySelector(":scope > accidental")) === null || _j === void 0 ? void 0 : _j.textContent) !== null && _k !== void 0 ? _k : null);
             const accid = explicitAccid !== null && explicitAccid !== void 0 ? explicitAccid : alterToAccid(alterText);
             const noteAttrs = [
+                `xml:id="${esc((_l = noteIdBySource.get(n)) !== null && _l !== void 0 ? _l : allocateNoteId())}"`,
                 `pname="${esc(toPname(step))}"`,
                 `oct="${esc(octaveText)}"`,
             ];
@@ -17363,17 +17391,20 @@ const buildLayerContent = (notes, sourceDivisions, measureTicks) => {
             const tieAttr = extractMeiTieFromMusicXmlNote(n);
             if (tieAttr)
                 noteAttrs.push(`tie="${esc(tieAttr)}"`);
-            const slurAttr = extractMeiSlurFromMusicXmlNote(n);
-            if (slurAttr)
-                noteAttrs.push(`slur="${esc(slurAttr)}"`);
             const arts = extractMeiArticulationTokensFromMusicXmlNote(n);
-            if (arts.length)
-                noteAttrs.push(`artic="${esc(arts.join(" "))}"`);
+            const articulationXml = buildMeiArticulationChildren(arts);
             const lyric = extractMusicXmlLyric(n);
-            if (lyric) {
-                const wordpos = lyricWordposFromSyllabic(lyric.syllabic);
-                const wordposAttr = wordpos ? ` wordpos="${esc(wordpos)}"` : "";
-                return `<note ${noteAttrs.join(" ")}><verse n="1"><syl${wordposAttr}>${esc(lyric.text)}</syl></verse></note>`;
+            if (lyric || articulationXml) {
+                const parts = [];
+                if (lyric) {
+                    const wordpos = lyricWordposFromSyllabic(lyric.syllabic);
+                    const wordposAttr = wordpos ? ` wordpos="${esc(wordpos)}"` : "";
+                    parts.push(`<verse n="1"><syl${wordposAttr}>${esc(lyric.text)}</syl></verse>`);
+                }
+                if (articulationXml) {
+                    parts.push(articulationXml);
+                }
+                return `<note ${noteAttrs.join(" ")}>${parts.join("")}</note>`;
             }
             return `<note ${noteAttrs.join(" ")}/>`;
         });
@@ -17520,12 +17551,54 @@ const collectMeiHarmsForStaff = (measure, localStaff, sourceDivisions, beatType)
     }
     return out;
 };
-const directionOffsetTicks = (direction) => {
+const collectDirectionOnsetTicksInMeasure = (measure) => {
+    var _a, _b, _c, _d;
+    const out = new Map();
+    let cursor = 0;
+    for (const child of Array.from(measure.children)) {
+        if (!(child instanceof Element))
+            continue;
+        const kind = localNameOf(child);
+        if (kind === "backup") {
+            const dur = Math.max(0, parseIntSafe((_a = child.querySelector(":scope > duration")) === null || _a === void 0 ? void 0 : _a.textContent, 0));
+            cursor = Math.max(0, cursor - dur);
+            continue;
+        }
+        if (kind === "forward") {
+            const dur = Math.max(0, parseIntSafe((_b = child.querySelector(":scope > duration")) === null || _b === void 0 ? void 0 : _b.textContent, 0));
+            cursor += dur;
+            continue;
+        }
+        if (kind === "note") {
+            const isChord = child.querySelector(":scope > chord") !== null;
+            const isGrace = child.querySelector(":scope > grace") !== null;
+            if (!isChord && !isGrace) {
+                const dur = Math.max(0, parseIntSafe((_c = child.querySelector(":scope > duration")) === null || _c === void 0 ? void 0 : _c.textContent, 0));
+                cursor += dur;
+            }
+            continue;
+        }
+        if (kind === "direction") {
+            const offsetNode = child.querySelector(":scope > offset");
+            let onset = cursor;
+            if (offsetNode && String((_d = offsetNode.textContent) !== null && _d !== void 0 ? _d : "").trim() !== "") {
+                const rel = parseIntSafe(offsetNode.textContent, 0);
+                onset = Math.max(0, cursor + rel);
+            }
+            out.set(child, onset);
+        }
+    }
+    return out;
+};
+const directionOffsetTicks = (direction, onsetTicksByDirection) => {
     var _a;
+    const mapped = onsetTicksByDirection === null || onsetTicksByDirection === void 0 ? void 0 : onsetTicksByDirection.get(direction);
+    if (Number.isFinite(mapped))
+        return Math.max(0, Math.round(mapped));
     return Math.max(0, parseIntSafe((_a = direction.querySelector(":scope > offset")) === null || _a === void 0 ? void 0 : _a.textContent, 0));
 };
-const directionTstamp = (direction, divisions, beatType) => {
-    return offsetTicksToTstamp(directionOffsetTicks(direction), divisions, beatType);
+const directionTstamp = (direction, divisions, beatType, onsetTicksByDirection) => {
+    return offsetTicksToTstamp(directionOffsetTicks(direction, onsetTicksByDirection), divisions, beatType);
 };
 const directionStaffMatches = (direction, localStaff) => {
     var _a;
@@ -17533,13 +17606,14 @@ const directionStaffMatches = (direction, localStaff) => {
     return staffNo === localStaff;
 };
 const collectMeiDirectionControlsForStaff = (measure, localStaff, sourceDivisions, beatType) => {
-    var _a, _b;
+    var _a, _b, _c;
     const out = [];
+    const onsetTicksByDirection = collectDirectionOnsetTicksInMeasure(measure);
     const directions = Array.from(measure.querySelectorAll(":scope > direction")).filter((direction) => directionStaffMatches(direction, localStaff));
     for (const direction of directions) {
         const placement = (direction.getAttribute("placement") || "").trim().toLowerCase();
         const placeAttr = placement === "above" || placement === "below" ? ` place="${esc(placement)}"` : "";
-        const tstamp = directionTstamp(direction, sourceDivisions, beatType);
+        const tstamp = directionTstamp(direction, sourceDivisions, beatType, onsetTicksByDirection);
         const dynamicsNode = direction.querySelector(":scope > direction-type > dynamics");
         if (dynamicsNode) {
             const symbol = Array.from(dynamicsNode.children)
@@ -17550,9 +17624,30 @@ const collectMeiDirectionControlsForStaff = (measure, localStaff, sourceDivision
                 continue;
             }
         }
-        const words = (((_a = direction.querySelector(":scope > direction-type > words")) === null || _a === void 0 ? void 0 : _a.textContent) || "").trim();
+        const tempoRaw = (((_a = direction.querySelector(":scope > sound")) === null || _a === void 0 ? void 0 : _a.getAttribute("tempo")) || "").trim();
+        const tempo = Number.parseFloat(tempoRaw);
+        const words = (((_b = direction.querySelector(":scope > direction-type > words")) === null || _b === void 0 ? void 0 : _b.textContent) || "").trim();
+        if (words && Number.isFinite(tempo) && tempo > 0) {
+            out.push(`<tempo tstamp="${esc(tstamp)}" midi.bpm="${esc(String(tempo))}"${placeAttr}>${esc(words)}</tempo>`);
+            continue;
+        }
         if (words) {
             out.push(`<dynam tstamp="${esc(tstamp)}"${placeAttr}>${esc(words)}</dynam>`);
+        }
+    }
+    if (localStaff === 1) {
+        const measureSounds = Array.from(measure.querySelectorAll(":scope > sound"));
+        for (const sound of measureSounds) {
+            const tempoRaw = (sound.getAttribute("tempo") || "").trim();
+            const tempo = Number.parseFloat(tempoRaw);
+            if (!Number.isFinite(tempo) || tempo <= 0)
+                continue;
+            const offsetTicks = Math.max(0, parseIntSafe(sound.getAttribute("offset"), 0));
+            const tstamp = offsetTicksToTstamp(offsetTicks, sourceDivisions, beatType);
+            const bpm = Number.isInteger(tempo)
+                ? String(Math.round(tempo))
+                : tempo.toFixed(2).replace(/\.00$/, "").replace(/(\.\d)0$/, "$1");
+            out.push(`<tempo type="mscore-infer-from-text" tstamp="${esc(tstamp)}" midi.bpm="${esc(bpm)}">♩ = ${esc(bpm)}</tempo>`);
         }
     }
     const pendingByNumber = new Map();
@@ -17562,7 +17657,7 @@ const collectMeiDirectionControlsForStaff = (measure, localStaff, sourceDivision
             continue;
         const type = (wedge.getAttribute("type") || "").trim().toLowerCase();
         const number = (wedge.getAttribute("number") || "1").trim() || "1";
-        const tstamp = directionTstamp(direction, sourceDivisions, beatType);
+        const tstamp = directionTstamp(direction, sourceDivisions, beatType, onsetTicksByDirection);
         const placement = (direction.getAttribute("placement") || "").trim().toLowerCase();
         const placeAttr = placement === "above" || placement === "below" ? ` place="${esc(placement)}"` : "";
         if (type === "crescendo" || type === "diminuendo") {
@@ -17587,7 +17682,7 @@ const collectMeiDirectionControlsForStaff = (measure, localStaff, sourceDivision
             continue;
         const type = (pedal.getAttribute("type") || "").trim().toLowerCase();
         const number = (pedal.getAttribute("number") || "1").trim() || "1";
-        const tstamp = directionTstamp(direction, sourceDivisions, beatType);
+        const tstamp = directionTstamp(direction, sourceDivisions, beatType, onsetTicksByDirection);
         const placement = (direction.getAttribute("placement") || "").trim().toLowerCase();
         const placeAttr = placement === "above" || placement === "below" ? ` place="${esc(placement)}"` : "";
         if (type === "start" || type === "resume" || type === "change") {
@@ -17618,7 +17713,7 @@ const collectMeiDirectionControlsForStaff = (measure, localStaff, sourceDivision
         const size = parseIntSafe(octave.getAttribute("size"), 8);
         const dis = Math.max(1, Math.round(size));
         const disPlace = type === "down" ? "below" : "above";
-        const tstamp = directionTstamp(direction, sourceDivisions, beatType);
+        const tstamp = directionTstamp(direction, sourceDivisions, beatType, onsetTicksByDirection);
         const placement = (direction.getAttribute("placement") || "").trim().toLowerCase();
         const placeAttr = placement === "above" || placement === "below" ? ` place="${esc(placement)}"` : "";
         if (type === "up" || type === "down") {
@@ -17640,7 +17735,7 @@ const collectMeiDirectionControlsForStaff = (measure, localStaff, sourceDivision
         out.push(`<octave dis="${pending.dis}" dis.place="${pending.disPlace}" tstamp="${esc(pending.tstamp)}"${pending.placeAttr}/>`);
     }
     for (const direction of directions) {
-        const tstamp = directionTstamp(direction, sourceDivisions, beatType);
+        const tstamp = directionTstamp(direction, sourceDivisions, beatType, onsetTicksByDirection);
         const placement = (direction.getAttribute("placement") || "").trim().toLowerCase();
         const placeAttr = placement === "above" || placement === "below" ? ` place="${esc(placement)}"` : "";
         const segno = direction.querySelector(":scope > direction-type > segno");
@@ -17653,7 +17748,7 @@ const collectMeiDirectionControlsForStaff = (measure, localStaff, sourceDivision
             out.push(`<repeatMark tstamp="${esc(tstamp)}"${placeAttr}>coda</repeatMark>`);
             continue;
         }
-        const words = (((_b = direction.querySelector(":scope > direction-type > words")) === null || _b === void 0 ? void 0 : _b.textContent) || "").trim();
+        const words = (((_c = direction.querySelector(":scope > direction-type > words")) === null || _c === void 0 ? void 0 : _c.textContent) || "").trim();
         if (!words)
             continue;
         const lowered = words.toLowerCase();
@@ -17667,7 +17762,7 @@ const collectMeiDirectionControlsForStaff = (measure, localStaff, sourceDivision
     }
     return out;
 };
-const collectStaffTimelineForExport = (measure, localStaff, divisions) => {
+const collectStaffTimelineForExport = (measure, localStaff, divisions, noteIdBySource) => {
     var _a, _b, _c, _d;
     const out = [];
     let cursor = 0;
@@ -17690,7 +17785,7 @@ const collectStaffTimelineForExport = (measure, localStaff, divisions) => {
         const isChordContinuation = note.querySelector(":scope > chord") !== null;
         const dur = parseIntSafe((_d = note.querySelector(":scope > duration")) === null || _d === void 0 ? void 0 : _d.textContent, 0);
         if (staffNo === localStaff) {
-            out.push({ note, onset: cursor });
+            out.push({ note, onset: cursor, noteId: noteIdBySource === null || noteIdBySource === void 0 ? void 0 : noteIdBySource.get(note) });
         }
         if (!isChordContinuation) {
             cursor += Math.max(0, dur);
@@ -17744,11 +17839,12 @@ const tiePitchKeyFromMusicXmlNote = (note) => {
     const voice = (((_d = note.querySelector(":scope > voice")) === null || _d === void 0 ? void 0 : _d.textContent) || "1").trim() || "1";
     return `${step}:${alter}:${octave}:v${voice}`;
 };
-const collectMeiTieSlurControlsForStaff = (measure, localStaff, divisions, beatType) => {
+const collectMeiTieSlurControlsForStaff = (measure, localStaff, divisions, beatType, noteIdBySource, carryState) => {
+    var _a, _b;
     const out = [];
-    const timeline = collectStaffTimelineForExport(measure, localStaff, divisions);
-    const pendingSlurByNumber = new Map();
-    const pendingTieByPitch = new Map();
+    const timeline = collectStaffTimelineForExport(measure, localStaff, divisions, noteIdBySource);
+    const pendingSlurByNumber = (_a = carryState === null || carryState === void 0 ? void 0 : carryState.pendingSlurByNumber) !== null && _a !== void 0 ? _a : new Map();
+    const pendingTieByPitch = (_b = carryState === null || carryState === void 0 ? void 0 : carryState.pendingTieByPitch) !== null && _b !== void 0 ? _b : new Map();
     for (const item of timeline) {
         const note = item.note;
         const tstamp = offsetTicksToTstamp(item.onset, divisions, beatType);
@@ -17757,13 +17853,18 @@ const collectMeiTieSlurControlsForStaff = (measure, localStaff, divisions, beatT
             const type = (slur.getAttribute("type") || "").trim().toLowerCase();
             const number = String(Math.max(1, parseIntSafe(slur.getAttribute("number"), 1)));
             if (type === "start") {
-                pendingSlurByNumber.set(number, { tstamp });
+                pendingSlurByNumber.set(number, { tstamp, noteId: item.noteId });
                 continue;
             }
             if (type === "stop") {
                 const pending = pendingSlurByNumber.get(number);
                 if (pending) {
-                    out.push(`<slur tstamp="${esc(pending.tstamp)}" tstamp2="${esc(tstamp)}"/>`);
+                    if (pending.noteId && item.noteId) {
+                        out.push(`<slur startid="#${esc(pending.noteId)}" endid="#${esc(item.noteId)}"/>`);
+                    }
+                    else {
+                        out.push(`<slur tstamp="${esc(pending.tstamp)}" tstamp2="${esc(tstamp)}"/>`);
+                    }
                     pendingSlurByNumber.delete(number);
                 }
             }
@@ -17779,12 +17880,17 @@ const collectMeiTieSlurControlsForStaff = (measure, localStaff, divisions, beatT
                 if (hasStop) {
                     const pending = pendingTieByPitch.get(pitchKey);
                     if (pending) {
-                        out.push(`<tie tstamp="${esc(pending.tstamp)}" tstamp2="${esc(tstamp)}"/>`);
+                        if (pending.noteId && item.noteId) {
+                            out.push(`<tie startid="#${esc(pending.noteId)}" endid="#${esc(item.noteId)}"/>`);
+                        }
+                        else {
+                            out.push(`<tie tstamp="${esc(pending.tstamp)}" tstamp2="${esc(tstamp)}"/>`);
+                        }
                         pendingTieByPitch.delete(pitchKey);
                     }
                 }
                 if (hasStart) {
-                    pendingTieByPitch.set(pitchKey, { tstamp });
+                    pendingTieByPitch.set(pitchKey, { tstamp, noteId: item.noteId });
                 }
             }
         }
@@ -17835,13 +17941,19 @@ const collectMeiOrnamentAndBreathControlsForStaff = (measure, localStaff, divisi
 };
 const normalizeMeiVersion = (raw) => {
     const v = String(raw !== null && raw !== void 0 ? raw : "").trim();
-    if (/^\d+\.\d+(\.\d+)?$/.test(v))
+    if (/^\d+\.\d+(\.\d+)?(\+[A-Za-z0-9._-]+)?$/.test(v))
         return v;
-    return "5.1";
+    return "5.1+basic";
 };
 const exportMusicXmlDomToMei = (doc, options = {}) => {
     var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p, _q, _r, _s, _t, _u, _v;
     const meiVersion = normalizeMeiVersion(options.meiVersion);
+    let nextGeneratedNoteId = 1;
+    const allocateNoteId = () => {
+        const id = `mkN${nextGeneratedNoteId}`;
+        nextGeneratedNoteId += 1;
+        return id;
+    };
     const parts = Array.from(doc.querySelectorAll("score-partwise > part"));
     if (parts.length === 0) {
         throw new Error("MusicXML part is missing.");
@@ -17869,13 +17981,17 @@ const exportMusicXmlDomToMei = (doc, options = {}) => {
             Number.isFinite(transpose === null || transpose === void 0 ? void 0 : transpose.diatonic) ? ` trans.diat="${Math.round(Number(transpose === null || transpose === void 0 ? void 0 : transpose.diatonic))}"` : "",
             Number.isFinite(transpose === null || transpose === void 0 ? void 0 : transpose.chromatic) ? ` trans.semi="${Math.round(Number(transpose === null || transpose === void 0 ? void 0 : transpose.chromatic))}"` : "",
         ].join("");
-        scoreDefLines.push(`<staffDef n="${slot.globalStaff}" label="${esc(slot.label)}" lines="5" clef.shape="${esc(clef.shape)}" clef.line="${clef.line}"${transposeAttrs}/>`);
+        scoreDefLines.push(`<staffDef n="${slot.globalStaff}" label="${esc(slot.label)}" lines="5" clef.shape="${esc(clef.shape)}" clef.line="${clef.line}"${transposeAttrs}>` +
+            `<label>${esc(slot.label)}</label>` +
+            `<clef shape="${esc(clef.shape)}" line="${clef.line}"/>` +
+            `</staffDef>`);
     }
     scoreDefLines.push("</staffGrp>");
     scoreDefLines.push("</scoreDef>");
     const measuresOut = [];
     const measureNumbers = gatherMeasureNumbers(parts);
     const currentDivisionsByPart = new Map();
+    const tieSlurStateByStaffKey = new Map();
     for (const part of parts) {
         const partId = ((_j = part.getAttribute("id")) !== null && _j !== void 0 ? _j : "").trim();
         if (!partId)
@@ -17885,6 +18001,7 @@ const exportMusicXmlDomToMei = (doc, options = {}) => {
     }
     for (const number of measureNumbers) {
         const measureLines = [];
+        const measureControlNodes = [];
         measureLines.push(`<measure n="${esc(number)}">`);
         for (const slot of slots) {
             const part = parts.find((candidate) => { var _a; return ((_a = candidate.getAttribute("id")) !== null && _a !== void 0 ? _a : "") === slot.partId; });
@@ -17913,6 +18030,17 @@ const exportMusicXmlDomToMei = (doc, options = {}) => {
             if (voiceMap.size === 0)
                 continue;
             measureLines.push(`<staff n="${slot.globalStaff}">`);
+            const noteIdBySource = new Map();
+            const tieSlurCarryState = (() => {
+                const key = `${slot.partId}:${slot.localStaff}`;
+                if (!tieSlurStateByStaffKey.has(key)) {
+                    tieSlurStateByStaffKey.set(key, {
+                        pendingSlurByNumber: new Map(),
+                        pendingTieByPitch: new Map(),
+                    });
+                }
+                return tieSlurStateByStaffKey.get(key);
+            })();
             const miscFields = extractMiscellaneousFieldsFromMeasure(measure);
             for (const field of miscFields) {
                 measureLines.push(`<annot type="musicxml-misc-field" label="${esc(field.name)}">${esc(field.value)}</annot>`);
@@ -17921,35 +18049,41 @@ const exportMusicXmlDomToMei = (doc, options = {}) => {
             if (measureMeta) {
                 measureLines.push(`<annot type="musicxml-measure-meta" label="mks:measure-meta">${esc(measureMeta)}</annot>`);
             }
-            const controlNodes = collectMeiDirectionControlsForStaff(measure, slot.localStaff, sourceDivisions, beatType);
-            for (const controlNode of controlNodes) {
-                measureLines.push(controlNode);
-            }
-            const glissSlideNodes = collectMeiGlissSlideControlsForStaff(measure, slot.localStaff, sourceDivisions, beatType);
-            for (const node of glissSlideNodes) {
-                measureLines.push(node);
-            }
-            const tieSlurNodes = collectMeiTieSlurControlsForStaff(measure, slot.localStaff, sourceDivisions, beatType);
-            for (const node of tieSlurNodes) {
-                measureLines.push(node);
-            }
-            const ornamentNodes = collectMeiOrnamentAndBreathControlsForStaff(measure, slot.localStaff, sourceDivisions, beatType);
-            for (const node of ornamentNodes) {
-                measureLines.push(node);
-            }
-            const harmNodes = collectMeiHarmsForStaff(measure, slot.localStaff, sourceDivisions, beatType);
-            for (const harmNode of harmNodes) {
-                measureLines.push(harmNode);
-            }
             for (const voice of Array.from(voiceMap.keys()).sort(voiceSort)) {
                 const notes = (_u = voiceMap.get(voice)) !== null && _u !== void 0 ? _u : [];
                 const measureBeats = parseIntSafe((_v = measure.querySelector(":scope > attributes > time > beats")) === null || _v === void 0 ? void 0 : _v.textContent, meterCount);
                 const measureTicks = Math.max(1, Math.round((measureBeats * 4 * sourceDivisions) / Math.max(1, beatType)));
-                const layer = buildLayerContent(notes, sourceDivisions, measureTicks);
+                const layer = buildLayerContent(notes, sourceDivisions, measureTicks, noteIdBySource, allocateNoteId);
                 measureLines.push(`<layer n="${esc(voice)}">${layer}</layer>`);
+            }
+            const controlNodes = collectMeiDirectionControlsForStaff(measure, slot.localStaff, sourceDivisions, beatType);
+            for (const controlNode of controlNodes) {
+                measureLines.push(controlNode);
+                measureControlNodes.push(withStaffAttr(controlNode, slot.globalStaff));
+            }
+            const glissSlideNodes = collectMeiGlissSlideControlsForStaff(measure, slot.localStaff, sourceDivisions, beatType);
+            for (const node of glissSlideNodes) {
+                measureLines.push(node);
+                measureControlNodes.push(withStaffAttr(node, slot.globalStaff));
+            }
+            const tieSlurNodes = collectMeiTieSlurControlsForStaff(measure, slot.localStaff, sourceDivisions, beatType, noteIdBySource, tieSlurCarryState);
+            for (const node of tieSlurNodes) {
+                measureLines.push(node);
+                measureControlNodes.push(withStaffAttr(node, slot.globalStaff));
+            }
+            const ornamentNodes = collectMeiOrnamentAndBreathControlsForStaff(measure, slot.localStaff, sourceDivisions, beatType);
+            for (const node of ornamentNodes) {
+                measureLines.push(node);
+                measureControlNodes.push(withStaffAttr(node, slot.globalStaff));
+            }
+            const harmNodes = collectMeiHarmsForStaff(measure, slot.localStaff, sourceDivisions, beatType);
+            for (const harmNode of harmNodes) {
+                measureLines.push(harmNode);
+                measureControlNodes.push(withStaffAttr(harmNode, slot.globalStaff));
             }
             measureLines.push("</staff>");
         }
+        measureLines.push(...measureControlNodes);
         measureLines.push("</measure>");
         measuresOut.push(measureLines.join(""));
     }

--- a/src/ts/download-flow.ts
+++ b/src/ts/download-flow.ts
@@ -403,14 +403,18 @@ export const createAbcDownloadPayload = (
 
 export const createMeiDownloadPayload = (
   xmlText: string,
-  convertMusicXmlToMei: (doc: Document) => string
+  convertMusicXmlToMei: (
+    doc: Document,
+    options?: { meiVersion?: string }
+  ) => string,
+  options: { meiVersion?: string } = {}
 ): DownloadFilePayload | null => {
   const musicXmlDoc = parseMusicXmlDocument(xmlText);
   if (!musicXmlDoc) return null;
 
   let meiText = "";
   try {
-    meiText = convertMusicXmlToMei(musicXmlDoc);
+    meiText = convertMusicXmlToMei(musicXmlDoc, options);
   } catch {
     return null;
   }

--- a/src/ts/mei-io.ts
+++ b/src/ts/mei-io.ts
@@ -236,19 +236,6 @@ const extractMeiTieFromMusicXmlNote = (note: Element): string => {
   return "";
 };
 
-const extractMeiSlurFromMusicXmlNote = (note: Element): string => {
-  const slurNodes = Array.from(note.querySelectorAll(":scope > notations > slur"));
-  if (slurNodes.length === 0) return "";
-  const tokens: string[] = [];
-  for (const slur of slurNodes) {
-    const type = (slur.getAttribute("type") || "").trim().toLowerCase();
-    const number = Math.max(1, parseIntSafe(slur.getAttribute("number"), 1));
-    if (type === "start") tokens.push(`i${number}`);
-    if (type === "stop") tokens.push(`t${number}`);
-  }
-  return tokens.join(" ");
-};
-
 const extractMeiArticulationTokensFromMusicXmlNote = (note: Element): string[] => {
   const arts = note.querySelector(":scope > notations > articulations");
   if (!arts) return [];
@@ -262,7 +249,17 @@ const extractMeiArticulationTokensFromMusicXmlNote = (note: Element): string[] =
   return Array.from(new Set(out));
 };
 
-const buildSimplePitchNote = (note: Element, sourceDivisions: number, includeGraceAttr = true): string => {
+const buildMeiArticulationChildren = (tokens: string[]): string => {
+  if (!tokens.length) return "";
+  return tokens.map((token) => `<artic artic="${esc(token)}"/>`).join("");
+};
+
+const buildSimplePitchNote = (
+  note: Element,
+  sourceDivisions: number,
+  includeGraceAttr = true,
+  xmlId?: string
+): string => {
   const typeText = note.querySelector(":scope > type")?.textContent?.trim() ?? "quarter";
   const dur = noteTypeToDur(typeText);
   const dots = note.querySelectorAll(":scope > dot").length;
@@ -278,6 +275,7 @@ const buildSimplePitchNote = (note: Element, sourceDivisions: number, includeGra
     `oct="${esc(octaveText)}"`,
     `dur="${esc(dur)}"`,
   ];
+  if (xmlId) attrs.push(`xml:id="${esc(xmlId)}"`);
   const durationTicks = parseIntSafe(note.querySelector(":scope > duration")?.textContent, NaN);
   if (Number.isFinite(durationTicks) && durationTicks > 0) {
     attrs.push(`mks-dur-480="${toMksDur480(durationTicks, sourceDivisions)}"`);
@@ -303,14 +301,19 @@ const buildSimplePitchNote = (note: Element, sourceDivisions: number, includeGra
   }
   const tieAttr = extractMeiTieFromMusicXmlNote(note);
   if (tieAttr) attrs.push(`tie="${esc(tieAttr)}"`);
-  const slurAttr = extractMeiSlurFromMusicXmlNote(note);
-  if (slurAttr) attrs.push(`slur="${esc(slurAttr)}"`);
-  if (arts.length) attrs.push(`artic="${esc(arts.join(" "))}"`);
+  const articulationXml = buildMeiArticulationChildren(arts);
   const lyric = extractMusicXmlLyric(note);
-  if (lyric) {
-    const wordpos = lyricWordposFromSyllabic(lyric.syllabic);
-    const wordposAttr = wordpos ? ` wordpos="${esc(wordpos)}"` : "";
-    return `<note ${attrs.join(" ")}><verse n="1"><syl${wordposAttr}>${esc(lyric.text)}</syl></verse></note>`;
+  if (lyric || articulationXml) {
+    const parts: string[] = [];
+    if (lyric) {
+      const wordpos = lyricWordposFromSyllabic(lyric.syllabic);
+      const wordposAttr = wordpos ? ` wordpos="${esc(wordpos)}"` : "";
+      parts.push(`<verse n="1"><syl${wordposAttr}>${esc(lyric.text)}</syl></verse>`);
+    }
+    if (articulationXml) {
+      parts.push(articulationXml);
+    }
+    return `<note ${attrs.join(" ")}>${parts.join("")}</note>`;
   }
   return `<note ${attrs.join(" ")}/>`;
 };
@@ -331,6 +334,11 @@ const buildSimpleRest = (note: Element, sourceDivisions: number): string => {
   return `<${isInvisible ? "space" : "rest"} ${attrs.join(" ")}/>`;
 };
 
+const withStaffAttr = (nodeXml: string, staffNo: number): string => {
+  if (/\bstaff="[^"]+"/.test(nodeXml)) return nodeXml;
+  return nodeXml.replace(/^<([A-Za-z][\w.-]*)(\s|>)/, `<$1 staff="${Math.max(1, Math.round(staffNo))}"$2`);
+};
+
 const gatherMeasureNumbers = (parts: Element[]): string[] => {
   const out: string[] = [];
   for (const part of parts) {
@@ -349,7 +357,13 @@ const voiceSort = (a: string, b: string): number => {
   return a.localeCompare(b);
 };
 
-const buildLayerContent = (notes: Element[], sourceDivisions: number, measureTicks: number): string => {
+const buildLayerContent = (
+  notes: Element[],
+  sourceDivisions: number,
+  measureTicks: number,
+  noteIdBySource: Map<Element, string>,
+  allocateNoteId: () => string
+): string => {
   const pitchNotes = notes.filter((n) => !n.querySelector(":scope > rest"));
   const simpleRests = notes.filter((n) => n.querySelector(":scope > rest"));
   if (pitchNotes.length === 0 && simpleRests.length === 1 && notes.length === 1) {
@@ -374,6 +388,7 @@ const buildLayerContent = (notes: Element[], sourceDivisions: number, measureTic
     const hasChordFlag = Boolean(note.querySelector(":scope > chord"));
     const isGracePitchNote = !isRest && !hasChordFlag && note.querySelector(":scope > grace") !== null;
     if (isGracePitchNote) {
+      if (!noteIdBySource.has(note)) noteIdBySource.set(note, allocateNoteId());
       const graceGroup: Element[] = [note];
       let hasSlash = (note.querySelector(":scope > grace")?.getAttribute("slash") ?? "").trim().toLowerCase() === "yes";
       for (let j = i + 1; j < notes.length; j += 1) {
@@ -382,17 +397,23 @@ const buildLayerContent = (notes: Element[], sourceDivisions: number, measureTic
         const nextHasChordFlag = Boolean(next.querySelector(":scope > chord"));
         const nextIsGracePitch = !nextIsRest && !nextHasChordFlag && next.querySelector(":scope > grace") !== null;
         if (!nextIsGracePitch) break;
+        if (!noteIdBySource.has(next)) noteIdBySource.set(next, allocateNoteId());
         graceGroup.push(next);
         hasSlash = hasSlash || (next.querySelector(":scope > grace")?.getAttribute("slash") ?? "").trim().toLowerCase() === "yes";
         i = j;
       }
-      const members = graceGroup.map((g) => buildSimplePitchNote(g, sourceDivisions, false)).join("");
+      const members = graceGroup
+        .map((g) => buildSimplePitchNote(g, sourceDivisions, false, noteIdBySource.get(g)))
+        .join("");
       out.push(`<graceGrp slash="${hasSlash ? "yes" : "no"}">${members}</graceGrp>`);
       continue;
     }
     if (isRest || hasChordFlag) {
       if (isRest) out.push(buildSimpleRest(note, sourceDivisions));
-      else out.push(buildSimplePitchNote(note, sourceDivisions));
+      else {
+        if (!noteIdBySource.has(note)) noteIdBySource.set(note, allocateNoteId());
+        out.push(buildSimplePitchNote(note, sourceDivisions, true, noteIdBySource.get(note)));
+      }
       continue;
     }
 
@@ -404,7 +425,8 @@ const buildLayerContent = (notes: Element[], sourceDivisions: number, measureTic
       i = j;
     }
     if (chordNotes.length === 1) {
-      out.push(buildSimplePitchNote(note, sourceDivisions));
+      if (!noteIdBySource.has(note)) noteIdBySource.set(note, allocateNoteId());
+      out.push(buildSimplePitchNote(note, sourceDivisions, true, noteIdBySource.get(note)));
       continue;
     }
 
@@ -420,6 +442,7 @@ const buildLayerContent = (notes: Element[], sourceDivisions: number, measureTic
     }
     if (dots > 0) chordAttrs.push(`dots="${dots}"`);
     const members = chordNotes.map((n) => {
+      if (!noteIdBySource.has(n)) noteIdBySource.set(n, allocateNoteId());
       const step = n.querySelector(":scope > pitch > step")?.textContent?.trim() ?? "C";
       const octaveText = n.querySelector(":scope > pitch > octave")?.textContent?.trim() ?? "4";
       const alterText = n.querySelector(":scope > pitch > alter")?.textContent ?? null;
@@ -428,21 +451,27 @@ const buildLayerContent = (notes: Element[], sourceDivisions: number, measureTic
       );
       const accid = explicitAccid ?? alterToAccid(alterText);
       const noteAttrs = [
+        `xml:id="${esc(noteIdBySource.get(n) ?? allocateNoteId())}"`,
         `pname="${esc(toPname(step))}"`,
         `oct="${esc(octaveText)}"`,
       ];
       if (accid) noteAttrs.push(`accid="${accid}"`);
       const tieAttr = extractMeiTieFromMusicXmlNote(n);
       if (tieAttr) noteAttrs.push(`tie="${esc(tieAttr)}"`);
-      const slurAttr = extractMeiSlurFromMusicXmlNote(n);
-      if (slurAttr) noteAttrs.push(`slur="${esc(slurAttr)}"`);
       const arts = extractMeiArticulationTokensFromMusicXmlNote(n);
-      if (arts.length) noteAttrs.push(`artic="${esc(arts.join(" "))}"`);
+      const articulationXml = buildMeiArticulationChildren(arts);
       const lyric = extractMusicXmlLyric(n);
-      if (lyric) {
-        const wordpos = lyricWordposFromSyllabic(lyric.syllabic);
-        const wordposAttr = wordpos ? ` wordpos="${esc(wordpos)}"` : "";
-        return `<note ${noteAttrs.join(" ")}><verse n="1"><syl${wordposAttr}>${esc(lyric.text)}</syl></verse></note>`;
+      if (lyric || articulationXml) {
+        const parts: string[] = [];
+        if (lyric) {
+          const wordpos = lyricWordposFromSyllabic(lyric.syllabic);
+          const wordposAttr = wordpos ? ` wordpos="${esc(wordpos)}"` : "";
+          parts.push(`<verse n="1"><syl${wordposAttr}>${esc(lyric.text)}</syl></verse>`);
+        }
+        if (articulationXml) {
+          parts.push(articulationXml);
+        }
+        return `<note ${noteAttrs.join(" ")}>${parts.join("")}</note>`;
       }
       return `<note ${noteAttrs.join(" ")}/>`;
     });
@@ -577,12 +606,57 @@ const collectMeiHarmsForStaff = (measure: Element, localStaff: number, sourceDiv
   return out;
 };
 
-const directionOffsetTicks = (direction: Element): number => {
+const collectDirectionOnsetTicksInMeasure = (measure: Element): Map<Element, number> => {
+  const out = new Map<Element, number>();
+  let cursor = 0;
+  for (const child of Array.from(measure.children)) {
+    if (!(child instanceof Element)) continue;
+    const kind = localNameOf(child);
+    if (kind === "backup") {
+      const dur = Math.max(0, parseIntSafe(child.querySelector(":scope > duration")?.textContent, 0));
+      cursor = Math.max(0, cursor - dur);
+      continue;
+    }
+    if (kind === "forward") {
+      const dur = Math.max(0, parseIntSafe(child.querySelector(":scope > duration")?.textContent, 0));
+      cursor += dur;
+      continue;
+    }
+    if (kind === "note") {
+      const isChord = child.querySelector(":scope > chord") !== null;
+      const isGrace = child.querySelector(":scope > grace") !== null;
+      if (!isChord && !isGrace) {
+        const dur = Math.max(0, parseIntSafe(child.querySelector(":scope > duration")?.textContent, 0));
+        cursor += dur;
+      }
+      continue;
+    }
+    if (kind === "direction") {
+      const offsetNode = child.querySelector(":scope > offset");
+      let onset = cursor;
+      if (offsetNode && String(offsetNode.textContent ?? "").trim() !== "") {
+        const rel = parseIntSafe(offsetNode.textContent, 0);
+        onset = Math.max(0, cursor + rel);
+      }
+      out.set(child, onset);
+    }
+  }
+  return out;
+};
+
+const directionOffsetTicks = (direction: Element, onsetTicksByDirection?: Map<Element, number>): number => {
+  const mapped = onsetTicksByDirection?.get(direction);
+  if (Number.isFinite(mapped)) return Math.max(0, Math.round(mapped as number));
   return Math.max(0, parseIntSafe(direction.querySelector(":scope > offset")?.textContent, 0));
 };
 
-const directionTstamp = (direction: Element, divisions: number, beatType: number): string => {
-  return offsetTicksToTstamp(directionOffsetTicks(direction), divisions, beatType);
+const directionTstamp = (
+  direction: Element,
+  divisions: number,
+  beatType: number,
+  onsetTicksByDirection?: Map<Element, number>
+): string => {
+  return offsetTicksToTstamp(directionOffsetTicks(direction, onsetTicksByDirection), divisions, beatType);
 };
 
 const directionStaffMatches = (direction: Element, localStaff: number): boolean => {
@@ -597,6 +671,7 @@ const collectMeiDirectionControlsForStaff = (
   beatType: number
 ): string[] => {
   const out: string[] = [];
+  const onsetTicksByDirection = collectDirectionOnsetTicksInMeasure(measure);
   const directions = Array.from(measure.querySelectorAll(":scope > direction")).filter((direction) =>
     directionStaffMatches(direction, localStaff)
   );
@@ -604,7 +679,7 @@ const collectMeiDirectionControlsForStaff = (
   for (const direction of directions) {
     const placement = (direction.getAttribute("placement") || "").trim().toLowerCase();
     const placeAttr = placement === "above" || placement === "below" ? ` place="${esc(placement)}"` : "";
-    const tstamp = directionTstamp(direction, sourceDivisions, beatType);
+    const tstamp = directionTstamp(direction, sourceDivisions, beatType, onsetTicksByDirection);
     const dynamicsNode = direction.querySelector(":scope > direction-type > dynamics");
     if (dynamicsNode) {
       const symbol = Array.from(dynamicsNode.children)
@@ -615,9 +690,31 @@ const collectMeiDirectionControlsForStaff = (
         continue;
       }
     }
+    const tempoRaw = (direction.querySelector(":scope > sound")?.getAttribute("tempo") || "").trim();
+    const tempo = Number.parseFloat(tempoRaw);
     const words = (direction.querySelector(":scope > direction-type > words")?.textContent || "").trim();
+    if (words && Number.isFinite(tempo) && tempo > 0) {
+      out.push(`<tempo tstamp="${esc(tstamp)}" midi.bpm="${esc(String(tempo))}"${placeAttr}>${esc(words)}</tempo>`);
+      continue;
+    }
     if (words) {
       out.push(`<dynam tstamp="${esc(tstamp)}"${placeAttr}>${esc(words)}</dynam>`);
+    }
+  }
+  if (localStaff === 1) {
+    const measureSounds = Array.from(measure.querySelectorAll(":scope > sound"));
+    for (const sound of measureSounds) {
+      const tempoRaw = (sound.getAttribute("tempo") || "").trim();
+      const tempo = Number.parseFloat(tempoRaw);
+      if (!Number.isFinite(tempo) || tempo <= 0) continue;
+      const offsetTicks = Math.max(0, parseIntSafe(sound.getAttribute("offset"), 0));
+      const tstamp = offsetTicksToTstamp(offsetTicks, sourceDivisions, beatType);
+      const bpm = Number.isInteger(tempo)
+        ? String(Math.round(tempo))
+        : tempo.toFixed(2).replace(/\.00$/, "").replace(/(\.\d)0$/, "$1");
+      out.push(
+        `<tempo type="mscore-infer-from-text" tstamp="${esc(tstamp)}" midi.bpm="${esc(bpm)}">♩ = ${esc(bpm)}</tempo>`
+      );
     }
   }
 
@@ -628,7 +725,7 @@ const collectMeiDirectionControlsForStaff = (
     if (!wedge) continue;
     const type = (wedge.getAttribute("type") || "").trim().toLowerCase();
     const number = (wedge.getAttribute("number") || "1").trim() || "1";
-    const tstamp = directionTstamp(direction, sourceDivisions, beatType);
+    const tstamp = directionTstamp(direction, sourceDivisions, beatType, onsetTicksByDirection);
     const placement = (direction.getAttribute("placement") || "").trim().toLowerCase();
     const placeAttr = placement === "above" || placement === "below" ? ` place="${esc(placement)}"` : "";
     if (type === "crescendo" || type === "diminuendo") {
@@ -655,7 +752,7 @@ const collectMeiDirectionControlsForStaff = (
     if (!pedal) continue;
     const type = (pedal.getAttribute("type") || "").trim().toLowerCase();
     const number = (pedal.getAttribute("number") || "1").trim() || "1";
-    const tstamp = directionTstamp(direction, sourceDivisions, beatType);
+    const tstamp = directionTstamp(direction, sourceDivisions, beatType, onsetTicksByDirection);
     const placement = (direction.getAttribute("placement") || "").trim().toLowerCase();
     const placeAttr = placement === "above" || placement === "below" ? ` place="${esc(placement)}"` : "";
     if (type === "start" || type === "resume" || type === "change") {
@@ -686,7 +783,7 @@ const collectMeiDirectionControlsForStaff = (
     const size = parseIntSafe(octave.getAttribute("size"), 8);
     const dis = Math.max(1, Math.round(size));
     const disPlace: "above" | "below" = type === "down" ? "below" : "above";
-    const tstamp = directionTstamp(direction, sourceDivisions, beatType);
+    const tstamp = directionTstamp(direction, sourceDivisions, beatType, onsetTicksByDirection);
     const placement = (direction.getAttribute("placement") || "").trim().toLowerCase();
     const placeAttr = placement === "above" || placement === "below" ? ` place="${esc(placement)}"` : "";
     if (type === "up" || type === "down") {
@@ -712,7 +809,7 @@ const collectMeiDirectionControlsForStaff = (
   }
 
   for (const direction of directions) {
-    const tstamp = directionTstamp(direction, sourceDivisions, beatType);
+    const tstamp = directionTstamp(direction, sourceDivisions, beatType, onsetTicksByDirection);
     const placement = (direction.getAttribute("placement") || "").trim().toLowerCase();
     const placeAttr = placement === "above" || placement === "below" ? ` place="${esc(placement)}"` : "";
     const segno = direction.querySelector(":scope > direction-type > segno");
@@ -744,9 +841,10 @@ const collectMeiDirectionControlsForStaff = (
 const collectStaffTimelineForExport = (
   measure: Element,
   localStaff: number,
-  divisions: number
-): Array<{ note: Element; onset: number }> => {
-  const out: Array<{ note: Element; onset: number }> = [];
+  divisions: number,
+  noteIdBySource?: Map<Element, string>
+): Array<{ note: Element; onset: number; noteId?: string }> => {
+  const out: Array<{ note: Element; onset: number; noteId?: string }> = [];
   let cursor = 0;
   for (const child of Array.from(measure.children)) {
     const name = localNameOf(child);
@@ -766,7 +864,7 @@ const collectStaffTimelineForExport = (
     const isChordContinuation = note.querySelector(":scope > chord") !== null;
     const dur = parseIntSafe(note.querySelector(":scope > duration")?.textContent, 0);
     if (staffNo === localStaff) {
-      out.push({ note, onset: cursor });
+      out.push({ note, onset: cursor, noteId: noteIdBySource?.get(note) });
     }
     if (!isChordContinuation) {
       cursor += Math.max(0, dur);
@@ -828,13 +926,18 @@ const collectMeiTieSlurControlsForStaff = (
   measure: Element,
   localStaff: number,
   divisions: number,
-  beatType: number
+  beatType: number,
+  noteIdBySource?: Map<Element, string>,
+  carryState?: {
+    pendingSlurByNumber: Map<string, { tstamp: string; noteId?: string }>;
+    pendingTieByPitch: Map<string, { tstamp: string; noteId?: string }>;
+  }
 ): string[] => {
   const out: string[] = [];
-  const timeline = collectStaffTimelineForExport(measure, localStaff, divisions);
+  const timeline = collectStaffTimelineForExport(measure, localStaff, divisions, noteIdBySource);
 
-  const pendingSlurByNumber = new Map<string, { tstamp: string }>();
-  const pendingTieByPitch = new Map<string, { tstamp: string }>();
+  const pendingSlurByNumber = carryState?.pendingSlurByNumber ?? new Map<string, { tstamp: string; noteId?: string }>();
+  const pendingTieByPitch = carryState?.pendingTieByPitch ?? new Map<string, { tstamp: string; noteId?: string }>();
 
   for (const item of timeline) {
     const note = item.note;
@@ -845,13 +948,17 @@ const collectMeiTieSlurControlsForStaff = (
       const type = (slur.getAttribute("type") || "").trim().toLowerCase();
       const number = String(Math.max(1, parseIntSafe(slur.getAttribute("number"), 1)));
       if (type === "start") {
-        pendingSlurByNumber.set(number, { tstamp });
+        pendingSlurByNumber.set(number, { tstamp, noteId: item.noteId });
         continue;
       }
       if (type === "stop") {
         const pending = pendingSlurByNumber.get(number);
         if (pending) {
-          out.push(`<slur tstamp="${esc(pending.tstamp)}" tstamp2="${esc(tstamp)}"/>`);
+          if (pending.noteId && item.noteId) {
+            out.push(`<slur startid="#${esc(pending.noteId)}" endid="#${esc(item.noteId)}"/>`);
+          } else {
+            out.push(`<slur tstamp="${esc(pending.tstamp)}" tstamp2="${esc(tstamp)}"/>`);
+          }
           pendingSlurByNumber.delete(number);
         }
       }
@@ -868,12 +975,16 @@ const collectMeiTieSlurControlsForStaff = (
         if (hasStop) {
           const pending = pendingTieByPitch.get(pitchKey);
           if (pending) {
-            out.push(`<tie tstamp="${esc(pending.tstamp)}" tstamp2="${esc(tstamp)}"/>`);
+            if (pending.noteId && item.noteId) {
+              out.push(`<tie startid="#${esc(pending.noteId)}" endid="#${esc(item.noteId)}"/>`);
+            } else {
+              out.push(`<tie tstamp="${esc(pending.tstamp)}" tstamp2="${esc(tstamp)}"/>`);
+            }
             pendingTieByPitch.delete(pitchKey);
           }
         }
         if (hasStart) {
-          pendingTieByPitch.set(pitchKey, { tstamp });
+          pendingTieByPitch.set(pitchKey, { tstamp, noteId: item.noteId });
         }
       }
     }
@@ -931,12 +1042,18 @@ const collectMeiOrnamentAndBreathControlsForStaff = (
 
 const normalizeMeiVersion = (raw: string | undefined): string => {
   const v = String(raw ?? "").trim();
-  if (/^\d+\.\d+(\.\d+)?$/.test(v)) return v;
-  return "5.1";
+  if (/^\d+\.\d+(\.\d+)?(\+[A-Za-z0-9._-]+)?$/.test(v)) return v;
+  return "5.1+basic";
 };
 
 export const exportMusicXmlDomToMei = (doc: Document, options: MeiExportOptions = {}): string => {
   const meiVersion = normalizeMeiVersion(options.meiVersion);
+  let nextGeneratedNoteId = 1;
+  const allocateNoteId = (): string => {
+    const id = `mkN${nextGeneratedNoteId}`;
+    nextGeneratedNoteId += 1;
+    return id;
+  };
   const parts = Array.from(doc.querySelectorAll("score-partwise > part"));
   if (parts.length === 0) {
     throw new Error("MusicXML part is missing.");
@@ -973,7 +1090,10 @@ export const exportMusicXmlDomToMei = (doc: Document, options: MeiExportOptions 
       Number.isFinite(transpose?.chromatic) ? ` trans.semi="${Math.round(Number(transpose?.chromatic))}"` : "",
     ].join("");
     scoreDefLines.push(
-      `<staffDef n="${slot.globalStaff}" label="${esc(slot.label)}" lines="5" clef.shape="${esc(clef.shape)}" clef.line="${clef.line}"${transposeAttrs}/>`
+      `<staffDef n="${slot.globalStaff}" label="${esc(slot.label)}" lines="5" clef.shape="${esc(clef.shape)}" clef.line="${clef.line}"${transposeAttrs}>` +
+        `<label>${esc(slot.label)}</label>` +
+        `<clef shape="${esc(clef.shape)}" line="${clef.line}"/>` +
+      `</staffDef>`
     );
   }
   scoreDefLines.push("</staffGrp>");
@@ -982,6 +1102,13 @@ export const exportMusicXmlDomToMei = (doc: Document, options: MeiExportOptions 
   const measuresOut: string[] = [];
   const measureNumbers = gatherMeasureNumbers(parts);
   const currentDivisionsByPart = new Map<string, number>();
+  const tieSlurStateByStaffKey = new Map<
+    string,
+    {
+      pendingSlurByNumber: Map<string, { tstamp: string; noteId?: string }>;
+      pendingTieByPitch: Map<string, { tstamp: string; noteId?: string }>;
+    }
+  >();
   for (const part of parts) {
     const partId = (part.getAttribute("id") ?? "").trim();
     if (!partId) continue;
@@ -993,6 +1120,7 @@ export const exportMusicXmlDomToMei = (doc: Document, options: MeiExportOptions 
   }
   for (const number of measureNumbers) {
     const measureLines: string[] = [];
+    const measureControlNodes: string[] = [];
     measureLines.push(`<measure n="${esc(number)}">`);
 
     for (const slot of slots) {
@@ -1030,6 +1158,17 @@ export const exportMusicXmlDomToMei = (doc: Document, options: MeiExportOptions 
       if (voiceMap.size === 0) continue;
 
       measureLines.push(`<staff n="${slot.globalStaff}">`);
+      const noteIdBySource = new Map<Element, string>();
+      const tieSlurCarryState = (() => {
+        const key = `${slot.partId}:${slot.localStaff}`;
+        if (!tieSlurStateByStaffKey.has(key)) {
+          tieSlurStateByStaffKey.set(key, {
+            pendingSlurByNumber: new Map<string, { tstamp: string; noteId?: string }>(),
+            pendingTieByPitch: new Map<string, { tstamp: string; noteId?: string }>(),
+          });
+        }
+        return tieSlurStateByStaffKey.get(key)!;
+      })();
       const miscFields = extractMiscellaneousFieldsFromMeasure(measure);
       for (const field of miscFields) {
         measureLines.push(
@@ -1042,26 +1181,6 @@ export const exportMusicXmlDomToMei = (doc: Document, options: MeiExportOptions 
           `<annot type="musicxml-measure-meta" label="mks:measure-meta">${esc(measureMeta)}</annot>`
         );
       }
-      const controlNodes = collectMeiDirectionControlsForStaff(measure, slot.localStaff, sourceDivisions, beatType);
-      for (const controlNode of controlNodes) {
-        measureLines.push(controlNode);
-      }
-      const glissSlideNodes = collectMeiGlissSlideControlsForStaff(measure, slot.localStaff, sourceDivisions, beatType);
-      for (const node of glissSlideNodes) {
-        measureLines.push(node);
-      }
-      const tieSlurNodes = collectMeiTieSlurControlsForStaff(measure, slot.localStaff, sourceDivisions, beatType);
-      for (const node of tieSlurNodes) {
-        measureLines.push(node);
-      }
-      const ornamentNodes = collectMeiOrnamentAndBreathControlsForStaff(measure, slot.localStaff, sourceDivisions, beatType);
-      for (const node of ornamentNodes) {
-        measureLines.push(node);
-      }
-      const harmNodes = collectMeiHarmsForStaff(measure, slot.localStaff, sourceDivisions, beatType);
-      for (const harmNode of harmNodes) {
-        measureLines.push(harmNode);
-      }
       for (const voice of Array.from(voiceMap.keys()).sort(voiceSort)) {
         const notes = voiceMap.get(voice) ?? [];
         const measureBeats = parseIntSafe(
@@ -1069,12 +1188,45 @@ export const exportMusicXmlDomToMei = (doc: Document, options: MeiExportOptions 
           meterCount
         );
         const measureTicks = Math.max(1, Math.round((measureBeats * 4 * sourceDivisions) / Math.max(1, beatType)));
-        const layer = buildLayerContent(notes, sourceDivisions, measureTicks);
+        const layer = buildLayerContent(notes, sourceDivisions, measureTicks, noteIdBySource, allocateNoteId);
         measureLines.push(`<layer n="${esc(voice)}">${layer}</layer>`);
+      }
+      const controlNodes = collectMeiDirectionControlsForStaff(measure, slot.localStaff, sourceDivisions, beatType);
+      for (const controlNode of controlNodes) {
+        measureLines.push(controlNode);
+        measureControlNodes.push(withStaffAttr(controlNode, slot.globalStaff));
+      }
+      const glissSlideNodes = collectMeiGlissSlideControlsForStaff(measure, slot.localStaff, sourceDivisions, beatType);
+      for (const node of glissSlideNodes) {
+        measureLines.push(node);
+        measureControlNodes.push(withStaffAttr(node, slot.globalStaff));
+      }
+      const tieSlurNodes = collectMeiTieSlurControlsForStaff(
+        measure,
+        slot.localStaff,
+        sourceDivisions,
+        beatType,
+        noteIdBySource,
+        tieSlurCarryState
+      );
+      for (const node of tieSlurNodes) {
+        measureLines.push(node);
+        measureControlNodes.push(withStaffAttr(node, slot.globalStaff));
+      }
+      const ornamentNodes = collectMeiOrnamentAndBreathControlsForStaff(measure, slot.localStaff, sourceDivisions, beatType);
+      for (const node of ornamentNodes) {
+        measureLines.push(node);
+        measureControlNodes.push(withStaffAttr(node, slot.globalStaff));
+      }
+      const harmNodes = collectMeiHarmsForStaff(measure, slot.localStaff, sourceDivisions, beatType);
+      for (const harmNode of harmNodes) {
+        measureLines.push(harmNode);
+        measureControlNodes.push(withStaffAttr(harmNode, slot.globalStaff));
       }
       measureLines.push("</staff>");
     }
 
+    measureLines.push(...measureControlNodes);
     measureLines.push("</measure>");
     measuresOut.push(measureLines.join(""));
   }

--- a/src/ts/musescore-io.ts
+++ b/src/ts/musescore-io.ts
@@ -2223,8 +2223,8 @@ const makeMuseChordXml = (
     fingeringText?: string;
     stringNumber?: number;
   }>,
-  slurStarts?: number[],
-  slurStops?: number[],
+  slurStartFractions?: string[],
+  slurStopFractions?: string[],
   articulationSubtypes?: string[],
   trillMarkOnly?: boolean,
   trillStarts?: number[],
@@ -2263,13 +2263,13 @@ const makeMuseChordXml = (
   if (trillMarkOnly && (trillStarts?.length ?? 0) === 0) {
     xml += "<Ornament><subtype>ornamentTrill</subtype></Ornament>";
   }
-  const slurSpanDiv = Math.max(1, Math.round(displayDurationDiv > 0 ? displayDurationDiv : durationDiv));
-  const slurSpanFraction = fractionFromDivisions(slurSpanDiv, divisions);
-  for (const _no of slurStops ?? []) {
-    xml += `<Spanner type="Slur"><prev><location><fractions>-${slurSpanFraction}</fractions></location></prev></Spanner>`;
+  for (const span of slurStopFractions ?? []) {
+    const normalized = String(span || "").trim() || fractionFromDivisions(Math.max(1, Math.round(displayDurationDiv > 0 ? displayDurationDiv : durationDiv)), divisions);
+    xml += `<Spanner type="Slur"><prev><location><fractions>-${normalized}</fractions></location></prev></Spanner>`;
   }
-  for (const _no of slurStarts ?? []) {
-    xml += `<Spanner type="Slur"><Slur/><next><location><fractions>${slurSpanFraction}</fractions></location></next></Spanner>`;
+  for (const span of slurStartFractions ?? []) {
+    const normalized = String(span || "").trim() || fractionFromDivisions(Math.max(1, Math.round(displayDurationDiv > 0 ? displayDurationDiv : durationDiv)), divisions);
+    xml += `<Spanner type="Slur"><Slur/><next><location><fractions>${normalized}</fractions></location></next></Spanner>`;
   }
   for (const subtype of articulationSubtypes ?? []) {
     xml += `<Articulation><subtype>${xmlEscape(subtype)}</subtype></Articulation>`;
@@ -3257,6 +3257,7 @@ export const exportMusicXmlDomToMuseScore = (doc: Document, options: MuseScoreEx
     const staffXmlByLane = Array.from({ length: laneCount }, (_unused, laneIndex) => {
       const staffNo = laneIndex + 1;
       let currentClef: ClefSign = initialClefByStaff.get(staffNo) ?? "G";
+      const activeSlurSpanFractionByVoice = new Map<number, Map<number, string>>();
       let staffXml = `<Staff id="${staffIds[laneIndex]}">`;
 
       for (let mi = 0; mi < measures.length; mi += 1) {
@@ -3378,6 +3379,8 @@ export const exportMusicXmlDomToMuseScore = (doc: Document, options: MuseScoreEx
           let cursorDiv = 0;
           let nextTupletRefNo = 1;
           const activeTupletRefByNumber = new Map<number, string>();
+          const activeSlurSpanFractionById = activeSlurSpanFractionByVoice.get(voiceNo) ?? new Map<number, string>();
+          activeSlurSpanFractionByVoice.set(voiceNo, activeSlurSpanFractionById);
           for (const event of events) {
             if (event.atDiv > cursorDiv) {
               const gap = Math.min(event.atDiv, renderCapacityDiv) - cursorDiv;
@@ -3433,15 +3436,28 @@ export const exportMusicXmlDomToMuseScore = (doc: Document, options: MuseScoreEx
             if (event.pitches === null) {
               voiceXml += makeMuseRestXml(event.durationDiv, tupletDisplayDurationDiv, divisions, tupletRefId);
             } else {
+              const defaultSlurSpanFraction = fractionFromDivisions(
+                Math.max(1, Math.round(tupletDisplayDurationDiv > 0 ? tupletDisplayDurationDiv : event.durationDiv)),
+                divisions
+              );
               const resolvedSlurStops = resolveSlurIds(event.slurStops, staffNo, voiceNo, false);
               const resolvedSlurStarts = resolveSlurIds(event.slurStarts, staffNo, voiceNo, true);
+              const slurStopFractions = resolvedSlurStops.map((slurId) => {
+                const span = activeSlurSpanFractionById.get(slurId) ?? defaultSlurSpanFraction;
+                activeSlurSpanFractionById.delete(slurId);
+                return span;
+              });
+              const slurStartFractions = resolvedSlurStarts.map((slurId) => {
+                activeSlurSpanFractionById.set(slurId, defaultSlurSpanFraction);
+                return defaultSlurSpanFraction;
+              });
               voiceXml += makeMuseChordXml(
                 event.durationDiv,
                 tupletDisplayDurationDiv,
                 divisions,
                 event.pitches,
-                resolvedSlurStarts,
-                resolvedSlurStops,
+                slurStartFractions,
+                slurStopFractions,
                 event.articulationSubtypes,
                 event.trillMarkOnly,
                 event.trillStarts,

--- a/tests/unit/mei-io.spec.ts
+++ b/tests/unit/mei-io.spec.ts
@@ -1,4 +1,5 @@
 // @vitest-environment jsdom
+import { execSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
@@ -49,6 +50,7 @@ describe("MEI export", () => {
     expect(mei).toContain("<scoreDef");
     expect(mei).toContain("meter.count=\"4\"");
     expect(mei).toContain("<staffDef");
+    expect(mei).toContain("<label>Piano</label>");
     expect(mei).toContain("<measure n=\"1\">");
     expect(mei).toContain("<note ");
     expect(mei).toContain("<rest ");
@@ -82,7 +84,7 @@ describe("MEI export", () => {
     expect(mei).toContain('trans.semi="-3"');
   });
 
-  it("exports MEI with default meiversion=5.1", () => {
+  it("exports MEI with default meiversion=5.1+basic", () => {
     const xml = `<?xml version="1.0" encoding="UTF-8"?>
 <score-partwise version="3.1">
   <part-list><score-part id="P1"><part-name>Piano</part-name></score-part></part-list>
@@ -92,7 +94,7 @@ describe("MEI export", () => {
     expect(doc).not.toBeNull();
     if (!doc) return;
     const mei = exportMusicXmlDomToMei(doc);
-    expect(mei).toContain('meiversion="5.1"');
+    expect(mei).toContain('meiversion="5.1+basic"');
   });
 
   it("exports MEI with custom meiversion when specified", () => {
@@ -106,6 +108,208 @@ describe("MEI export", () => {
     if (!doc) return;
     const mei = exportMusicXmlDomToMei(doc, { meiVersion: "4.0.1" });
     expect(mei).toContain('meiversion="4.0.1"');
+  });
+
+  it("exports tempo direction (words + sound tempo) as MEI tempo", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list><score-part id="P1"><part-name>P1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>480</divisions><time><beats>4</beats><beat-type>4</beat-type></time></attributes>
+      <direction placement="above">
+        <direction-type><words>Allegretto moderato</words></direction-type>
+        <sound tempo="116"/>
+      </direction>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>480</duration><voice>1</voice><type>quarter</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const doc = parseMusicXmlDocument(xml);
+    expect(doc).not.toBeNull();
+    if (!doc) return;
+    const mei = exportMusicXmlDomToMei(doc);
+    expect(mei).toContain('<tempo staff="1" tstamp="1" midi.bpm="116" place="above">Allegretto moderato</tempo>');
+    expect(mei).not.toContain("<dynam tstamp=\"1\" place=\"above\">Allegretto moderato</dynam>");
+  });
+
+  it("exports dynamics direction without offset at current measure cursor", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list><score-part id="P1"><part-name>P1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>480</divisions><time><beats>4</beats><beat-type>4</beat-type></time></attributes>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>480</duration><voice>1</voice><type>quarter</type></note>
+      <direction placement="below">
+        <direction-type><dynamics><p/></dynamics></direction-type>
+      </direction>
+      <note><pitch><step>D</step><octave>4</octave></pitch><duration>480</duration><voice>1</voice><type>quarter</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const doc = parseMusicXmlDocument(xml);
+    expect(doc).not.toBeNull();
+    if (!doc) return;
+    const mei = exportMusicXmlDomToMei(doc);
+    expect(mei).toContain('<dynam staff="1" tstamp="2" place="below">p</dynam>');
+  });
+
+  it("exports standalone measure sound tempo as MuseScore helper tempo", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list><score-part id="P1"><part-name>P1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>8</divisions><time><beats>6</beats><beat-type>8</beat-type></time></attributes>
+      <direction placement="above">
+        <direction-type><words>Allegretto moderato</words></direction-type>
+        <sound tempo="116"/>
+      </direction>
+      <sound tempo="60"/>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>4</duration><voice>1</voice><type>eighth</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const doc = parseMusicXmlDocument(xml);
+    expect(doc).not.toBeNull();
+    if (!doc) return;
+    const mei = exportMusicXmlDomToMei(doc);
+    expect(mei).toContain(
+      '<tempo staff="1" type="mscore-infer-from-text" tstamp="1" midi.bpm="60">♩ = 60</tempo>'
+    );
+  });
+
+
+  it("exports slur controls using startid/endid with generated xml:id notes", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list><score-part id="P1"><part-name>P1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>480</divisions><time><beats>4</beats><beat-type>4</beat-type></time></attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>480</duration><voice>1</voice><type>quarter</type>
+        <notations><slur type="start" number="1"/></notations>
+      </note>
+      <note>
+        <pitch><step>D</step><octave>4</octave></pitch>
+        <duration>480</duration><voice>1</voice><type>quarter</type>
+        <notations><slur type="stop" number="1"/></notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const doc = parseMusicXmlDocument(xml);
+    expect(doc).not.toBeNull();
+    if (!doc) return;
+    const mei = exportMusicXmlDomToMei(doc);
+    expect(mei).toMatch(/<note[^>]*xml:id="mkN\d+"/);
+    expect(mei).toMatch(/<slur staff="1" startid="#mkN\d+" endid="#mkN\d+"[^>]*\/>/);
+  });
+
+  it("exports cross-measure slur as startid/endid control", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list><score-part id="P1"><part-name>P1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>480</divisions><time><beats>4</beats><beat-type>4</beat-type></time></attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>480</duration><voice>1</voice><type>quarter</type>
+        <notations><slur type="start" number="1"/></notations>
+      </note>
+      <note><rest/><duration>1440</duration><voice>1</voice><type>half</type><dot/></note>
+    </measure>
+    <measure number="2">
+      <note>
+        <pitch><step>D</step><octave>4</octave></pitch>
+        <duration>480</duration><voice>1</voice><type>quarter</type>
+        <notations><slur type="stop" number="1"/></notations>
+      </note>
+      <note><rest/><duration>1440</duration><voice>1</voice><type>half</type><dot/></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const doc = parseMusicXmlDocument(xml);
+    expect(doc).not.toBeNull();
+    if (!doc) return;
+    const mei = exportMusicXmlDomToMei(doc);
+    expect(mei).toMatch(/<slur staff="1" startid="#mkN\d+" endid="#mkN\d+"\/>/);
+  });
+
+  it("exports sample2.mxl with MuseScore-friendly MEI tempo/slur controls", () => {
+    const mxlPath = resolve(process.cwd(), "src", "samples", "musicxml", "sample2.mxl");
+    const xml = execSync(`unzip -p "${mxlPath}" score.xml`, { encoding: "utf-8" });
+    const doc = parseMusicXmlDocument(xml);
+    expect(doc).not.toBeNull();
+    if (!doc) return;
+    const mei = exportMusicXmlDomToMei(doc);
+    expect(mei).toContain('<tempo staff="1" tstamp="1" midi.bpm="116" place="above">Allegretto moderato</tempo>');
+    expect(mei).toContain(
+      '<tempo staff="1" type="mscore-infer-from-text" tstamp="1" midi.bpm="60">♩ = 60</tempo>'
+    );
+    expect(mei).toMatch(/<slur staff="1" startid="#mkN\d+" endid="#mkN\d+"[^>]*\/>/);
+  });
+
+  it("exports sample1.mxl Violin2 measure1 staccato as MEI artic elements", () => {
+    const mxlPath = resolve(process.cwd(), "src", "samples", "musicxml", "sample1.mxl");
+    const xml = execSync(`unzip -p "${mxlPath}" score.xml`, { encoding: "utf-8" });
+    const doc = parseMusicXmlDocument(xml);
+    expect(doc).not.toBeNull();
+    if (!doc) return;
+    const mei = exportMusicXmlDomToMei(doc);
+    expect(mei).toMatch(/<measure n="1">[\s\S]*<staff n="2">[\s\S]*<artic artic="stacc"\/>/);
+  });
+
+  it("exports sample1.mxl measure9 dynamics with distinct/stable timing per staff", () => {
+    const mxlPath = resolve(process.cwd(), "src", "samples", "musicxml", "sample1.mxl");
+    const xml = execSync(`unzip -p "${mxlPath}" score.xml`, { encoding: "utf-8" });
+    const doc = parseMusicXmlDocument(xml);
+    expect(doc).not.toBeNull();
+    if (!doc) return;
+
+    const mei = exportMusicXmlDomToMei(doc);
+    const meiDoc = new DOMParser().parseFromString(mei, "application/xml");
+    const measure9 = Array.from(meiDoc.querySelectorAll("measure")).find(
+      (m) => (m.getAttribute("n") || "").trim() === "9"
+    );
+    expect(measure9).not.toBeUndefined();
+    if (!measure9) return;
+
+    const assertFpOrdering = (staffNo: string): void => {
+      const dyns = Array.from(measure9.querySelectorAll(`:scope > dynam[staff="${staffNo}"]`));
+      const f = dyns.find((d) => (d.textContent || "").trim() === "f");
+      const p = dyns.find((d) => (d.textContent || "").trim() === "p");
+      expect(f).toBeDefined();
+      expect(p).toBeDefined();
+      if (!f || !p) return;
+      const fTstamp = Number.parseFloat((f.getAttribute("tstamp") || "").trim());
+      const pTstamp = Number.parseFloat((p.getAttribute("tstamp") || "").trim());
+      expect(Number.isFinite(fTstamp)).toBe(true);
+      expect(Number.isFinite(pTstamp)).toBe(true);
+      if (!Number.isFinite(fTstamp) || !Number.isFinite(pTstamp)) return;
+      expect(pTstamp).toBeGreaterThan(fTstamp);
+    };
+
+    assertFpOrdering("1");
+    assertFpOrdering("2");
+    assertFpOrdering("4");
+  });
+
+  it("keeps custom meiversion profile suffix (5.1+basic)", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list><score-part id="P1"><part-name>Piano</part-name></score-part></part-list>
+  <part id="P1"><measure number="1"><note><rest/><duration>480</duration><voice>1</voice><type>quarter</type></note></measure></part>
+</score-partwise>`;
+    const doc = parseMusicXmlDocument(xml);
+    expect(doc).not.toBeNull();
+    if (!doc) return;
+    const mei = exportMusicXmlDomToMei(doc, { meiVersion: "5.1+basic" });
+    expect(mei).toContain('meiversion="5.1+basic"');
   });
 
   it("exports full-measure rest as MEI mRest", () => {
@@ -3066,11 +3270,11 @@ describe("MEI export", () => {
     expect(srcDoc).not.toBeNull();
     if (!srcDoc) return;
     const mei = exportMusicXmlDomToMei(srcDoc);
-    expect(mei).toContain('artic="stacc"');
-    expect(mei).toContain('artic="acc"');
-    expect(mei).toContain('artic="spicc"');
-    expect(mei).toContain('artic="ten"');
-    expect(mei).toContain('artic="marc"');
+    expect(mei).toContain('<artic artic="stacc"/>');
+    expect(mei).toContain('<artic artic="acc"/>');
+    expect(mei).toContain('<artic artic="spicc"/>');
+    expect(mei).toContain('<artic artic="ten"/>');
+    expect(mei).toContain('<artic artic="marc"/>');
 
     const roundtripXml = convertMeiToMusicXml(mei);
     const outDoc = parseMusicXmlDocument(roundtripXml);
@@ -3083,7 +3287,7 @@ describe("MEI export", () => {
     expect(outDoc.querySelector("part > measure > note:nth-of-type(5) > notations > articulations > strong-accent")).not.toBeNull();
   });
 
-  it("roundtrips tie/slur from MusicXML note notation into MEI @tie/@slur and back", () => {
+  it("roundtrips tie/slur from MusicXML note notation into MEI controls and back", () => {
     const xml = `<?xml version="1.0" encoding="UTF-8"?>
 <score-partwise version="4.0">
   <part-list><score-part id="P1"><part-name>Part 1</part-name></score-part></part-list>
@@ -3111,11 +3315,11 @@ describe("MEI export", () => {
     const mei = exportMusicXmlDomToMei(srcDoc);
     expect(mei).toContain('tie="i"');
     expect(mei).toContain('tie="t"');
-    expect(mei).toContain('slur="i1"');
-    expect(mei).toContain('slur="t1"');
+    expect(mei).not.toContain('slur="i1"');
+    expect(mei).not.toContain('slur="t1"');
     expect(mei).toContain("<tie ");
-    expect(mei).toContain('tstamp="1"');
-    expect(mei).toContain('tstamp2="2"');
+    expect(mei).toContain('startid="#mkN1"');
+    expect(mei).toContain('endid="#mkN2"');
     expect(mei).toContain("<slur ");
 
     const roundtripXml = convertMeiToMusicXml(mei);

--- a/tests/unit/musescore-io.spec.ts
+++ b/tests/unit/musescore-io.spec.ts
@@ -1474,6 +1474,29 @@ describe("musescore-io", () => {
     expect(prevPos).toBeLessThan(nextPos);
   });
 
+  it("reuses slur start span for slur stop when start/stop note durations differ", () => {
+    const musicXml = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>P1</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>32</divisions><time><beats>3</beats><beat-type>8</beat-type></time></attributes>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>32</duration><voice>1</voice><type>quarter</type><notations><slur type="start" number="1"/></notations></note>
+      <note><pitch><step>D</step><octave>4</octave></pitch><duration>8</duration><voice>1</voice><type>16th</type></note>
+      <note><pitch><step>E</step><octave>4</octave></pitch><duration>4</duration><voice>1</voice><type>32nd</type><notations><slur type="stop" number="1"/></notations></note>
+      <note><rest/><duration>4</duration><voice>1</voice><type>32nd</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const doc = parseMusicXmlDocument(musicXml);
+    expect(doc).not.toBeNull();
+    if (!doc) return;
+    const mscx = exportMusicXmlDomToMuseScore(doc);
+    expect(mscx).toContain("<Spanner type=\"Slur\"><Slur/><next><location><fractions>1/4</fractions></location></next></Spanner>");
+    expect(mscx).toContain("<Spanner type=\"Slur\"><prev><location><fractions>-1/4</fractions></location></prev></Spanner>");
+    expect(mscx).not.toContain("<Spanner type=\"Slur\"><prev><location><fractions>-1/32</fractions></location></prev></Spanner>");
+  });
+
   it("exports MusicXML alto clef as MuseScore concertClefType C", () => {
     const musicXml = `<?xml version="1.0" encoding="UTF-8"?>
 <score-partwise version="4.0">
@@ -1656,6 +1679,25 @@ describe("musescore-io", () => {
     expect(mscx).toContain("<defaultClef>F</defaultClef>");
     expect(mscx).toContain("<Instrument><trackName>Viola</trackName><longName>Viola</longName><shortName>Vla.</shortName><clef>C3</clef></Instrument>");
     expect(mscx).toContain("<Instrument><trackName>Violoncello</trackName><longName>Violoncello</longName><shortName>Vc.</shortName><clef>F</clef></Instrument>");
+  });
+
+  it("exports sample2.mxl Violin1 m2 slur stop span consistent with its start span", () => {
+    const mxlPath = resolve(process.cwd(), "src", "samples", "musicxml", "sample2.mxl");
+    const xml = execSync(`unzip -p "${mxlPath}" score.xml`, { encoding: "utf-8" });
+    const doc = parseMusicXmlDocument(xml);
+    expect(doc).not.toBeNull();
+    if (!doc) return;
+    const mscx = exportMusicXmlDomToMuseScore(doc);
+
+    const mfPos = mscx.indexOf("<subtype>mf</subtype>");
+    expect(mfPos).toBeGreaterThanOrEqual(0);
+    const measureEnd = mscx.indexOf("</Measure>", mfPos);
+    expect(measureEnd).toBeGreaterThan(mfPos);
+    const excerpt = mscx.slice(mfPos, measureEnd);
+
+    expect(excerpt).toContain("<Chord><durationType>quarter</durationType><Spanner type=\"Slur\"><Slur/><next><location><fractions>1/4</fractions></location></next></Spanner><Note><pitch>65</pitch></Note></Chord>");
+    expect(excerpt).toContain("<Chord><durationType>32nd</durationType><Spanner type=\"Slur\"><prev><location><fractions>-1/4</fractions></location></prev></Spanner><Note><pitch>67</pitch></Note></Chord>");
+    expect(excerpt).not.toContain("<Chord><durationType>32nd</durationType><Spanner type=\"Slur\"><prev><location><fractions>-1/32</fractions></location></prev></Spanner><Note><pitch>67</pitch></Note></Chord>");
   });
 
   it("keeps viola/cello clefs on sample2.mscz -> MusicXML -> MuseScore path", () => {


### PR DESCRIPTION
## 概要
MEI および MuseScore 出力の互換性問題をまとめて修正しました。
主に `sample1` / `sample2` で確認された「スラー」「強弱位置」「テンポ表現」「パート名表示」「スタッカート表示」の崩れを対象にしています。

## 変更内容

- MEI 出力のスラー表現を改善
- note 属性 `@slur` 出力を削除し、`<slur startid/endid>` 制御イベント中心に変更
- 小節跨ぎスラー/タイを staff 単位で持ち回って解決
- note ごとに `xml:id` を安定生成して `startid/endid` 参照を強化

- MEI 出力の強弱位置（direction 時刻計算）を修正
- direction の `tstamp` を `<offset>` だけでなく、小節内カーソル（note/backup/forward）から算出
- これにより、`sample1` m9 の dynamics が先頭に潰れる問題を修正

- MEI 出力のテンポを MuseScore 互換寄りに調整
- `words + sound@tempo` を `<tempo>` で出力
- measure 直下の `<sound tempo>` を helper tempo（`type="mscore-infer-from-text"`）として出力
- helper tempo の表示文字列を `♩ = N` に変更（SMuFL glyph 依存を回避）

- MEI のメタ/構造出力を改善
- default `meiversion` を `5.1+basic` に変更
- `staffDef` に `<label>` と `<clef>` 子要素を追加（MuseScore のパート名表示互換）

- アーティキュレーション出力を修正
- `artic="..."` 属性から `<artic artic="..."/>` 子要素形式へ変更
- `sample1` の Violin2 m1 スラー+スタッカート描画互換を改善

- MuseScore 出力のスラー span を修正
- スラー stop 側 `prev` fractions が stop 音価に引きずられる問題を修正
- start 側 span を保持して stop 側に再利用するよう変更

- MEI profile 分離の試行履歴を TODO に記録
- `strict / musescore` 分離を試した結果、実運用不足により一本化へ戻した旨を追記

## 影響ファイル

- `src/ts/mei-io.ts`
- `src/ts/musescore-io.ts`
- `src/ts/download-flow.ts`
- `tests/unit/mei-io.spec.ts`
- `tests/unit/musescore-io.spec.ts`
- `TODO.md`
- `src/js/main.js`
- `mikuscore.html`

## テスト

- 追加/更新した主な回帰テスト
- MEI tempo 出力（visible tempo + helper tempo）
- MEI cross-measure slur/tie（startid/endid）
- sample1 m9 dynamics の時刻順（f -> p）
- sample1 Violin2 m1 staccato 出力
- sample2 slur/tempo の MuseScore 互換
- MuseScore slur span の start/stop fractions 整合

- 実行
- `npm run test:unit -- tests/unit/mei-io.spec.ts`
- `npm run test:unit -- tests/unit/musescore-io.spec.ts`
- `npm run build`

## 補足
- 本PRは互換性重視の修正です。MEI strict 準拠保証を目的としたものではありません。
- 現時点では MuseScore 実運用互換を優先しています。