### PR TITLE
`lht-select-help` の設定同期を修正し、Quick Playback Tone の `Sine` を正しく反映する

### DIFF
--- a/mikuscore-src.html
+++ b/mikuscore-src.html
@@ -142,7 +142,7 @@
                   </lht-select-help>
                 </div>
               </label>
-              <label class="ms-field">Key signature
+              <div class="ms-field">Key signature
                 <lht-select-help field-id="newKeyFifths" field-class="md-select" label="Key signature">
                   <script type="application/json" slot="options">[
                     {"value":"1","label":"♯1 (G)"},
@@ -162,7 +162,7 @@
                     {"value":"-7","label":"♭7 (Cb)"}
                   ]</script>
                 </lht-select-help>
-              </label>
+              </div>
             </div>
             <div id="newPartClefList" class="ms-stack-sm" aria-live="polite"></div>
           </div>
@@ -440,10 +440,10 @@
                 </div>
               </label>
               <input id="pitchOctave" type="hidden" value="4" />
-              <label class="ms-field">
+              <div class="ms-field">
                 <span class="ms-field-label">Duration</span>
                 <lht-select-help field-id="durationPreset" field-class="md-select" label="Duration preset"></lht-select-help>
-              </label>
+              </div>
             </div>
           </div>
           <div id="editSubTabXmlPanel" class="ms-edit-subtab-panel md-hidden" role="tabpanel">
@@ -672,7 +672,7 @@
               <div class="ms-settings-body">
                 <div class="ms-settings-block">
                   <h4 class="ms-settings-subtitle">MIDI &amp; Playback Shared Settings</h4>
-                  <label class="ms-field" for="graceTimingMode">
+                  <div class="ms-field">
                     <span class="ms-field-label">
                       <span>Grace Timing Mode</span>
                       <lht-help-tooltip label="Grace timing mode help">
@@ -688,7 +688,7 @@
                         {"value":"classical_equal","label":"Classical equal split"}
                       ]</script>
                     </lht-select-help>
-                  </label>
+                  </div>
                   <div class="ms-field ms-field--switch">
                     <span class="ms-field-label">
                       <span>Use metric beat accents</span>
@@ -704,7 +704,7 @@
                     <lht-switch-help class="ms-switch-field ms-switch-field--control" switch-id="metricAccentEnabled" checked>
                     </lht-switch-help>
                   </div>
-                  <label class="ms-field" for="metricAccentProfile">
+                  <div class="ms-field">
                     <span class="ms-field-label">
                       <span>Accent amount</span>
                       <lht-help-tooltip label="Accent amount help">
@@ -720,11 +720,11 @@
                         {"value":"strong","label":"Strong"}
                       ]</script>
                     </lht-select-help>
-                  </label>
+                  </div>
                 </div>
                 <div class="ms-settings-block">
                   <h4 class="ms-settings-subtitle">MIDI Settings</h4>
-                  <label class="ms-field" for="midiProgramSelect">
+                  <div class="ms-field">
                     <span class="ms-field-label">
                       <span>MIDI Export Instrument</span>
                       <lht-help-tooltip label="MIDI export instrument help">
@@ -749,8 +749,8 @@
                         {"value":"violin","label":"Violin"}
                       ]</script>
                     </lht-select-help>
-                  </label>
-                  <label class="ms-field" for="midiExportProfile">
+                  </div>
+                  <div class="ms-field">
                     <span class="ms-field-label">
                       <span>MIDI Export Profile</span>
                       <lht-help-tooltip label="MIDI export profile help">
@@ -766,8 +766,8 @@
                         {"value":"musescore_parity","label":"musescore_parity (closer rendering)"}
                       ]</script>
                     </lht-select-help>
-                  </label>
-                  <label class="ms-field" for="midiImportQuantizeGrid">
+                  </div>
+                  <div class="ms-field">
                     <span class="ms-field-label">
                       <span>MIDI Import Quantize Grid</span>
                       <lht-help-tooltip label="MIDI import quantize grid help">
@@ -785,7 +785,7 @@
                         {"value":"1/64","label":"1/64"}
                       ]</script>
                     </lht-select-help>
-                  </label>
+                  </div>
                   <div class="ms-field ms-field--switch">
                     <span class="ms-field-label">
                       <span>Triplet-aware MIDI import</span>
@@ -825,7 +825,7 @@
                     <lht-switch-help class="ms-switch-field ms-switch-field--control" switch-id="playbackUseMidiLike" checked>
                     </lht-switch-help>
                   </div>
-                  <label class="ms-field" for="playbackWaveform">
+                  <div class="ms-field">
                     <span class="ms-field-label">Quick Playback Tone</span>
                     <lht-select-help field-id="playbackWaveform" field-class="md-select" label="Quick Playback Tone">
                       <script type="application/json" slot="options">[
@@ -834,7 +834,7 @@
                         {"value":"square","label":"Square"}
                       ]</script>
                     </lht-select-help>
-                  </label>
+                  </div>
                 </div>
               </div>
             </details>

