### PR TITLE
Playback 中ハイライトをピンクに変更し、選択小節からの再生位置表示を修正

### DIFF
--- a/mikuscore.html
+++ b/mikuscore.html
@@ -1075,13 +1075,13 @@ lht-help-tooltip:not([data-initialized="true"]) * {
 }
 
 .ms-debug-score .ms-measure-playing {
-  fill: #8b3dff !important;
-  stroke: #5f1fc7 !important;
+  fill: #e83e8c !important;
+  stroke: #b01f63 !important;
 }
 
 .ms-debug-score .ms-measure-playing * {
-  fill: #8b3dff !important;
-  stroke: #5f1fc7 !important;
+  fill: #e83e8c !important;
+  stroke: #b01f63 !important;
 }
 
 .ms-dev {
@@ -17539,6 +17539,19 @@ const findPlaybackLocationAtTick = (ranges, tick) => {
     }
     return (_b = (_a = ranges[ranges.length - 1]) === null || _a === void 0 ? void 0 : _a.location) !== null && _b !== void 0 ? _b : null;
 };
+const trimMeasureTimelineFromTick = (ranges, startTick) => {
+    if (!ranges.length || !Number.isFinite(startTick) || startTick <= 0) {
+        return ranges;
+    }
+    const safeStartTick = Math.max(0, Math.round(startTick));
+    return ranges
+        .filter((range) => range.endTick > safeStartTick)
+        .map((range) => ({
+        startTick: Math.max(0, range.startTick - safeStartTick),
+        endTick: Math.max(0, range.endTick - safeStartTick),
+        location: range.location,
+    }));
+};
 const resolveMeasureStartTickInPart = (doc, startFromMeasure, fallbackDivisions) => {
     const ranges = (0, exports.buildMeasureTimelineForPart)(doc, startFromMeasure.partId, fallbackDivisions);
     const hit = ranges.find((range) => { var _a; return range.location.measureNumber === String((_a = startFromMeasure.measureNumber) !== null && _a !== void 0 ? _a : "").trim(); });
@@ -17633,9 +17646,11 @@ const startPlayback = async (options, params) => {
         ? (0, midi_io_1.collectMidiControlEventsFromMusicXmlDoc)(playbackDoc, options.ticksPerQuarter)
         : [];
     const playbackAnchorPartId = (_e = (_b = (_a = params.startFromMeasure) === null || _a === void 0 ? void 0 : _a.partId) !== null && _b !== void 0 ? _b : (_d = (_c = playbackDoc.querySelector("score-partwise > part")) === null || _c === void 0 ? void 0 : _c.getAttribute("id")) === null || _d === void 0 ? void 0 : _d.trim()) !== null && _e !== void 0 ? _e : "";
+    let playbackStartTick = 0;
     if (params.startFromMeasure) {
         const startTick = resolveMeasureStartTickInPart(playbackDoc, params.startFromMeasure, options.ticksPerQuarter);
         if (startTick !== null && startTick > 0) {
+            playbackStartTick = startTick;
             const trimmed = trimPlaybackFromTick(effectiveParsedPlayback, effectiveTempoEvents, effectiveControlEvents, startTick);
             effectiveParsedPlayback = trimmed.parsedPlayback;
             effectiveTempoEvents = trimmed.tempoEvents;
@@ -17656,8 +17671,11 @@ const startPlayback = async (options, params) => {
         : [];
     const waveform = options.getPlaybackWaveform();
     const measureTimeline = playbackAnchorPartId
-        ? (0, exports.buildMeasureTimelineForPart)(playbackDoc, playbackAnchorPartId, options.ticksPerQuarter)
+        ? trimMeasureTimelineFromTick((0, exports.buildMeasureTimelineForPart)(playbackDoc, playbackAnchorPartId, options.ticksPerQuarter), playbackStartTick)
         : [];
+    if (params.startFromMeasure) {
+        options.setActivePlaybackLocation(params.startFromMeasure);
+    }
     let midiBytes;
     try {
         const scoreTitle = (_l = (_h = (_g = (_f = playbackDoc.querySelector("score-partwise > work > work-title")) === null || _f === void 0 ? void 0 : _f.textContent) === null || _g === void 0 ? void 0 : _g.trim()) !== null && _h !== void 0 ? _h : (_k = (_j = playbackDoc.querySelector("score-partwise > movement-title")) === null || _j === void 0 ? void 0 : _j.textContent) === null || _k === void 0 ? void 0 : _k.trim()) !== null && _l !== void 0 ? _l : "";

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -1067,13 +1067,13 @@ lht-help-tooltip:not([data-initialized="true"]) * {
 }
 
 .ms-debug-score .ms-measure-playing {
-  fill: #8b3dff !important;
-  stroke: #5f1fc7 !important;
+  fill: #e83e8c !important;
+  stroke: #b01f63 !important;
 }
 
 .ms-debug-score .ms-measure-playing * {
-  fill: #8b3dff !important;
-  stroke: #5f1fc7 !important;
+  fill: #e83e8c !important;
+  stroke: #b01f63 !important;
 }
 
 .ms-dev {

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -9493,6 +9493,19 @@ const findPlaybackLocationAtTick = (ranges, tick) => {
     }
     return (_b = (_a = ranges[ranges.length - 1]) === null || _a === void 0 ? void 0 : _a.location) !== null && _b !== void 0 ? _b : null;
 };
+const trimMeasureTimelineFromTick = (ranges, startTick) => {
+    if (!ranges.length || !Number.isFinite(startTick) || startTick <= 0) {
+        return ranges;
+    }
+    const safeStartTick = Math.max(0, Math.round(startTick));
+    return ranges
+        .filter((range) => range.endTick > safeStartTick)
+        .map((range) => ({
+        startTick: Math.max(0, range.startTick - safeStartTick),
+        endTick: Math.max(0, range.endTick - safeStartTick),
+        location: range.location,
+    }));
+};
 const resolveMeasureStartTickInPart = (doc, startFromMeasure, fallbackDivisions) => {
     const ranges = (0, exports.buildMeasureTimelineForPart)(doc, startFromMeasure.partId, fallbackDivisions);
     const hit = ranges.find((range) => { var _a; return range.location.measureNumber === String((_a = startFromMeasure.measureNumber) !== null && _a !== void 0 ? _a : "").trim(); });
@@ -9587,9 +9600,11 @@ const startPlayback = async (options, params) => {
         ? (0, midi_io_1.collectMidiControlEventsFromMusicXmlDoc)(playbackDoc, options.ticksPerQuarter)
         : [];
     const playbackAnchorPartId = (_e = (_b = (_a = params.startFromMeasure) === null || _a === void 0 ? void 0 : _a.partId) !== null && _b !== void 0 ? _b : (_d = (_c = playbackDoc.querySelector("score-partwise > part")) === null || _c === void 0 ? void 0 : _c.getAttribute("id")) === null || _d === void 0 ? void 0 : _d.trim()) !== null && _e !== void 0 ? _e : "";
+    let playbackStartTick = 0;
     if (params.startFromMeasure) {
         const startTick = resolveMeasureStartTickInPart(playbackDoc, params.startFromMeasure, options.ticksPerQuarter);
         if (startTick !== null && startTick > 0) {
+            playbackStartTick = startTick;
             const trimmed = trimPlaybackFromTick(effectiveParsedPlayback, effectiveTempoEvents, effectiveControlEvents, startTick);
             effectiveParsedPlayback = trimmed.parsedPlayback;
             effectiveTempoEvents = trimmed.tempoEvents;
@@ -9610,8 +9625,11 @@ const startPlayback = async (options, params) => {
         : [];
     const waveform = options.getPlaybackWaveform();
     const measureTimeline = playbackAnchorPartId
-        ? (0, exports.buildMeasureTimelineForPart)(playbackDoc, playbackAnchorPartId, options.ticksPerQuarter)
+        ? trimMeasureTimelineFromTick((0, exports.buildMeasureTimelineForPart)(playbackDoc, playbackAnchorPartId, options.ticksPerQuarter), playbackStartTick)
         : [];
+    if (params.startFromMeasure) {
+        options.setActivePlaybackLocation(params.startFromMeasure);
+    }
     let midiBytes;
     try {
         const scoreTitle = (_l = (_h = (_g = (_f = playbackDoc.querySelector("score-partwise > work > work-title")) === null || _f === void 0 ? void 0 : _f.textContent) === null || _g === void 0 ? void 0 : _g.trim()) !== null && _h !== void 0 ? _h : (_k = (_j = playbackDoc.querySelector("score-partwise > movement-title")) === null || _j === void 0 ? void 0 : _j.textContent) === null || _k === void 0 ? void 0 : _k.trim()) !== null && _l !== void 0 ? _l : "";

--- a/src/ts/playback-flow.ts
+++ b/src/ts/playback-flow.ts
@@ -834,6 +834,23 @@ const findPlaybackLocationAtTick = (
   return ranges[ranges.length - 1]?.location ?? null;
 };
 
+const trimMeasureTimelineFromTick = (
+  ranges: Array<{ startTick: number; endTick: number; location: PlaybackStartLocation }>,
+  startTick: number
+): Array<{ startTick: number; endTick: number; location: PlaybackStartLocation }> => {
+  if (!ranges.length || !Number.isFinite(startTick) || startTick <= 0) {
+    return ranges;
+  }
+  const safeStartTick = Math.max(0, Math.round(startTick));
+  return ranges
+    .filter((range) => range.endTick > safeStartTick)
+    .map((range) => ({
+      startTick: Math.max(0, range.startTick - safeStartTick),
+      endTick: Math.max(0, range.endTick - safeStartTick),
+      location: range.location,
+    }));
+};
+
 const resolveMeasureStartTickInPart = (
   doc: Document,
   startFromMeasure: PlaybackStartLocation,
@@ -952,9 +969,11 @@ export const startPlayback = async (
     params.startFromMeasure?.partId ??
     playbackDoc.querySelector("score-partwise > part")?.getAttribute("id")?.trim() ??
     "";
+  let playbackStartTick = 0;
   if (params.startFromMeasure) {
     const startTick = resolveMeasureStartTickInPart(playbackDoc, params.startFromMeasure, options.ticksPerQuarter);
     if (startTick !== null && startTick > 0) {
+      playbackStartTick = startTick;
       const trimmed = trimPlaybackFromTick(
         effectiveParsedPlayback,
         effectiveTempoEvents,
@@ -981,8 +1000,14 @@ export const startPlayback = async (
 
   const waveform = options.getPlaybackWaveform();
   const measureTimeline = playbackAnchorPartId
-    ? buildMeasureTimelineForPart(playbackDoc, playbackAnchorPartId, options.ticksPerQuarter)
+    ? trimMeasureTimelineFromTick(
+      buildMeasureTimelineForPart(playbackDoc, playbackAnchorPartId, options.ticksPerQuarter),
+      playbackStartTick
+    )
     : [];
+  if (params.startFromMeasure) {
+    options.setActivePlaybackLocation(params.startFromMeasure);
+  }
 
   let midiBytes: Uint8Array;
   try {

--- a/tests/unit/playback-flow.spec.ts
+++ b/tests/unit/playback-flow.spec.ts
@@ -4,6 +4,7 @@ import {
   buildMeasureTimelineForPart,
   compactSynthScheduleForPlayback,
   createBasicWaveSynthEngine,
+  startPlayback,
   type SynthSchedule,
 } from "../../src/ts/playback-flow";
 import { parseMusicXmlDocument } from "../../src/ts/musicxml-io";
@@ -396,5 +397,68 @@ describe("playback-flow midi-like scheduling", () => {
     expect(timeline[0]?.startTick).toBe(0);
     expect(timeline[0]?.endTick).toBe(480);
     expect(timeline[1]?.startTick).toBe(480);
+  });
+
+  it("maps playback location to the selected measure when playback starts mid-score", async () => {
+    const xml = `
+      <score-partwise version="4.0">
+        <part-list>
+          <score-part id="P1"><part-name>P1</part-name></score-part>
+        </part-list>
+        <part id="P1">
+          <measure number="1">
+            <attributes>
+              <divisions>4</divisions>
+              <time><beats>4</beats><beat-type>4</beat-type></time>
+            </attributes>
+            <note><pitch><step>C</step><octave>4</octave></pitch><duration>16</duration><voice>1</voice><type>whole</type></note>
+          </measure>
+          <measure number="2">
+            <note><pitch><step>D</step><octave>4</octave></pitch><duration>16</duration><voice>1</voice><type>whole</type></note>
+          </measure>
+        </part>
+      </score-partwise>
+    `;
+    const setActivePlaybackLocation = vi.fn();
+    const engine = {
+      stop: vi.fn(),
+      playSchedule: vi.fn(async (_schedule, _waveform, onTickUpdate) => {
+        onTickUpdate?.(0);
+      }),
+    } as unknown as ReturnType<typeof createBasicWaveSynthEngine>;
+    const options = {
+      engine,
+      ticksPerQuarter: 480,
+      editableVoice: "1",
+      getPlaybackWaveform: () => "sine" as OscillatorType,
+      getUseMidiLikePlayback: () => false,
+      getGraceTimingMode: () => "steal-current" as const,
+      getMetricAccentEnabled: () => false,
+      getMetricAccentProfile: () => "classic" as const,
+      debugLog: false,
+      getIsPlaying: () => false,
+      setIsPlaying: vi.fn(),
+      setPlaybackText: vi.fn(),
+      setActivePlaybackLocation,
+      renderControlState: vi.fn(),
+      renderAll: vi.fn(),
+      logDiagnostics: vi.fn(),
+      dumpOverfullContext: vi.fn(),
+      onFullSaveResult: vi.fn(),
+      onMeasureSaveDiagnostics: vi.fn(),
+    };
+    const core = {
+      save: () => ({ ok: true, xml, diagnostics: [], warnings: [], dirtyChanged: false, changedNodeIds: [], affectedMeasureNumbers: [] }),
+      debugSerializeCurrentXml: () => xml,
+    };
+
+    await startPlayback(options, {
+      isLoaded: true,
+      core,
+      startFromMeasure: { partId: "P1", measureNumber: "2" },
+    });
+
+    expect(setActivePlaybackLocation).toHaveBeenCalledWith({ partId: "P1", measureNumber: "2" });
+    expect(setActivePlaybackLocation.mock.calls.at(-1)?.[0]).toEqual({ partId: "P1", measureNumber: "2" });
   });
 });


### PR DESCRIPTION
## 概要

Playback 中の再生小節ハイライト色を、従来の紫系からピンク系へ変更しました。
あわせて、スコア上で小節をクリックしてその小節から再生した場合に、再生中小節表示が正しい位置を指さない問題を修正しています。

## 変更内容

### 1. Playback 中ハイライト色の変更
- `src/css/app.css`
  - `.ms-measure-playing` の色を濃いピンク系に変更
  - 対象要素とその子要素の `fill` / `stroke` を更新

変更後の色:
- `fill: #e83e8c`
- `stroke: #b01f63`

### 2. 選択小節から再生したときの再生中小節表示を修正
- `src/ts/playback-flow.ts`
  - `trimMeasureTimelineFromTick(...)` を追加
  - 小節選択から playback を開始する場合、再生開始 tick に合わせて measure timeline も同じ開始位置に揃えるよう変更
  - 選択小節から再生する場合は、再生開始前にその小節を `activePlaybackLocation` として設定するよう変更

これにより、
- イベント列は途中小節から再生される
- 再生中小節の表示も同じ開始位置に揃う
- 再生開始直後にハイライトが空になる瞬間を避ける

という挙動になります。

### 3. 回帰テスト追加
- `tests/unit/playback-flow.spec.ts`
  - 小節途中開始 playback で、再生位置表示が選択小節を指すことを確認するテストを追加

### 4. ビルド生成物更新
- `src/js/main.js`
- `mikuscore.html`

## 意図

- Playback 中の小節ハイライトを見やすくする
- 小節選択後の playback で、見た目の再生位置と実際の開始位置がずれないようにする

## テスト

実施済み:
- `npx vitest run tests/unit/playback-flow.spec.ts --reporter=verbose`
- `npm run typecheck`
- `npm run build`

## 補足

今回の修正は full playback の「選択小節から開始」経路に対するものです。
選択小節を起点とした再生でも、開始直後から再生中小節ハイライトが正しく乗るようにしています。