### PR TITLE
整理済みの `lht-cmn` フィードバックへ再編し、tooltip の自己完結性不足を明文化する

### DIFF
--- a/docs/spec/LHT_CMN_FEEDBACK.md
+++ b/docs/spec/LHT_CMN_FEEDBACK.md
@@ -1,196 +1,58 @@
 # LHT_CMN_FEEDBACK
 
-Last updated: 2026-03-07
+Last updated: 2026-03-08
 Target: `lht-cmn` maintainers
 Source project: `mikuscore`
 
-This note summarizes issues and improvement requests found during real integration of `lht-cmn` into `mikuscore`.
+This note now tracks only open or partially-resolved integration issues. Items already reflected in `lht-cmn` were removed from this file and are tracked historically in `LHT_CMN_FEEDBACK_STATUS.md`.
 
-## 1. Critical design contract
+## 1. Open component issues
 
-These are the highest-priority design issues because they affect the whole `lht-cmn` model, not just one component.
-
-### 1-1. `lht-*` must be self-contained from the app's point of view
-
-- Problem:
-  - App code is expected to use `lht-*` as the public UI layer.
-  - However, some `lht-*` components still depend on whether internal `md-*` elements happen to be loaded.
-  - This leaks internal dependency responsibility to the app side.
-- Request:
-  - Define the contract clearly: if an app loads `lht-cmn`, `lht-*` must work without requiring the app to manage `md-*` registration.
-  - Each component should use one of these approaches consistently:
-    - `lht-cmn` internally guarantees the required `md-*` registration before use.
-    - `lht-cmn` provides an internal non-`md-*` fallback with defined parity.
-
-### 1-2. Apply the self-contained rule across all components, not only `lht-switch-help`
+### 1-1. `lht-help-tooltip` should be fully self-contained, including base positioning CSS
 
 - Observed:
-  - `lht-switch-help` exposed this issue most clearly, but the same design risk applies to other internals such as `md-icon-button`, `md-filled-button`, `md-outlined-select`, and `md-outlined-text-field`.
-- Request:
-  - Treat this as a cross-component policy.
-  - Audit all `lht-*` components for leaked `md-*` responsibility and align them to the same contract.
-
-## 2. High-priority component issues
-
-### 2-1. `lht-help-tooltip`: viewport collision handling should be built in
-
-- Observed:
-  - Tooltips can overflow the left or right viewport edge.
-  - App-side CSS/runtime adjustment was required to keep content visible.
+  - `lht-help-tooltip` already has runtime placement logic such as `placement="auto"`, viewport measurement, and resize follow-up.
+  - However, a later `mikuscore` integration regression showed that hover behavior could still break even when the app used `<lht-help-tooltip>` normally.
+  - The root cause was missing component-owned base CSS for tooltip anchoring and visibility, especially around:
+    - `position: relative` on the anchor container
+    - `position: absolute` on the tooltip layer
+    - `overflow: visible` on the relevant host/container
 - Impact:
-  - Clipped help text, especially on narrow mobile viewports.
+  - Integrators can see the help icon hover as "broken" even though the app is not misusing the component.
+  - This creates a false impression that the host app needs to supply tooltip-layout CSS.
 - Request:
-  - Add built-in collision handling with auto placement adjustment and viewport clamp.
-  - Suggested API:
-    - `placement="auto|left|right|top|bottom"`
-    - default should be `auto`
-- Integration-proven behavior:
-  - Measure both left/right candidates.
-  - Choose the smaller overflow score.
-  - Clamp width to viewport.
-  - Re-measure and shift horizontally if needed.
-  - Re-run on resize and during active hover/focus states.
+  - Treat the minimum positioning/visibility CSS as part of the public `lht-help-tooltip` contract.
+  - Do not consider tooltip support complete based on placement logic alone.
+  - Verify that a plain `<lht-help-tooltip>` works correctly in isolation without app-specific tooltip CSS.
 
-### 2-2. Pre-upgrade content flash should be prevented centrally
+### 1-2. `lht-help-tooltip` needs regression coverage for the complete contract
 
 - Observed:
