### PR TITLE
Playback 中の現在小節を左寄せ基準で自動スクロール追従する

### DIFF
--- a/mikuscore.html
+++ b/mikuscore.html
@@ -8178,6 +8178,7 @@ const playbackText = qo("#playbackText");
 const outputXml = qo("#outputXml");
 const diagArea = qo("#diagArea");
 const debugScoreMeta = qo("#debugScoreMeta");
+const debugScoreWrap = q("#debugScoreWrap");
 const debugScoreArea = q("#debugScoreArea");
 const scoreHeaderMetaText = q("#scoreHeaderMetaText");
 const inputUiMessage = q("#inputUiMessage");
@@ -8229,6 +8230,7 @@ let scoreTitleText = "";
 let scoreComposerText = "";
 let selectedMeasure = null;
 let activePlaybackLocation = null;
+let lastPlaybackAutoScrollKey = "";
 let draftCore = null;
 let draftNoteNodeIds = [];
 let draftSvgIdToNodeId = new Map();
@@ -9476,6 +9478,51 @@ const highlightSelectedMeasureInMainPreview = () => {
         }
     }
 };
+const scrollActivePlaybackMeasureIntoView = () => {
+    if (!activePlaybackLocation) {
+        lastPlaybackAutoScrollKey = "";
+        return;
+    }
+    const playingNodes = Array.from(debugScoreArea.querySelectorAll(".ms-measure-playing"));
+    if (playingNodes.length === 0)
+        return;
+    let minLeft = Number.POSITIVE_INFINITY;
+    let maxRight = Number.NEGATIVE_INFINITY;
+    const wrapRect = debugScoreWrap.getBoundingClientRect();
+    for (const node of playingNodes) {
+        const rect = node.getBoundingClientRect();
+        if (!(rect.width > 0) || !(rect.height > 0))
+            continue;
+        const left = rect.left - wrapRect.left + debugScoreWrap.scrollLeft;
+        const right = rect.right - wrapRect.left + debugScoreWrap.scrollLeft;
+        minLeft = Math.min(minLeft, left);
+        maxRight = Math.max(maxRight, right);
+    }
+    if (!Number.isFinite(minLeft) || !Number.isFinite(maxRight) || maxRight <= minLeft)
+        return;
+    const viewLeft = debugScoreWrap.scrollLeft;
+    const viewWidth = debugScoreWrap.clientWidth;
+    const viewRight = viewLeft + viewWidth;
+    const leftTargetRatio = 0.2;
+    const rightThresholdRatio = 0.7;
+    const desiredLeft = Math.max(0, Math.min(debugScoreWrap.scrollWidth - debugScoreWrap.clientWidth, minLeft - debugScoreWrap.clientWidth * leftTargetRatio));
+    const measureKey = `${activePlaybackLocation.partId}:${activePlaybackLocation.measureNumber}:${Math.round(desiredLeft)}`;
+    const isOffscreen = minLeft < viewLeft || maxRight > viewRight;
+    const isTooFarRight = maxRight > viewLeft + viewWidth * rightThresholdRatio;
+    if (!isOffscreen && !isTooFarRight)
+        return;
+    if (lastPlaybackAutoScrollKey === measureKey)
+        return;
+    if (Math.abs(debugScoreWrap.scrollLeft - desiredLeft) < 2) {
+        lastPlaybackAutoScrollKey = measureKey;
+        return;
+    }
+    debugScoreWrap.scrollTo({
+        left: desiredLeft,
+        behavior: "smooth",
+    });
+    lastPlaybackAutoScrollKey = measureKey;
+};
 const renderDiagnostics = () => {
     if (!diagArea)
         return;
@@ -10183,7 +10230,11 @@ const playbackFlowOptions = {
     },
     setActivePlaybackLocation: (location) => {
         activePlaybackLocation = location;
+        if (!location) {
+            lastPlaybackAutoScrollKey = "";
+        }
         highlightSelectedMeasureInMainPreview();
+        scrollActivePlaybackMeasureIntoView();
     },
     renderControlState,
     renderAll,

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -132,6 +132,7 @@ const playbackText = qo("#playbackText");
 const outputXml = qo("#outputXml");
 const diagArea = qo("#diagArea");
 const debugScoreMeta = qo("#debugScoreMeta");
+const debugScoreWrap = q("#debugScoreWrap");
 const debugScoreArea = q("#debugScoreArea");
 const scoreHeaderMetaText = q("#scoreHeaderMetaText");
 const inputUiMessage = q("#inputUiMessage");
@@ -183,6 +184,7 @@ let scoreTitleText = "";
 let scoreComposerText = "";
 let selectedMeasure = null;
 let activePlaybackLocation = null;
+let lastPlaybackAutoScrollKey = "";
 let draftCore = null;
 let draftNoteNodeIds = [];
 let draftSvgIdToNodeId = new Map();
@@ -1430,6 +1432,51 @@ const highlightSelectedMeasureInMainPreview = () => {
         }
     }
 };
