### PR TITLE
Playback 中の現在小節ハイライトを追加し、dense score 安定化を強化

### DIFF
--- a/mikuscore.html
+++ b/mikuscore.html
@@ -1074,6 +1074,16 @@ lht-help-tooltip:not([data-initialized="true"]) * {
   stroke: #ff0000 !important;
 }
 
+.ms-debug-score .ms-measure-playing {
+  fill: #8b3dff !important;
+  stroke: #5f1fc7 !important;
+}
+
+.ms-debug-score .ms-measure-playing * {
+  fill: #8b3dff !important;
+  stroke: #5f1fc7 !important;
+}
+
 .ms-dev {
   margin-top: 1.1rem;
   border: 1px solid #e6e1ee;
@@ -8218,6 +8228,7 @@ let measureNumbersByPart = new Map();
 let scoreTitleText = "";
 let scoreComposerText = "";
 let selectedMeasure = null;
+let activePlaybackLocation = null;
 let draftCore = null;
 let draftNoteNodeIds = [];
 let draftSvgIdToNodeId = new Map();
@@ -9433,24 +9444,35 @@ const highlightSelectedDraftNoteInEditor = () => {
 };
 const highlightSelectedMeasureInMainPreview = () => {
     debugScoreArea
-        .querySelectorAll(".ms-measure-selected")
-        .forEach((el) => el.classList.remove("ms-measure-selected"));
-    if (!selectedMeasure || currentSvgIdToNodeId.size === 0)
+        .querySelectorAll(".ms-measure-selected, .ms-measure-playing")
+        .forEach((el) => {
+        el.classList.remove("ms-measure-selected");
+        el.classList.remove("ms-measure-playing");
+    });
+    if (currentSvgIdToNodeId.size === 0)
         return;
     for (const [svgId, nodeId] of currentSvgIdToNodeId.entries()) {
         const location = nodeIdToLocation.get(nodeId);
         if (!location)
             continue;
-        if (location.partId !== selectedMeasure.partId || location.measureNumber !== selectedMeasure.measureNumber) {
-            continue;
-        }
         const target = document.getElementById(svgId);
         if (!target || !debugScoreArea.contains(target))
             continue;
-        target.classList.add("ms-measure-selected");
         const group = target.closest("g");
-        if (group && debugScoreArea.contains(group)) {
-            group.classList.add("ms-measure-selected");
+        const applyClass = (className) => {
+            target.classList.add(className);
+            if (group && debugScoreArea.contains(group)) {
+                group.classList.add(className);
+            }
+        };
+        if (selectedMeasure
+            && location.partId === selectedMeasure.partId
+            && location.measureNumber === selectedMeasure.measureNumber) {
+            applyClass("ms-measure-selected");
+        }
+        if (activePlaybackLocation
+            && location.measureNumber === activePlaybackLocation.measureNumber) {
+            applyClass("ms-measure-playing");
         }
     }
 };
@@ -10158,6 +10180,10 @@ const playbackFlowOptions = {
         if (playbackText) {
             playbackText.textContent = text;
         }
+    },
+    setActivePlaybackLocation: (location) => {
+        activePlaybackLocation = location;
+        highlightSelectedMeasureInMainPreview();
     },
     renderControlState,
     renderAll,
@@ -16772,7 +16798,7 @@ exports.replaceMeasureInMainDocument = replaceMeasureInMainDocument;
   "src/ts/playback-flow.js": function (require, module, exports) {
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.startMeasurePlayback = exports.startPlayback = exports.stopPlayback = exports.createBasicWaveSynthEngine = exports.compactSynthScheduleForPlayback = exports.PLAYBACK_TICKS_PER_QUARTER = void 0;
+exports.startMeasurePlayback = exports.startPlayback = exports.stopPlayback = exports.buildMeasureTimelineForPart = exports.createBasicWaveSynthEngine = exports.compactSynthScheduleForPlayback = exports.PLAYBACK_TICKS_PER_QUARTER = void 0;
 const midi_io_1 = require("./midi-io");
 const musicxml_io_1 = require("./musicxml-io");
 exports.PLAYBACK_TICKS_PER_QUARTER = 480;
@@ -16960,6 +16986,7 @@ const createBasicWaveSynthEngine = (options) => {
     let audioContext = null;
     let activeSynthNodes = [];
     let synthStopTimer = null;
+    let playbackProgressTimer = null;
     const hasActiveUserGesture = () => {
         const nav = navigator;
         const ua = nav.userActivation;
@@ -17037,6 +17064,10 @@ const createBasicWaveSynthEngine = (options) => {
             window.clearTimeout(synthStopTimer);
             synthStopTimer = null;
         }
+        if (playbackProgressTimer !== null) {
+            window.clearInterval(playbackProgressTimer);
+            playbackProgressTimer = null;
+        }
         for (const node of activeSynthNodes) {
             try {
                 node.oscillator.stop();
@@ -17086,7 +17117,7 @@ const createBasicWaveSynthEngine = (options) => {
             return false;
         }
     };
-    const playSchedule = async (schedule, waveform, onEnded) => {
+    const playSchedule = async (schedule, waveform, onTickUpdate, onEnded) => {
         var _a, _b, _c, _d, _e, _f, _g;
         if (!schedule || !Array.isArray(schedule.events) || schedule.events.length === 0) {
             throw new Error("Please convert first.");
@@ -17137,6 +17168,27 @@ const createBasicWaveSynthEngine = (options) => {
                     break;
             }
             return seconds;
+        };
+        const secondsToTick = (elapsedSeconds) => {
+            var _a, _b;
+            if (!(elapsedSeconds > 0))
+                return 0;
+            let remainingSeconds = elapsedSeconds;
+            let resolvedTick = 0;
+            for (let i = 0; i < mergedTempoEvents.length; i += 1) {
+                const current = mergedTempoEvents[i];
+                const nextStart = (_b = (_a = mergedTempoEvents[i + 1]) === null || _a === void 0 ? void 0 : _a.startTick) !== null && _b !== void 0 ? _b : Number.POSITIVE_INFINITY;
+                const currentStart = current.startTick;
+                const spanTicks = Number.isFinite(nextStart) ? Math.max(0, nextStart - currentStart) : Number.POSITIVE_INFINITY;
+                const secPerTick = 60 / (current.bpm * ticksPerQuarter);
+                const spanSeconds = Number.isFinite(spanTicks) ? spanTicks * secPerTick : Number.POSITIVE_INFINITY;
+                if (remainingSeconds <= spanSeconds) {
+                    return Math.max(resolvedTick, currentStart + Math.round(remainingSeconds / secPerTick));
+                }
+                remainingSeconds -= spanSeconds;
+                resolvedTick = Number.isFinite(spanTicks) ? nextStart : resolvedTick;
+            }
+            return Math.max(0, resolvedTick);
         };
         const baseTime = runningContext.currentTime + 0.04;
         let latestEndTime = baseTime;
@@ -17203,9 +17255,20 @@ const createBasicWaveSynthEngine = (options) => {
             latestEndTime = Math.max(latestEndTime, scheduleBasicWaveNote(event, startAt, bodyDuration, normalizedWaveform, sustainHoldSeconds, legatoFromOverlap));
             lastNoteByLane.set(laneKey, { startTick: event.start, endTick: event.start + event.ticks });
         }
+        if (typeof onTickUpdate === "function") {
+            onTickUpdate(0);
+            playbackProgressTimer = window.setInterval(() => {
+                const elapsed = Math.max(0, runningContext.currentTime - baseTime);
+                onTickUpdate(secondsToTick(elapsed));
+            }, 90);
+        }
         const waitMs = Math.max(0, Math.ceil((latestEndTime - runningContext.currentTime) * 1000));
         synthStopTimer = window.setTimeout(() => {
             activeSynthNodes = [];
+            if (playbackProgressTimer !== null) {
+                window.clearInterval(playbackProgressTimer);
+                playbackProgressTimer = null;
+            }
             if (typeof onEnded === "function") {
                 onEnded();
             }
@@ -17273,35 +17336,162 @@ const parsePositiveInt = (text) => {
     const value = Number.parseInt(String(text !== null && text !== void 0 ? text : "").trim(), 10);
     return Number.isFinite(value) && value > 0 ? value : null;
 };
-const resolveMeasureStartTickInPart = (doc, startFromMeasure, fallbackDivisions) => {
-    var _a, _b, _c, _d, _e;
-    const part = Array.from(doc.querySelectorAll("score-partwise > part")).find((p) => { var _a; return ((_a = p.getAttribute("id")) !== null && _a !== void 0 ? _a : "").trim() === String(startFromMeasure.partId || "").trim(); });
-    if (!part)
+const getFirstNumber = (el, selector) => {
+    var _a, _b;
+    const text = (_b = (_a = el.querySelector(selector)) === null || _a === void 0 ? void 0 : _a.textContent) === null || _b === void 0 ? void 0 : _b.trim();
+    if (!text)
         return null;
+    const n = Number(text);
+    return Number.isFinite(n) ? n : null;
+};
+const measureCapacityDivFromContext = (divisions, beats, beatType) => {
+    const safeDivisions = Math.max(1, Math.round(divisions));
+    const safeBeats = Math.max(1, Math.round(beats));
+    const safeBeatType = Math.max(1, Math.round(beatType));
+    return Math.max(1, Math.round((safeDivisions * 4 * safeBeats) / safeBeatType));
+};
+const estimateMeasureContentSpanDiv = (measure) => {
+    var _a, _b, _c, _d;
+    let cursorDiv = 0;
+    let measureMaxDiv = 0;
+    const lastStartByVoice = new Map();
+    for (const child of Array.from(measure.children)) {
+        if (child.tagName === "backup" || child.tagName === "forward") {
+            const dur = getFirstNumber(child, "duration");
+            if (!dur || dur <= 0)
+                continue;
+            if (child.tagName === "backup") {
+                cursorDiv = Math.max(0, cursorDiv - dur);
+            }
+            else {
+                cursorDiv += dur;
+                measureMaxDiv = Math.max(measureMaxDiv, cursorDiv);
+            }
+            continue;
+        }
+        if (child.tagName !== "note")
+            continue;
+        const durationDiv = getFirstNumber(child, "duration");
+        if (!durationDiv || durationDiv <= 0)
+            continue;
+        const voice = (_c = (_b = (_a = child.querySelector("voice")) === null || _a === void 0 ? void 0 : _a.textContent) === null || _b === void 0 ? void 0 : _b.trim()) !== null && _c !== void 0 ? _c : "1";
+        const isChord = Boolean(child.querySelector("chord"));
+        const startDiv = isChord ? ((_d = lastStartByVoice.get(voice)) !== null && _d !== void 0 ? _d : cursorDiv) : cursorDiv;
+        if (!isChord) {
+            lastStartByVoice.set(voice, startDiv);
+            cursorDiv += durationDiv;
+        }
+        measureMaxDiv = Math.max(measureMaxDiv, cursorDiv, startDiv + durationDiv);
+    }
+    return measureMaxDiv;
+};
+const shouldTreatFirstUnderfullAsPickup = (doc) => {
+    var _a, _b, _c;
+    const parts = Array.from(doc.querySelectorAll("score-partwise > part"));
+    if (parts.length < 2)
+        return false;
+    for (const part of parts) {
+        const firstMeasure = part.querySelector(":scope > measure");
+        if (!firstMeasure)
+            return false;
+        const divisions = (_a = getFirstNumber(firstMeasure, "attributes > divisions")) !== null && _a !== void 0 ? _a : 1;
+        const beats = (_b = getFirstNumber(firstMeasure, "attributes > time > beats")) !== null && _b !== void 0 ? _b : 4;
+        const beatType = (_c = getFirstNumber(firstMeasure, "attributes > time > beat-type")) !== null && _c !== void 0 ? _c : 4;
+        const capacityDiv = measureCapacityDivFromContext(divisions, beats, beatType);
+        const contentDiv = estimateMeasureContentSpanDiv(firstMeasure);
+        if (!(contentDiv > 0 && contentDiv < capacityDiv)) {
+            return false;
+        }
+    }
+    return true;
+};
+const isImplicitMeasure = (measure) => {
+    if (!measure)
+        return false;
+    const implicitAttr = (measure.getAttribute("implicit") || "").trim().toLowerCase();
+    return implicitAttr === "yes" || implicitAttr === "true" || implicitAttr === "1";
+};
+const resolveMeasureAdvanceDiv = (measure, measureMaxDiv, currentDivisions, currentBeats, currentBeatType, nextMeasureIsImplicit = false, firstMeasureUnderfullAsPickup = false) => {
+    const safeDivisions = Math.max(1, Math.round(currentDivisions));
+    const safeBeats = Math.max(1, Math.round(currentBeats));
+    const safeBeatType = Math.max(1, Math.round(currentBeatType));
+    const capacityDiv = Math.max(1, Math.round((safeDivisions * 4 * safeBeats) / safeBeatType));
+    const implicitAttr = (measure.getAttribute("implicit") || "").trim().toLowerCase();
+    const isImplicit = implicitAttr === "yes" || implicitAttr === "true" || implicitAttr === "1";
+    if (isImplicit) {
+        return measureMaxDiv > 0 ? measureMaxDiv : capacityDiv;
+    }
+    let hasPreviousMeasure = false;
+    for (let prev = measure.previousElementSibling; prev; prev = prev.previousElementSibling) {
+        const prevName = (prev.localName || prev.tagName || "").toLowerCase();
+        if (prevName === "measure") {
+            hasPreviousMeasure = true;
+            break;
+        }
+    }
+    const isFirstMeasureInPart = !hasPreviousMeasure;
+    if (firstMeasureUnderfullAsPickup && isFirstMeasureInPart && measureMaxDiv > 0 && measureMaxDiv < capacityDiv) {
+        return measureMaxDiv;
+    }
+    if (nextMeasureIsImplicit && measureMaxDiv > 0 && measureMaxDiv < capacityDiv) {
+        return measureMaxDiv;
+    }
+    return Math.max(capacityDiv, measureMaxDiv);
+};
+const buildMeasureTimelineForPart = (doc, partId, fallbackDivisions) => {
+    var _a, _b;
+    const part = Array.from(doc.querySelectorAll("score-partwise > part")).find((p) => { var _a; return ((_a = p.getAttribute("id")) !== null && _a !== void 0 ? _a : "").trim() === String(partId || "").trim(); });
+    if (!part)
+        return [];
+    const firstUnderfullAsPickup = shouldTreatFirstUnderfullAsPickup(doc);
     let divisions = Math.max(1, Math.round(fallbackDivisions));
     let beats = 4;
     let beatType = 4;
     let tick = 0;
+    const ranges = [];
     const measures = Array.from(part.querySelectorAll(":scope > measure"));
-    for (const measure of measures) {
-        const attrs = measure.querySelector(":scope > attributes");
-        const nextDivisions = parsePositiveInt((_a = attrs === null || attrs === void 0 ? void 0 : attrs.querySelector(":scope > divisions")) === null || _a === void 0 ? void 0 : _a.textContent);
-        if (nextDivisions)
+    for (let measureIndex = 0; measureIndex < measures.length; measureIndex += 1) {
+        const measure = measures[measureIndex];
+        const nextMeasure = (_a = measures[measureIndex + 1]) !== null && _a !== void 0 ? _a : null;
+        const nextDivisions = getFirstNumber(measure, "attributes > divisions");
+        if (nextDivisions && nextDivisions > 0)
             divisions = nextDivisions;
-        const nextBeats = parsePositiveInt((_b = attrs === null || attrs === void 0 ? void 0 : attrs.querySelector(":scope > time > beats")) === null || _b === void 0 ? void 0 : _b.textContent);
-        if (nextBeats)
+        const nextBeats = getFirstNumber(measure, "attributes > time > beats");
+        const nextBeatType = getFirstNumber(measure, "attributes > time > beat-type");
+        if (nextBeats && nextBeats > 0 && nextBeatType && nextBeatType > 0) {
             beats = nextBeats;
-        const nextBeatType = parsePositiveInt((_c = attrs === null || attrs === void 0 ? void 0 : attrs.querySelector(":scope > time > beat-type")) === null || _c === void 0 ? void 0 : _c.textContent);
-        if (nextBeatType)
             beatType = nextBeatType;
-        const measureNo = ((_d = measure.getAttribute("number")) !== null && _d !== void 0 ? _d : "").trim();
-        if (measureNo === String((_e = startFromMeasure.measureNumber) !== null && _e !== void 0 ? _e : "").trim()) {
-            return tick;
         }
-        const measureTicks = Math.max(1, Math.round((divisions * beats * 4) / Math.max(1, beatType)));
+        const measureNumber = ((_b = measure.getAttribute("number")) !== null && _b !== void 0 ? _b : "").trim();
+        const measureContentDiv = estimateMeasureContentSpanDiv(measure);
+        const advanceDiv = resolveMeasureAdvanceDiv(measure, measureContentDiv, divisions, beats, beatType, isImplicitMeasure(nextMeasure), firstUnderfullAsPickup);
+        const measureTicks = Math.max(1, Math.round((advanceDiv / Math.max(1, divisions)) * fallbackDivisions));
+        ranges.push({
+            startTick: tick,
+            endTick: tick + measureTicks,
+            location: { partId, measureNumber },
+        });
         tick += measureTicks;
     }
-    return null;
+    return ranges;
+};
+exports.buildMeasureTimelineForPart = buildMeasureTimelineForPart;
+const findPlaybackLocationAtTick = (ranges, tick) => {
+    var _a, _b;
+    if (!ranges.length)
+        return null;
+    const safeTick = Math.max(0, Math.round(tick));
+    for (const range of ranges) {
+        if (safeTick >= range.startTick && safeTick < range.endTick) {
+            return range.location;
+        }
+    }
+    return (_b = (_a = ranges[ranges.length - 1]) === null || _a === void 0 ? void 0 : _a.location) !== null && _b !== void 0 ? _b : null;
+};
+const resolveMeasureStartTickInPart = (doc, startFromMeasure, fallbackDivisions) => {
+    const ranges = (0, exports.buildMeasureTimelineForPart)(doc, startFromMeasure.partId, fallbackDivisions);
+    const hit = ranges.find((range) => { var _a; return range.location.measureNumber === String((_a = startFromMeasure.measureNumber) !== null && _a !== void 0 ? _a : "").trim(); });
+    return hit ? hit.startTick : null;
 };
 const trimPlaybackFromTick = (parsedPlayback, tempoEvents, controlEvents, startTick) => {
     if (!Number.isFinite(startTick) || startTick <= 0) {
@@ -17340,14 +17530,16 @@ const trimPlaybackFromTick = (parsedPlayback, tempoEvents, controlEvents, startT
 const stopPlayback = (options) => {
     options.engine.stop();
     options.setIsPlaying(false);
+    options.setActivePlaybackLocation(null);
     options.setPlaybackText("Playback: stopped");
     options.renderControlState();
 };
 exports.stopPlayback = stopPlayback;
 const startPlayback = async (options, params) => {
-    var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p, _q;
+    var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p, _q, _r, _s, _t, _u, _v;
     if (!params.isLoaded || options.getIsPlaying())
         return;
+    options.setActivePlaybackLocation(null);
     const saveResult = params.core.save();
     options.onFullSaveResult(saveResult);
     if (!saveResult.ok) {
@@ -17389,6 +17581,7 @@ const startPlayback = async (options, params) => {
     let effectiveControlEvents = useMidiLikePlayback
         ? (0, midi_io_1.collectMidiControlEventsFromMusicXmlDoc)(playbackDoc, options.ticksPerQuarter)
         : [];
+    const playbackAnchorPartId = (_e = (_b = (_a = params.startFromMeasure) === null || _a === void 0 ? void 0 : _a.partId) !== null && _b !== void 0 ? _b : (_d = (_c = playbackDoc.querySelector("score-partwise > part")) === null || _c === void 0 ? void 0 : _c.getAttribute("id")) === null || _d === void 0 ? void 0 : _d.trim()) !== null && _e !== void 0 ? _e : "";
     if (params.startFromMeasure) {
         const startTick = resolveMeasureStartTickInPart(playbackDoc, params.startFromMeasure, options.ticksPerQuarter);
         if (startTick !== null && startTick > 0) {
@@ -17411,12 +17604,15 @@ const startPlayback = async (options, params) => {
         ? (0, midi_io_1.collectMidiKeySignatureEventsFromMusicXmlDoc)(playbackDoc, options.ticksPerQuarter)
         : [];
     const waveform = options.getPlaybackWaveform();
+    const measureTimeline = playbackAnchorPartId
+        ? (0, exports.buildMeasureTimelineForPart)(playbackDoc, playbackAnchorPartId, options.ticksPerQuarter)
+        : [];
     let midiBytes;
     try {
-        const scoreTitle = (_f = (_c = (_b = (_a = playbackDoc.querySelector("score-partwise > work > work-title")) === null || _a === void 0 ? void 0 : _a.textContent) === null || _b === void 0 ? void 0 : _b.trim()) !== null && _c !== void 0 ? _c : (_e = (_d = playbackDoc.querySelector("score-partwise > movement-title")) === null || _d === void 0 ? void 0 : _d.textContent) === null || _e === void 0 ? void 0 : _e.trim()) !== null && _f !== void 0 ? _f : "";
-        const movementTitle = (_j = (_h = (_g = playbackDoc.querySelector("score-partwise > movement-title")) === null || _g === void 0 ? void 0 : _g.textContent) === null || _h === void 0 ? void 0 : _h.trim()) !== null && _j !== void 0 ? _j : "";
-        const scoreComposer = (_q = (_m = (_l = (_k = playbackDoc
-            .querySelector('score-partwise > identification > creator[type="composer"]')) === null || _k === void 0 ? void 0 : _k.textContent) === null || _l === void 0 ? void 0 : _l.trim()) !== null && _m !== void 0 ? _m : (_p = (_o = playbackDoc.querySelector("score-partwise > identification > creator")) === null || _o === void 0 ? void 0 : _o.textContent) === null || _p === void 0 ? void 0 : _p.trim()) !== null && _q !== void 0 ? _q : "";
+        const scoreTitle = (_l = (_h = (_g = (_f = playbackDoc.querySelector("score-partwise > work > work-title")) === null || _f === void 0 ? void 0 : _f.textContent) === null || _g === void 0 ? void 0 : _g.trim()) !== null && _h !== void 0 ? _h : (_k = (_j = playbackDoc.querySelector("score-partwise > movement-title")) === null || _j === void 0 ? void 0 : _j.textContent) === null || _k === void 0 ? void 0 : _k.trim()) !== null && _l !== void 0 ? _l : "";
+        const movementTitle = (_p = (_o = (_m = playbackDoc.querySelector("score-partwise > movement-title")) === null || _m === void 0 ? void 0 : _m.textContent) === null || _o === void 0 ? void 0 : _o.trim()) !== null && _p !== void 0 ? _p : "";
+        const scoreComposer = (_v = (_s = (_r = (_q = playbackDoc
+            .querySelector('score-partwise > identification > creator[type="composer"]')) === null || _q === void 0 ? void 0 : _q.textContent) === null || _r === void 0 ? void 0 : _r.trim()) !== null && _s !== void 0 ? _s : (_u = (_t = playbackDoc.querySelector("score-partwise > identification > creator")) === null || _t === void 0 ? void 0 : _t.textContent) === null || _u === void 0 ? void 0 : _u.trim()) !== null && _v !== void 0 ? _v : "";
         midiBytes = (0, midi_io_1.buildMidiBytesForPlayback)(events, effectiveParsedPlayback.tempo, "electric_piano_2", (0, midi_io_1.collectMidiProgramOverridesFromMusicXmlDoc)(playbackDoc), effectiveControlEvents, effectiveTempoEvents, timeSignatureEvents, keySignatureEvents, {
             metadata: {
                 title: scoreTitle,
@@ -17431,8 +17627,11 @@ const startPlayback = async (options, params) => {
         return;
     }
     try {
-        await options.engine.playSchedule(toSynthSchedule(effectiveParsedPlayback.tempo, events, effectiveTempoEvents, effectiveControlEvents), waveform, () => {
+        await options.engine.playSchedule(toSynthSchedule(effectiveParsedPlayback.tempo, events, effectiveTempoEvents, effectiveControlEvents), waveform, (currentTick) => {
+            options.setActivePlaybackLocation(findPlaybackLocationAtTick(measureTimeline, currentTick));
+        }, () => {
             options.setIsPlaying(false);
+            options.setActivePlaybackLocation(null);
             options.setPlaybackText("Playback: stopped");
             options.renderControlState();
         });
@@ -17452,8 +17651,10 @@ const startPlayback = async (options, params) => {
 };
 exports.startPlayback = startPlayback;
 const startMeasurePlayback = async (options, params) => {
+    var _a, _b, _c;
     if (!params.draftCore || options.getIsPlaying())
         return;
+    options.setActivePlaybackLocation(null);
     const saveResult = params.draftCore.save();
     if (!saveResult.ok) {
         options.onMeasureSaveDiagnostics(saveResult.diagnostics);
@@ -17492,9 +17693,16 @@ const startMeasurePlayback = async (options, params) => {
         ? (0, midi_io_1.collectMidiControlEventsFromMusicXmlDoc)(playbackDoc, options.ticksPerQuarter)
         : [];
     const waveform = options.getPlaybackWaveform();
+    const playbackAnchorPartId = (_c = (_b = (_a = playbackDoc.querySelector("score-partwise > part")) === null || _a === void 0 ? void 0 : _a.getAttribute("id")) === null || _b === void 0 ? void 0 : _b.trim()) !== null && _c !== void 0 ? _c : "";
+    const measureTimeline = playbackAnchorPartId
+        ? (0, exports.buildMeasureTimelineForPart)(playbackDoc, playbackAnchorPartId, options.ticksPerQuarter)
+        : [];
     try {
-        await options.engine.playSchedule(toSynthSchedule(parsedPlayback.tempo, events, tempoEvents, controlEvents), waveform, () => {
+        await options.engine.playSchedule(toSynthSchedule(parsedPlayback.tempo, events, tempoEvents, controlEvents), waveform, (currentTick) => {
+            options.setActivePlaybackLocation(findPlaybackLocationAtTick(measureTimeline, currentTick));
+        }, () => {
             options.setIsPlaying(false);
+            options.setActivePlaybackLocation(null);
             options.setPlaybackText("Playback: stopped");
             options.renderControlState();
         });

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -1066,6 +1066,16 @@ lht-help-tooltip:not([data-initialized="true"]) * {
   stroke: #ff0000 !important;
 }
 
+.ms-debug-score .ms-measure-playing {
+  fill: #8b3dff !important;
+  stroke: #5f1fc7 !important;
+}
+
+.ms-debug-score .ms-measure-playing * {
+  fill: #8b3dff !important;
+  stroke: #5f1fc7 !important;
+}
+
 .ms-dev {
   margin-top: 1.1rem;
   border: 1px solid #e6e1ee;

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -182,6 +182,7 @@ let measureNumbersByPart = new Map();
 let scoreTitleText = "";
 let scoreComposerText = "";
 let selectedMeasure = null;
+let activePlaybackLocation = null;
 let draftCore = null;
 let draftNoteNodeIds = [];
 let draftSvgIdToNodeId = new Map();
@@ -1397,24 +1398,35 @@ const highlightSelectedDraftNoteInEditor = () => {
 };
 const highlightSelectedMeasureInMainPreview = () => {
     debugScoreArea
-        .querySelectorAll(".ms-measure-selected")
-        .forEach((el) => el.classList.remove("ms-measure-selected"));
-    if (!selectedMeasure || currentSvgIdToNodeId.size === 0)
+        .querySelectorAll(".ms-measure-selected, .ms-measure-playing")
+        .forEach((el) => {
+        el.classList.remove("ms-measure-selected");
+        el.classList.remove("ms-measure-playing");
+    });
+    if (currentSvgIdToNodeId.size === 0)
         return;
     for (const [svgId, nodeId] of currentSvgIdToNodeId.entries()) {
         const location = nodeIdToLocation.get(nodeId);
         if (!location)
             continue;
-        if (location.partId !== selectedMeasure.partId || location.measureNumber !== selectedMeasure.measureNumber) {
-            continue;
-        }
         const target = document.getElementById(svgId);
         if (!target || !debugScoreArea.contains(target))
             continue;
-        target.classList.add("ms-measure-selected");
         const group = target.closest("g");
-        if (group && debugScoreArea.contains(group)) {
-            group.classList.add("ms-measure-selected");
+        const applyClass = (className) => {
+            target.classList.add(className);
+            if (group && debugScoreArea.contains(group)) {
+                group.classList.add(className);
+            }
+        };
+        if (selectedMeasure
+            && location.partId === selectedMeasure.partId
+            && location.measureNumber === selectedMeasure.measureNumber) {
+            applyClass("ms-measure-selected");
+        }
+        if (activePlaybackLocation
+            && location.measureNumber === activePlaybackLocation.measureNumber) {
+            applyClass("ms-measure-playing");
         }
     }
 };
@@ -2122,6 +2134,10 @@ const playbackFlowOptions = {
         if (playbackText) {
             playbackText.textContent = text;
         }
+    },
+    setActivePlaybackLocation: (location) => {
+        activePlaybackLocation = location;
+        highlightSelectedMeasureInMainPreview();
     },
     renderControlState,
     renderAll,
@@ -8736,7 +8752,7 @@ exports.replaceMeasureInMainDocument = replaceMeasureInMainDocument;
   "src/ts/playback-flow.js": function (require, module, exports) {
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.startMeasurePlayback = exports.startPlayback = exports.stopPlayback = exports.createBasicWaveSynthEngine = exports.compactSynthScheduleForPlayback = exports.PLAYBACK_TICKS_PER_QUARTER = void 0;
+exports.startMeasurePlayback = exports.startPlayback = exports.stopPlayback = exports.buildMeasureTimelineForPart = exports.createBasicWaveSynthEngine = exports.compactSynthScheduleForPlayback = exports.PLAYBACK_TICKS_PER_QUARTER = void 0;
 const midi_io_1 = require("./midi-io");
 const musicxml_io_1 = require("./musicxml-io");
 exports.PLAYBACK_TICKS_PER_QUARTER = 480;
@@ -8924,6 +8940,7 @@ const createBasicWaveSynthEngine = (options) => {
     let audioContext = null;
     let activeSynthNodes = [];
     let synthStopTimer = null;
+    let playbackProgressTimer = null;
     const hasActiveUserGesture = () => {
         const nav = navigator;
         const ua = nav.userActivation;
@@ -9001,6 +9018,10 @@ const createBasicWaveSynthEngine = (options) => {
             window.clearTimeout(synthStopTimer);
             synthStopTimer = null;
         }
+        if (playbackProgressTimer !== null) {
+            window.clearInterval(playbackProgressTimer);
+            playbackProgressTimer = null;
+        }
         for (const node of activeSynthNodes) {
             try {
                 node.oscillator.stop();
@@ -9050,7 +9071,7 @@ const createBasicWaveSynthEngine = (options) => {
             return false;
         }
     };
-    const playSchedule = async (schedule, waveform, onEnded) => {
+    const playSchedule = async (schedule, waveform, onTickUpdate, onEnded) => {
         var _a, _b, _c, _d, _e, _f, _g;
         if (!schedule || !Array.isArray(schedule.events) || schedule.events.length === 0) {
             throw new Error("Please convert first.");
@@ -9101,6 +9122,27 @@ const createBasicWaveSynthEngine = (options) => {
                     break;
             }
             return seconds;
+        };
+        const secondsToTick = (elapsedSeconds) => {
+            var _a, _b;
+            if (!(elapsedSeconds > 0))
+                return 0;
+            let remainingSeconds = elapsedSeconds;
+            let resolvedTick = 0;
+            for (let i = 0; i < mergedTempoEvents.length; i += 1) {
+                const current = mergedTempoEvents[i];
+                const nextStart = (_b = (_a = mergedTempoEvents[i + 1]) === null || _a === void 0 ? void 0 : _a.startTick) !== null && _b !== void 0 ? _b : Number.POSITIVE_INFINITY;
+                const currentStart = current.startTick;
+                const spanTicks = Number.isFinite(nextStart) ? Math.max(0, nextStart - currentStart) : Number.POSITIVE_INFINITY;
+                const secPerTick = 60 / (current.bpm * ticksPerQuarter);
+                const spanSeconds = Number.isFinite(spanTicks) ? spanTicks * secPerTick : Number.POSITIVE_INFINITY;
+                if (remainingSeconds <= spanSeconds) {
+                    return Math.max(resolvedTick, currentStart + Math.round(remainingSeconds / secPerTick));
+                }
+                remainingSeconds -= spanSeconds;
+                resolvedTick = Number.isFinite(spanTicks) ? nextStart : resolvedTick;
+            }
+            return Math.max(0, resolvedTick);
         };
         const baseTime = runningContext.currentTime + 0.04;
         let latestEndTime = baseTime;
@@ -9167,9 +9209,20 @@ const createBasicWaveSynthEngine = (options) => {
             latestEndTime = Math.max(latestEndTime, scheduleBasicWaveNote(event, startAt, bodyDuration, normalizedWaveform, sustainHoldSeconds, legatoFromOverlap));
             lastNoteByLane.set(laneKey, { startTick: event.start, endTick: event.start + event.ticks });
         }
+        if (typeof onTickUpdate === "function") {
+            onTickUpdate(0);
+            playbackProgressTimer = window.setInterval(() => {
+                const elapsed = Math.max(0, runningContext.currentTime - baseTime);
+                onTickUpdate(secondsToTick(elapsed));
+            }, 90);
+        }
         const waitMs = Math.max(0, Math.ceil((latestEndTime - runningContext.currentTime) * 1000));
         synthStopTimer = window.setTimeout(() => {
             activeSynthNodes = [];
+            if (playbackProgressTimer !== null) {
+                window.clearInterval(playbackProgressTimer);
+                playbackProgressTimer = null;
+            }
             if (typeof onEnded === "function") {
                 onEnded();
             }
@@ -9237,35 +9290,162 @@ const parsePositiveInt = (text) => {
     const value = Number.parseInt(String(text !== null && text !== void 0 ? text : "").trim(), 10);
     return Number.isFinite(value) && value > 0 ? value : null;
 };
-const resolveMeasureStartTickInPart = (doc, startFromMeasure, fallbackDivisions) => {
-    var _a, _b, _c, _d, _e;
-    const part = Array.from(doc.querySelectorAll("score-partwise > part")).find((p) => { var _a; return ((_a = p.getAttribute("id")) !== null && _a !== void 0 ? _a : "").trim() === String(startFromMeasure.partId || "").trim(); });
-    if (!part)
+const getFirstNumber = (el, selector) => {
+    var _a, _b;
+    const text = (_b = (_a = el.querySelector(selector)) === null || _a === void 0 ? void 0 : _a.textContent) === null || _b === void 0 ? void 0 : _b.trim();
+    if (!text)
         return null;
+    const n = Number(text);
+    return Number.isFinite(n) ? n : null;
+};
+const measureCapacityDivFromContext = (divisions, beats, beatType) => {
+    const safeDivisions = Math.max(1, Math.round(divisions));
+    const safeBeats = Math.max(1, Math.round(beats));
+    const safeBeatType = Math.max(1, Math.round(beatType));
+    return Math.max(1, Math.round((safeDivisions * 4 * safeBeats) / safeBeatType));
+};
+const estimateMeasureContentSpanDiv = (measure) => {
+    var _a, _b, _c, _d;
+    let cursorDiv = 0;
+    let measureMaxDiv = 0;
+    const lastStartByVoice = new Map();
+    for (const child of Array.from(measure.children)) {
+        if (child.tagName === "backup" || child.tagName === "forward") {
+            const dur = getFirstNumber(child, "duration");
+            if (!dur || dur <= 0)
+                continue;
+            if (child.tagName === "backup") {
+                cursorDiv = Math.max(0, cursorDiv - dur);
+            }
+            else {
+                cursorDiv += dur;
+                measureMaxDiv = Math.max(measureMaxDiv, cursorDiv);
+            }
+            continue;
+        }
+        if (child.tagName !== "note")
+            continue;
+        const durationDiv = getFirstNumber(child, "duration");
+        if (!durationDiv || durationDiv <= 0)
+            continue;
+        const voice = (_c = (_b = (_a = child.querySelector("voice")) === null || _a === void 0 ? void 0 : _a.textContent) === null || _b === void 0 ? void 0 : _b.trim()) !== null && _c !== void 0 ? _c : "1";
+        const isChord = Boolean(child.querySelector("chord"));
+        const startDiv = isChord ? ((_d = lastStartByVoice.get(voice)) !== null && _d !== void 0 ? _d : cursorDiv) : cursorDiv;
+        if (!isChord) {
+            lastStartByVoice.set(voice, startDiv);
+            cursorDiv += durationDiv;
+        }
+        measureMaxDiv = Math.max(measureMaxDiv, cursorDiv, startDiv + durationDiv);
+    }
+    return measureMaxDiv;
+};
+const shouldTreatFirstUnderfullAsPickup = (doc) => {
+    var _a, _b, _c;
+    const parts = Array.from(doc.querySelectorAll("score-partwise > part"));
+    if (parts.length < 2)
+        return false;
+    for (const part of parts) {
+        const firstMeasure = part.querySelector(":scope > measure");
+        if (!firstMeasure)
+            return false;
+        const divisions = (_a = getFirstNumber(firstMeasure, "attributes > divisions")) !== null && _a !== void 0 ? _a : 1;
+        const beats = (_b = getFirstNumber(firstMeasure, "attributes > time > beats")) !== null && _b !== void 0 ? _b : 4;
+        const beatType = (_c = getFirstNumber(firstMeasure, "attributes > time > beat-type")) !== null && _c !== void 0 ? _c : 4;
+        const capacityDiv = measureCapacityDivFromContext(divisions, beats, beatType);
+        const contentDiv = estimateMeasureContentSpanDiv(firstMeasure);
+        if (!(contentDiv > 0 && contentDiv < capacityDiv)) {
+            return false;
+        }
+    }
+    return true;
+};
+const isImplicitMeasure = (measure) => {
+    if (!measure)
+        return false;
+    const implicitAttr = (measure.getAttribute("implicit") || "").trim().toLowerCase();
+    return implicitAttr === "yes" || implicitAttr === "true" || implicitAttr === "1";
+};
+const resolveMeasureAdvanceDiv = (measure, measureMaxDiv, currentDivisions, currentBeats, currentBeatType, nextMeasureIsImplicit = false, firstMeasureUnderfullAsPickup = false) => {
+    const safeDivisions = Math.max(1, Math.round(currentDivisions));
+    const safeBeats = Math.max(1, Math.round(currentBeats));
+    const safeBeatType = Math.max(1, Math.round(currentBeatType));
+    const capacityDiv = Math.max(1, Math.round((safeDivisions * 4 * safeBeats) / safeBeatType));
+    const implicitAttr = (measure.getAttribute("implicit") || "").trim().toLowerCase();
+    const isImplicit = implicitAttr === "yes" || implicitAttr === "true" || implicitAttr === "1";
+    if (isImplicit) {
+        return measureMaxDiv > 0 ? measureMaxDiv : capacityDiv;
+    }
+    let hasPreviousMeasure = false;
+    for (let prev = measure.previousElementSibling; prev; prev = prev.previousElementSibling) {
+        const prevName = (prev.localName || prev.tagName || "").toLowerCase();
+        if (prevName === "measure") {
+            hasPreviousMeasure = true;
+            break;
+        }
+    }
+    const isFirstMeasureInPart = !hasPreviousMeasure;
+    if (firstMeasureUnderfullAsPickup && isFirstMeasureInPart && measureMaxDiv > 0 && measureMaxDiv < capacityDiv) {
+        return measureMaxDiv;
+    }
+    if (nextMeasureIsImplicit && measureMaxDiv > 0 && measureMaxDiv < capacityDiv) {
+        return measureMaxDiv;
+    }
+    return Math.max(capacityDiv, measureMaxDiv);
+};
+const buildMeasureTimelineForPart = (doc, partId, fallbackDivisions) => {
+    var _a, _b;
+    const part = Array.from(doc.querySelectorAll("score-partwise > part")).find((p) => { var _a; return ((_a = p.getAttribute("id")) !== null && _a !== void 0 ? _a : "").trim() === String(partId || "").trim(); });
+    if (!part)
+        return [];
+    const firstUnderfullAsPickup = shouldTreatFirstUnderfullAsPickup(doc);
     let divisions = Math.max(1, Math.round(fallbackDivisions));
     let beats = 4;
     let beatType = 4;
     let tick = 0;
+    const ranges = [];
     const measures = Array.from(part.querySelectorAll(":scope > measure"));
-    for (const measure of measures) {
-        const attrs = measure.querySelector(":scope > attributes");
-        const nextDivisions = parsePositiveInt((_a = attrs === null || attrs === void 0 ? void 0 : attrs.querySelector(":scope > divisions")) === null || _a === void 0 ? void 0 : _a.textContent);
-        if (nextDivisions)
+    for (let measureIndex = 0; measureIndex < measures.length; measureIndex += 1) {
+        const measure = measures[measureIndex];
+        const nextMeasure = (_a = measures[measureIndex + 1]) !== null && _a !== void 0 ? _a : null;
+        const nextDivisions = getFirstNumber(measure, "attributes > divisions");
+        if (nextDivisions && nextDivisions > 0)
             divisions = nextDivisions;
-        const nextBeats = parsePositiveInt((_b = attrs === null || attrs === void 0 ? void 0 : attrs.querySelector(":scope > time > beats")) === null || _b === void 0 ? void 0 : _b.textContent);
-        if (nextBeats)
+        const nextBeats = getFirstNumber(measure, "attributes > time > beats");
+        const nextBeatType = getFirstNumber(measure, "attributes > time > beat-type");
+        if (nextBeats && nextBeats > 0 && nextBeatType && nextBeatType > 0) {
             beats = nextBeats;
-        const nextBeatType = parsePositiveInt((_c = attrs === null || attrs === void 0 ? void 0 : attrs.querySelector(":scope > time > beat-type")) === null || _c === void 0 ? void 0 : _c.textContent);
-        if (nextBeatType)
             beatType = nextBeatType;
-        const measureNo = ((_d = measure.getAttribute("number")) !== null && _d !== void 0 ? _d : "").trim();
-        if (measureNo === String((_e = startFromMeasure.measureNumber) !== null && _e !== void 0 ? _e : "").trim()) {
-            return tick;
         }
-        const measureTicks = Math.max(1, Math.round((divisions * beats * 4) / Math.max(1, beatType)));
+        const measureNumber = ((_b = measure.getAttribute("number")) !== null && _b !== void 0 ? _b : "").trim();
+        const measureContentDiv = estimateMeasureContentSpanDiv(measure);
+        const advanceDiv = resolveMeasureAdvanceDiv(measure, measureContentDiv, divisions, beats, beatType, isImplicitMeasure(nextMeasure), firstUnderfullAsPickup);
+        const measureTicks = Math.max(1, Math.round((advanceDiv / Math.max(1, divisions)) * fallbackDivisions));
+        ranges.push({
+            startTick: tick,
+            endTick: tick + measureTicks,
+            location: { partId, measureNumber },
+        });
         tick += measureTicks;
     }
-    return null;
+    return ranges;
+};
+exports.buildMeasureTimelineForPart = buildMeasureTimelineForPart;
+const findPlaybackLocationAtTick = (ranges, tick) => {
+    var _a, _b;
+    if (!ranges.length)
+        return null;
+    const safeTick = Math.max(0, Math.round(tick));
+    for (const range of ranges) {
+        if (safeTick >= range.startTick && safeTick < range.endTick) {
+            return range.location;
+        }
+    }
+    return (_b = (_a = ranges[ranges.length - 1]) === null || _a === void 0 ? void 0 : _a.location) !== null && _b !== void 0 ? _b : null;
+};
+const resolveMeasureStartTickInPart = (doc, startFromMeasure, fallbackDivisions) => {
+    const ranges = (0, exports.buildMeasureTimelineForPart)(doc, startFromMeasure.partId, fallbackDivisions);
+    const hit = ranges.find((range) => { var _a; return range.location.measureNumber === String((_a = startFromMeasure.measureNumber) !== null && _a !== void 0 ? _a : "").trim(); });
+    return hit ? hit.startTick : null;
 };
 const trimPlaybackFromTick = (parsedPlayback, tempoEvents, controlEvents, startTick) => {
     if (!Number.isFinite(startTick) || startTick <= 0) {
@@ -9304,14 +9484,16 @@ const trimPlaybackFromTick = (parsedPlayback, tempoEvents, controlEvents, startT
 const stopPlayback = (options) => {
     options.engine.stop();
     options.setIsPlaying(false);
+    options.setActivePlaybackLocation(null);
     options.setPlaybackText("Playback: stopped");
     options.renderControlState();
 };
 exports.stopPlayback = stopPlayback;
 const startPlayback = async (options, params) => {
-    var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p, _q;
+    var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p, _q, _r, _s, _t, _u, _v;
     if (!params.isLoaded || options.getIsPlaying())
         return;
+    options.setActivePlaybackLocation(null);
     const saveResult = params.core.save();
     options.onFullSaveResult(saveResult);
     if (!saveResult.ok) {
@@ -9353,6 +9535,7 @@ const startPlayback = async (options, params) => {
     let effectiveControlEvents = useMidiLikePlayback
         ? (0, midi_io_1.collectMidiControlEventsFromMusicXmlDoc)(playbackDoc, options.ticksPerQuarter)
         : [];
+    const playbackAnchorPartId = (_e = (_b = (_a = params.startFromMeasure) === null || _a === void 0 ? void 0 : _a.partId) !== null && _b !== void 0 ? _b : (_d = (_c = playbackDoc.querySelector("score-partwise > part")) === null || _c === void 0 ? void 0 : _c.getAttribute("id")) === null || _d === void 0 ? void 0 : _d.trim()) !== null && _e !== void 0 ? _e : "";
     if (params.startFromMeasure) {
         const startTick = resolveMeasureStartTickInPart(playbackDoc, params.startFromMeasure, options.ticksPerQuarter);
         if (startTick !== null && startTick > 0) {
@@ -9375,12 +9558,15 @@ const startPlayback = async (options, params) => {
         ? (0, midi_io_1.collectMidiKeySignatureEventsFromMusicXmlDoc)(playbackDoc, options.ticksPerQuarter)
         : [];
     const waveform = options.getPlaybackWaveform();
+    const measureTimeline = playbackAnchorPartId
+        ? (0, exports.buildMeasureTimelineForPart)(playbackDoc, playbackAnchorPartId, options.ticksPerQuarter)
+        : [];
     let midiBytes;
     try {
-        const scoreTitle = (_f = (_c = (_b = (_a = playbackDoc.querySelector("score-partwise > work > work-title")) === null || _a === void 0 ? void 0 : _a.textContent) === null || _b === void 0 ? void 0 : _b.trim()) !== null && _c !== void 0 ? _c : (_e = (_d = playbackDoc.querySelector("score-partwise > movement-title")) === null || _d === void 0 ? void 0 : _d.textContent) === null || _e === void 0 ? void 0 : _e.trim()) !== null && _f !== void 0 ? _f : "";
-        const movementTitle = (_j = (_h = (_g = playbackDoc.querySelector("score-partwise > movement-title")) === null || _g === void 0 ? void 0 : _g.textContent) === null || _h === void 0 ? void 0 : _h.trim()) !== null && _j !== void 0 ? _j : "";
-        const scoreComposer = (_q = (_m = (_l = (_k = playbackDoc
-            .querySelector('score-partwise > identification > creator[type="composer"]')) === null || _k === void 0 ? void 0 : _k.textContent) === null || _l === void 0 ? void 0 : _l.trim()) !== null && _m !== void 0 ? _m : (_p = (_o = playbackDoc.querySelector("score-partwise > identification > creator")) === null || _o === void 0 ? void 0 : _o.textContent) === null || _p === void 0 ? void 0 : _p.trim()) !== null && _q !== void 0 ? _q : "";
+        const scoreTitle = (_l = (_h = (_g = (_f = playbackDoc.querySelector("score-partwise > work > work-title")) === null || _f === void 0 ? void 0 : _f.textContent) === null || _g === void 0 ? void 0 : _g.trim()) !== null && _h !== void 0 ? _h : (_k = (_j = playbackDoc.querySelector("score-partwise > movement-title")) === null || _j === void 0 ? void 0 : _j.textContent) === null || _k === void 0 ? void 0 : _k.trim()) !== null && _l !== void 0 ? _l : "";
+        const movementTitle = (_p = (_o = (_m = playbackDoc.querySelector("score-partwise > movement-title")) === null || _m === void 0 ? void 0 : _m.textContent) === null || _o === void 0 ? void 0 : _o.trim()) !== null && _p !== void 0 ? _p : "";
+        const scoreComposer = (_v = (_s = (_r = (_q = playbackDoc
+            .querySelector('score-partwise > identification > creator[type="composer"]')) === null || _q === void 0 ? void 0 : _q.textContent) === null || _r === void 0 ? void 0 : _r.trim()) !== null && _s !== void 0 ? _s : (_u = (_t = playbackDoc.querySelector("score-partwise > identification > creator")) === null || _t === void 0 ? void 0 : _t.textContent) === null || _u === void 0 ? void 0 : _u.trim()) !== null && _v !== void 0 ? _v : "";
         midiBytes = (0, midi_io_1.buildMidiBytesForPlayback)(events, effectiveParsedPlayback.tempo, "electric_piano_2", (0, midi_io_1.collectMidiProgramOverridesFromMusicXmlDoc)(playbackDoc), effectiveControlEvents, effectiveTempoEvents, timeSignatureEvents, keySignatureEvents, {
             metadata: {
                 title: scoreTitle,
@@ -9395,8 +9581,11 @@ const startPlayback = async (options, params) => {
         return;
     }
     try {
-        await options.engine.playSchedule(toSynthSchedule(effectiveParsedPlayback.tempo, events, effectiveTempoEvents, effectiveControlEvents), waveform, () => {
+        await options.engine.playSchedule(toSynthSchedule(effectiveParsedPlayback.tempo, events, effectiveTempoEvents, effectiveControlEvents), waveform, (currentTick) => {
+            options.setActivePlaybackLocation(findPlaybackLocationAtTick(measureTimeline, currentTick));
+        }, () => {
             options.setIsPlaying(false);
+            options.setActivePlaybackLocation(null);
             options.setPlaybackText("Playback: stopped");
             options.renderControlState();
         });
@@ -9416,8 +9605,10 @@ const startPlayback = async (options, params) => {
 };
 exports.startPlayback = startPlayback;
 const startMeasurePlayback = async (options, params) => {
+    var _a, _b, _c;
     if (!params.draftCore || options.getIsPlaying())
         return;
+    options.setActivePlaybackLocation(null);
     const saveResult = params.draftCore.save();
     if (!saveResult.ok) {
         options.onMeasureSaveDiagnostics(saveResult.diagnostics);
@@ -9456,9 +9647,16 @@ const startMeasurePlayback = async (options, params) => {
         ? (0, midi_io_1.collectMidiControlEventsFromMusicXmlDoc)(playbackDoc, options.ticksPerQuarter)
         : [];
     const waveform = options.getPlaybackWaveform();
+    const playbackAnchorPartId = (_c = (_b = (_a = playbackDoc.querySelector("score-partwise > part")) === null || _a === void 0 ? void 0 : _a.getAttribute("id")) === null || _b === void 0 ? void 0 : _b.trim()) !== null && _c !== void 0 ? _c : "";
+    const measureTimeline = playbackAnchorPartId
+        ? (0, exports.buildMeasureTimelineForPart)(playbackDoc, playbackAnchorPartId, options.ticksPerQuarter)
+        : [];
     try {
-        await options.engine.playSchedule(toSynthSchedule(parsedPlayback.tempo, events, tempoEvents, controlEvents), waveform, () => {
+        await options.engine.playSchedule(toSynthSchedule(parsedPlayback.tempo, events, tempoEvents, controlEvents), waveform, (currentTick) => {
+            options.setActivePlaybackLocation(findPlaybackLocationAtTick(measureTimeline, currentTick));
+        }, () => {
             options.setIsPlaying(false);
+            options.setActivePlaybackLocation(null);
             options.setPlaybackText("Playback: stopped");
             options.renderControlState();
         });

--- a/src/ts/main.ts
+++ b/src/ts/main.ts
@@ -248,6 +248,7 @@ let measureNumbersByPart = new Map<string, string[]>();
 let scoreTitleText = "";
 let scoreComposerText = "";
 let selectedMeasure: NoteLocation | null = null;
+let activePlaybackLocation: NoteLocation | null = null;
 let draftCore: ScoreCore | null = null;
 let draftNoteNodeIds: string[] = [];
 let draftSvgIdToNodeId = new Map<string, string>();
@@ -1555,23 +1556,38 @@ const highlightSelectedDraftNoteInEditor = (): void => {
 
 const highlightSelectedMeasureInMainPreview = (): void => {
   debugScoreArea
-    .querySelectorAll(".ms-measure-selected")
-    .forEach((el) => el.classList.remove("ms-measure-selected"));
+    .querySelectorAll(".ms-measure-selected, .ms-measure-playing")
+    .forEach((el) => {
+      el.classList.remove("ms-measure-selected");
+      el.classList.remove("ms-measure-playing");
+    });
 
-  if (!selectedMeasure || currentSvgIdToNodeId.size === 0) return;
+  if (currentSvgIdToNodeId.size === 0) return;
 
   for (const [svgId, nodeId] of currentSvgIdToNodeId.entries()) {
     const location = nodeIdToLocation.get(nodeId);
     if (!location) continue;
-    if (location.partId !== selectedMeasure.partId || location.measureNumber !== selectedMeasure.measureNumber) {
-      continue;
-    }
     const target = document.getElementById(svgId);
     if (!target || !debugScoreArea.contains(target)) continue;
-    target.classList.add("ms-measure-selected");
     const group = target.closest("g");
-    if (group && debugScoreArea.contains(group)) {
-      group.classList.add("ms-measure-selected");
+    const applyClass = (className: "ms-measure-selected" | "ms-measure-playing"): void => {
+      target.classList.add(className);
+      if (group && debugScoreArea.contains(group)) {
+        group.classList.add(className);
+      }
+    };
+    if (
+      selectedMeasure
+      && location.partId === selectedMeasure.partId
+      && location.measureNumber === selectedMeasure.measureNumber
+    ) {
+      applyClass("ms-measure-selected");
+    }
+    if (
+      activePlaybackLocation
+      && location.measureNumber === activePlaybackLocation.measureNumber
+    ) {
+      applyClass("ms-measure-playing");
     }
   }
 };
@@ -2304,6 +2320,10 @@ const playbackFlowOptions: PlaybackFlowOptions = {
     if (playbackText) {
       playbackText.textContent = text;
     }
+  },
+  setActivePlaybackLocation: (location) => {
+    activePlaybackLocation = location;
+    highlightSelectedMeasureInMainPreview();
   },
   renderControlState,
   renderAll,

--- a/src/ts/playback-flow.ts
+++ b/src/ts/playback-flow.ts
@@ -32,6 +32,7 @@ export type BasicWaveSynthEngine = {
   playSchedule: (
     schedule: SynthSchedule,
     waveform: OscillatorType,
+    onTickUpdate?: (currentTick: number) => void,
     onEnded?: () => void
   ) => Promise<void>;
   stop: () => void;
@@ -245,6 +246,7 @@ export const createBasicWaveSynthEngine = (options: { ticksPerQuarter: number })
   let audioContext: AudioContext | null = null;
   let activeSynthNodes: Array<{ oscillator: OscillatorNode; gainNode: GainNode }> = [];
   let synthStopTimer: number | null = null;
+  let playbackProgressTimer: number | null = null;
 
   const hasActiveUserGesture = (): boolean => {
     const nav = navigator as Navigator & {
@@ -334,6 +336,10 @@ export const createBasicWaveSynthEngine = (options: { ticksPerQuarter: number })
       window.clearTimeout(synthStopTimer);
       synthStopTimer = null;
     }
+    if (playbackProgressTimer !== null) {
+      window.clearInterval(playbackProgressTimer);
+      playbackProgressTimer = null;
+    }
     for (const node of activeSynthNodes) {
       try {
         node.oscillator.stop();
@@ -384,6 +390,7 @@ export const createBasicWaveSynthEngine = (options: { ticksPerQuarter: number })
   const playSchedule = async (
     schedule: SynthSchedule,
     waveform: OscillatorType,
+    onTickUpdate?: (currentTick: number) => void,
     onEnded?: () => void
   ): Promise<void> => {
     if (!schedule || !Array.isArray(schedule.events) || schedule.events.length === 0) {
@@ -433,6 +440,25 @@ export const createBasicWaveSynthEngine = (options: { ticksPerQuarter: number })
         if (segEnd >= targetTick) break;
       }
       return seconds;
+    };
+    const secondsToTick = (elapsedSeconds: number): number => {
+      if (!(elapsedSeconds > 0)) return 0;
+      let remainingSeconds = elapsedSeconds;
+      let resolvedTick = 0;
+      for (let i = 0; i < mergedTempoEvents.length; i += 1) {
+        const current = mergedTempoEvents[i];
+        const nextStart = mergedTempoEvents[i + 1]?.startTick ?? Number.POSITIVE_INFINITY;
+        const currentStart = current.startTick;
+        const spanTicks = Number.isFinite(nextStart) ? Math.max(0, nextStart - currentStart) : Number.POSITIVE_INFINITY;
+        const secPerTick = 60 / (current.bpm * ticksPerQuarter);
+        const spanSeconds = Number.isFinite(spanTicks) ? spanTicks * secPerTick : Number.POSITIVE_INFINITY;
+        if (remainingSeconds <= spanSeconds) {
+          return Math.max(resolvedTick, currentStart + Math.round(remainingSeconds / secPerTick));
+        }
+        remainingSeconds -= spanSeconds;
+        resolvedTick = Number.isFinite(spanTicks) ? nextStart : resolvedTick;
+      }
+      return Math.max(0, resolvedTick);
     };
     const baseTime = runningContext.currentTime + 0.04;
     let latestEndTime = baseTime;
@@ -511,9 +537,20 @@ export const createBasicWaveSynthEngine = (options: { ticksPerQuarter: number })
       lastNoteByLane.set(laneKey, { startTick: event.start, endTick: event.start + event.ticks });
     }
 
+    if (typeof onTickUpdate === "function") {
+      onTickUpdate(0);
+      playbackProgressTimer = window.setInterval(() => {
+        const elapsed = Math.max(0, runningContext.currentTime - baseTime);
+        onTickUpdate(secondsToTick(elapsed));
+      }, 90);
+    }
     const waitMs = Math.max(0, Math.ceil((latestEndTime - runningContext.currentTime) * 1000));
     synthStopTimer = window.setTimeout(() => {
       activeSynthNodes = [];
+      if (playbackProgressTimer !== null) {
+        window.clearInterval(playbackProgressTimer);
+        playbackProgressTimer = null;
+      }
       if (typeof onEnded === "function") {
         onEnded();
       }
@@ -602,6 +639,7 @@ export type PlaybackFlowOptions = {
   getIsPlaying: () => boolean;
   setIsPlaying: (isPlaying: boolean) => void;
   setPlaybackText: (text: string) => void;
+  setActivePlaybackLocation: (location: PlaybackStartLocation | null) => void;
   renderControlState: () => void;
   renderAll: () => void;
   logDiagnostics: (
@@ -628,36 +666,182 @@ const parsePositiveInt = (text: string | null | undefined): number | null => {
   return Number.isFinite(value) && value > 0 ? value : null;
 };
 
+const getFirstNumber = (el: ParentNode, selector: string): number | null => {
+  const text = el.querySelector(selector)?.textContent?.trim();
+  if (!text) return null;
+  const n = Number(text);
+  return Number.isFinite(n) ? n : null;
+};
+
+const measureCapacityDivFromContext = (divisions: number, beats: number, beatType: number): number => {
+  const safeDivisions = Math.max(1, Math.round(divisions));
+  const safeBeats = Math.max(1, Math.round(beats));
+  const safeBeatType = Math.max(1, Math.round(beatType));
+  return Math.max(1, Math.round((safeDivisions * 4 * safeBeats) / safeBeatType));
+};
+
+const estimateMeasureContentSpanDiv = (measure: Element): number => {
+  let cursorDiv = 0;
+  let measureMaxDiv = 0;
+  const lastStartByVoice = new Map<string, number>();
+  for (const child of Array.from(measure.children)) {
+    if (child.tagName === "backup" || child.tagName === "forward") {
+      const dur = getFirstNumber(child, "duration");
+      if (!dur || dur <= 0) continue;
+      if (child.tagName === "backup") {
+        cursorDiv = Math.max(0, cursorDiv - dur);
+      } else {
+        cursorDiv += dur;
+        measureMaxDiv = Math.max(measureMaxDiv, cursorDiv);
+      }
+      continue;
+    }
+    if (child.tagName !== "note") continue;
+    const durationDiv = getFirstNumber(child, "duration");
+    if (!durationDiv || durationDiv <= 0) continue;
+    const voice = child.querySelector("voice")?.textContent?.trim() ?? "1";
+    const isChord = Boolean(child.querySelector("chord"));
+    const startDiv = isChord ? (lastStartByVoice.get(voice) ?? cursorDiv) : cursorDiv;
+    if (!isChord) {
+      lastStartByVoice.set(voice, startDiv);
+      cursorDiv += durationDiv;
+    }
+    measureMaxDiv = Math.max(measureMaxDiv, cursorDiv, startDiv + durationDiv);
+  }
+  return measureMaxDiv;
+};
+
+const shouldTreatFirstUnderfullAsPickup = (doc: Document): boolean => {
+  const parts = Array.from(doc.querySelectorAll("score-partwise > part"));
+  if (parts.length < 2) return false;
+  for (const part of parts) {
+    const firstMeasure = part.querySelector(":scope > measure");
+    if (!firstMeasure) return false;
+    const divisions = getFirstNumber(firstMeasure, "attributes > divisions") ?? 1;
+    const beats = getFirstNumber(firstMeasure, "attributes > time > beats") ?? 4;
+    const beatType = getFirstNumber(firstMeasure, "attributes > time > beat-type") ?? 4;
+    const capacityDiv = measureCapacityDivFromContext(divisions, beats, beatType);
+    const contentDiv = estimateMeasureContentSpanDiv(firstMeasure);
+    if (!(contentDiv > 0 && contentDiv < capacityDiv)) {
+      return false;
+    }
+  }
+  return true;
+};
+
+const isImplicitMeasure = (measure: Element | null | undefined): boolean => {
+  if (!measure) return false;
+  const implicitAttr = (measure.getAttribute("implicit") || "").trim().toLowerCase();
+  return implicitAttr === "yes" || implicitAttr === "true" || implicitAttr === "1";
+};
+
+const resolveMeasureAdvanceDiv = (
+  measure: Element,
+  measureMaxDiv: number,
+  currentDivisions: number,
+  currentBeats: number,
+  currentBeatType: number,
+  nextMeasureIsImplicit = false,
+  firstMeasureUnderfullAsPickup = false
+): number => {
+  const safeDivisions = Math.max(1, Math.round(currentDivisions));
+  const safeBeats = Math.max(1, Math.round(currentBeats));
+  const safeBeatType = Math.max(1, Math.round(currentBeatType));
+  const capacityDiv = Math.max(1, Math.round((safeDivisions * 4 * safeBeats) / safeBeatType));
+  const implicitAttr = (measure.getAttribute("implicit") || "").trim().toLowerCase();
+  const isImplicit = implicitAttr === "yes" || implicitAttr === "true" || implicitAttr === "1";
+  if (isImplicit) {
+    return measureMaxDiv > 0 ? measureMaxDiv : capacityDiv;
+  }
+  let hasPreviousMeasure = false;
+  for (let prev = measure.previousElementSibling; prev; prev = prev.previousElementSibling) {
+    const prevName = (prev.localName || prev.tagName || "").toLowerCase();
+    if (prevName === "measure") {
+      hasPreviousMeasure = true;
+      break;
+    }
+  }
+  const isFirstMeasureInPart = !hasPreviousMeasure;
+  if (firstMeasureUnderfullAsPickup && isFirstMeasureInPart && measureMaxDiv > 0 && measureMaxDiv < capacityDiv) {
+    return measureMaxDiv;
+  }
+  if (nextMeasureIsImplicit && measureMaxDiv > 0 && measureMaxDiv < capacityDiv) {
+    return measureMaxDiv;
+  }
+  return Math.max(capacityDiv, measureMaxDiv);
+};
+
+export const buildMeasureTimelineForPart = (
+  doc: Document,
+  partId: string,
+  fallbackDivisions: number
+): Array<{ startTick: number; endTick: number; location: PlaybackStartLocation }> => {
+  const part = Array.from(doc.querySelectorAll("score-partwise > part")).find(
+    (p) => (p.getAttribute("id") ?? "").trim() === String(partId || "").trim()
+  );
+  if (!part) return [];
+  const firstUnderfullAsPickup = shouldTreatFirstUnderfullAsPickup(doc);
+  let divisions = Math.max(1, Math.round(fallbackDivisions));
+  let beats = 4;
+  let beatType = 4;
+  let tick = 0;
+  const ranges: Array<{ startTick: number; endTick: number; location: PlaybackStartLocation }> = [];
+  const measures = Array.from(part.querySelectorAll(":scope > measure"));
+  for (let measureIndex = 0; measureIndex < measures.length; measureIndex += 1) {
+    const measure = measures[measureIndex];
+    const nextMeasure = measures[measureIndex + 1] ?? null;
+    const nextDivisions = getFirstNumber(measure, "attributes > divisions");
+    if (nextDivisions && nextDivisions > 0) divisions = nextDivisions;
+    const nextBeats = getFirstNumber(measure, "attributes > time > beats");
+    const nextBeatType = getFirstNumber(measure, "attributes > time > beat-type");
+    if (nextBeats && nextBeats > 0 && nextBeatType && nextBeatType > 0) {
+      beats = nextBeats;
+      beatType = nextBeatType;
+    }
+    const measureNumber = (measure.getAttribute("number") ?? "").trim();
+    const measureContentDiv = estimateMeasureContentSpanDiv(measure);
+    const advanceDiv = resolveMeasureAdvanceDiv(
+      measure,
+      measureContentDiv,
+      divisions,
+      beats,
+      beatType,
+      isImplicitMeasure(nextMeasure),
+      firstUnderfullAsPickup
+    );
+    const measureTicks = Math.max(1, Math.round((advanceDiv / Math.max(1, divisions)) * fallbackDivisions));
+    ranges.push({
+      startTick: tick,
+      endTick: tick + measureTicks,
+      location: { partId, measureNumber },
+    });
+    tick += measureTicks;
+  }
+  return ranges;
+};
+
+const findPlaybackLocationAtTick = (
+  ranges: Array<{ startTick: number; endTick: number; location: PlaybackStartLocation }>,
+  tick: number
+): PlaybackStartLocation | null => {
+  if (!ranges.length) return null;
+  const safeTick = Math.max(0, Math.round(tick));
+  for (const range of ranges) {
+    if (safeTick >= range.startTick && safeTick < range.endTick) {
+      return range.location;
+    }
+  }
+  return ranges[ranges.length - 1]?.location ?? null;
+};
+
 const resolveMeasureStartTickInPart = (
   doc: Document,
   startFromMeasure: PlaybackStartLocation,
   fallbackDivisions: number
 ): number | null => {
-  const part = Array.from(doc.querySelectorAll("score-partwise > part")).find(
-    (p) => (p.getAttribute("id") ?? "").trim() === String(startFromMeasure.partId || "").trim()
-  );
-  if (!part) return null;
-  let divisions = Math.max(1, Math.round(fallbackDivisions));
-  let beats = 4;
-  let beatType = 4;
-  let tick = 0;
-  const measures = Array.from(part.querySelectorAll(":scope > measure"));
-  for (const measure of measures) {
-    const attrs = measure.querySelector(":scope > attributes");
-    const nextDivisions = parsePositiveInt(attrs?.querySelector(":scope > divisions")?.textContent);
-    if (nextDivisions) divisions = nextDivisions;
-    const nextBeats = parsePositiveInt(attrs?.querySelector(":scope > time > beats")?.textContent);
-    if (nextBeats) beats = nextBeats;
-    const nextBeatType = parsePositiveInt(attrs?.querySelector(":scope > time > beat-type")?.textContent);
-    if (nextBeatType) beatType = nextBeatType;
-    const measureNo = (measure.getAttribute("number") ?? "").trim();
-    if (measureNo === String(startFromMeasure.measureNumber ?? "").trim()) {
-      return tick;
-    }
-    const measureTicks = Math.max(1, Math.round((divisions * beats * 4) / Math.max(1, beatType)));
-    tick += measureTicks;
-  }
-  return null;
+  const ranges = buildMeasureTimelineForPart(doc, startFromMeasure.partId, fallbackDivisions);
+  const hit = ranges.find((range) => range.location.measureNumber === String(startFromMeasure.measureNumber ?? "").trim());
+  return hit ? hit.startTick : null;
 };
 
 const trimPlaybackFromTick = (
@@ -710,6 +894,7 @@ const trimPlaybackFromTick = (
 export const stopPlayback = (options: PlaybackFlowOptions): void => {
   options.engine.stop();
   options.setIsPlaying(false);
+  options.setActivePlaybackLocation(null);
   options.setPlaybackText("Playback: stopped");
   options.renderControlState();
 };
@@ -719,6 +904,7 @@ export const startPlayback = async (
   params: { isLoaded: boolean; core: SaveCapableCore; startFromMeasure?: PlaybackStartLocation | null }
 ): Promise<void> => {
   if (!params.isLoaded || options.getIsPlaying()) return;
+  options.setActivePlaybackLocation(null);
 
   const saveResult = params.core.save();
   options.onFullSaveResult(saveResult);
@@ -762,6 +948,10 @@ export const startPlayback = async (
   let effectiveControlEvents = useMidiLikePlayback
     ? collectMidiControlEventsFromMusicXmlDoc(playbackDoc, options.ticksPerQuarter)
     : [];
+  const playbackAnchorPartId =
+    params.startFromMeasure?.partId ??
+    playbackDoc.querySelector("score-partwise > part")?.getAttribute("id")?.trim() ??
+    "";
   if (params.startFromMeasure) {
     const startTick = resolveMeasureStartTickInPart(playbackDoc, params.startFromMeasure, options.ticksPerQuarter);
     if (startTick !== null && startTick > 0) {
@@ -790,6 +980,9 @@ export const startPlayback = async (
     : [];
 
   const waveform = options.getPlaybackWaveform();
+  const measureTimeline = playbackAnchorPartId
+    ? buildMeasureTimelineForPart(playbackDoc, playbackAnchorPartId, options.ticksPerQuarter)
+    : [];
 
   let midiBytes: Uint8Array;
   try {
@@ -834,8 +1027,12 @@ export const startPlayback = async (
     await options.engine.playSchedule(
       toSynthSchedule(effectiveParsedPlayback.tempo, events, effectiveTempoEvents, effectiveControlEvents),
       waveform,
+      (currentTick) => {
+        options.setActivePlaybackLocation(findPlaybackLocationAtTick(measureTimeline, currentTick));
+      },
       () => {
         options.setIsPlaying(false);
+        options.setActivePlaybackLocation(null);
         options.setPlaybackText("Playback: stopped");
         options.renderControlState();
       }
@@ -864,6 +1061,7 @@ export const startMeasurePlayback = async (
   params: { draftCore: SaveCapableCore | null }
 ): Promise<void> => {
   if (!params.draftCore || options.getIsPlaying()) return;
+  options.setActivePlaybackLocation(null);
 
   const saveResult = params.draftCore.save();
   if (!saveResult.ok) {
@@ -908,13 +1106,22 @@ export const startMeasurePlayback = async (
     : [];
 
   const waveform = options.getPlaybackWaveform();
+  const playbackAnchorPartId =
+    playbackDoc.querySelector("score-partwise > part")?.getAttribute("id")?.trim() ?? "";
+  const measureTimeline = playbackAnchorPartId
+    ? buildMeasureTimelineForPart(playbackDoc, playbackAnchorPartId, options.ticksPerQuarter)
+    : [];
 
   try {
     await options.engine.playSchedule(
       toSynthSchedule(parsedPlayback.tempo, events, tempoEvents, controlEvents),
       waveform,
+      (currentTick) => {
+        options.setActivePlaybackLocation(findPlaybackLocationAtTick(measureTimeline, currentTick));
+      },
       () => {
         options.setIsPlaying(false);
+        options.setActivePlaybackLocation(null);
         options.setPlaybackText("Playback: stopped");
         options.renderControlState();
       }

--- a/tests/unit/playback-flow.spec.ts
+++ b/tests/unit/playback-flow.spec.ts
@@ -1,10 +1,12 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  buildMeasureTimelineForPart,
   compactSynthScheduleForPlayback,
   createBasicWaveSynthEngine,
   type SynthSchedule,
 } from "../../src/ts/playback-flow";
+import { parseMusicXmlDocument } from "../../src/ts/musicxml-io";
 
 type MutableWindow = Window & typeof globalThis & { webkitAudioContext?: typeof AudioContext };
 
@@ -202,6 +204,27 @@ describe("playback-flow midi-like scheduling", () => {
     expect(oscillators[0].stop).toHaveBeenCalledWith(expect.closeTo(0.51, 6));
   });
 
+  it("reports playback tick progress when scheduling starts", async () => {
+    const { context } = createInspectableAudioContext();
+    mutableWindow.AudioContext = vi.fn(function MockAudioContext() {
+      return context as unknown as AudioContext;
+    }) as unknown as typeof AudioContext;
+    mutableWindow.webkitAudioContext = undefined;
+    const engine = createBasicWaveSynthEngine({ ticksPerQuarter: 128 });
+    const onTickUpdate = vi.fn();
+
+    await engine.playSchedule(
+      {
+        tempo: 120,
+        events: [{ midiNumber: 69, start: 0, ticks: 64, channel: 1 }],
+      },
+      "sine",
+      onTickUpdate
+    );
+
+    expect(onTickUpdate).toHaveBeenCalledWith(0);
+  });
+
   it("compacts dense schedules by capping notes per onset and overall event budget", () => {
     const schedule: SynthSchedule = {
       tempo: 120,
@@ -328,5 +351,50 @@ describe("playback-flow midi-like scheduling", () => {
     expect(keptMidis).toContain(100);
     expect(keptMidis).not.toContain(36);
     expect(keptMidis).not.toContain(48);
+  });
+
+  it("builds measure timeline with pickup-aware first bar lengths", () => {
+    const xml = `
+      <score-partwise version="4.0">
+        <part-list>
+          <score-part id="P1"><part-name>P1</part-name></score-part>
+          <score-part id="P2"><part-name>P2</part-name></score-part>
+        </part-list>
+        <part id="P1">
+          <measure number="0">
+            <attributes>
+              <divisions>4</divisions>
+              <time><beats>4</beats><beat-type>4</beat-type></time>
+            </attributes>
+            <note><pitch><step>C</step><octave>4</octave></pitch><duration>4</duration><voice>1</voice><type>quarter</type></note>
+          </measure>
+          <measure number="1">
+            <note><pitch><step>D</step><octave>4</octave></pitch><duration>16</duration><voice>1</voice><type>whole</type></note>
+          </measure>
+        </part>
+        <part id="P2">
+          <measure number="0">
+            <attributes>
+              <divisions>4</divisions>
+              <time><beats>4</beats><beat-type>4</beat-type></time>
+            </attributes>
+            <note><pitch><step>E</step><octave>4</octave></pitch><duration>4</duration><voice>1</voice><type>quarter</type></note>
+          </measure>
+          <measure number="1">
+            <note><pitch><step>F</step><octave>4</octave></pitch><duration>16</duration><voice>1</voice><type>whole</type></note>
+          </measure>
+        </part>
+      </score-partwise>
+    `;
+    const doc = parseMusicXmlDocument(xml);
+    expect(doc).not.toBeNull();
+    if (!doc) return;
+
+    const timeline = buildMeasureTimelineForPart(doc, "P1", 480);
+
+    expect(timeline).toHaveLength(2);
+    expect(timeline[0]?.startTick).toBe(0);
+    expect(timeline[0]?.endTick).toBe(480);
+    expect(timeline[1]?.startTick).toBe(480);
   });
 });


### PR DESCRIPTION
## 概要

quick playback 中に、現在再生中の小節をスコアプレビュー上でハイライトする機能を追加しました。 あわせて、大きい譜面向けの lightweight playback 制御を強化し、弱起を含む小節進行の扱いも改善しています。

## 変更内容

### 1. 再生中小節ハイライトを追加
- `src/ts/playback-flow.ts`
  - playback 進行に応じて current tick を通知する仕組みを追加
  - tick から現在小節を解決する measure timeline を導入
  - playback 停止時や開始失敗時に active location を確実にクリアするよう整理
- `src/ts/main.ts`
  - `activePlaybackLocation` を追加
  - score preview の measure highlight に「selected」と「playing」の 2 状態を持たせた
  - 再生中は同じ小節番号の全パートをハイライト対象にするよう変更
- `src/css/app.css`
  - 再生中小節用の `ms-measure-playing` スタイルを追加
  - 見やすさを優先して濃い紫系のハイライト色を適用

### 2. 弱起を含む小節進行の補正
- `src/ts/playback-flow.ts`
  - playback 用 measure timeline の算出を、単純な拍子長ではなく pickup / implicit measure を考慮するロジックへ変更
  - `resolveMeasureAdvanceDiv` 相当の計算を playback timeline 側でも使うようにして、弱起でのずれを抑制

### 3. dense playback 安定化の改善
- `src/ts/playback-flow.ts`
  - dense schedule の軽量化を継続
  - 小さい same-onset chord は保護
  - dense onset 内では外声とオクターブ非重複音を優先して保持
  - 中間のオクターブ重複音を後回しにする保持順へ調整

### 4. テスト追加
- `tests/unit/playback-flow.spec.ts`
  - playback tick progress 通知のテストを追加
  - dense schedule compaction の回帰テストを追加
  - small same-onset chord 保護のテストを追加
  - 外声 / 非オクターブ重複音の優先保持テストを追加
  - pickup-aware な measure timeline 構築テストを追加

### 5. ビルド生成物更新
- `src/js/main.js`
- `mikuscore.html`

## 意図

- playback 中に「今どこが鳴っているか」を視覚的に追えるようにする
- 大きい譜面でも quick playback が止まりにくい状態を維持する
- 弱起や implicit measure を含む譜面でのハイライト位置ずれを減らす

## テスト

実施済み:
- `npx vitest run tests/unit/playback-flow.spec.ts --reporter=verbose`
- `npm run typecheck`
- `npm run build`

## 補足

- 再生中ハイライトは選択中小節ハイライトとは別状態です
- 現在は「同じ小節番号の全パート」を再生中としてハイライトします
- dense score では安定性優先で一部音を省略する可能性があります