### PR TITLE
Playback の dense score 安定化と軽量化ルールの追加

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -125,6 +125,12 @@
   - optionally drop/merge ultra-short or duplicate-nearby notes for stability-first playback.
   - allow omitting ornaments/grace in lightweight mode with explicit UI toggle and policy.
   - define quality vs stability presets and default behavior for large scores.
+  - Note (2026-03-08): current quick-playback stabilization keeps small same-onset groups intact, prefers outer voices plus non-octave-duplicate notes, and only reduces dense onsets / total event budget after a large-event threshold. Revisit thresholds and UI exposure after more real-score validation.
+  - Note (2026-03-08): if dense-score playback still fails after schedule compaction, the next suspect is browser-side Web Audio node saturation rather than JS scheduling cost; WASM is unlikely to solve that part directly.
+- [ ] Investigation: profile load-time hotspots before considering WASM for import/load acceleration:
+  - Note (2026-03-08): current measurements suggest `normalizeImportedMusicXmlText(...)` and render-side DOM clone / serialize preparation are larger load costs than representative small MIDI->MusicXML conversion.
+  - Separate "pure compute" candidates (possible WASM target) from DOM/render pipeline costs (likely better solved by reducing clone/serialize work or changing render/update strategy).
+  - Re-measure with larger local MIDI / MuseScore fixtures before making any WASM decision for load paths.
 - [ ] Decide whether to reintroduce `insert_note_after` in UI.
 - [ ] Reconfirm in-session `xml:id` strategy and operation rules.
 - [ ] Add chord editing support in core/editor commands (currently chord targets are read/play only in MVP).