+const scrollActivePlaybackMeasureIntoView = () => {
+    if (!activePlaybackLocation) {
+        lastPlaybackAutoScrollKey = "";
+        return;
+    }
+    const playingNodes = Array.from(debugScoreArea.querySelectorAll(".ms-measure-playing"));
+    if (playingNodes.length === 0)
+        return;
+    let minLeft = Number.POSITIVE_INFINITY;
+    let maxRight = Number.NEGATIVE_INFINITY;
+    const wrapRect = debugScoreWrap.getBoundingClientRect();
+    for (const node of playingNodes) {
+        const rect = node.getBoundingClientRect();
+        if (!(rect.width > 0) || !(rect.height > 0))
+            continue;
+        const left = rect.left - wrapRect.left + debugScoreWrap.scrollLeft;
+        const right = rect.right - wrapRect.left + debugScoreWrap.scrollLeft;
+        minLeft = Math.min(minLeft, left);
+        maxRight = Math.max(maxRight, right);
+    }
+    if (!Number.isFinite(minLeft) || !Number.isFinite(maxRight) || maxRight <= minLeft)
+        return;
+    const viewLeft = debugScoreWrap.scrollLeft;
+    const viewWidth = debugScoreWrap.clientWidth;
+    const viewRight = viewLeft + viewWidth;
+    const leftTargetRatio = 0.2;
+    const rightThresholdRatio = 0.7;
+    const desiredLeft = Math.max(0, Math.min(debugScoreWrap.scrollWidth - debugScoreWrap.clientWidth, minLeft - debugScoreWrap.clientWidth * leftTargetRatio));
+    const measureKey = `${activePlaybackLocation.partId}:${activePlaybackLocation.measureNumber}:${Math.round(desiredLeft)}`;
+    const isOffscreen = minLeft < viewLeft || maxRight > viewRight;
+    const isTooFarRight = maxRight > viewLeft + viewWidth * rightThresholdRatio;
+    if (!isOffscreen && !isTooFarRight)
+        return;
+    if (lastPlaybackAutoScrollKey === measureKey)
+        return;
+    if (Math.abs(debugScoreWrap.scrollLeft - desiredLeft) < 2) {
+        lastPlaybackAutoScrollKey = measureKey;
+        return;
+    }
+    debugScoreWrap.scrollTo({
+        left: desiredLeft,
+        behavior: "smooth",
+    });
+    lastPlaybackAutoScrollKey = measureKey;
+};
 const renderDiagnostics = () => {
     if (!diagArea)
         return;
@@ -2137,7 +2184,11 @@ const playbackFlowOptions = {
     },
     setActivePlaybackLocation: (location) => {
         activePlaybackLocation = location;
+        if (!location) {
+            lastPlaybackAutoScrollKey = "";
+        }
         highlightSelectedMeasureInMainPreview();
+        scrollActivePlaybackMeasureIntoView();
     },
     renderControlState,
     renderAll,

--- a/src/ts/main.ts
+++ b/src/ts/main.ts
@@ -196,6 +196,7 @@ const playbackText = qo<HTMLParagraphElement>("#playbackText");
 const outputXml = qo<HTMLTextAreaElement>("#outputXml");
 const diagArea = qo<HTMLDivElement>("#diagArea");
 const debugScoreMeta = qo<HTMLParagraphElement>("#debugScoreMeta");
+const debugScoreWrap = q<HTMLDivElement>("#debugScoreWrap");
 const debugScoreArea = q<HTMLDivElement>("#debugScoreArea");
 const scoreHeaderMetaText = q<HTMLParagraphElement>("#scoreHeaderMetaText");
 const inputUiMessage = q<HTMLElement>("#inputUiMessage");
@@ -249,6 +250,7 @@ let scoreTitleText = "";
 let scoreComposerText = "";
 let selectedMeasure: NoteLocation | null = null;
 let activePlaybackLocation: NoteLocation | null = null;
+let lastPlaybackAutoScrollKey = "";
 let draftCore: ScoreCore | null = null;
 let draftNoteNodeIds: string[] = [];
 let draftSvgIdToNodeId = new Map<string, string>();
@@ -1592,6 +1594,56 @@ const highlightSelectedMeasureInMainPreview = (): void => {
   }
 };
 