-  - Before custom elements upgrade, raw tooltip/help content can flash into the layout.
-- Impact:
-  - Initial render looks broken or unstable.
+  - Existing tests cover fallback rendering, `placement="auto"`, and Escape hide behavior.
+  - They do not clearly prove that the component is self-contained from a CSS/layout point of view.
 - Request:
-  - Add a default pre-upgrade guard in `lht-cmn/css/components.css`.
-  - Standardize an initialization-state contract such as `data-initialized="true"`.
+  - Add regression coverage that checks the complete tooltip contract, not only JS logic.
+  - Minimum expectation:
+    - the tooltip host/group has the positioning needed for anchoring
+    - hover/focus state can reveal the tooltip without relying on app CSS
+    - base tooltip styling is bundled in `lht-cmn`
 
-### 2-3. `lht-file-select`: event ownership should be explicit
+## 2. Open cross-cutting test request
+
+### 2-1. Add a clearer two-mode regression matrix
 
 - Observed:
-  - `lht-file-select` internally calls `input.click()` from the trigger button.
-  - Host code may also bind to the same button ID, which creates ownership ambiguity.
-- Impact:
-  - Double-open risk and integration complexity.
-- Request:
-  - Provide an explicit event contract, for example:
-    - `lht-file-select:before-open`
-    - `lht-file-select:change`
-  - Or provide `auto-open="false"` so the host can take over safely.
-
-### 2-4. `lht-error-alert` should support `warning` and `info`
-
-- Observed:
-  - Real apps often need `error`, `warning`, and `info` levels.
-  - Current behavior is effectively error-only.
-- Request:
-  - Add `variant="error|warning|info"`.
-  - Align `role` / `aria-live` behavior with each variant's semantics.
-
-### 2-5. `lht-switch-help` should not depend on app-side `md-switch` availability
-
-- Observed:
-  - Current implementation branches on whether `customElements.get("md-switch")` is already defined.
-  - This means appearance and behavior depend on external load conditions.
-- Request:
-  - Make `lht-switch-help` self-contained.
-  - Choose one explicit model:
-    - `lht-cmn` internally guarantees `md-switch`
-    - `lht-switch-help` uses a self-owned implementation/fallback contract
-- Additional note:
-  - If fallback is used, its DOM contract should be documented.
-  - In the current integration, the fallback needed the `input.md-switch-input + span.md-switch` structure to match existing CSS behavior.
-
-## 3. Documentation and test requests
-
-### 3-1. Add an explicit integration contract section to README
-
-- README should clearly define:
-  - which IDs are app-provided vs internally generated
-  - which methods/events are public APIs
-  - initialization lifecycle guarantees
-  - safe CSS extension points
-
-### 3-2. Document fallback policy and parity per component
-
-- Request:
-  - Add a compact table covering at least:
-    - `lht-select-help`
-    - `lht-text-field-help`
-    - `lht-switch-help`
-    - `lht-file-select`
-- For each component, document:
-  - whether fallback exists
-  - fallback element type
-  - guaranteed parity
-    - `value`
-    - `input/change` events
-    - `required/disabled`
-    - `min/max/step/rows`
-    - class propagation
-
-### 3-3. Clarify `lht-select-help` declarative JSON options lifecycle
-
-- Observed:
-  - `lht-select-help` supports declarative JSON via:
-    - `<script type="application/json" slot="options">[...]</script>`
-  - During integration, an edge case caused blank dropdowns when declarative options handling and observer behavior interacted badly.
-- Request:
-  - Document:
-    - when JSON is parsed
-    - whether the `script[slot="options"]` node is consumed/removed
-    - when legacy child `<option>` fallback is considered
-    - whether observer-based re-sync runs after declarative init
-  - Add a simple DO / DON'T example:
-    - DO: use JSON declarative options as the primary static format
-    - DON'T: mix declarative JSON and manual child mutation unless a supported refresh API exists
-
-### 3-4. Provide an official dynamic-options pattern for `lht-select-help`
-
-- Observed:
-  - Some selects are static and fit JSON well.
-  - Others are populated dynamically by app code.
-- Request:
-  - Provide one official pattern:
-    - `setOptions([...])`, or
-    - a documented clear/append/notify sequence
-  - Also document selected-value retention when options are replaced.
-
-### 3-5. Add regression tests for both dependency modes
-
-- Request:
-  - Add CI/test coverage for both:
+  - New component tests exist and several fallback cases are covered.
+  - But the test story is still not a clear matrix of:
     - Material loaded
     - Material not loaded