--- a/mikuscore.html
+++ b/mikuscore.html
@@ -16772,10 +16772,15 @@ exports.replaceMeasureInMainDocument = replaceMeasureInMainDocument;
   "src/ts/playback-flow.js": function (require, module, exports) {
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.startMeasurePlayback = exports.startPlayback = exports.stopPlayback = exports.createBasicWaveSynthEngine = exports.PLAYBACK_TICKS_PER_QUARTER = void 0;
+exports.startMeasurePlayback = exports.startPlayback = exports.stopPlayback = exports.createBasicWaveSynthEngine = exports.compactSynthScheduleForPlayback = exports.PLAYBACK_TICKS_PER_QUARTER = void 0;
 const midi_io_1 = require("./midi-io");
 const musicxml_io_1 = require("./musicxml-io");
 exports.PLAYBACK_TICKS_PER_QUARTER = 480;
+const DENSE_PLAYBACK_EVENT_THRESHOLD = 2048;
+const DENSE_PLAYBACK_MAX_EVENTS = 4096;
+const DENSE_PLAYBACK_MAX_EVENTS_PER_ONSET = 48;
+const DENSE_PLAYBACK_MIN_EVENT_TICKS_DIVISOR = 64;
+const DENSE_PLAYBACK_PROTECTED_ONSET_SIZE = 8;
 const summarizeDiagnostics = (diagnostics) => {
     if (!diagnostics.length)
         return "unknown reason";
@@ -16801,6 +16806,153 @@ const normalizeWaveform = (value) => {
         return value;
     return "sine";
 };
+const compareScheduleEventsForRetention = (a, b) => {
+    var _a, _b;
+    if (b.ticks !== a.ticks)
+        return b.ticks - a.ticks;
+    if (a.channel === 10 && b.channel !== 10)
+        return -1;
+    if (b.channel === 10 && a.channel !== 10)
+        return 1;
+    if (a.start !== b.start)
+        return a.start - b.start;
+    if (a.midiNumber !== b.midiNumber)
+        return b.midiNumber - a.midiNumber;
+    return ((_a = a.trackId) !== null && _a !== void 0 ? _a : "").localeCompare((_b = b.trackId) !== null && _b !== void 0 ? _b : "");
+};
+const prioritizeOnsetGroupForRetention = (group) => {
+    var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k;
+    const sortedByMidi = group.slice().sort((a, b) => a.midiNumber === b.midiNumber ? compareScheduleEventsForRetention(a, b) : a.midiNumber - b.midiNumber);
+    const lowestMidi = (_b = (_a = sortedByMidi[0]) === null || _a === void 0 ? void 0 : _a.midiNumber) !== null && _b !== void 0 ? _b : 0;
+    const highestMidi = (_d = (_c = sortedByMidi[sortedByMidi.length - 1]) === null || _c === void 0 ? void 0 : _c.midiNumber) !== null && _d !== void 0 ? _d : 0;
+    const byPitchClass = new Map();
+    for (const event of sortedByMidi) {
+        const pitchClass = ((event.midiNumber % 12) + 12) % 12;
+        const bucket = (_e = byPitchClass.get(pitchClass)) !== null && _e !== void 0 ? _e : [];
+        bucket.push(event);
+        byPitchClass.set(pitchClass, bucket);
+    }
+    const anchors = [];
+    const uniquePitchClasses = [];
+    const octaveOuter = [];
+    const octaveInner = [];
+    for (const event of sortedByMidi) {
+        if (event.midiNumber === lowestMidi || event.midiNumber === highestMidi) {
+            anchors.push(event);
+            continue;
+        }
+        const pitchClass = ((event.midiNumber % 12) + 12) % 12;
+        const bucket = (_f = byPitchClass.get(pitchClass)) !== null && _f !== void 0 ? _f : [];
+        if (bucket.length <= 1) {
+            uniquePitchClasses.push(event);
+            continue;
+        }
+        const bucketLowest = (_h = (_g = bucket[0]) === null || _g === void 0 ? void 0 : _g.midiNumber) !== null && _h !== void 0 ? _h : event.midiNumber;
+        const bucketHighest = (_k = (_j = bucket[bucket.length - 1]) === null || _j === void 0 ? void 0 : _j.midiNumber) !== null && _k !== void 0 ? _k : event.midiNumber;
+        if (event.midiNumber === bucketLowest || event.midiNumber === bucketHighest) {
+            octaveOuter.push(event);
+        }
+        else {
+            octaveInner.push(event);
+        }
+    }
+    const sortBucket = (bucket) => bucket.slice().sort(compareScheduleEventsForRetention);
+    return [
+        ...sortBucket(anchors),
+        ...sortBucket(uniquePitchClasses),
+        ...sortBucket(octaveOuter),
+        ...sortBucket(octaveInner),
+    ];
+};
+const compactSynthScheduleForPlayback = (schedule, ticksPerQuarter) => {
+    var _a, _b;
+    const originalEventCount = Array.isArray(schedule.events) ? schedule.events.length : 0;
+    if (originalEventCount <= DENSE_PLAYBACK_EVENT_THRESHOLD) {
+        return {
+            schedule,
+            summary: {
+                applied: false,
+                originalEventCount,
+                finalEventCount: originalEventCount,
+                droppedUltraShortCount: 0,
+                droppedDenseOnsetCount: 0,
+                droppedBudgetCount: 0,
+            },
+        };
+    }
+    const minDenseEventTicks = Math.max(1, Math.round(ticksPerQuarter / DENSE_PLAYBACK_MIN_EVENT_TICKS_DIVISOR));
+    const keptAfterShortFilter = [];
+    let droppedUltraShortCount = 0;
+    for (const event of schedule.events) {
+        if (((_a = event.ticks) !== null && _a !== void 0 ? _a : 0) < minDenseEventTicks) {
+            droppedUltraShortCount += 1;
+            continue;
+        }
+        keptAfterShortFilter.push(event);
+    }
+    const byOnset = new Map();
+    for (const event of keptAfterShortFilter) {
+        const group = (_b = byOnset.get(event.start)) !== null && _b !== void 0 ? _b : [];
+        group.push(event);
+        byOnset.set(event.start, group);
+    }
+    const orderedOnsets = Array.from(byOnset.keys()).sort((a, b) => a - b);
+    const onsetGroups = orderedOnsets.map((start) => {
+        var _a;
+        const retained = prioritizeOnsetGroupForRetention((_a = byOnset.get(start)) !== null && _a !== void 0 ? _a : []);
+        return retained.slice(0, DENSE_PLAYBACK_MAX_EVENTS_PER_ONSET);
+    });
+    const denseLimitedEvents = [];
+    for (const group of onsetGroups) {
+        denseLimitedEvents.push(...group);
+    }
+    const droppedDenseOnsetCount = keptAfterShortFilter.length - denseLimitedEvents.length;
+    let finalEvents = denseLimitedEvents;
+    let droppedBudgetCount = 0;
+    if (denseLimitedEvents.length > DENSE_PLAYBACK_MAX_EVENTS) {
+        const protectedGroups = onsetGroups.filter((group) => group.length <= DENSE_PLAYBACK_PROTECTED_ONSET_SIZE);
+        const reducibleGroups = onsetGroups
+            .filter((group) => group.length > DENSE_PLAYBACK_PROTECTED_ONSET_SIZE)
+            .map((group) => group.slice());
+        const retained = [];
+        for (const group of protectedGroups) {
+            retained.push(...group);
+        }
+        if (retained.length < DENSE_PLAYBACK_MAX_EVENTS) {
+            const rounds = reducibleGroups.reduce((max, group) => Math.max(max, group.length), 0);
+            for (let round = 0; round < rounds && retained.length < DENSE_PLAYBACK_MAX_EVENTS; round += 1) {
+                for (const group of reducibleGroups) {
+                    const event = group[round];
+                    if (!event)
+                        continue;
+                    retained.push(event);
+                    if (retained.length >= DENSE_PLAYBACK_MAX_EVENTS)
+                        break;
+                }
+            }
+        }
+        if (retained.length > DENSE_PLAYBACK_MAX_EVENTS) {
+            retained.length = DENSE_PLAYBACK_MAX_EVENTS;
+        }
+        finalEvents = retained.sort((a, b) => a.start === b.start ? a.midiNumber - b.midiNumber : a.start - b.start);
+        droppedBudgetCount = denseLimitedEvents.length - finalEvents.length;
+    }
+    return {
+        schedule: {
+            ...schedule,
+            events: finalEvents,
+        },
+        summary: {
+            applied: true,
+            originalEventCount,
+            finalEventCount: finalEvents.length,
+            droppedUltraShortCount,
+            droppedDenseOnsetCount,
+            droppedBudgetCount,
+        },
+    };
+};
+exports.compactSynthScheduleForPlayback = compactSynthScheduleForPlayback;
 const createBasicWaveSynthEngine = (options) => {
     const ticksPerQuarter = Number.isFinite(options.ticksPerQuarter)
         ? Math.max(1, Math.round(options.ticksPerQuarter))
@@ -16941,10 +17093,12 @@ const createBasicWaveSynthEngine = (options) => {
         }
         const runningContext = await ensureAudioContextRunning();
         stop();
+        const compacted = (0, exports.compactSynthScheduleForPlayback)(schedule, ticksPerQuarter);
+        const effectiveSchedule = compacted.schedule;
         const normalizedWaveform = normalizeWaveform(waveform);
-        const normalizedTempoEvents = (((_a = schedule.tempoEvents) === null || _a === void 0 ? void 0 : _a.length)
-            ? schedule.tempoEvents
-            : [{ startTick: 0, bpm: Math.max(1, Number(schedule.tempo) || 120) }])
+        const normalizedTempoEvents = (((_a = effectiveSchedule.tempoEvents) === null || _a === void 0 ? void 0 : _a.length)
+            ? effectiveSchedule.tempoEvents
+            : [{ startTick: 0, bpm: Math.max(1, Number(effectiveSchedule.tempo) || 120) }])
             .map((event) => ({
             startTick: Math.max(0, Math.round(event.startTick)),
             bpm: Math.max(1, Math.round(event.bpm || 120)),
@@ -16961,7 +17115,7 @@ const createBasicWaveSynthEngine = (options) => {
             }
         }
         if (!mergedTempoEvents.length || mergedTempoEvents[0].startTick !== 0) {
-            mergedTempoEvents.unshift({ startTick: 0, bpm: Math.max(1, Number(schedule.tempo) || 120) });
+            mergedTempoEvents.unshift({ startTick: 0, bpm: Math.max(1, Number(effectiveSchedule.tempo) || 120) });
         }
         const tickToSeconds = (targetTick) => {
             var _a, _b;
@@ -16986,7 +17140,7 @@ const createBasicWaveSynthEngine = (options) => {
         };
         const baseTime = runningContext.currentTime + 0.04;
         let latestEndTime = baseTime;
-        const pedalRanges = ((_b = schedule.pedalRanges) !== null && _b !== void 0 ? _b : []).map((range) => ({
+        const pedalRanges = ((_b = effectiveSchedule.pedalRanges) !== null && _b !== void 0 ? _b : []).map((range) => ({
             channel: Math.max(1, Math.min(16, Math.round(range.channel || 1))),
             startTick: Math.max(0, Math.round(range.startTick)),
             endTick: Math.max(0, Math.round(range.endTick)),
@@ -16995,7 +17149,7 @@ const createBasicWaveSynthEngine = (options) => {
             return pedalRanges.some((range) => range.channel === channel && tick >= range.startTick && tick < range.endTick);
         };
         const laneStarts = new Map();
-        for (const event of schedule.events) {
+        for (const event of effectiveSchedule.events) {
             const laneKey = `${event.channel}|${(_c = event.trackId) !== null && _c !== void 0 ? _c : ""}`;
             const starts = (_d = laneStarts.get(laneKey)) !== null && _d !== void 0 ? _d : [];
             starts.push(event.start);
@@ -17026,7 +17180,7 @@ const createBasicWaveSynthEngine = (options) => {
             return ans >= 0 ? ans : null;
         };
         const lastNoteByLane = new Map();
-        for (const event of schedule.events) {
+        for (const event of effectiveSchedule.events) {
             const laneKey = `${event.channel}|${(_e = event.trackId) !== null && _e !== void 0 ? _e : ""}`;
             const prevInLane = lastNoteByLane.get(laneKey);
             const legatoFromOverlap = ((_f = prevInLane === null || prevInLane === void 0 ? void 0 : prevInLane.startTick) !== null && _f !== void 0 ? _f : -1) < event.start && ((_g = prevInLane === null || prevInLane === void 0 ? void 0 : prevInLane.endTick) !== null && _g !== void 0 ? _g : -1) > event.start;

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -8736,10 +8736,15 @@ exports.replaceMeasureInMainDocument = replaceMeasureInMainDocument;
   "src/ts/playback-flow.js": function (require, module, exports) {
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.startMeasurePlayback = exports.startPlayback = exports.stopPlayback = exports.createBasicWaveSynthEngine = exports.PLAYBACK_TICKS_PER_QUARTER = void 0;
+exports.startMeasurePlayback = exports.startPlayback = exports.stopPlayback = exports.createBasicWaveSynthEngine = exports.compactSynthScheduleForPlayback = exports.PLAYBACK_TICKS_PER_QUARTER = void 0;
 const midi_io_1 = require("./midi-io");
 const musicxml_io_1 = require("./musicxml-io");
 exports.PLAYBACK_TICKS_PER_QUARTER = 480;
+const DENSE_PLAYBACK_EVENT_THRESHOLD = 2048;
+const DENSE_PLAYBACK_MAX_EVENTS = 4096;
+const DENSE_PLAYBACK_MAX_EVENTS_PER_ONSET = 48;
+const DENSE_PLAYBACK_MIN_EVENT_TICKS_DIVISOR = 64;
+const DENSE_PLAYBACK_PROTECTED_ONSET_SIZE = 8;
 const summarizeDiagnostics = (diagnostics) => {
     if (!diagnostics.length)
         return "unknown reason";
@@ -8765,6 +8770,153 @@ const normalizeWaveform = (value) => {
         return value;
     return "sine";
 };
+const compareScheduleEventsForRetention = (a, b) => {
+    var _a, _b;
+    if (b.ticks !== a.ticks)
+        return b.ticks - a.ticks;
+    if (a.channel === 10 && b.channel !== 10)
+        return -1;
+    if (b.channel === 10 && a.channel !== 10)
+        return 1;
+    if (a.start !== b.start)
+        return a.start - b.start;
+    if (a.midiNumber !== b.midiNumber)
+        return b.midiNumber - a.midiNumber;
+    return ((_a = a.trackId) !== null && _a !== void 0 ? _a : "").localeCompare((_b = b.trackId) !== null && _b !== void 0 ? _b : "");
+};
+const prioritizeOnsetGroupForRetention = (group) => {
+    var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k;
+    const sortedByMidi = group.slice().sort((a, b) => a.midiNumber === b.midiNumber ? compareScheduleEventsForRetention(a, b) : a.midiNumber - b.midiNumber);
+    const lowestMidi = (_b = (_a = sortedByMidi[0]) === null || _a === void 0 ? void 0 : _a.midiNumber) !== null && _b !== void 0 ? _b : 0;
+    const highestMidi = (_d = (_c = sortedByMidi[sortedByMidi.length - 1]) === null || _c === void 0 ? void 0 : _c.midiNumber) !== null && _d !== void 0 ? _d : 0;
+    const byPitchClass = new Map();
+    for (const event of sortedByMidi) {
+        const pitchClass = ((event.midiNumber % 12) + 12) % 12;
+        const bucket = (_e = byPitchClass.get(pitchClass)) !== null && _e !== void 0 ? _e : [];
+        bucket.push(event);
+        byPitchClass.set(pitchClass, bucket);
+    }
+    const anchors = [];
+    const uniquePitchClasses = [];
+    const octaveOuter = [];
+    const octaveInner = [];
+    for (const event of sortedByMidi) {
+        if (event.midiNumber === lowestMidi || event.midiNumber === highestMidi) {
+            anchors.push(event);
+            continue;
+        }
+        const pitchClass = ((event.midiNumber % 12) + 12) % 12;
+        const bucket = (_f = byPitchClass.get(pitchClass)) !== null && _f !== void 0 ? _f : [];
+        if (bucket.length <= 1) {
+            uniquePitchClasses.push(event);
+            continue;
+        }
+        const bucketLowest = (_h = (_g = bucket[0]) === null || _g === void 0 ? void 0 : _g.midiNumber) !== null && _h !== void 0 ? _h : event.midiNumber;
+        const bucketHighest = (_k = (_j = bucket[bucket.length - 1]) === null || _j === void 0 ? void 0 : _j.midiNumber) !== null && _k !== void 0 ? _k : event.midiNumber;
+        if (event.midiNumber === bucketLowest || event.midiNumber === bucketHighest) {
+            octaveOuter.push(event);
+        }
+        else {
+            octaveInner.push(event);
+        }
+    }
+    const sortBucket = (bucket) => bucket.slice().sort(compareScheduleEventsForRetention);
+    return [
+        ...sortBucket(anchors),
+        ...sortBucket(uniquePitchClasses),
+        ...sortBucket(octaveOuter),
+        ...sortBucket(octaveInner),
+    ];
+};
+const compactSynthScheduleForPlayback = (schedule, ticksPerQuarter) => {
+    var _a, _b;
+    const originalEventCount = Array.isArray(schedule.events) ? schedule.events.length : 0;
+    if (originalEventCount <= DENSE_PLAYBACK_EVENT_THRESHOLD) {
+        return {
+            schedule,
+            summary: {
+                applied: false,
+                originalEventCount,
+                finalEventCount: originalEventCount,
+                droppedUltraShortCount: 0,
+                droppedDenseOnsetCount: 0,
+                droppedBudgetCount: 0,
+            },
+        };
+    }
+    const minDenseEventTicks = Math.max(1, Math.round(ticksPerQuarter / DENSE_PLAYBACK_MIN_EVENT_TICKS_DIVISOR));
+    const keptAfterShortFilter = [];
+    let droppedUltraShortCount = 0;
+    for (const event of schedule.events) {
+        if (((_a = event.ticks) !== null && _a !== void 0 ? _a : 0) < minDenseEventTicks) {
+            droppedUltraShortCount += 1;
+            continue;
+        }
+        keptAfterShortFilter.push(event);
+    }
+    const byOnset = new Map();
+    for (const event of keptAfterShortFilter) {
+        const group = (_b = byOnset.get(event.start)) !== null && _b !== void 0 ? _b : [];
+        group.push(event);
+        byOnset.set(event.start, group);
+    }
+    const orderedOnsets = Array.from(byOnset.keys()).sort((a, b) => a - b);
+    const onsetGroups = orderedOnsets.map((start) => {
+        var _a;
+        const retained = prioritizeOnsetGroupForRetention((_a = byOnset.get(start)) !== null && _a !== void 0 ? _a : []);
+        return retained.slice(0, DENSE_PLAYBACK_MAX_EVENTS_PER_ONSET);
+    });
+    const denseLimitedEvents = [];
+    for (const group of onsetGroups) {
+        denseLimitedEvents.push(...group);
+    }
+    const droppedDenseOnsetCount = keptAfterShortFilter.length - denseLimitedEvents.length;
+    let finalEvents = denseLimitedEvents;
+    let droppedBudgetCount = 0;
+    if (denseLimitedEvents.length > DENSE_PLAYBACK_MAX_EVENTS) {
+        const protectedGroups = onsetGroups.filter((group) => group.length <= DENSE_PLAYBACK_PROTECTED_ONSET_SIZE);
+        const reducibleGroups = onsetGroups
+            .filter((group) => group.length > DENSE_PLAYBACK_PROTECTED_ONSET_SIZE)
+            .map((group) => group.slice());
+        const retained = [];
+        for (const group of protectedGroups) {
+            retained.push(...group);
+        }
+        if (retained.length < DENSE_PLAYBACK_MAX_EVENTS) {
+            const rounds = reducibleGroups.reduce((max, group) => Math.max(max, group.length), 0);
+            for (let round = 0; round < rounds && retained.length < DENSE_PLAYBACK_MAX_EVENTS; round += 1) {
+                for (const group of reducibleGroups) {
+                    const event = group[round];
+                    if (!event)
+                        continue;
+                    retained.push(event);
+                    if (retained.length >= DENSE_PLAYBACK_MAX_EVENTS)
+                        break;
+                }
+            }
+        }
+        if (retained.length > DENSE_PLAYBACK_MAX_EVENTS) {
+            retained.length = DENSE_PLAYBACK_MAX_EVENTS;
+        }
+        finalEvents = retained.sort((a, b) => a.start === b.start ? a.midiNumber - b.midiNumber : a.start - b.start);
+        droppedBudgetCount = denseLimitedEvents.length - finalEvents.length;
+    }
+    return {
+        schedule: {
+            ...schedule,
+            events: finalEvents,
+        },
+        summary: {
+            applied: true,
+            originalEventCount,
+            finalEventCount: finalEvents.length,
+            droppedUltraShortCount,
+            droppedDenseOnsetCount,
+            droppedBudgetCount,
+        },
+    };
+};
+exports.compactSynthScheduleForPlayback = compactSynthScheduleForPlayback;
 const createBasicWaveSynthEngine = (options) => {
     const ticksPerQuarter = Number.isFinite(options.ticksPerQuarter)
         ? Math.max(1, Math.round(options.ticksPerQuarter))
@@ -8905,10 +9057,12 @@ const createBasicWaveSynthEngine = (options) => {
         }
         const runningContext = await ensureAudioContextRunning();
         stop();
+        const compacted = (0, exports.compactSynthScheduleForPlayback)(schedule, ticksPerQuarter);
+        const effectiveSchedule = compacted.schedule;
         const normalizedWaveform = normalizeWaveform(waveform);
-        const normalizedTempoEvents = (((_a = schedule.tempoEvents) === null || _a === void 0 ? void 0 : _a.length)
-            ? schedule.tempoEvents
-            : [{ startTick: 0, bpm: Math.max(1, Number(schedule.tempo) || 120) }])
+        const normalizedTempoEvents = (((_a = effectiveSchedule.tempoEvents) === null || _a === void 0 ? void 0 : _a.length)
+            ? effectiveSchedule.tempoEvents
+            : [{ startTick: 0, bpm: Math.max(1, Number(effectiveSchedule.tempo) || 120) }])
             .map((event) => ({
             startTick: Math.max(0, Math.round(event.startTick)),
             bpm: Math.max(1, Math.round(event.bpm || 120)),
@@ -8925,7 +9079,7 @@ const createBasicWaveSynthEngine = (options) => {
             }
         }
         if (!mergedTempoEvents.length || mergedTempoEvents[0].startTick !== 0) {
-            mergedTempoEvents.unshift({ startTick: 0, bpm: Math.max(1, Number(schedule.tempo) || 120) });
+            mergedTempoEvents.unshift({ startTick: 0, bpm: Math.max(1, Number(effectiveSchedule.tempo) || 120) });
         }
         const tickToSeconds = (targetTick) => {
             var _a, _b;
@@ -8950,7 +9104,7 @@ const createBasicWaveSynthEngine = (options) => {
         };
         const baseTime = runningContext.currentTime + 0.04;
         let latestEndTime = baseTime;
-        const pedalRanges = ((_b = schedule.pedalRanges) !== null && _b !== void 0 ? _b : []).map((range) => ({
+        const pedalRanges = ((_b = effectiveSchedule.pedalRanges) !== null && _b !== void 0 ? _b : []).map((range) => ({
             channel: Math.max(1, Math.min(16, Math.round(range.channel || 1))),
             startTick: Math.max(0, Math.round(range.startTick)),
             endTick: Math.max(0, Math.round(range.endTick)),
@@ -8959,7 +9113,7 @@ const createBasicWaveSynthEngine = (options) => {
             return pedalRanges.some((range) => range.channel === channel && tick >= range.startTick && tick < range.endTick);
         };
         const laneStarts = new Map();
-        for (const event of schedule.events) {
+        for (const event of effectiveSchedule.events) {
             const laneKey = `${event.channel}|${(_c = event.trackId) !== null && _c !== void 0 ? _c : ""}`;
             const starts = (_d = laneStarts.get(laneKey)) !== null && _d !== void 0 ? _d : [];
             starts.push(event.start);
@@ -8990,7 +9144,7 @@ const createBasicWaveSynthEngine = (options) => {
             return ans >= 0 ? ans : null;
         };
         const lastNoteByLane = new Map();
-        for (const event of schedule.events) {
+        for (const event of effectiveSchedule.events) {
             const laneKey = `${event.channel}|${(_e = event.trackId) !== null && _e !== void 0 ? _e : ""}`;
             const prevInLane = lastNoteByLane.get(laneKey);
             const legatoFromOverlap = ((_f = prevInLane === null || prevInLane === void 0 ? void 0 : prevInLane.startTick) !== null && _f !== void 0 ? _f : -1) < event.start && ((_g = prevInLane === null || prevInLane === void 0 ? void 0 : prevInLane.endTick) !== null && _g !== void 0 ? _g : -1) > event.start;

--- a/src/ts/playback-flow.ts
+++ b/src/ts/playback-flow.ts
@@ -38,6 +38,11 @@ export type BasicWaveSynthEngine = {
 };
 
 export const PLAYBACK_TICKS_PER_QUARTER = 480;
+const DENSE_PLAYBACK_EVENT_THRESHOLD = 2048;
+const DENSE_PLAYBACK_MAX_EVENTS = 4096;
+const DENSE_PLAYBACK_MAX_EVENTS_PER_ONSET = 48;
+const DENSE_PLAYBACK_MIN_EVENT_TICKS_DIVISOR = 64;
+const DENSE_PLAYBACK_PROTECTED_ONSET_SIZE = 8;
 
 const summarizeDiagnostics = (diagnostics: Diagnostic[]): string => {
   if (!diagnostics.length) return "unknown reason";
@@ -63,6 +68,174 @@ const midiToHz = (midi: number): number => 440 * Math.pow(2, (midi - 69) / 12);
 const normalizeWaveform = (value: string): OscillatorType => {
   if (value === "square" || value === "triangle") return value;
   return "sine";
+};
+
+type LightweightPlaybackSummary = {
+  applied: boolean;
+  originalEventCount: number;
+  finalEventCount: number;
+  droppedUltraShortCount: number;
+  droppedDenseOnsetCount: number;
+  droppedBudgetCount: number;
+};
+
+const compareScheduleEventsForRetention = (
+  a: SynthSchedule["events"][number],
+  b: SynthSchedule["events"][number]
+): number => {
+  if (b.ticks !== a.ticks) return b.ticks - a.ticks;
+  if (a.channel === 10 && b.channel !== 10) return -1;
+  if (b.channel === 10 && a.channel !== 10) return 1;
+  if (a.start !== b.start) return a.start - b.start;
+  if (a.midiNumber !== b.midiNumber) return b.midiNumber - a.midiNumber;
+  return (a.trackId ?? "").localeCompare(b.trackId ?? "");
+};
+
+const prioritizeOnsetGroupForRetention = (
+  group: SynthSchedule["events"]
+): SynthSchedule["events"] => {
+  const sortedByMidi = group.slice().sort((a, b) =>
+    a.midiNumber === b.midiNumber ? compareScheduleEventsForRetention(a, b) : a.midiNumber - b.midiNumber
+  );
+  const lowestMidi = sortedByMidi[0]?.midiNumber ?? 0;
+  const highestMidi = sortedByMidi[sortedByMidi.length - 1]?.midiNumber ?? 0;
+  const byPitchClass = new Map<number, SynthSchedule["events"]>();
+  for (const event of sortedByMidi) {
+    const pitchClass = ((event.midiNumber % 12) + 12) % 12;
+    const bucket = byPitchClass.get(pitchClass) ?? [];
+    bucket.push(event);
+    byPitchClass.set(pitchClass, bucket);
+  }
+
+  const anchors: SynthSchedule["events"] = [];
+  const uniquePitchClasses: SynthSchedule["events"] = [];
+  const octaveOuter: SynthSchedule["events"] = [];
+  const octaveInner: SynthSchedule["events"] = [];
+
+  for (const event of sortedByMidi) {
+    if (event.midiNumber === lowestMidi || event.midiNumber === highestMidi) {
+      anchors.push(event);
+      continue;
+    }
+    const pitchClass = ((event.midiNumber % 12) + 12) % 12;
+    const bucket = byPitchClass.get(pitchClass) ?? [];
+    if (bucket.length <= 1) {
+      uniquePitchClasses.push(event);
+      continue;
+    }
+    const bucketLowest = bucket[0]?.midiNumber ?? event.midiNumber;
+    const bucketHighest = bucket[bucket.length - 1]?.midiNumber ?? event.midiNumber;
+    if (event.midiNumber === bucketLowest || event.midiNumber === bucketHighest) {
+      octaveOuter.push(event);
+    } else {
+      octaveInner.push(event);
+    }
+  }
+
+  const sortBucket = (bucket: SynthSchedule["events"]): SynthSchedule["events"] =>
+    bucket.slice().sort(compareScheduleEventsForRetention);
+
+  return [
+    ...sortBucket(anchors),
+    ...sortBucket(uniquePitchClasses),
+    ...sortBucket(octaveOuter),
+    ...sortBucket(octaveInner),
+  ];
+};
+
+export const compactSynthScheduleForPlayback = (
+  schedule: SynthSchedule,
+  ticksPerQuarter: number
+): { schedule: SynthSchedule; summary: LightweightPlaybackSummary } => {
+  const originalEventCount = Array.isArray(schedule.events) ? schedule.events.length : 0;
+  if (originalEventCount <= DENSE_PLAYBACK_EVENT_THRESHOLD) {
+    return {
+      schedule,
+      summary: {
+        applied: false,
+        originalEventCount,
+        finalEventCount: originalEventCount,
+        droppedUltraShortCount: 0,
+        droppedDenseOnsetCount: 0,
+        droppedBudgetCount: 0,
+      },
+    };
+  }
+
+  const minDenseEventTicks = Math.max(1, Math.round(ticksPerQuarter / DENSE_PLAYBACK_MIN_EVENT_TICKS_DIVISOR));
+  const keptAfterShortFilter: SynthSchedule["events"] = [];
+  let droppedUltraShortCount = 0;
+  for (const event of schedule.events) {
+    if ((event.ticks ?? 0) < minDenseEventTicks) {
+      droppedUltraShortCount += 1;
+      continue;
+    }
+    keptAfterShortFilter.push(event);
+  }
+
+  const byOnset = new Map<number, SynthSchedule["events"]>();
+  for (const event of keptAfterShortFilter) {
+    const group = byOnset.get(event.start) ?? [];
+    group.push(event);
+    byOnset.set(event.start, group);
+  }
+
+  const orderedOnsets = Array.from(byOnset.keys()).sort((a, b) => a - b);
+  const onsetGroups = orderedOnsets.map((start) => {
+    const retained = prioritizeOnsetGroupForRetention(byOnset.get(start) ?? []);
+    return retained.slice(0, DENSE_PLAYBACK_MAX_EVENTS_PER_ONSET);
+  });
+  const denseLimitedEvents: SynthSchedule["events"] = [];
+  for (const group of onsetGroups) {
+    denseLimitedEvents.push(...group);
+  }
+  const droppedDenseOnsetCount = keptAfterShortFilter.length - denseLimitedEvents.length;
+
+  let finalEvents = denseLimitedEvents;
+  let droppedBudgetCount = 0;
+  if (denseLimitedEvents.length > DENSE_PLAYBACK_MAX_EVENTS) {
+    const protectedGroups = onsetGroups.filter((group) => group.length <= DENSE_PLAYBACK_PROTECTED_ONSET_SIZE);
+    const reducibleGroups = onsetGroups
+      .filter((group) => group.length > DENSE_PLAYBACK_PROTECTED_ONSET_SIZE)
+      .map((group) => group.slice());
+    const retained: SynthSchedule["events"] = [];
+    for (const group of protectedGroups) {
+      retained.push(...group);
+    }
+    if (retained.length < DENSE_PLAYBACK_MAX_EVENTS) {
+      const rounds = reducibleGroups.reduce((max, group) => Math.max(max, group.length), 0);
+      for (let round = 0; round < rounds && retained.length < DENSE_PLAYBACK_MAX_EVENTS; round += 1) {
+        for (const group of reducibleGroups) {
+          const event = group[round];
+          if (!event) continue;
+          retained.push(event);
+          if (retained.length >= DENSE_PLAYBACK_MAX_EVENTS) break;
+        }
+      }
+    }
+    if (retained.length > DENSE_PLAYBACK_MAX_EVENTS) {
+      retained.length = DENSE_PLAYBACK_MAX_EVENTS;
+    }
+    finalEvents = retained.sort((a, b) =>
+      a.start === b.start ? a.midiNumber - b.midiNumber : a.start - b.start
+    );
+    droppedBudgetCount = denseLimitedEvents.length - finalEvents.length;
+  }
+
+  return {
+    schedule: {
+      ...schedule,
+      events: finalEvents,
+    },
+    summary: {
+      applied: true,
+      originalEventCount,
+      finalEventCount: finalEvents.length,
+      droppedUltraShortCount,
+      droppedDenseOnsetCount,
+      droppedBudgetCount,
+    },
+  };
 };
 
 export const createBasicWaveSynthEngine = (options: { ticksPerQuarter: number }): BasicWaveSynthEngine => {
@@ -219,11 +392,13 @@ export const createBasicWaveSynthEngine = (options: { ticksPerQuarter: number })
 
     const runningContext = await ensureAudioContextRunning();
     stop();
+    const compacted = compactSynthScheduleForPlayback(schedule, ticksPerQuarter);
+    const effectiveSchedule = compacted.schedule;
 
     const normalizedWaveform = normalizeWaveform(waveform);
-    const normalizedTempoEvents = (schedule.tempoEvents?.length
-      ? schedule.tempoEvents
-      : [{ startTick: 0, bpm: Math.max(1, Number(schedule.tempo) || 120) }]
+    const normalizedTempoEvents = (effectiveSchedule.tempoEvents?.length
+      ? effectiveSchedule.tempoEvents
+      : [{ startTick: 0, bpm: Math.max(1, Number(effectiveSchedule.tempo) || 120) }]
     )
       .map((event) => ({
         startTick: Math.max(0, Math.round(event.startTick)),
@@ -240,7 +415,7 @@ export const createBasicWaveSynthEngine = (options: { ticksPerQuarter: number })
       }
     }
     if (!mergedTempoEvents.length || mergedTempoEvents[0].startTick !== 0) {
-      mergedTempoEvents.unshift({ startTick: 0, bpm: Math.max(1, Number(schedule.tempo) || 120) });
+      mergedTempoEvents.unshift({ startTick: 0, bpm: Math.max(1, Number(effectiveSchedule.tempo) || 120) });
     }
     const tickToSeconds = (targetTick: number): number => {
       let seconds = 0;
@@ -261,7 +436,7 @@ export const createBasicWaveSynthEngine = (options: { ticksPerQuarter: number })
     };
     const baseTime = runningContext.currentTime + 0.04;
     let latestEndTime = baseTime;
-    const pedalRanges = (schedule.pedalRanges ?? []).map((range) => ({
+    const pedalRanges = (effectiveSchedule.pedalRanges ?? []).map((range) => ({
       channel: Math.max(1, Math.min(16, Math.round(range.channel || 1))),
       startTick: Math.max(0, Math.round(range.startTick)),
       endTick: Math.max(0, Math.round(range.endTick)),
@@ -270,7 +445,7 @@ export const createBasicWaveSynthEngine = (options: { ticksPerQuarter: number })
       return pedalRanges.some((range) => range.channel === channel && tick >= range.startTick && tick < range.endTick);
     };
     const laneStarts = new Map<string, number[]>();
-    for (const event of schedule.events) {
+    for (const event of effectiveSchedule.events) {
       const laneKey = `${event.channel}|${event.trackId ?? ""}`;
       const starts = laneStarts.get(laneKey) ?? [];
       starts.push(event.start);
@@ -299,7 +474,7 @@ export const createBasicWaveSynthEngine = (options: { ticksPerQuarter: number })
     };
     const lastNoteByLane = new Map<string, { startTick: number; endTick: number }>();
 
-    for (const event of schedule.events) {
+    for (const event of effectiveSchedule.events) {
       const laneKey = `${event.channel}|${event.trackId ?? ""}`;
       const prevInLane = lastNoteByLane.get(laneKey);
       const legatoFromOverlap =

--- a/tests/unit/playback-flow.spec.ts
+++ b/tests/unit/playback-flow.spec.ts
@@ -1,6 +1,10 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createBasicWaveSynthEngine, type SynthSchedule } from "../../src/ts/playback-flow";
+import {
+  compactSynthScheduleForPlayback,
+  createBasicWaveSynthEngine,
+  type SynthSchedule,
+} from "../../src/ts/playback-flow";
 
 type MutableWindow = Window & typeof globalThis & { webkitAudioContext?: typeof AudioContext };
 
@@ -196,5 +200,133 @@ describe("playback-flow midi-like scheduling", () => {
 
     expect(oscillators).toHaveLength(1);
     expect(oscillators[0].stop).toHaveBeenCalledWith(expect.closeTo(0.51, 6));
+  });
+
+  it("compacts dense schedules by capping notes per onset and overall event budget", () => {
+    const schedule: SynthSchedule = {
+      tempo: 120,
+      events: Array.from({ length: 120 }, (_, onset) =>
+        Array.from({ length: 60 }, (_, pitch) => ({
+          midiNumber: 30 + (pitch % 60),
+          start: onset * 10,
+          ticks: pitch < 10 ? 1 : 64 + (pitch % 3),
+          channel: 1,
+          trackId: `t${pitch}`,
+        }))
+      ).flat(),
+    };
+
+    const compacted = compactSynthScheduleForPlayback(schedule, 128);
+
+    expect(compacted.summary.applied).toBe(true);
+    expect(compacted.summary.originalEventCount).toBe(7200);
+    expect(compacted.summary.finalEventCount).toBeLessThanOrEqual(4096);
+    expect(compacted.summary.droppedUltraShortCount).toBe(1200);
+    expect(compacted.summary.droppedDenseOnsetCount).toBe(240);
+    expect(compacted.summary.droppedBudgetCount).toBeGreaterThan(0);
+    const countsByOnset = new Map<number, number>();
+    for (const event of compacted.schedule.events) {
+      countsByOnset.set(event.start, (countsByOnset.get(event.start) ?? 0) + 1);
+      expect(event.ticks).toBeGreaterThanOrEqual(2);
+    }
+    expect(Math.max(...countsByOnset.values())).toBeLessThanOrEqual(48);
+  });
+
+  it("uses compacted schedules before creating oscillators for dense playback", async () => {
+    const { context, oscillators } = createInspectableAudioContext();
+    mutableWindow.AudioContext = vi.fn(function MockAudioContext() {
+      return context as unknown as AudioContext;
+    }) as unknown as typeof AudioContext;
+    mutableWindow.webkitAudioContext = undefined;
+    const engine = createBasicWaveSynthEngine({ ticksPerQuarter: 128 });
+
+    const denseSchedule: SynthSchedule = {
+      tempo: 120,
+      events: Array.from({ length: 60 }, (_, onset) =>
+        Array.from({ length: 50 }, (_, pitch) => ({
+          midiNumber: 40 + (pitch % 40),
+          start: onset * 8,
+          ticks: 48,
+          channel: 1,
+          trackId: `part-${pitch}`,
+        }))
+      ).flat(),
+    };
+
+    await engine.playSchedule(denseSchedule, "sine");
+
+    expect(oscillators.length).toBe(2880);
+  });
+
+  it("keeps small same-onset chords intact even when dense playback compaction applies", () => {
+    const denseEvents = Array.from({ length: 90 }, (_, onset) =>
+      Array.from({ length: 48 }, (_, pitch) => ({
+        midiNumber: 20 + pitch,
+        start: onset * 12,
+        ticks: 48,
+        channel: 1,
+        trackId: `dense-${onset}-${pitch}`,
+      }))
+    ).flat();
+    const smallChordStarts = [9999, 10011, 10023];
+    const smallChordEvents = smallChordStarts.map((start, index) => ({
+      midiNumber: 72 + index,
+      start,
+      ticks: 48,
+      channel: 1,
+      trackId: `small-${index}`,
+    }));
+    const schedule: SynthSchedule = {
+      tempo: 120,
+      events: [...denseEvents, ...smallChordEvents],
+    };
+
+    const compacted = compactSynthScheduleForPlayback(schedule, 128);
+
+    expect(compacted.summary.applied).toBe(true);
+    for (const start of smallChordStarts) {
+      const keptAtStart = compacted.schedule.events.filter((event) => event.start === start);
+      expect(keptAtStart).toHaveLength(1);
+    }
+  });
+
+  it("prefers keeping outer voices and non-octave duplicates inside a dense onset", () => {
+    const wideOctaveCluster = Array.from({ length: 10 }, (_, octave) => ({
+      midiNumber: 24 + octave * 12,
+      start: 0,
+      ticks: 48,
+      channel: 1,
+      trackId: `oct-${octave}`,
+    }));
+    const uniqueUpper = Array.from({ length: 40 }, (_, i) => ({
+      midiNumber: 61 + i,
+      start: 0,
+      ticks: 48,
+      channel: 1,
+      trackId: `uniq-${i}`,
+    }));
+    const filler = Array.from({ length: 2100 }, (_, i) => ({
+      midiNumber: 30 + (i % 24),
+      start: 100 + i * 2,
+      ticks: 48,
+      channel: 1,
+      trackId: `fill-${i}`,
+    }));
+    const schedule: SynthSchedule = {
+      tempo: 120,
+      events: [...wideOctaveCluster, ...uniqueUpper, ...filler],
+    };
+
+    const compacted = compactSynthScheduleForPlayback(schedule, 128);
+    const keptAtZero = compacted.schedule.events.filter((event) => event.start === 0);
+    const keptMidis = keptAtZero.map((event) => event.midiNumber);
+
+    expect(keptAtZero).toHaveLength(48);
+    expect(keptMidis).toContain(24);
+    expect(keptMidis).toContain(132);
+    expect(keptMidis).toContain(61);
+    expect(keptMidis).toContain(100);
+    expect(keptMidis).not.toContain(36);
+    expect(keptMidis).not.toContain(48);
   });
 });


### PR DESCRIPTION
## 概要

大きい譜面で quick playback が再生不能になりやすい問題に対して、再生直前の `SynthSchedule` を軽量化する仕組みを追加しました。

今回の変更では、通常サイズの譜面はそのまま再生しつつ、イベント数が大きい場合だけ自動で dense playback 向けの間引きルールを適用します。あわせて、単純な高音優先ではなく、外声やオクターブ非重複音を優先して残す方針に見直しています。

## 変更内容

- `src/ts/playback-flow.ts`
  - dense playback 向けの `compactSynthScheduleForPlayback(...)` を追加
  - 再生イベント総数がしきい値を超えたときのみ軽量化を発動
  - 極端に短い音の除外を追加
  - 同一オンセットの最大保持数を制限
  - 総イベント数の上限を追加
  - 小さい same-onset chord は総量制限時にも保護
  - 同一オンセット内では以下の優先順で保持
    - 最低音 / 最高音
    - オクターブ重複していない音
    - オクターブ重複の外側
    - オクターブ重複の中間音
  - `createBasicWaveSynthEngine().playSchedule(...)` が compacted schedule を使うよう変更

- `tests/unit/playback-flow.spec.ts`
  - dense schedule の圧縮が発動することを確認するテストを追加
  - node 数削減が実際に効くことを確認するテストを追加
  - small same-onset chord が保護されることを確認するテストを追加
  - dense onset 内で外声と非オクターブ重複音が優先されることを確認するテストを追加

- `TODO.md`
  - dense playback 軽量化の現状方針をメモ
  - Web Audio node saturation が次の調査候補であることを追記
  - load 時の WASM 検討前に、正規化や render 前処理の計測を優先すべきという知見を追記

- ビルド生成物更新
  - `src/js/main.js`
  - `mikuscore.html`

## 意図

- 大きい譜面でも quick playback が止まりにくくする
- 小さい和音や外声をできるだけ保ちながら、過密部分だけを削る
- 今後の WASM 検討について、Playback と load のどこに効くかを整理する

## テスト

実施済み:

- `npx vitest run tests/unit/playback-flow.spec.ts --reporter=verbose`
- `npm run typecheck`
- `npm run build`

## 補足

この変更は「音質完全維持」より「ブラウザ内 quick playback の安定性」を優先しています。 極端に dense な譜面では一部の音を省略する可能性がありますが、小さい same-onset chord や外声はなるべく残す方針です。