--- a/mikuscore.html
+++ b/mikuscore.html
@@ -1336,7 +1336,7 @@ lht-help-tooltip:not([data-initialized="true"]) * {
                   </lht-select-help>
                 </div>
               </label>
-              <label class="ms-field">Key signature
+              <div class="ms-field">Key signature
                 <lht-select-help field-id="newKeyFifths" field-class="md-select" label="Key signature">
                   <script type="application/json" slot="options">[
                     {"value":"1","label":"♯1 (G)"},
@@ -1356,7 +1356,7 @@ lht-help-tooltip:not([data-initialized="true"]) * {
                     {"value":"-7","label":"♭7 (Cb)"}
                   ]</script>
                 </lht-select-help>
-              </label>
+              </div>
             </div>
             <div id="newPartClefList" class="ms-stack-sm" aria-live="polite"></div>
           </div>
@@ -1634,10 +1634,10 @@ lht-help-tooltip:not([data-initialized="true"]) * {
                 </div>
               </label>
               <input id="pitchOctave" type="hidden" value="4" />
-              <label class="ms-field">
+              <div class="ms-field">
                 <span class="ms-field-label">Duration</span>
                 <lht-select-help field-id="durationPreset" field-class="md-select" label="Duration preset"></lht-select-help>
-              </label>
+              </div>
             </div>
           </div>
           <div id="editSubTabXmlPanel" class="ms-edit-subtab-panel md-hidden" role="tabpanel">
@@ -1866,7 +1866,7 @@ lht-help-tooltip:not([data-initialized="true"]) * {
               <div class="ms-settings-body">
                 <div class="ms-settings-block">
                   <h4 class="ms-settings-subtitle">MIDI &amp; Playback Shared Settings</h4>
-                  <label class="ms-field" for="graceTimingMode">
+                  <div class="ms-field">
                     <span class="ms-field-label">
                       <span>Grace Timing Mode</span>
                       <lht-help-tooltip label="Grace timing mode help">
@@ -1882,7 +1882,7 @@ lht-help-tooltip:not([data-initialized="true"]) * {
                         {"value":"classical_equal","label":"Classical equal split"}
                       ]</script>
                     </lht-select-help>
-                  </label>
+                  </div>
                   <div class="ms-field ms-field--switch">
                     <span class="ms-field-label">
                       <span>Use metric beat accents</span>
@@ -1898,7 +1898,7 @@ lht-help-tooltip:not([data-initialized="true"]) * {
                     <lht-switch-help class="ms-switch-field ms-switch-field--control" switch-id="metricAccentEnabled" checked>
                     </lht-switch-help>
                   </div>
-                  <label class="ms-field" for="metricAccentProfile">
+                  <div class="ms-field">
                     <span class="ms-field-label">
                       <span>Accent amount</span>
                       <lht-help-tooltip label="Accent amount help">
@@ -1914,11 +1914,11 @@ lht-help-tooltip:not([data-initialized="true"]) * {
                         {"value":"strong","label":"Strong"}
                       ]</script>
                     </lht-select-help>
-                  </label>
+                  </div>
                 </div>
                 <div class="ms-settings-block">
                   <h4 class="ms-settings-subtitle">MIDI Settings</h4>
-                  <label class="ms-field" for="midiProgramSelect">
+                  <div class="ms-field">
                     <span class="ms-field-label">
                       <span>MIDI Export Instrument</span>
                       <lht-help-tooltip label="MIDI export instrument help">
@@ -1943,8 +1943,8 @@ lht-help-tooltip:not([data-initialized="true"]) * {
                         {"value":"violin","label":"Violin"}
                       ]</script>
                     </lht-select-help>
-                  </label>
-                  <label class="ms-field" for="midiExportProfile">
+                  </div>
+                  <div class="ms-field">
                     <span class="ms-field-label">
                       <span>MIDI Export Profile</span>
                       <lht-help-tooltip label="MIDI export profile help">
@@ -1960,8 +1960,8 @@ lht-help-tooltip:not([data-initialized="true"]) * {
                         {"value":"musescore_parity","label":"musescore_parity (closer rendering)"}
                       ]</script>
                     </lht-select-help>
-                  </label>
-                  <label class="ms-field" for="midiImportQuantizeGrid">
+                  </div>
+                  <div class="ms-field">
                     <span class="ms-field-label">
                       <span>MIDI Import Quantize Grid</span>
                       <lht-help-tooltip label="MIDI import quantize grid help">
@@ -1979,7 +1979,7 @@ lht-help-tooltip:not([data-initialized="true"]) * {
                         {"value":"1/64","label":"1/64"}
                       ]</script>
                     </lht-select-help>
-                  </label>
+                  </div>
                   <div class="ms-field ms-field--switch">
                     <span class="ms-field-label">
                       <span>Triplet-aware MIDI import</span>
@@ -2019,7 +2019,7 @@ lht-help-tooltip:not([data-initialized="true"]) * {
                     <lht-switch-help class="ms-switch-field ms-switch-field--control" switch-id="playbackUseMidiLike" checked>
                     </lht-switch-help>
                   </div>
-                  <label class="ms-field" for="playbackWaveform">
+                  <div class="ms-field">
                     <span class="ms-field-label">Quick Playback Tone</span>
                     <lht-select-help field-id="playbackWaveform" field-class="md-select" label="Quick Playback Tone">
                       <script type="application/json" slot="options">[
@@ -2028,7 +2028,7 @@ lht-help-tooltip:not([data-initialized="true"]) * {
                         {"value":"square","label":"Square"}
                       ]</script>
                     </lht-select-help>
-                  </label>
+                  </div>
                 </div>
               </div>
             </details>
@@ -8114,6 +8114,7 @@ const fileSelectBtn = q("#fileSelectBtn");
 const fileInput = q("#fileInput");
 const fileNameText = q("#fileNameText");
 const zipEntrySelectBlock = q("#zipEntrySelectBlock");
+const zipEntrySelectHelp = document.querySelector("lht-select-help[field-id='zipEntrySelect']");
 const zipEntrySelect = q("#zipEntrySelect");
 const fileLoadOverlay = q("#fileLoadOverlay");
 const loadBtn = q("#loadBtn");
@@ -8270,6 +8271,28 @@ const isLhtErrorAlertElement = (element) => {
     return (element.tagName.toLowerCase() === "lht-error-alert"
         && typeof element.show === "function");
 };
+const isLhtSelectHelpElement = (element) => {
+    return !!element
+        && element.tagName.toLowerCase() === "lht-select-help"
+        && typeof element.setOptions === "function";
+};
+const syncSelectHelpValue = (fieldId, value) => {
+    var _a;
+    const normalized = value == null ? "" : String(value);
+    const host = document.querySelector(`lht-select-help[field-id='${fieldId}']`);
+    const field = document.getElementById(fieldId);
+    if (field) {
+        field.value = normalized;
+    }
+    if (!isLhtSelectHelpElement(host))
+        return;
+    host.setAttribute("value", normalized);
+    (_a = host.setValue) === null || _a === void 0 ? void 0 : _a.call(host, normalized);
+    requestAnimationFrame(() => {
+        var _a;
+        (_a = host.setValue) === null || _a === void 0 ? void 0 : _a.call(host, normalized);
+    });
+};
 const normalizeMidiProgram = (value) => {
     switch (value) {
         case "acoustic_grand_piano":
@@ -8290,7 +8313,7 @@ const normalizeMidiProgram = (value) => {
     }
 };
 const normalizeWaveformSetting = (value) => {
-    if (value === "triangle" || value === "square")
+    if (value === "sine" || value === "triangle" || value === "square")
         return value;
     return DEFAULT_PLAYBACK_WAVEFORM;
 };
@@ -8405,15 +8428,20 @@ const syncGeneralExportSettings = () => {
 const applyInitialPlaybackSettings = () => {
     var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p, _q, _r, _s;
     const stored = readPlaybackSettings();
-    midiProgramSelect.value = (_a = stored === null || stored === void 0 ? void 0 : stored.midiProgram) !== null && _a !== void 0 ? _a : DEFAULT_MIDI_PROGRAM;
-    playbackWaveform.value = (_b = stored === null || stored === void 0 ? void 0 : stored.waveform) !== null && _b !== void 0 ? _b : DEFAULT_PLAYBACK_WAVEFORM;
-    playbackUseMidiLike.checked = (_c = stored === null || stored === void 0 ? void 0 : stored.useMidiLikePlayback) !== null && _c !== void 0 ? _c : DEFAULT_PLAYBACK_USE_MIDI_LIKE;
-    graceTimingModeSelect.value = (_d = stored === null || stored === void 0 ? void 0 : stored.graceTimingMode) !== null && _d !== void 0 ? _d : DEFAULT_GRACE_TIMING_MODE;
-    metricAccentEnabledInput.checked = (_e = stored === null || stored === void 0 ? void 0 : stored.metricAccentEnabled) !== null && _e !== void 0 ? _e : DEFAULT_METRIC_ACCENT_ENABLED;
-    metricAccentProfileSelect.value = (_f = stored === null || stored === void 0 ? void 0 : stored.metricAccentProfile) !== null && _f !== void 0 ? _f : DEFAULT_METRIC_ACCENT_PROFILE;
-    midiExportProfileSelect.value = (_g = stored === null || stored === void 0 ? void 0 : stored.midiExportProfile) !== null && _g !== void 0 ? _g : DEFAULT_MIDI_EXPORT_PROFILE;
-    midiImportQuantizeGridSelect.value =
-        (_h = stored === null || stored === void 0 ? void 0 : stored.midiImportQuantizeGrid) !== null && _h !== void 0 ? _h : DEFAULT_MIDI_IMPORT_QUANTIZE_GRID;
+    const midiProgram = (_a = stored === null || stored === void 0 ? void 0 : stored.midiProgram) !== null && _a !== void 0 ? _a : DEFAULT_MIDI_PROGRAM;
+    const waveform = (_b = stored === null || stored === void 0 ? void 0 : stored.waveform) !== null && _b !== void 0 ? _b : DEFAULT_PLAYBACK_WAVEFORM;
+    const graceTimingMode = (_c = stored === null || stored === void 0 ? void 0 : stored.graceTimingMode) !== null && _c !== void 0 ? _c : DEFAULT_GRACE_TIMING_MODE;
+    const metricAccentProfile = (_d = stored === null || stored === void 0 ? void 0 : stored.metricAccentProfile) !== null && _d !== void 0 ? _d : DEFAULT_METRIC_ACCENT_PROFILE;
+    const midiExportProfile = (_e = stored === null || stored === void 0 ? void 0 : stored.midiExportProfile) !== null && _e !== void 0 ? _e : DEFAULT_MIDI_EXPORT_PROFILE;
+    const midiImportQuantizeGrid = (_f = stored === null || stored === void 0 ? void 0 : stored.midiImportQuantizeGrid) !== null && _f !== void 0 ? _f : DEFAULT_MIDI_IMPORT_QUANTIZE_GRID;
+    midiProgramSelect.value = midiProgram;
+    playbackWaveform.value = waveform;
+    playbackUseMidiLike.checked = (_g = stored === null || stored === void 0 ? void 0 : stored.useMidiLikePlayback) !== null && _g !== void 0 ? _g : DEFAULT_PLAYBACK_USE_MIDI_LIKE;
+    graceTimingModeSelect.value = graceTimingMode;
+    metricAccentEnabledInput.checked = (_h = stored === null || stored === void 0 ? void 0 : stored.metricAccentEnabled) !== null && _h !== void 0 ? _h : DEFAULT_METRIC_ACCENT_ENABLED;
+    metricAccentProfileSelect.value = metricAccentProfile;
+    midiExportProfileSelect.value = midiExportProfile;
+    midiImportQuantizeGridSelect.value = midiImportQuantizeGrid;
     midiImportTripletAware.checked =
         (_j = stored === null || stored === void 0 ? void 0 : stored.midiImportTripletAware) !== null && _j !== void 0 ? _j : DEFAULT_MIDI_IMPORT_TRIPLET_AWARE;
     forceMidiProgramOverride.checked =
@@ -8429,6 +8457,12 @@ const applyInitialPlaybackSettings = () => {
     compressXmlMuseScoreExport.checked =
         (_q = stored === null || stored === void 0 ? void 0 : stored.compressXmlMuseScoreExport) !== null && _q !== void 0 ? _q : DEFAULT_COMPRESS_XML_MUSESCORE_EXPORT;
     syncGeneralExportSettings();
+    syncSelectHelpValue("midiProgramSelect", midiProgram);
+    syncSelectHelpValue("playbackWaveform", waveform);
+    syncSelectHelpValue("graceTimingMode", graceTimingMode);
+    syncSelectHelpValue("metricAccentProfile", metricAccentProfile);
+    syncSelectHelpValue("midiExportProfile", midiExportProfile);
+    syncSelectHelpValue("midiImportQuantizeGrid", midiImportQuantizeGrid);
     generalSettingsAccordion.open = (_r = stored === null || stored === void 0 ? void 0 : stored.generalSettingsExpanded) !== null && _r !== void 0 ? _r : false;
     settingsAccordion.open = (_s = stored === null || stored === void 0 ? void 0 : stored.settingsExpanded) !== null && _s !== void 0 ? _s : false;
 };
@@ -8449,6 +8483,12 @@ const onResetPlaybackSettings = () => {
     exportMusicXmlAsXmlExtension.checked = DEFAULT_EXPORT_MUSICXML_AS_XML_EXTENSION;
     compressXmlMuseScoreExport.checked = DEFAULT_COMPRESS_XML_MUSESCORE_EXPORT;
     syncGeneralExportSettings();
+    syncSelectHelpValue("midiProgramSelect", DEFAULT_MIDI_PROGRAM);
+    syncSelectHelpValue("playbackWaveform", DEFAULT_PLAYBACK_WAVEFORM);
+    syncSelectHelpValue("graceTimingMode", DEFAULT_GRACE_TIMING_MODE);
+    syncSelectHelpValue("metricAccentProfile", DEFAULT_METRIC_ACCENT_PROFILE);
+    syncSelectHelpValue("midiExportProfile", DEFAULT_MIDI_EXPORT_PROFILE);
+    syncSelectHelpValue("midiImportQuantizeGrid", DEFAULT_MIDI_IMPORT_QUANTIZE_GRID);
     writePlaybackSettings();
     renderControlState();
 };
@@ -8725,7 +8765,14 @@ const renderInputMode = () => {
     }
 };
 const resetZipEntrySelectionUi = () => {
-    zipEntrySelect.innerHTML = "";
+    var _a, _b;
+    if (isLhtSelectHelpElement(zipEntrySelectHelp)) {
+        (_a = zipEntrySelectHelp.setOptions) === null || _a === void 0 ? void 0 : _a.call(zipEntrySelectHelp, [], { preserveValue: false });
+        (_b = zipEntrySelectHelp.setValue) === null || _b === void 0 ? void 0 : _b.call(zipEntrySelectHelp, "");
+    }
+    else {
+        zipEntrySelect.innerHTML = "";
+    }
     zipEntrySelectBlock.classList.add("md-hidden");
     selectedZipEntryVirtualFile = null;
 };
@@ -8763,6 +8810,7 @@ const loadZipEntryAsVirtualFile = async (archive, entryPath) => {
     return new File([copiedBuffer], entryPath, { type: "application/octet-stream" });
 };
 const prepareZipEntrySelection = async (archive) => {
+    var _a, _b, _c;
     resetZipEntrySelectionUi();
     let entryPaths = [];
     try {
@@ -8782,10 +8830,17 @@ const prepareZipEntrySelection = async (archive) => {
     }
     zipEntrySelectBlock.classList.remove("md-hidden");
     if (entryPaths.length === 1) {
-        const onlyOption = document.createElement("option");
-        onlyOption.value = entryPaths[0];
-        onlyOption.textContent = entryPaths[0];
-        zipEntrySelect.appendChild(onlyOption);
+        if (isLhtSelectHelpElement(zipEntrySelectHelp)) {
+            (_a = zipEntrySelectHelp.setOptions) === null || _a === void 0 ? void 0 : _a.call(zipEntrySelectHelp, [
+                { value: entryPaths[0], label: entryPaths[0], selected: true }
+            ], { preserveValue: false });
+        }
+        else {
+            const onlyOption = document.createElement("option");
+            onlyOption.value = entryPaths[0];
+            onlyOption.textContent = entryPaths[0];
+            zipEntrySelect.appendChild(onlyOption);
+        }
         try {
             selectedZipEntryVirtualFile = await loadZipEntryAsVirtualFile(archive, entryPaths[0]);
             return { ok: true, autoLoad: true };
@@ -8797,17 +8852,26 @@ const prepareZipEntrySelection = async (archive) => {
             };
         }
     }
-    const placeholder = document.createElement("option");
-    placeholder.value = "";
-    placeholder.textContent = "Select a ZIP root entry";
-    placeholder.disabled = true;
-    placeholder.selected = true;
-    zipEntrySelect.appendChild(placeholder);
-    for (const path of entryPaths) {
-        const option = document.createElement("option");
-        option.value = path;
-        option.textContent = path;
-        zipEntrySelect.appendChild(option);
+    if (isLhtSelectHelpElement(zipEntrySelectHelp)) {
+        (_b = zipEntrySelectHelp.setOptions) === null || _b === void 0 ? void 0 : _b.call(zipEntrySelectHelp, [
+            { value: "", label: "Select a ZIP root entry", selected: true, disabled: true },
+            ...entryPaths.map((path) => ({ value: path, label: path }))
+        ], { preserveValue: false });
+        (_c = zipEntrySelectHelp.setValue) === null || _c === void 0 ? void 0 : _c.call(zipEntrySelectHelp, "");
+    }
+    else {
+        const placeholder = document.createElement("option");
+        placeholder.value = "";
+        placeholder.textContent = "Select a ZIP root entry";
+        placeholder.disabled = true;
+        placeholder.selected = true;
+        zipEntrySelect.appendChild(placeholder);
+        for (const path of entryPaths) {
+            const option = document.createElement("option");
+            option.value = path;
+            option.textContent = path;
+            zipEntrySelect.appendChild(option);
+        }
     }
     selectedZipEntryVirtualFile = null;
     return { ok: true, autoLoad: false };
@@ -16780,8 +16844,9 @@ const createBasicWaveSynthEngine = (options) => {
     const scheduleBasicWaveNote = (event, startAt, bodyDuration, waveform, sustainHoldSeconds = 0, legatoFromOverlap = false) => {
         if (!audioContext)
             return startAt;
-        const attack = legatoFromOverlap ? 0.0015 : 0.005;
-        const release = legatoFromOverlap ? 0.03 : 0.01;
+        const isSine = waveform === "sine";
+        const attack = legatoFromOverlap && !isSine ? 0.0015 : 0.005;
+        const release = legatoFromOverlap || isSine ? 0.03 : 0.01;
         const endAt = startAt + bodyDuration;
         const heldEndAt = endAt + Math.max(0, sustainHoldSeconds);
         const oscillator = audioContext.createOscillator();
@@ -16789,7 +16854,7 @@ const createBasicWaveSynthEngine = (options) => {
         oscillator.frequency.setValueAtTime(midiToHz(event.midiNumber), startAt);
         const gainNode = audioContext.createGain();
         const gainLevel = event.channel === 10 ? 0.06 : 0.1;
-        if (legatoFromOverlap) {
+        if (legatoFromOverlap && !isSine) {
             gainNode.gain.setValueAtTime(gainLevel * 0.75, startAt);
             gainNode.gain.linearRampToValueAtTime(gainLevel, startAt + attack);
         }
@@ -16969,7 +17034,10 @@ const createBasicWaveSynthEngine = (options) => {
             const endAt = baseTime + tickToSeconds(event.start + event.ticks);
             let bodyDuration = Math.max(0.04, endAt - startAt);
             const nextStartTick = findNextStartTickOnLane(laneKey, event.start);
-            if (!legatoFromOverlap && nextStartTick !== null && nextStartTick > event.start) {
+            if (normalizedWaveform !== "sine"
+                && !legatoFromOverlap
+                && nextStartTick !== null
+                && nextStartTick > event.start) {
                 const hasForwardOverlapIntent = event.start + event.ticks > nextStartTick;
                 if (!hasForwardOverlapIntent) {
                     const nextStartAt = baseTime + tickToSeconds(nextStartTick);

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -78,6 +78,7 @@ const fileSelectBtn = q("#fileSelectBtn");
 const fileInput = q("#fileInput");
 const fileNameText = q("#fileNameText");
 const zipEntrySelectBlock = q("#zipEntrySelectBlock");
+const zipEntrySelectHelp = document.querySelector("lht-select-help[field-id='zipEntrySelect']");
 const zipEntrySelect = q("#zipEntrySelect");
 const fileLoadOverlay = q("#fileLoadOverlay");
 const loadBtn = q("#loadBtn");
@@ -234,6 +235,28 @@ const isLhtErrorAlertElement = (element) => {
     return (element.tagName.toLowerCase() === "lht-error-alert"
         && typeof element.show === "function");
 };
+const isLhtSelectHelpElement = (element) => {
+    return !!element
+        && element.tagName.toLowerCase() === "lht-select-help"
+        && typeof element.setOptions === "function";
+};
+const syncSelectHelpValue = (fieldId, value) => {
+    var _a;
+    const normalized = value == null ? "" : String(value);
+    const host = document.querySelector(`lht-select-help[field-id='${fieldId}']`);
+    const field = document.getElementById(fieldId);
+    if (field) {
+        field.value = normalized;
+    }
+    if (!isLhtSelectHelpElement(host))
+        return;
+    host.setAttribute("value", normalized);
+    (_a = host.setValue) === null || _a === void 0 ? void 0 : _a.call(host, normalized);
+    requestAnimationFrame(() => {
+        var _a;
+        (_a = host.setValue) === null || _a === void 0 ? void 0 : _a.call(host, normalized);
+    });
+};
 const normalizeMidiProgram = (value) => {
     switch (value) {
         case "acoustic_grand_piano":
@@ -254,7 +277,7 @@ const normalizeMidiProgram = (value) => {
     }
 };
 const normalizeWaveformSetting = (value) => {
-    if (value === "triangle" || value === "square")
+    if (value === "sine" || value === "triangle" || value === "square")
         return value;
     return DEFAULT_PLAYBACK_WAVEFORM;
 };
@@ -369,15 +392,20 @@ const syncGeneralExportSettings = () => {
 const applyInitialPlaybackSettings = () => {
     var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p, _q, _r, _s;
     const stored = readPlaybackSettings();
-    midiProgramSelect.value = (_a = stored === null || stored === void 0 ? void 0 : stored.midiProgram) !== null && _a !== void 0 ? _a : DEFAULT_MIDI_PROGRAM;
-    playbackWaveform.value = (_b = stored === null || stored === void 0 ? void 0 : stored.waveform) !== null && _b !== void 0 ? _b : DEFAULT_PLAYBACK_WAVEFORM;
-    playbackUseMidiLike.checked = (_c = stored === null || stored === void 0 ? void 0 : stored.useMidiLikePlayback) !== null && _c !== void 0 ? _c : DEFAULT_PLAYBACK_USE_MIDI_LIKE;
-    graceTimingModeSelect.value = (_d = stored === null || stored === void 0 ? void 0 : stored.graceTimingMode) !== null && _d !== void 0 ? _d : DEFAULT_GRACE_TIMING_MODE;
-    metricAccentEnabledInput.checked = (_e = stored === null || stored === void 0 ? void 0 : stored.metricAccentEnabled) !== null && _e !== void 0 ? _e : DEFAULT_METRIC_ACCENT_ENABLED;
-    metricAccentProfileSelect.value = (_f = stored === null || stored === void 0 ? void 0 : stored.metricAccentProfile) !== null && _f !== void 0 ? _f : DEFAULT_METRIC_ACCENT_PROFILE;
-    midiExportProfileSelect.value = (_g = stored === null || stored === void 0 ? void 0 : stored.midiExportProfile) !== null && _g !== void 0 ? _g : DEFAULT_MIDI_EXPORT_PROFILE;
-    midiImportQuantizeGridSelect.value =
-        (_h = stored === null || stored === void 0 ? void 0 : stored.midiImportQuantizeGrid) !== null && _h !== void 0 ? _h : DEFAULT_MIDI_IMPORT_QUANTIZE_GRID;
+    const midiProgram = (_a = stored === null || stored === void 0 ? void 0 : stored.midiProgram) !== null && _a !== void 0 ? _a : DEFAULT_MIDI_PROGRAM;
+    const waveform = (_b = stored === null || stored === void 0 ? void 0 : stored.waveform) !== null && _b !== void 0 ? _b : DEFAULT_PLAYBACK_WAVEFORM;
+    const graceTimingMode = (_c = stored === null || stored === void 0 ? void 0 : stored.graceTimingMode) !== null && _c !== void 0 ? _c : DEFAULT_GRACE_TIMING_MODE;
+    const metricAccentProfile = (_d = stored === null || stored === void 0 ? void 0 : stored.metricAccentProfile) !== null && _d !== void 0 ? _d : DEFAULT_METRIC_ACCENT_PROFILE;
+    const midiExportProfile = (_e = stored === null || stored === void 0 ? void 0 : stored.midiExportProfile) !== null && _e !== void 0 ? _e : DEFAULT_MIDI_EXPORT_PROFILE;
+    const midiImportQuantizeGrid = (_f = stored === null || stored === void 0 ? void 0 : stored.midiImportQuantizeGrid) !== null && _f !== void 0 ? _f : DEFAULT_MIDI_IMPORT_QUANTIZE_GRID;
+    midiProgramSelect.value = midiProgram;
+    playbackWaveform.value = waveform;
+    playbackUseMidiLike.checked = (_g = stored === null || stored === void 0 ? void 0 : stored.useMidiLikePlayback) !== null && _g !== void 0 ? _g : DEFAULT_PLAYBACK_USE_MIDI_LIKE;
+    graceTimingModeSelect.value = graceTimingMode;
+    metricAccentEnabledInput.checked = (_h = stored === null || stored === void 0 ? void 0 : stored.metricAccentEnabled) !== null && _h !== void 0 ? _h : DEFAULT_METRIC_ACCENT_ENABLED;
+    metricAccentProfileSelect.value = metricAccentProfile;
+    midiExportProfileSelect.value = midiExportProfile;
+    midiImportQuantizeGridSelect.value = midiImportQuantizeGrid;
     midiImportTripletAware.checked =
         (_j = stored === null || stored === void 0 ? void 0 : stored.midiImportTripletAware) !== null && _j !== void 0 ? _j : DEFAULT_MIDI_IMPORT_TRIPLET_AWARE;
     forceMidiProgramOverride.checked =
@@ -393,6 +421,12 @@ const applyInitialPlaybackSettings = () => {
     compressXmlMuseScoreExport.checked =
         (_q = stored === null || stored === void 0 ? void 0 : stored.compressXmlMuseScoreExport) !== null && _q !== void 0 ? _q : DEFAULT_COMPRESS_XML_MUSESCORE_EXPORT;
     syncGeneralExportSettings();
+    syncSelectHelpValue("midiProgramSelect", midiProgram);
+    syncSelectHelpValue("playbackWaveform", waveform);
+    syncSelectHelpValue("graceTimingMode", graceTimingMode);
+    syncSelectHelpValue("metricAccentProfile", metricAccentProfile);
+    syncSelectHelpValue("midiExportProfile", midiExportProfile);
+    syncSelectHelpValue("midiImportQuantizeGrid", midiImportQuantizeGrid);
     generalSettingsAccordion.open = (_r = stored === null || stored === void 0 ? void 0 : stored.generalSettingsExpanded) !== null && _r !== void 0 ? _r : false;
     settingsAccordion.open = (_s = stored === null || stored === void 0 ? void 0 : stored.settingsExpanded) !== null && _s !== void 0 ? _s : false;
 };
@@ -413,6 +447,12 @@ const onResetPlaybackSettings = () => {
     exportMusicXmlAsXmlExtension.checked = DEFAULT_EXPORT_MUSICXML_AS_XML_EXTENSION;
     compressXmlMuseScoreExport.checked = DEFAULT_COMPRESS_XML_MUSESCORE_EXPORT;
     syncGeneralExportSettings();
+    syncSelectHelpValue("midiProgramSelect", DEFAULT_MIDI_PROGRAM);
+    syncSelectHelpValue("playbackWaveform", DEFAULT_PLAYBACK_WAVEFORM);
+    syncSelectHelpValue("graceTimingMode", DEFAULT_GRACE_TIMING_MODE);
+    syncSelectHelpValue("metricAccentProfile", DEFAULT_METRIC_ACCENT_PROFILE);
+    syncSelectHelpValue("midiExportProfile", DEFAULT_MIDI_EXPORT_PROFILE);
+    syncSelectHelpValue("midiImportQuantizeGrid", DEFAULT_MIDI_IMPORT_QUANTIZE_GRID);
     writePlaybackSettings();
     renderControlState();
 };
@@ -689,7 +729,14 @@ const renderInputMode = () => {
     }
 };
 const resetZipEntrySelectionUi = () => {
-    zipEntrySelect.innerHTML = "";
+    var _a, _b;
+    if (isLhtSelectHelpElement(zipEntrySelectHelp)) {
+        (_a = zipEntrySelectHelp.setOptions) === null || _a === void 0 ? void 0 : _a.call(zipEntrySelectHelp, [], { preserveValue: false });
+        (_b = zipEntrySelectHelp.setValue) === null || _b === void 0 ? void 0 : _b.call(zipEntrySelectHelp, "");
+    }
+    else {
+        zipEntrySelect.innerHTML = "";
+    }
     zipEntrySelectBlock.classList.add("md-hidden");
     selectedZipEntryVirtualFile = null;
 };
@@ -727,6 +774,7 @@ const loadZipEntryAsVirtualFile = async (archive, entryPath) => {
     return new File([copiedBuffer], entryPath, { type: "application/octet-stream" });
 };
 const prepareZipEntrySelection = async (archive) => {
+    var _a, _b, _c;
     resetZipEntrySelectionUi();
     let entryPaths = [];
     try {
@@ -746,10 +794,17 @@ const prepareZipEntrySelection = async (archive) => {
     }
     zipEntrySelectBlock.classList.remove("md-hidden");
     if (entryPaths.length === 1) {
-        const onlyOption = document.createElement("option");
-        onlyOption.value = entryPaths[0];
-        onlyOption.textContent = entryPaths[0];
-        zipEntrySelect.appendChild(onlyOption);
+        if (isLhtSelectHelpElement(zipEntrySelectHelp)) {
+            (_a = zipEntrySelectHelp.setOptions) === null || _a === void 0 ? void 0 : _a.call(zipEntrySelectHelp, [
+                { value: entryPaths[0], label: entryPaths[0], selected: true }
+            ], { preserveValue: false });
+        }
+        else {
+            const onlyOption = document.createElement("option");
+            onlyOption.value = entryPaths[0];
+            onlyOption.textContent = entryPaths[0];
+            zipEntrySelect.appendChild(onlyOption);
+        }
         try {
             selectedZipEntryVirtualFile = await loadZipEntryAsVirtualFile(archive, entryPaths[0]);
             return { ok: true, autoLoad: true };
@@ -761,17 +816,26 @@ const prepareZipEntrySelection = async (archive) => {
             };
         }
     }
-    const placeholder = document.createElement("option");
-    placeholder.value = "";
-    placeholder.textContent = "Select a ZIP root entry";
-    placeholder.disabled = true;
-    placeholder.selected = true;
-    zipEntrySelect.appendChild(placeholder);
-    for (const path of entryPaths) {
-        const option = document.createElement("option");
-        option.value = path;
-        option.textContent = path;
-        zipEntrySelect.appendChild(option);
+    if (isLhtSelectHelpElement(zipEntrySelectHelp)) {
+        (_b = zipEntrySelectHelp.setOptions) === null || _b === void 0 ? void 0 : _b.call(zipEntrySelectHelp, [
+            { value: "", label: "Select a ZIP root entry", selected: true, disabled: true },
+            ...entryPaths.map((path) => ({ value: path, label: path }))
+        ], { preserveValue: false });
+        (_c = zipEntrySelectHelp.setValue) === null || _c === void 0 ? void 0 : _c.call(zipEntrySelectHelp, "");
+    }
+    else {
+        const placeholder = document.createElement("option");
+        placeholder.value = "";
+        placeholder.textContent = "Select a ZIP root entry";
+        placeholder.disabled = true;
+        placeholder.selected = true;
+        zipEntrySelect.appendChild(placeholder);
+        for (const path of entryPaths) {
+            const option = document.createElement("option");
+            option.value = path;
+            option.textContent = path;
+            zipEntrySelect.appendChild(option);
+        }
     }
     selectedZipEntryVirtualFile = null;
     return { ok: true, autoLoad: false };
@@ -8744,8 +8808,9 @@ const createBasicWaveSynthEngine = (options) => {
     const scheduleBasicWaveNote = (event, startAt, bodyDuration, waveform, sustainHoldSeconds = 0, legatoFromOverlap = false) => {
         if (!audioContext)
             return startAt;
-        const attack = legatoFromOverlap ? 0.0015 : 0.005;
-        const release = legatoFromOverlap ? 0.03 : 0.01;
+        const isSine = waveform === "sine";
+        const attack = legatoFromOverlap && !isSine ? 0.0015 : 0.005;
+        const release = legatoFromOverlap || isSine ? 0.03 : 0.01;
         const endAt = startAt + bodyDuration;
         const heldEndAt = endAt + Math.max(0, sustainHoldSeconds);
         const oscillator = audioContext.createOscillator();
@@ -8753,7 +8818,7 @@ const createBasicWaveSynthEngine = (options) => {
         oscillator.frequency.setValueAtTime(midiToHz(event.midiNumber), startAt);
         const gainNode = audioContext.createGain();
         const gainLevel = event.channel === 10 ? 0.06 : 0.1;
-        if (legatoFromOverlap) {
+        if (legatoFromOverlap && !isSine) {
             gainNode.gain.setValueAtTime(gainLevel * 0.75, startAt);
             gainNode.gain.linearRampToValueAtTime(gainLevel, startAt + attack);
         }
@@ -8933,7 +8998,10 @@ const createBasicWaveSynthEngine = (options) => {
             const endAt = baseTime + tickToSeconds(event.start + event.ticks);
             let bodyDuration = Math.max(0.04, endAt - startAt);
             const nextStartTick = findNextStartTickOnLane(laneKey, event.start);
-            if (!legatoFromOverlap && nextStartTick !== null && nextStartTick > event.start) {
+            if (normalizedWaveform !== "sine"
+                && !legatoFromOverlap
+                && nextStartTick !== null
+                && nextStartTick > event.start) {
                 const hasForwardOverlapIntent = event.start + event.ticks > nextStartTick;
                 if (!hasForwardOverlapIntent) {
                     const nextStartAt = baseTime + tickToSeconds(nextStartTick);

--- a/src/ts/main.ts
+++ b/src/ts/main.ts
@@ -142,6 +142,7 @@ const fileSelectBtn = q<HTMLButtonElement>("#fileSelectBtn");
 const fileInput = q<HTMLInputElement>("#fileInput");
 const fileNameText = q<HTMLSpanElement>("#fileNameText");
 const zipEntrySelectBlock = q<HTMLDivElement>("#zipEntrySelectBlock");
+const zipEntrySelectHelp = document.querySelector<HTMLElement>("lht-select-help[field-id='zipEntrySelect']");
 const zipEntrySelect = q<HTMLSelectElement>("#zipEntrySelect");
 const fileLoadOverlay = q<HTMLElement>("#fileLoadOverlay");
 const loadBtn = q<HTMLButtonElement>("#loadBtn");
@@ -305,6 +306,14 @@ type LhtErrorAlertElement = HTMLElement & {
   clear?: () => void;
 };
 
+type LhtSelectHelpElement = HTMLElement & {
+  setOptions?: (
+    options: Array<{ value: string; label: string; selected?: boolean; disabled?: boolean }>,
+    config?: { preserveValue?: boolean }
+  ) => void;
+  setValue?: (value: string) => void;
+};
+
 const isLhtLoadingOverlayElement = (element: Element): element is LhtLoadingOverlayElement => {
   return (
     element.tagName.toLowerCase() === "lht-loading-overlay"
@@ -317,6 +326,27 @@ const isLhtErrorAlertElement = (element: Element): element is LhtErrorAlertEleme
     element.tagName.toLowerCase() === "lht-error-alert"
     && typeof (element as LhtErrorAlertElement).show === "function"
   );
+};
+
+const isLhtSelectHelpElement = (element: Element | null): element is LhtSelectHelpElement => {
+  return !!element
+    && element.tagName.toLowerCase() === "lht-select-help"
+    && typeof (element as LhtSelectHelpElement).setOptions === "function";
+};
+
+const syncSelectHelpValue = (fieldId: string, value: string): void => {
+  const normalized = value == null ? "" : String(value);
+  const host = document.querySelector(`lht-select-help[field-id='${fieldId}']`);
+  const field = document.getElementById(fieldId) as HTMLSelectElement | null;
+  if (field) {
+    field.value = normalized;
+  }
+  if (!isLhtSelectHelpElement(host)) return;
+  host.setAttribute("value", normalized);
+  host.setValue?.(normalized);
+  requestAnimationFrame(() => {
+    host.setValue?.(normalized);
+  });
 };
 
 type LocalDraft = {
@@ -365,7 +395,7 @@ const normalizeMidiProgram = (value: string): PlaybackSettings["midiProgram"] =>
 };
 
 const normalizeWaveformSetting = (value: string): PlaybackSettings["waveform"] => {
-  if (value === "triangle" || value === "square") return value;
+  if (value === "sine" || value === "triangle" || value === "square") return value;
   return DEFAULT_PLAYBACK_WAVEFORM;
 };
 
@@ -488,15 +518,22 @@ const syncGeneralExportSettings = (): void => {
 
 const applyInitialPlaybackSettings = (): void => {
   const stored = readPlaybackSettings();
-  midiProgramSelect.value = stored?.midiProgram ?? DEFAULT_MIDI_PROGRAM;
-  playbackWaveform.value = stored?.waveform ?? DEFAULT_PLAYBACK_WAVEFORM;
-  playbackUseMidiLike.checked = stored?.useMidiLikePlayback ?? DEFAULT_PLAYBACK_USE_MIDI_LIKE;
-  graceTimingModeSelect.value = stored?.graceTimingMode ?? DEFAULT_GRACE_TIMING_MODE;
-  metricAccentEnabledInput.checked = stored?.metricAccentEnabled ?? DEFAULT_METRIC_ACCENT_ENABLED;
-  metricAccentProfileSelect.value = stored?.metricAccentProfile ?? DEFAULT_METRIC_ACCENT_PROFILE;
-  midiExportProfileSelect.value = stored?.midiExportProfile ?? DEFAULT_MIDI_EXPORT_PROFILE;
-  midiImportQuantizeGridSelect.value =
+  const midiProgram = stored?.midiProgram ?? DEFAULT_MIDI_PROGRAM;
+  const waveform = stored?.waveform ?? DEFAULT_PLAYBACK_WAVEFORM;
+  const graceTimingMode = stored?.graceTimingMode ?? DEFAULT_GRACE_TIMING_MODE;
+  const metricAccentProfile = stored?.metricAccentProfile ?? DEFAULT_METRIC_ACCENT_PROFILE;
+  const midiExportProfile = stored?.midiExportProfile ?? DEFAULT_MIDI_EXPORT_PROFILE;
+  const midiImportQuantizeGrid =
     stored?.midiImportQuantizeGrid ?? DEFAULT_MIDI_IMPORT_QUANTIZE_GRID;
+
+  midiProgramSelect.value = midiProgram;
+  playbackWaveform.value = waveform;
+  playbackUseMidiLike.checked = stored?.useMidiLikePlayback ?? DEFAULT_PLAYBACK_USE_MIDI_LIKE;
+  graceTimingModeSelect.value = graceTimingMode;
+  metricAccentEnabledInput.checked = stored?.metricAccentEnabled ?? DEFAULT_METRIC_ACCENT_ENABLED;
+  metricAccentProfileSelect.value = metricAccentProfile;
+  midiExportProfileSelect.value = midiExportProfile;
+  midiImportQuantizeGridSelect.value = midiImportQuantizeGrid;
   midiImportTripletAware.checked =
     stored?.midiImportTripletAware ?? DEFAULT_MIDI_IMPORT_TRIPLET_AWARE;
   forceMidiProgramOverride.checked =
@@ -512,6 +549,12 @@ const applyInitialPlaybackSettings = (): void => {
   compressXmlMuseScoreExport.checked =
     stored?.compressXmlMuseScoreExport ?? DEFAULT_COMPRESS_XML_MUSESCORE_EXPORT;
   syncGeneralExportSettings();
+  syncSelectHelpValue("midiProgramSelect", midiProgram);
+  syncSelectHelpValue("playbackWaveform", waveform);
+  syncSelectHelpValue("graceTimingMode", graceTimingMode);
+  syncSelectHelpValue("metricAccentProfile", metricAccentProfile);
+  syncSelectHelpValue("midiExportProfile", midiExportProfile);
+  syncSelectHelpValue("midiImportQuantizeGrid", midiImportQuantizeGrid);
   generalSettingsAccordion.open = stored?.generalSettingsExpanded ?? false;
   settingsAccordion.open = stored?.settingsExpanded ?? false;
 };
@@ -533,6 +576,12 @@ const onResetPlaybackSettings = (): void => {
   exportMusicXmlAsXmlExtension.checked = DEFAULT_EXPORT_MUSICXML_AS_XML_EXTENSION;
   compressXmlMuseScoreExport.checked = DEFAULT_COMPRESS_XML_MUSESCORE_EXPORT;
   syncGeneralExportSettings();
+  syncSelectHelpValue("midiProgramSelect", DEFAULT_MIDI_PROGRAM);
+  syncSelectHelpValue("playbackWaveform", DEFAULT_PLAYBACK_WAVEFORM);
+  syncSelectHelpValue("graceTimingMode", DEFAULT_GRACE_TIMING_MODE);
+  syncSelectHelpValue("metricAccentProfile", DEFAULT_METRIC_ACCENT_PROFILE);
+  syncSelectHelpValue("midiExportProfile", DEFAULT_MIDI_EXPORT_PROFILE);
+  syncSelectHelpValue("midiImportQuantizeGrid", DEFAULT_MIDI_IMPORT_QUANTIZE_GRID);
   writePlaybackSettings();
   renderControlState();
 };
@@ -818,7 +867,12 @@ const renderInputMode = (): void => {
 };
 
 const resetZipEntrySelectionUi = (): void => {
-  zipEntrySelect.innerHTML = "";
+  if (isLhtSelectHelpElement(zipEntrySelectHelp)) {
+    zipEntrySelectHelp.setOptions?.([], { preserveValue: false });
+    zipEntrySelectHelp.setValue?.("");
+  } else {
+    zipEntrySelect.innerHTML = "";
+  }
   zipEntrySelectBlock.classList.add("md-hidden");
   selectedZipEntryVirtualFile = null;
 };
@@ -880,10 +934,16 @@ const prepareZipEntrySelection = async (
   }
   zipEntrySelectBlock.classList.remove("md-hidden");
   if (entryPaths.length === 1) {
-    const onlyOption = document.createElement("option");
-    onlyOption.value = entryPaths[0];
-    onlyOption.textContent = entryPaths[0];
-    zipEntrySelect.appendChild(onlyOption);
+    if (isLhtSelectHelpElement(zipEntrySelectHelp)) {
+      zipEntrySelectHelp.setOptions?.([
+        { value: entryPaths[0], label: entryPaths[0], selected: true }
+      ], { preserveValue: false });
+    } else {
+      const onlyOption = document.createElement("option");
+      onlyOption.value = entryPaths[0];
+      onlyOption.textContent = entryPaths[0];
+      zipEntrySelect.appendChild(onlyOption);
+    }
     try {
       selectedZipEntryVirtualFile = await loadZipEntryAsVirtualFile(archive, entryPaths[0]);
       return { ok: true, autoLoad: true };
@@ -894,17 +954,25 @@ const prepareZipEntrySelection = async (
       };
     }
   }
-  const placeholder = document.createElement("option");
-  placeholder.value = "";
-  placeholder.textContent = "Select a ZIP root entry";
-  placeholder.disabled = true;
-  placeholder.selected = true;
-  zipEntrySelect.appendChild(placeholder);
-  for (const path of entryPaths) {
-    const option = document.createElement("option");
-    option.value = path;
-    option.textContent = path;
-    zipEntrySelect.appendChild(option);
+  if (isLhtSelectHelpElement(zipEntrySelectHelp)) {
+    zipEntrySelectHelp.setOptions?.([
+      { value: "", label: "Select a ZIP root entry", selected: true, disabled: true },
+      ...entryPaths.map((path) => ({ value: path, label: path }))
+    ], { preserveValue: false });
+    zipEntrySelectHelp.setValue?.("");
+  } else {
+    const placeholder = document.createElement("option");
+    placeholder.value = "";
+    placeholder.textContent = "Select a ZIP root entry";
+    placeholder.disabled = true;
+    placeholder.selected = true;
+    zipEntrySelect.appendChild(placeholder);
+    for (const path of entryPaths) {
+      const option = document.createElement("option");
+      option.value = path;
+      option.textContent = path;
+      zipEntrySelect.appendChild(option);
+    }
   }
   selectedZipEntryVirtualFile = null;
   return { ok: true, autoLoad: false };

--- a/src/ts/playback-flow.ts
+++ b/src/ts/playback-flow.ts
@@ -119,8 +119,9 @@ export const createBasicWaveSynthEngine = (options: { ticksPerQuarter: number })
     legatoFromOverlap = false
   ): number => {
     if (!audioContext) return startAt;
-    const attack = legatoFromOverlap ? 0.0015 : 0.005;
-    const release = legatoFromOverlap ? 0.03 : 0.01;
+    const isSine = waveform === "sine";
+    const attack = legatoFromOverlap && !isSine ? 0.0015 : 0.005;
+    const release = legatoFromOverlap || isSine ? 0.03 : 0.01;
     const endAt = startAt + bodyDuration;
     const heldEndAt = endAt + Math.max(0, sustainHoldSeconds);
     const oscillator = audioContext.createOscillator();
@@ -129,7 +130,7 @@ export const createBasicWaveSynthEngine = (options: { ticksPerQuarter: number })
 
     const gainNode = audioContext.createGain();
     const gainLevel = event.channel === 10 ? 0.06 : 0.1;
-    if (legatoFromOverlap) {
+    if (legatoFromOverlap && !isSine) {
       gainNode.gain.setValueAtTime(gainLevel * 0.75, startAt);
       gainNode.gain.linearRampToValueAtTime(gainLevel, startAt + attack);
     } else {
@@ -307,7 +308,12 @@ export const createBasicWaveSynthEngine = (options: { ticksPerQuarter: number })
       const endAt = baseTime + tickToSeconds(event.start + event.ticks);
       let bodyDuration = Math.max(0.04, endAt - startAt);
       const nextStartTick = findNextStartTickOnLane(laneKey, event.start);
-      if (!legatoFromOverlap && nextStartTick !== null && nextStartTick > event.start) {
+      if (
+        normalizedWaveform !== "sine"
+        && !legatoFromOverlap
+        && nextStartTick !== null
+        && nextStartTick > event.start
+      ) {
         const hasForwardOverlapIntent = event.start + event.ticks > nextStartTick;
         if (!hasForwardOverlapIntent) {
           const nextStartAt = baseTime + tickToSeconds(nextStartTick);

--- a/tests/unit/playback-flow.spec.ts
+++ b/tests/unit/playback-flow.spec.ts
@@ -195,6 +195,6 @@ describe("playback-flow midi-like scheduling", () => {
     );
 
     expect(oscillators).toHaveLength(1);
-    expect(oscillators[0].stop).toHaveBeenCalledWith(expect.closeTo(0.49, 6));
+    expect(oscillators[0].stop).toHaveBeenCalledWith(expect.closeTo(0.51, 6));
   });
 });


### PR DESCRIPTION
## 概要

`lht-select-help` を使ったセレクトUIと Quick Playback Tone の波形処理に関する不整合を修正します。

## 変更内容

- `syncSelectHelpValue()` を追加し、Playback Settings の初期適用時とリセット時に `lht-select-help` 側の表示値も同期するように修正
- ZIP ルートエントリ選択UIを、`lht-select-help` が利用可能な場合は `setOptions()` / `setValue()` 経由で初期化・更新・クリアするように修正
- 波形設定の正規化で `sine` を許可し、Quick Playback Tone で `Sine` を選んだときに `triangle` へフォールバックしないように修正
- 基本波形シンセのエンベロープ処理を調整し、`sine` の場合はより滑らかな発音・リリースになるよう修正
- 非 `sine` 波形向けのノート短縮ロジックから `sine` を除外
- カスタムセレクトを包む一部の `<label>` を `<div class="ms-field">` に置き換え、カスタム要素まわりのマークアップを安定化
- ビルド生成物を更新

## 修正理由

変更前は以下の問題がありました。

- `lht-select-help` を使った設定項目で、内部の値は更新されていてもUI表示が追従しない場合がある
- ZIP エントリ選択がネイティブ `<option>` 前提の更新処理になっており、`lht-select-help` の更新経路と一致していない
- Quick Playback Tone で `Sine` を選択しても、波形正規化で `triangle` に変換され、再生エンジンへ誤った値が渡る
- `sine` でも他波形と同様の短いアタック/リリース補正がかかり、発音が不自然になりやすい

## 確認内容

- playback-flow のユニットテスト期待値を更新
- `mikuscore.html` と `src/js/main.js` を再生成