-  - Verify that `lht-*` still provides minimum guaranteed behavior in both modes.
-
-## 4. Confirmed implementation notes worth preserving
-
-These are not all top-level feature requests. They are implementation details that proved important during integration and are easy to regress in future syncs.
-
-### 4-1. `LhtSelectHelp.connectedCallback()` must preserve declarative-options detection
-
-- Important detail:
-  - Evaluate declarative-options existence before consuming/removing the JSON script node.
-- Example shape:
-  - `const hasDeclarativeOptions = this._hasDeclarativeOptions();`
-- Reason:
-  - Re-checking after script consumption can misclassify the component as non-declarative and trigger unwanted re-hydration behavior.
-
-### 4-2. `LhtTextFieldHelp` fallback should be treated as a supported feature
-
-- Current status:
-  - Native fallback (`input` / `textarea`) is already present and solved a real integration issue.
+  - for each critical `lht-*` component.
 - Request:
-  - Keep it documented and covered by regression tests.
-
-### 4-3. `LhtSwitchHelp` fallback structure matters
-
-- Important detail:
-  - If fallback styling relies on existing CSS contracts, the fallback DOM shape must remain compatible.
-- In this integration:
-  - `input.md-switch-input + span.md-switch` was needed to preserve the expected switch appearance.
+  - Add an explicit regression matrix, or an equally clear equivalent structure, for critical components.
+  - The main goal is to make self-contained guarantees easy to verify and hard to regress.
 
 ## Suggested priority order
 
-1. Establish the self-contained `lht-*` design contract.
-2. Fix `lht-help-tooltip` collision handling and pre-upgrade flash.
-3. Clarify `lht-select-help` JSON/dynamic options contract.
-4. Clarify `lht-file-select` ownership and add `lht-error-alert` variants.
-5. Add README integration/fallback contract and dual-mode regression tests.
+1. Finish the `lht-help-tooltip` self-contained contract, including bundled base CSS.
+2. Add regression coverage that validates the full tooltip contract.
+3. Strengthen the two-mode regression matrix for critical `lht-*` components.

--- a/docs/spec/LHT_CMN_FEEDBACK_STATUS.md
+++ b/docs/spec/LHT_CMN_FEEDBACK_STATUS.md
@@ -18,7 +18,8 @@ Status labels used in this file:
 |---|---|---|
 | `lht-*` must be self-contained from the app's point of view | Reflected | README now states `lht-*` is self-contained and app code should not manage `md-*` registration. See [README.md](/Users/igapyon/Documents/git/mikuscore/lht-cmn/README.md):22 and [README.md](/Users/igapyon/Documents/git/mikuscore/lht-cmn/README.md):89 |
 | Apply the self-contained rule across all components | Reflected | Policy is documented, and `help-tooltip`, `command-block`, `file-select`, `switch-help`, `text-field-help` now have fallbacks. The chosen implementation path is fallback-oriented rather than internal `md-*` registration. See [components.js](/Users/igapyon/Documents/git/mikuscore/lht-cmn/js/components.js):23, [components.js](/Users/igapyon/Documents/git/mikuscore/lht-cmn/js/components.js):217, [components.js](/Users/igapyon/Documents/git/mikuscore/lht-cmn/js/components.js):322, [components.js](/Users/igapyon/Documents/git/mikuscore/lht-cmn/js/components.js):1030, [components.js](/Users/igapyon/Documents/git/mikuscore/lht-cmn/js/components.js):1132, [components.js](/Users/igapyon/Documents/git/mikuscore/lht-cmn/js/components.js):1239 |