+const scrollActivePlaybackMeasureIntoView = (): void => {
+  if (!activePlaybackLocation) {
+    lastPlaybackAutoScrollKey = "";
+    return;
+  }
+  const playingNodes = Array.from(debugScoreArea.querySelectorAll<HTMLElement>(".ms-measure-playing"));
+  if (playingNodes.length === 0) return;
+
+  let minLeft = Number.POSITIVE_INFINITY;
+  let maxRight = Number.NEGATIVE_INFINITY;
+  const wrapRect = debugScoreWrap.getBoundingClientRect();
+  for (const node of playingNodes) {
+    const rect = node.getBoundingClientRect();
+    if (!(rect.width > 0) || !(rect.height > 0)) continue;
+    const left = rect.left - wrapRect.left + debugScoreWrap.scrollLeft;
+    const right = rect.right - wrapRect.left + debugScoreWrap.scrollLeft;
+    minLeft = Math.min(minLeft, left);
+    maxRight = Math.max(maxRight, right);
+  }
+  if (!Number.isFinite(minLeft) || !Number.isFinite(maxRight) || maxRight <= minLeft) return;
+
+  const viewLeft = debugScoreWrap.scrollLeft;
+  const viewWidth = debugScoreWrap.clientWidth;
+  const viewRight = viewLeft + viewWidth;
+  const leftTargetRatio = 0.2;
+  const rightThresholdRatio = 0.7;
+  const desiredLeft = Math.max(
+    0,
+    Math.min(
+      debugScoreWrap.scrollWidth - debugScoreWrap.clientWidth,
+      minLeft - debugScoreWrap.clientWidth * leftTargetRatio
+    )
+  );
+  const measureKey = `${activePlaybackLocation.partId}:${activePlaybackLocation.measureNumber}:${Math.round(desiredLeft)}`;
+  const isOffscreen = minLeft < viewLeft || maxRight > viewRight;
+  const isTooFarRight = maxRight > viewLeft + viewWidth * rightThresholdRatio;
+  if (!isOffscreen && !isTooFarRight) return;
+  if (lastPlaybackAutoScrollKey === measureKey) return;
+
+  if (Math.abs(debugScoreWrap.scrollLeft - desiredLeft) < 2) {
+    lastPlaybackAutoScrollKey = measureKey;
+    return;
+  }
+  debugScoreWrap.scrollTo({
+    left: desiredLeft,
+    behavior: "smooth",
+  });
+  lastPlaybackAutoScrollKey = measureKey;
+};
+
 const renderDiagnostics = (): void => {
   if (!diagArea) return;
   diagArea.innerHTML = "";
@@ -2323,7 +2375,11 @@ const playbackFlowOptions: PlaybackFlowOptions = {
   },
   setActivePlaybackLocation: (location) => {
     activePlaybackLocation = location;
+    if (!location) {
+      lastPlaybackAutoScrollKey = "";
+    }
     highlightSelectedMeasureInMainPreview();
+    scrollActivePlaybackMeasureIntoView();
   },
   renderControlState,
   renderAll,


### PR DESCRIPTION
## 概要

Playback 中の現在再生小節に合わせて、スコアプレビューを自動で横スクロールする機能を追加しました。

常時中央追従ではなく、次の条件でのみスクロールします。

- 再生中小節が画面外に出たとき
- 再生中小節が画面の右寄りまで進んだとき

スクロール後は、その小節が画面のやや左側に見える位置へ寄せます。これにより、再生位置を見失いにくくしつつ、先の譜面も見やすくなります。

## 変更内容

### `src/ts/main.ts`
- `#debugScoreWrap` を取得して、score preview のスクロールコンテナとして利用
- `lastPlaybackAutoScrollKey` を追加し、同じ目標位置への重複スクロールを抑制
- `scrollActivePlaybackMeasureIntoView()` を追加
  - 再生中小節の描画位置を `.ms-measure-playing` から算出
  - 小節が画面外にあるか、右端が表示幅の `70%` を超えた場合にのみスクロール
  - スクロール先は、小節の左端が表示幅の `20%` 付近に来る位置
  - スクロールは `behavior: "smooth"` を使用
- `setActivePlaybackLocation(...)` から
  - 再生中小節ハイライト更新
  - 自動スクロール実行 を連動させるよう変更
- playback location が消えたときにスクロール用キーをリセット

### ビルド生成物更新
- `src/js/main.js`
- `mikuscore.html`

## 意図

- Playback 中に現在位置を追いやすくする
- 常時中央追従より自然な視線移動にする
- 先読み余白を確保しつつ、再生中小節が見切れないようにする

## 現在のスクロールルール

- 右寄り判定: 表示領域の `70%`
- 左寄せ目標: 表示領域の `20%`
- 発火条件:
  - 小節が画面外
  - または右寄り判定を超過

## テスト / 確認

実施済み:
- `npm run typecheck`
- `npm run build`

## 補足

- スクロールは必要なときだけ動きます
- ブラウザ標準の `smooth` スクロールを使っています
- 細かい揺れを避けるため、同一目標への連続スクロールは抑制しています