-| `lht-help-tooltip`: built-in viewport collision handling | Reflected | `placement="auto|left|right|top|bottom"` and runtime positioning logic were added. See [components.js](/Users/igapyon/Documents/git/mikuscore/lht-cmn/js/components.js):16 and [README.md](/Users/igapyon/Documents/git/mikuscore/lht-cmn/README.md):183 |
+| `lht-help-tooltip`: built-in viewport collision handling | Partially reflected | `placement="auto|left|right|top|bottom"` and runtime positioning logic were added, but a later integration regression showed that the component still lacked some self-owned base positioning CSS (`md-tooltip-group` / `md-tooltip` anchoring), so hover behavior could break even when app-side usage was correct. See [components.js](/Users/igapyon/Documents/git/mikuscore/lht-cmn/js/components.js):16, [README.md](/Users/igapyon/Documents/git/mikuscore/lht-cmn/README.md):183, and [components.css](/Users/igapyon/Documents/git/mikuscore/lht-cmn/css/components.css):42 |
+| `lht-help-tooltip` should bundle the minimum base CSS needed for correct hover/positioning | Partially reflected | `lht-cmn` owns the tooltip behavior conceptually, but this was not fully true in practice until the `mikuscore` integration restored missing base CSS. This should be treated as part of the component contract and covered by regression tests. See [components.css](/Users/igapyon/Documents/git/mikuscore/lht-cmn/css/components.css):42 and [LHT_CMN_FEEDBACK.md](/Users/igapyon/Documents/git/mikuscore/docs/spec/LHT_CMN_FEEDBACK.md) |
 | Prevent pre-upgrade content flash centrally | Reflected | `components.css` now hides uninitialized `lht-*` until `data-initialized="true"`. See [components.css](/Users/igapyon/Documents/git/mikuscore/lht-cmn/css/components.css):13 and [README.md](/Users/igapyon/Documents/git/mikuscore/lht-cmn/README.md):101 |
 | `lht-file-select`: explicit event ownership | Reflected | `auto-open`, `lht-file-select:before-open`, and `lht-file-select:change` are implemented and documented. See [components.js](/Users/igapyon/Documents/git/mikuscore/lht-cmn/js/components.js):1022, [components.js](/Users/igapyon/Documents/git/mikuscore/lht-cmn/js/components.js):1075, and [README.md](/Users/igapyon/Documents/git/mikuscore/lht-cmn/README.md):256 |
 | `lht-error-alert`: support `warning` and `info` | Reflected | `variant` support and ARIA behavior are implemented and documented. See [components.js](/Users/igapyon/Documents/git/mikuscore/lht-cmn/js/components.js):727, [components.js](/Users/igapyon/Documents/git/mikuscore/lht-cmn/js/components.js):792, [components.css](/Users/igapyon/Documents/git/mikuscore/lht-cmn/css/components.css):382, and [README.md](/Users/igapyon/Documents/git/mikuscore/lht-cmn/README.md):296 |
@@ -39,7 +40,6 @@ Status labels used in this file:
 - Reflected:
   - self-contained contract in README
   - cross-component fallback-oriented self-contained direction
-  - tooltip collision handling
   - pre-upgrade flash prevention
   - file-select event ownership API
   - error-alert variants
@@ -48,6 +48,8 @@ Status labels used in this file:
   - fallback/parity documentation
   - preservation of important select/text-field/switch implementation details
 - Partially reflected:
+  - tooltip collision handling, because base positioning CSS completeness was still missing in real integration
+  - tooltip self-owned base CSS contract and its regression coverage
   - regression coverage as an explicit two-mode matrix
 - Intentionally not adopted for now:
   - internal `md-*` registration as the primary solution

--- a/lht-cmn/css/components.css
+++ b/lht-cmn/css/components.css
@@ -8,6 +8,8 @@
 lht-help-tooltip {
   display: inline-flex;
   align-items: center;
+  position: relative;
+  overflow: visible;
 }
 
 /*
@@ -38,6 +40,36 @@ lht-preview-output:not([data-initialized="true"]) {
 }
 
 /* Tooltip defaults are centralized in lht to avoid per-page overflow regressions. */
+lht-help-tooltip .md-tooltip-group {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  vertical-align: middle;
+  overflow: visible;
+}
+
+lht-help-tooltip .md-tooltip {
+  position: absolute;
+  left: 50%;
+  top: calc(100% + 0.5rem);
+  transform: translateX(-50%);
+  z-index: 240;
+  min-width: min(16rem, calc(100vw - 2rem));
+  padding: 0.7rem 0.85rem;
+  border-radius: 12px;
+  border: 1px solid rgba(111, 106, 121, 0.18);
+  background: rgba(36, 31, 43, 0.96);
+  color: #f7f4fb;
+  box-shadow: 0 12px 24px rgba(25, 18, 36, 0.22);
+  font-size: 0.85rem;
+  font-weight: 400;
+  letter-spacing: normal;
+  text-transform: none;
+  line-height: 1.45;
+  white-space: normal;
+}
+
 lht-help-tooltip .md-tooltip-content {
   display: none;
   max-width: min(24rem, calc(100vw - 2rem));


### PR DESCRIPTION
## 概要

`lht-cmn` 連携メモを整理し、すでに解決済みの項目を `LHT_CMN_FEEDBACK.md` から除去しました。 あわせて、`lht-help-tooltip` の hover 回帰を踏まえ、tooltip の自己完結性がまだ不十分であることを `FEEDBACK_STATUS` に反映し、`lht-cmn/css/components.css` 側で不足していた基礎スタイルを補いました。

## 変更内容

### 1. `LHT_CMN_FEEDBACK.md` を未解決事項だけに再編
- 解決済み・反映済みの要求を除去
- 現時点で open / partially-resolved な論点だけを残す構成に変更
- 主に以下へ絞り込み
  - `lht-help-tooltip` の自己完結性不足
  - tooltip 契約全体を担保する回帰テスト不足
  - Material あり/なしの回帰マトリクス不足

### 2. `LHT_CMN_FEEDBACK_STATUS.md` を実態に合わせて更新
- `lht-help-tooltip` の viewport collision handling を `Reflected` から `Partially reflected` へ修正
- 「runtime placement logic はあるが、base positioning CSS が不足していた」点を追記
- `lht-help-tooltip` が最低限の hover / positioning 用 CSS を自前で持つべき、という項目を追加
- Summary も同じ整理に合わせて更新

### 3. `lht-cmn/css/components.css` に tooltip の基礎スタイルを追加
- `lht-help-tooltip` ホストに:
  - `position: relative`
  - `overflow: visible`
- `.md-tooltip-group` に:
  - `position: relative`
  - `display: inline-flex`
  - `overflow: visible`
- `.md-tooltip` に:
  - 絶対配置
  - z-index
  - 幅・余白・背景・枠線・影
  - 本文向けの `font-size` / `font-weight` / `line-height`
- これにより、アプリ側が特別な tooltip CSS を持たなくても、`<lht-help-tooltip>` 単体で hover 表示が成立する状態へ寄せています

## 背景

`mikuscore` で help icon の hover 挙動が壊れた調査の結果、原因はアプリ側の使い方ではなく、`lht-help-tooltip` が必要な基礎 CSS を `lht-cmn` 自身で十分に持っていなかったことでした。 今回の更新では、その事実をドキュメント上も明示し、実装側でも最低限の土台スタイルを補っています。

## 期待する効果

- `LHT_CMN_FEEDBACK.md` が「未解決課題の一覧」として読みやすくなる
- 反映済み/未反映の境界が `LHT_CMN_FEEDBACK_STATUS.md` で明確になる
- `lht-help-tooltip` がより自己完結した部品に近づき、アプリ側の誤診や回帰を減らせる

## 影響範囲

- `docs/spec/LHT_CMN_FEEDBACK.md`
- `docs/spec/LHT_CMN_FEEDBACK_STATUS.md`
- `lht-cmn/css/components.css`

## テスト / 確認

- tooltip 回帰の原因調査結果をもとに CSS を補強
- `mikuscore` 側では app-specific tooltip CSS なしでも hover 表示が成立する前提へ修正
- 今後は `lht-help-tooltip` 単体での自己完結性を検証する回帰テスト追加が望ましい