### PR TITLE
ABC 互換パーサと ABC I/O の対応範囲を拡張し、仕様・回帰テストを強化

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -121,6 +121,48 @@
     - Progress (2026-03-07): `npm run build`, `npm run test:unit`, and `npm run build:all` passed after `lht-cmn` follow-up work and after making `core-spec.css` optional in `scripts/build.mjs`.
 
 #### P2: Spec and tests sync
+- [ ] ABC spec/implementation audit follow-up (2026-04-05):
+  - Current audit result:
+    - high-confidence gaps where the spec reads as supported but the implementation is still incomplete: `0`
+    - known standard-ABC features that are still unsupported / only partially implemented: `3`
+  - Resume note (2026-04-06):
+    - Stop point for this series: quoted chord symbols and standard shorthand decoration symbols are already covered.
+    - Next restart target: continue the remaining standard-decoration expansion, not the chord-symbol work.
+    - Recommended restart order:
+      - 1. audit standard ABC 2.1 decoration names against the currently hardcoded subset
+      - 2. pick one small missing standard decoration cluster at a time
+      - 3. add import support
+      - 4. add `MusicXML -> ABC -> MusicXML` regression tests
+      - 5. update `docs/spec/ABC_IO.md` and this TODO entry
+    - Current practical interpretation:
+      - quoted chord symbols are now good enough for common forms; broader coverage can wait
+      - the main remaining ABC-series work is standard decoration coverage
+  - A. Spec says or strongly implies "supported", but implementation is still weak:
+    - Completed in current series:
+      - Chord-tie handling now ties whole chords in paths such as `[CE]-[CE]`.
+      - Standard alternate-ending syntax now covers both `[1` / `[2` and `|1` / `:|2`.
+      - Trill roundtrip now restores both `trill-mark` and `wavy-line(start)`.
+      - Turn variants now include delayed-turn preservation via `mikuscore` ABC decorations (`!delayedturn!`, `!delayedinvertedturn!`).
+      - Tremolo variants now roundtrip via `mikuscore` ABC decorations (`!tremolo-single-N!`, `!tremolo-start-N!`, `!tremolo-stop-N!`).
+      - Glissando / slide now roundtrip via `mikuscore` ABC decorations (`!gliss-start!`, `!gliss-stop!`, `!slide-start!`, `!slide-stop!`).
+      - Rehearsal mark text now roundtrips via `mikuscore` ABC decoration (`!rehearsal:TEXT!`).
+      - Fingering / string now roundtrip via `mikuscore` ABC decorations (`!fingering:TEXT!`, `!string:TEXT!`).
+      - Pluck text now roundtrips via `mikuscore` ABC decoration (`!pluck:TEXT!`).
+  - B. Standard ABC includes these, but `mikuscore` ABC import/export still does not support them properly:
+    - Beam-separation semantics expressed by whitespace are only partially preserved.
+      - Current status: import now treats whitespace as an explicit beam-break hint, but export/render behavior still primarily reconstructs beams from durations instead of preserving original ABC spacing intent.
+    - Standard ABC chord symbols / annotations in quotes such as `"Am"` are only partially mapped.
+      - Current status: common chord symbols such as `"Am"`, `"C6"`, `"Dm6"`, `"G9"`, `"Fmaj9"`, `"Em9"`, `"G11/B"`, `"A13"`, and slash-chord forms now roundtrip through MusicXML `harmony`, while non-harmonic quoted text still roundtrips as direction words / quoted annotations; broader chord-quality coverage is still incomplete.
+    - Standard decoration set beyond the currently hardcoded subset (`trill`, `turn`, `invertedturn`, `staccato`).
+      - Current status: the supported subset is now larger (`trill` with `tr` / `triller` aliases and `T` shorthand on import, `turn` with `lowerturn` alias on import, `invertedturn`, `mordent`, `inverted-mordent` with `prall` / `pralltrill` / `uppermordent` / `invertedmordent` / `inverted-mordent` aliases and `M` / `P` shorthand on import, `schleifer`, `shake`, `roll` with `arpeggio` / `arpeggiate` aliases and `~` shorthand on import, `staccato` with `stacc` / `stac` aliases on import, `staccatissimo` with `spiccato` alias on import, `accent` with `L` shorthand on import, `tenuto`, `stress`, `unstress`, `fermata` / `inverted-fermata` with `inverted fermata` alias and `H` shorthand on import, `marcato` with `strong accent` / `strongaccent` / `strong-accent` aliases on import, `breath` with `breathmark` / `breath mark` / `breath-mark` aliases on import, `caesura`, `segno` with `S` shorthand on import, `coda` with `O` shorthand on import, `fine`, `dacapo` with `da capo` / `da-capo` aliases on import, `dalsegno` with `dal segno` / `dal-segno` aliases on import, `tocoda` with `to coda` / `to-coda` aliases on import, `crescendo(` / `crescendo)` / `diminuendo(` / `diminuendo)` with `cresc` / `dim` / `decresc` / `decrescendo` aliases on import, `ppp`, `pp`, `p`, `mp`, `mf`, `f`, `ff`, `fff`, `fp`, `fz`, `rfz`, `sf`, `sfp`, `sfz`, `upbow` / `downbow` with `up bow` / `down bow` / `up-bow` / `down-bow` aliases and `u` / `v` shorthand on import, `doubletongue` / `tripletongue` with `double tongue` / `triple tongue` / `double-tongue` / `triple-tongue` aliases on import, `heel` / `toe` with `heel mark` / `toe mark` aliases on import, `open` with `openstring` / `open string` / `open-string` aliases on import, `snap` with `snappizzicato` / `snap pizzicato` / `snap-pizzicato` aliases on import, `harmonic`, `stopped`, `thumb` with `thumbposition` / `thumb-position` / `thumbpos` / `thumb pos` / `thumb position` aliases on import), but broader standard decoration coverage is still incomplete.
+      - Restart from here next time.
+    - Completed in current series:
+      - Inline body fields `[K:...]`, `[M:...]`, `[L:...]`, `[Q:...]`, `[V:...]`.
+      - `U:` user-defined single-character decoration aliases now import through normal decoration parsing.
+      - Inline quoted annotations / chord symbols such as `"Am"` attached to notes.
+      - Lyrics / underlay lines such as `w:`.
+      - Overlay syntax `&` now imports as synthetic overlay voices aligned at measure boundaries.
+        - Remaining limitation: overlay voices still become separate MusicXML parts, not one part with multiple synchronized voices.
 - [ ] Add save-XML/re-render consistency checks in `docs/spec`.
 - [ ] Document and test selection retention rules across re-render.
 - [ ] Add ABC roundtrip golden tests (`MusicXML -> ABC -> MusicXML`) for representative orchestral/piano scores.
@@ -128,6 +170,30 @@
 - [ ] Add optional `%@mks ...` metadata compaction:
   - On `MusicXML -> ABC`, suppress consecutive `%@mks` comment lines when values are unchanged from the previous measure.
   - On `ABC -> MusicXML`, if `%@mks` metadata is omitted, inherit the previous measure's metadata for reconstruction.
+- [ ] Plan removal of `%@mks` metadata that standard ABC now covers natively:
+  - Goal:
+    - stop emitting `mks` extension lines for cases now representable by standard ABC surface syntax, after regression tests prove roundtrip safety
+  - Progress (2026-04-05):
+    - `MusicXML -> ABC` now emits standard ABC repeat/ending surface syntax first.
+    - Redundant repeat/ending fields are no longer emitted in `%@mks measure` when standard ABC already carries them.
+    - `%@mks measure` is still kept for non-standard fields such as `number`, `implicit`, and extra hints such as `times>2`.
+    - `MusicXML -> ABC` now emits standard `K:` / inline `[K:...]` first.
+    - Redundant `%@mks key` emission has been removed from the standard export path; import compatibility remains.
+  - Removal candidates confirmed by the current ABC work:
+    - `%@mks measure ... repeat=... [times=...] [ending-start=...] [ending-stop=...] [ending-type=...]`
+      - remove only for repeat/ending information that is now expressible as standard ABC barlines / alternate endings (`|:`, `:|`, `[1`, `[2`, `|1`, `:|2`)
+      - keep `%@mks measure` for non-standard reconstruction fields such as `number` / `implicit`
+    - `%@mks key voice=... measure=... fifths=...`
+      - completed for the standard export path by preferring `K:` / inline `[K:...]`
+      - keep parser support for legacy/imported `%@mks key` lines
+  - Explicitly not removal candidates in this pass:
+    - `%@mks transpose ...`
+    - `%@mks trill ...`
+    - `%@mks diag ...`
+    - `mks:dbg:*` / `mks:src:*` MusicXML miscellaneous metadata
+  - Required before deletion:
+    - add focused `MusicXML -> ABC -> MusicXML` golden tests that prove the standard ABC form preserves the same repeat/ending and key semantics
+    - then switch export to prefer the standard ABC form first and drop the redundant `%@mks` emission
 - [ ] Reduce MuseScore MIDI parity gap (`moonlight` baseline, 2026-02-25):
   - `safe (cand(midi)) practical diff = 307`
   - `musescore_parity (cand(parity)) practical diff = 172`

--- a/docs/spec/ABC_IO.md
+++ b/docs/spec/ABC_IO.md
@@ -70,6 +70,7 @@ The parser accepts three categories of input:
 #### 1. Standard ABC surface
 
 - headers (`X:`, `T:`, `C:`, `M:`, `L:`, `K:`)
+- user-defined decoration header (`U:`) for single-character decoration aliases on import
 - voice directives (`V:` with optional `name`, `clef`, `transpose`)
 - body note/rest/chord tokens
 
@@ -78,6 +79,8 @@ The parser accepts three categories of input:
 - optional `%%score` voice ordering directive
 - partial/legacy patterns accepted for practical compatibility
 - unsupported inline text / decoration forms may be skipped with warnings
+- overlay marker `&` is imported by splitting one ABC body stream into synthetic overlay voices
+- current overlay limitation: these synthetic overlay voices become separate MusicXML parts rather than one part with multiple synchronized voices
 - standalone octave marks may be tolerated in unsupported positions
 
 #### 3. `mikuscore` extension metadata
@@ -113,7 +116,9 @@ Parser is intentionally lenient for real-world ABC:
 
 #### Supported decorations and grace forms
 
-- decorations: `!trill!`, `!turn!`, `!invertedturn!`, `!staccato!`
+- decorations: `!trill!` (also accepts `!tr!` / `!triller!` on import), `!turn!` (also accepts `!lowerturn!` as inverted-turn on import), `!invertedturn!`, `!mordent!`/`!pralltriller!` (including `!prall!`, `!pralltrill!`, `!uppermordent!`, `!lowermordent!`, `!invertedmordent!`, `!inverted-mordent!` aliases), `!schleifer!`, `!shake!`, `!roll!` (also accepts `!arpeggio!` / `!arpeggiate!` on import), `!staccato!` (also accepts `!stacc!` / `!stac!` on import), `!wedge!`/`!staccatissimo!` (also accepts `!spiccato!` on import), `!accent!`, `!tenuto!`, `!stress!`, `!unstress!`, `!fermata!` / `!invertedfermata!` (also accepts `!inverted fermata!` on import), `!marcato!` (also accepts `!strong accent!` / `!strongaccent!` / `!strong-accent!` on import), `!breath!` (also accepts `!breathmark!` / `!breath mark!` / `!breath-mark!` on import), `!caesura!`, `!segno!`, `!coda!`, `!fine!`, `!dacapo!` (also accepts `!da capo!` / `!da-capo!` on import), `!dalsegno!` (also accepts `!dal segno!` / `!dal-segno!` on import), `!tocoda!` (also accepts `!to coda!` / `!to-coda!` on import), wedge decorations `!crescendo(!`, `!crescendo)!`, `!diminuendo(!`, `!diminuendo)!` (also accepts aliases `!cresc(!`, `!cresc)!`, `!dim(!`, `!dim)!`, `!decresc(!`, `!decresc)!`, `!decrescendo(!`, `!decrescendo)!` on import), dynamics `!ppp!`, `!pp!`, `!p!`, `!mp!`, `!mf!`, `!f!`, `!ff!`, `!fff!`, `!fp!`, `!fz!`, `!rfz!`, `!sf!`, `!sfp!`, `!sfz!`, `!upbow!` / `!downbow!` (also accepts `!up bow!` / `!down bow!` / `!up-bow!` / `!down-bow!` on import), `!doubletongue!` / `!tripletongue!` (also accepts `!double tongue!` / `!triple tongue!` / `!double-tongue!` / `!triple-tongue!` on import), `!heel!` / `!toe!` (also accepts `!heel mark!` / `!toe mark!` on import), `!open!` (also accepts `!openstring!` / `!open string!` / `!open-string!` on import), `!snap!` (also accepts `!snappizzicato!` / `!snap pizzicato!` / `!snap-pizzicato!` on import), `!harmonic!`, `!stopped!` (including `!plus!`, `!stopped horn!`, `!stopped-horn!` aliases), `!thumb!` (also accepts `!thumbposition!` / `!thumb-position!` / `!thumbpos!` / `!thumb pos!` / `!thumb position!` on import)
+- standard shorthand decoration symbols on import: `~` (roll), `H` (fermata), `L` (accent), `M` (lowermordent), `O` (coda), `P` (uppermordent), `S` (segno), `T` (trill), `u` (up-bow), `v` (down-bow)
+- mikuscore extension decorations: `!delayedturn!`, `!delayedinvertedturn!`, `!tremolo-single-N!`, `!tremolo-start-N!`, `!tremolo-stop-N!`, `!gliss-start!`, `!gliss-stop!`, `!slide-start!`, `!slide-stop!`, `!rehearsal:TEXT!`, `!fingering:TEXT!`, `!string:TEXT!`, `!pluck:TEXT!`
 - grace groups `{...}` including slash grace variant (`{/g}`)
 
 ### Parse result characteristics
@@ -172,13 +177,14 @@ Exports:
   - suppresses redundant naturals in-context
   - emits required naturals where key/measure context differs
 - serializes each part as ABC measure stream (`|` separated)
+- supported standard ornament/decorations now include `trill`, `turn`, `invertedturn`, `mordent`, `pralltriller`, `schleifer`, `shake`, `roll`, selected articulations/technicals/dynamics, and selected jump markers
 
 ### `mikuscore` extension metadata on export
 
 For lossless or safer roundtrip behavior, `mikuscore` may emit extension comment lines after the ABC body:
 
-- `%@mks key voice=... measure=... fifths=...`
-- `%@mks measure voice=... measure=... number=... implicit=... [repeat=...] [times=...]`
+- `%@mks key voice=... measure=... fifths=...` (legacy/import-compatibility path; standard export now prefers `K:` / inline `[K:...]`)
+- `%@mks measure voice=... measure=... number=... implicit=... [times=...] [ending-stop=... ending-type=discontinue]`
 - `%@mks transpose voice=... chromatic=... [diatonic=...]`
 
 These lines are `mikuscore` extension metadata, not part of the standard ABC musical surface.
@@ -202,7 +208,7 @@ Generation policy:
 - writes first-measure attributes (key/time/clef and optional transpose)
 - preserves tie semantics using both `<tie>` and `<notations><tied>`
 - restores tuplet semantics using both `<time-modification>` and `<notations><tuplet>`
-- restores measure metadata (`number`, `implicit`) and repeat barlines from `%@mks measure`
+- restores standard repeat/ending barlines and key changes from ABC surface syntax, and restores non-standard measure metadata (`number`, `implicit`, extra repeat hints when needed) from `%@mks measure`
 - restores transpose (`chromatic`, `diatonic`) from `%@mks transpose`
 - inserts a fallback whole-rest note for empty measures
 

--- a/docs/spec/abc-compat-parser-ebnf.md
+++ b/docs/spec/abc-compat-parser-ebnf.md
@@ -12,8 +12,8 @@ The parser should be understood in three layers:
 - `mikuscore` extension metadata comments (`%@mks ...`) used for roundtrip support
 
 ## Scope
-- Header: `X,T,C,M,L,K,V` and `%%score`
-- Body: note/rest (`z/x`), accidentals, length, tie (`-`), broken rhythm (`>` `<`), barlines, chords, tuplets
+- Header: `X,T,C,M,L,K,U,V` and `%%score`
+- Body: note/rest (`z/x`), accidentals, length, tie (`-`), broken rhythm (`>` `<`), barlines, chords, tuplets, overlay (`&`)
 - Compatibility behavior: `M:C`, `M:C|`, inline text skip (`"..."`), standalone octave marker tolerance (`,` / `'`)
 - `mikuscore` extension metadata comments: `%@mks ...`
 
@@ -28,7 +28,7 @@ score_expr       = { score_group | voice_id | ws } ;
 score_group      = "(" , { ws | voice_id } , ")" ;
 
 header           = header_key , ":" , ws* , header_value ;
-header_key       = "X" | "T" | "C" | "M" | "L" | "K" | "V" | letter ;
+header_key       = "X" | "T" | "C" | "M" | "L" | "K" | "U" | "V" | letter ;
 header_value     = { any_char_except_newline } ;
 
 body             = { body_token | ws } ;
@@ -88,6 +88,8 @@ digit            = "0".."9" ;
 - Treat `x` rest as `z` rest.
 - Support chords (`[CEG]`, `[A,,CE]`).
 - Support tuplets (`(3abc`, `(5:4:5abcde`) with duration scaling.
+- Support overlay marker `&` by splitting the body stream into synthetic overlay voices at measure boundaries.
+- Support `U:` single-character user-defined decoration aliases on import by expanding them into regular decoration markers before parsing.
 - Ignore `:` in barline variants (`:|`, `|:`, `||`) without parse failure.
 - Ignore standalone `,` / `'` for compatibility.
 

--- a/mikuscore.html
+++ b/mikuscore.html
@@ -29463,6 +29463,9 @@ const parseAbcLengthToken = (token, lineNo) => {
     if (!token) {
         return { num: 1, den: 1 };
     }
+    if (/^\/+$/.test(token)) {
+        return { num: 1, den: 2 ** token.length };
+    }
     if (token === "/") {
         return { num: 1, den: 2 };
     }
@@ -29576,6 +29579,247 @@ if (typeof window !== "undefined") {
     window.AbcCommon = exports.AbcCommon;
 }
 const abcCommon = exports.AbcCommon;
+function parseRepeatEndingMarkerAt(text, idx) {
+    const match = String(text || "").slice(idx).match(/^\[(\d+(?:[,-]\d+)*)/);
+    if (!match) {
+        return null;
+    }
+    return {
+        marker: match[1],
+        nextIdx: idx + match[0].length,
+    };
+}
+function parseBareRepeatEndingMarkerAt(text, idx) {
+    const match = String(text || "").slice(idx).match(/^(\d+(?:[,-]\d+)*)/);
+    if (!match) {
+        return null;
+    }
+    return {
+        marker: match[1],
+        nextIdx: idx + match[0].length,
+    };
+}
+function parseInlineFieldAt(text, idx) {
+    const match = String(text || "").slice(idx).match(/^\[([A-Za-z]):([^\]]*)\]/);
+    if (!match) {
+        return null;
+    }
+    return {
+        fieldName: String(match[1] || "").toUpperCase(),
+        fieldValue: String(match[2] || "").trim(),
+        nextIdx: idx + match[0].length,
+    };
+}
+function tokenizeAbcLyricLine(text) {
+    const raw = String(text || "").trim();
+    if (!raw)
+        return [];
+    const chunks = raw
+        .replace(/\|/g, " ")
+        .split(/\s+/)
+        .map((token) => token.trim())
+        .filter(Boolean);
+    const tokens = [];
+    for (const chunk of chunks) {
+        if (chunk === "*") {
+            tokens.push({ type: "skip" });
+            continue;
+        }
+        if (chunk === "_") {
+            tokens.push({ type: "extend" });
+            continue;
+        }
+        const normalized = chunk.replace(/~/g, " ");
+        const parts = normalized.split("-").filter((part) => part.length > 0);
+        if (parts.length <= 1) {
+            tokens.push({ type: "text", text: normalized, syllabic: "single" });
+            continue;
+        }
+        for (let i = 0; i < parts.length; i += 1) {
+            const syllabic = i === 0
+                ? "begin"
+                : (i === parts.length - 1 ? "end" : "middle");
+            tokens.push({ type: "text", text: parts[i], syllabic });
+        }
+    }
+    return tokens;
+}
+function splitBodyTextByInlineVoice(text, initialVoiceId) {
+    const segments = [];
+    let activeVoiceId = String(initialVoiceId || "1").trim() || "1";
+    let buffer = "";
+    const raw = String(text || "");
+    let idx = 0;
+    while (idx < raw.length) {
+        if (raw[idx] === "[") {
+            const inlineField = parseInlineFieldAt(raw, idx);
+            if (inlineField && inlineField.fieldName === "V") {
+                if (buffer.trim()) {
+                    segments.push({ voiceId: activeVoiceId, text: buffer });
+                }
+                buffer = "";
+                const voiceMatch = String(inlineField.fieldValue || "").match(/^(\S+)/);
+                if (voiceMatch) {
+                    activeVoiceId = voiceMatch[1];
+                }
+                else {
+                    buffer += raw.slice(idx, inlineField.nextIdx);
+                }
+                idx = inlineField.nextIdx;
+                continue;
+            }
+        }
+        buffer += raw[idx];
+        idx += 1;
+    }
+    if (buffer.trim()) {
+        segments.push({ voiceId: activeVoiceId, text: buffer });
+    }
+    return segments;
+}
+function splitBodyTextByOverlay(text, baseVoiceId) {
+    const raw = String(text || "");
+    const normalizedBaseVoiceId = String(baseVoiceId || "1").trim() || "1";
+    const overlayBuffers = [""];
+    let completedMeasureSkeleton = "";
+    let activeOverlayIndex = 0;
+    let idx = 0;
+    const ensureOverlayBuffer = (overlayIndex) => {
+        while (overlayBuffers.length <= overlayIndex) {
+            overlayBuffers.push(completedMeasureSkeleton);
+        }
+    };
+    while (idx < raw.length) {
+        const ch = raw[idx];
+        if (ch === '"') {
+            let endIdx = idx + 1;
+            while (endIdx < raw.length && raw[endIdx] !== '"') {
+                endIdx += 1;
+            }
+            const token = raw.slice(idx, Math.min(raw.length, endIdx + 1));
+            ensureOverlayBuffer(activeOverlayIndex);
+            overlayBuffers[activeOverlayIndex] += token;
+            idx = Math.min(raw.length, endIdx + 1);
+            continue;
+        }
+        if (ch === "!" || ch === "+") {
+            let endIdx = idx + 1;
+            while (endIdx < raw.length && raw[endIdx] !== ch) {
+                endIdx += 1;
+            }
+            const token = raw.slice(idx, Math.min(raw.length, endIdx + 1));
+            ensureOverlayBuffer(activeOverlayIndex);
+            overlayBuffers[activeOverlayIndex] += token;
+            idx = Math.min(raw.length, endIdx + 1);
+            continue;
+        }
+        const barlineToken = parseBarlineTokenAt(raw, idx);
+        if (barlineToken) {
+            const tokenText = raw.slice(idx, barlineToken.nextIdx);
+            if (barlineToken.endsMeasure) {
+                for (let overlayIndex = 0; overlayIndex < overlayBuffers.length; overlayIndex += 1) {
+                    ensureOverlayBuffer(overlayIndex);
+                    overlayBuffers[overlayIndex] += tokenText;
+                }
+                completedMeasureSkeleton += tokenText;
+                activeOverlayIndex = 0;
+            }
+            else {
+                ensureOverlayBuffer(activeOverlayIndex);
+                overlayBuffers[activeOverlayIndex] += tokenText;
+            }
+            idx = barlineToken.nextIdx;
+            continue;
+        }
+        if (ch === "&") {
+            activeOverlayIndex += 1;
+            ensureOverlayBuffer(activeOverlayIndex);
+            idx += 1;
+            continue;
+        }
+        ensureOverlayBuffer(activeOverlayIndex);
+        overlayBuffers[activeOverlayIndex] += ch;
+        idx += 1;
+    }
+    return overlayBuffers
+        .map((segmentText, overlayIndex) => ({
+        voiceId: overlayIndex === 0 ? normalizedBaseVoiceId : `${normalizedBaseVoiceId}_ov${overlayIndex + 1}`,
+        overlayIndex,
+        text: segmentText,
+    }))
+        .filter((segment) => segment.text.trim().length > 0);
+}
+function parseUserDefinedDecoration(rawValue) {
+    const text = String(rawValue || "").trim();
+    const match = text.match(/^(\S)(?:\s*=\s*|\s+)(.+)$/);
+    if (!match)
+        return null;
+    const symbol = String(match[1] || "");
+    const rhs = String(match[2] || "").trim();
+    if (!symbol || !rhs)
+        return null;
+    const wrapped = rhs.match(/^[!+](.+)[!+]$/);
+    const decoration = String(wrapped ? wrapped[1] : rhs).trim();
+    if (!decoration)
+        return null;
+    return { symbol, decoration };
+}
+function expandUserDefinedDecorationSymbols(text, userDefinedDecorationBySymbol) {
+    const raw = String(text || "");
+    const symbolMap = userDefinedDecorationBySymbol || {};
+    if (!raw || Object.keys(symbolMap).length === 0) {
+        return raw;
+    }
+    let out = "";
+    let idx = 0;
+    while (idx < raw.length) {
+        const ch = raw[idx];
+        if (ch === '"' || ch === "!" || ch === "+") {
+            let endIdx = idx + 1;
+            while (endIdx < raw.length && raw[endIdx] !== ch) {
+                endIdx += 1;
+            }
+            out += raw.slice(idx, Math.min(raw.length, endIdx + 1));
+            idx = Math.min(raw.length, endIdx + 1);
+            continue;
+        }
+        if (Object.prototype.hasOwnProperty.call(symbolMap, ch)) {
+            out += `!${String(symbolMap[ch])}!`;
+            idx += 1;
+            continue;
+        }
+        out += ch;
+        idx += 1;
+    }
+    return out;
+}
+function parseBarlineTokenAt(text, idx) {
+    const slice = String(text || "").slice(idx);
+    const candidates = [
+        { token: ":|]", endsMeasure: true, repeatEnd: true, repeatStart: false, endingStop: true },
+        { token: ":|:", endsMeasure: true, repeatEnd: true, repeatStart: true, endingStop: false },
+        { token: "|:", endsMeasure: true, repeatEnd: false, repeatStart: true, endingStop: false },
+        { token: ":|", endsMeasure: true, repeatEnd: true, repeatStart: false, endingStop: false },
+        { token: "::", endsMeasure: true, repeatEnd: true, repeatStart: true, endingStop: false },
+        { token: "[|", endsMeasure: true, repeatEnd: false, repeatStart: false, endingStop: false },
+        { token: "|]", endsMeasure: true, repeatEnd: false, repeatStart: false, endingStop: false },
+        { token: "||", endsMeasure: true, repeatEnd: false, repeatStart: false, endingStop: false },
+        { token: "|", endsMeasure: true, repeatEnd: false, repeatStart: false, endingStop: false },
+        { token: ":", endsMeasure: false, repeatEnd: false, repeatStart: false, endingStop: false },
+    ];
+    for (const candidate of candidates) {
+        if (slice.startsWith(candidate.token)) {
+            return {
+                nextIdx: idx + candidate.token.length,
+                endsMeasure: candidate.endsMeasure,
+                repeatEnd: candidate.repeatEnd,
+                repeatStart: candidate.repeatStart,
+                endingStop: candidate.endingStop,
+            };
+        }
+    }
+    return null;
+}
 function parseTempoFromQ(rawQ, warnings) {
     const raw = String(rawQ || "").trim();
     if (!raw) {
@@ -29618,10 +29862,12 @@ function parseForMusicXml(source, settings) {
     const transposeHintByVoiceId = new Map();
     const headers = {};
     const bodyEntries = [];
+    const lyricEntriesByVoice = {};
     const declaredVoiceIds = [];
     const voiceNameById = {};
     const voiceClefById = {};
     const voiceTransposeById = {};
+    const userDefinedDecorationBySymbol = {};
     let currentVoiceId = "1";
     let scoreDirective = "";
     for (let i = 0; i < lines.length; i += 1) {
@@ -29678,14 +29924,23 @@ function parseForMusicXml(source, settings) {
                 const measureNumberText = String(params.number || "").trim();
                 const implicitRaw = String(params.implicit || "").trim().toLowerCase();
                 const repeatRaw = String(params.repeat || "").trim().toLowerCase();
+                const leftRepeatRaw = String(params["left-repeat"] || "").trim().toLowerCase();
+                const rightRepeatRaw = String(params["right-repeat"] || "").trim().toLowerCase();
                 const repeatTimesRaw = Number.parseInt(String(params.times || ""), 10);
+                const endingStart = String(params["ending-start"] || "").trim();
+                const endingStop = String(params["ending-stop"] || "").trim();
+                const endingStopTypeRaw = String(params["ending-type"] || "").trim().toLowerCase();
                 measureMetaByKey.set(`${voiceId}#${measureNo}`, {
                     number: measureNumberText || String(measureNo),
                     implicit: implicitRaw === "1" || implicitRaw === "true" || implicitRaw === "yes",
-                    repeat: repeatRaw === "forward" || repeatRaw === "backward"
-                        ? repeatRaw
-                        : "",
-                    repeatTimes: Number.isFinite(repeatTimesRaw) && repeatTimesRaw > 1 ? repeatTimesRaw : null
+                    repeatStart: leftRepeatRaw === "1" || leftRepeatRaw === "true" || leftRepeatRaw === "yes" || repeatRaw === "forward",
+                    repeatEnd: rightRepeatRaw === "1" || rightRepeatRaw === "true" || rightRepeatRaw === "yes" || repeatRaw === "backward",
+                    repeatTimes: Number.isFinite(repeatTimesRaw) && repeatTimesRaw > 1 ? repeatTimesRaw : null,
+                    endingStart,
+                    endingStop,
+                    endingStopType: endingStopTypeRaw === "discontinue" || endingStopTypeRaw === "stop"
+                        ? endingStopTypeRaw
+                        : (endingStop ? "stop" : "")
                 });
             }
             continue;
@@ -29727,6 +29982,13 @@ function parseForMusicXml(source, settings) {
         if (headerMatch && /^[A-Za-z]$/.test(headerMatch[1])) {
             const key = headerMatch[1];
             const value = headerMatch[2].trim();
+            if (key === "w") {
+                if (!Object.prototype.hasOwnProperty.call(lyricEntriesByVoice, currentVoiceId)) {
+                    lyricEntriesByVoice[currentVoiceId] = [];
+                }
+                lyricEntriesByVoice[currentVoiceId].push({ text: value, lineNo });
+                continue;
+            }
             if (key === "V") {
                 const m = value.match(/^(\S+)\s*(.*)$/);
                 if (!m) {
@@ -29748,17 +30010,65 @@ function parseForMusicXml(source, settings) {
                     voiceTransposeById[currentVoiceId] = parsedVoice.transpose;
                 }
                 if (parsedVoice.bodyText) {
-                    bodyEntries.push({ text: parsedVoice.bodyText, lineNo, voiceId: currentVoiceId });
+                    const expandedBodyText = expandUserDefinedDecorationSymbols(parsedVoice.bodyText, userDefinedDecorationBySymbol);
+                    const inlineVoiceSegments = splitBodyTextByInlineVoice(expandedBodyText, currentVoiceId);
+                    for (const segment of inlineVoiceSegments) {
+                        const overlaySegments = splitBodyTextByOverlay(segment.text, segment.voiceId);
+                        for (const overlaySegment of overlaySegments) {
+                            if (!declaredVoiceIds.includes(overlaySegment.voiceId)) {
+                                declaredVoiceIds.push(overlaySegment.voiceId);
+                            }
+                            if (overlaySegment.overlayIndex > 0) {
+                                const overlayLabel = `overlay ${overlaySegment.overlayIndex + 1}`;
+                                voiceNameById[overlaySegment.voiceId] = voiceNameById[segment.voiceId]
+                                    ? `${voiceNameById[segment.voiceId]} ${overlayLabel}`
+                                    : `Voice ${segment.voiceId} ${overlayLabel}`;
+                                if (voiceClefById[segment.voiceId] && !voiceClefById[overlaySegment.voiceId]) {
+                                    voiceClefById[overlaySegment.voiceId] = voiceClefById[segment.voiceId];
+                                }
+                                if (voiceTransposeById[segment.voiceId] && !voiceTransposeById[overlaySegment.voiceId]) {
+                                    voiceTransposeById[overlaySegment.voiceId] = { ...voiceTransposeById[segment.voiceId] };
+                                }
+                            }
+                            bodyEntries.push({ text: overlaySegment.text, lineNo, voiceId: overlaySegment.voiceId });
+                        }
+                    }
+                }
+                continue;
+            }
+            if (key === "U") {
+                const parsedUserDefinedDecoration = parseUserDefinedDecoration(value);
+                if (parsedUserDefinedDecoration) {
+                    userDefinedDecorationBySymbol[parsedUserDefinedDecoration.symbol] = parsedUserDefinedDecoration.decoration;
                 }
                 continue;
             }
             headers[key] = value;
             continue;
         }
-        if (!declaredVoiceIds.includes(currentVoiceId)) {
-            declaredVoiceIds.push(currentVoiceId);
+        const expandedBodyText = expandUserDefinedDecorationSymbols(noComment, userDefinedDecorationBySymbol);
+        const inlineVoiceSegments = splitBodyTextByInlineVoice(expandedBodyText, currentVoiceId);
+        for (const segment of inlineVoiceSegments) {
+            const overlaySegments = splitBodyTextByOverlay(segment.text, segment.voiceId);
+            for (const overlaySegment of overlaySegments) {
+                if (!declaredVoiceIds.includes(overlaySegment.voiceId)) {
+                    declaredVoiceIds.push(overlaySegment.voiceId);
+                }
+                if (overlaySegment.overlayIndex > 0) {
+                    const overlayLabel = `overlay ${overlaySegment.overlayIndex + 1}`;
+                    voiceNameById[overlaySegment.voiceId] = voiceNameById[segment.voiceId]
+                        ? `${voiceNameById[segment.voiceId]} ${overlayLabel}`
+                        : `Voice ${segment.voiceId} ${overlayLabel}`;
+                    if (voiceClefById[segment.voiceId] && !voiceClefById[overlaySegment.voiceId]) {
+                        voiceClefById[overlaySegment.voiceId] = voiceClefById[segment.voiceId];
+                    }
+                    if (voiceTransposeById[segment.voiceId] && !voiceTransposeById[overlaySegment.voiceId]) {
+                        voiceTransposeById[overlaySegment.voiceId] = { ...voiceTransposeById[segment.voiceId] };
+                    }
+                }
+                bodyEntries.push({ text: overlaySegment.text, lineNo, voiceId: overlaySegment.voiceId });
+            }
         }
-        bodyEntries.push({ text: noComment, lineNo, voiceId: currentVoiceId });
     }
     if (bodyEntries.length === 0) {
         throw new Error("Body not found. Please provide ABC note content. (line 1)");
@@ -29769,6 +30079,11 @@ function parseForMusicXml(source, settings) {
     const tempoBpm = parseTempoFromQ(headers.Q || "", warnings);
     const keySignatureAccidentals = keySignatureAlterByStep(keyInfo.fifths);
     const measuresByVoice = {};
+    const notationMeasureMetaByVoice = {};
+    const activeEndingByVoice = {};
+    const currentKeyFifthsByVoice = {};
+    const meterByMeasureByVoice = {};
+    const tempoByMeasureByVoice = {};
     let noteCount = 0;
     function ensureVoice(voiceId) {
         if (!Object.prototype.hasOwnProperty.call(measuresByVoice, voiceId)) {
@@ -29776,16 +30091,101 @@ function parseForMusicXml(source, settings) {
         }
         return measuresByVoice[voiceId];
     }
+    function ensureNotationMeasureMeta(voiceId, measureNo) {
+        if (!Object.prototype.hasOwnProperty.call(notationMeasureMetaByVoice, voiceId)) {
+            notationMeasureMetaByVoice[voiceId] = {};
+        }
+        if (!Object.prototype.hasOwnProperty.call(notationMeasureMetaByVoice[voiceId], measureNo)) {
+            notationMeasureMetaByVoice[voiceId][measureNo] = {
+                number: String(measureNo),
+                implicit: false,
+                repeatStart: false,
+                repeatEnd: false,
+                repeatTimes: null,
+                endingStart: "",
+                endingStop: "",
+                endingStopType: "",
+            };
+        }
+        return notationMeasureMetaByVoice[voiceId][measureNo];
+    }
+    function ensureMeterByMeasure(voiceId) {
+        if (!Object.prototype.hasOwnProperty.call(meterByMeasureByVoice, voiceId)) {
+            meterByMeasureByVoice[voiceId] = {};
+        }
+        return meterByMeasureByVoice[voiceId];
+    }
+    function ensureTempoByMeasure(voiceId) {
+        if (!Object.prototype.hasOwnProperty.call(tempoByMeasureByVoice, voiceId)) {
+            tempoByMeasureByVoice[voiceId] = {};
+        }
+        return tempoByMeasureByVoice[voiceId];
+    }
     for (const entry of bodyEntries) {
         const measures = ensureVoice(entry.voiceId);
         let currentMeasure = measures[measures.length - 1];
         let measureAccidentals = {};
+        let activeUnitLength = unitLength;
+        let activeMeter = meter;
+        let activeTempoBpm = Number.isFinite(tempoBpm) ? Number(tempoBpm) : null;
+        let activeKeyFifths = Number.isFinite(currentKeyFifthsByVoice[entry.voiceId])
+            ? Number(currentKeyFifthsByVoice[entry.voiceId])
+            : keyInfo.fifths;
+        let activeKeySignatureAccidentals = keySignatureAlterByStep(activeKeyFifths);
         let lastNote = null;
         let lastEventNotes = [];
         let pendingTieToNext = false;
         let pendingTrill = false;
         let pendingTurn = "";
+        let pendingDelayedTurn = false;
+        let pendingMordent = "";
+        let pendingTremolo = null;
+        let pendingGlissandoStart = false;
+        let pendingGlissandoStop = false;
+        let pendingSlideStart = false;
+        let pendingSlideStop = false;
+        let pendingSchleifer = false;
+        let pendingShake = false;
+        let pendingArpeggiate = false;
         let pendingStaccato = false;
+        let pendingStaccatissimo = false;
+        let pendingAccent = false;
+        let pendingTenuto = false;
+        let pendingStress = false;
+        let pendingUnstress = false;
+        let pendingFermata = "";
+        let pendingStrongAccent = false;
+        let pendingBreathMark = false;
+        let pendingCaesura = false;
+        let pendingSegno = false;
+        let pendingCoda = false;
+        let pendingFine = false;
+        let pendingDaCapo = false;
+        let pendingDalSegno = false;
+        let pendingToCoda = false;
+        let pendingCrescendoStart = false;
+        let pendingCrescendoStop = false;
+        let pendingDiminuendoStart = false;
+        let pendingDiminuendoStop = false;
+        let pendingDynamicMark = "";
+        let pendingSfz = false;
+        let pendingRehearsalMark = "";
+        let pendingUpBow = false;
+        let pendingDownBow = false;
+        let pendingOpenString = false;
+        let pendingSnapPizzicato = false;
+        let pendingHarmonic = false;
+        let pendingStopped = false;
+        let pendingThumbPosition = false;
+        let pendingDoubleTongue = false;
+        let pendingTripleTongue = false;
+        let pendingHeel = false;
+        let pendingToe = false;
+        let pendingFingerings = [];
+        let pendingStrings = [];
+        let pendingPlucks = [];
+        let pendingChordSymbols = [];
+        let pendingAnnotations = [];
         let pendingSlurStart = 0;
         let pendingRhythmScale = null;
         let tupletRemaining = 0;
@@ -29793,11 +30193,37 @@ function parseForMusicXml(source, settings) {
         let tupletSpec = null;
         let currentMeasureNo = Math.max(1, measures.length);
         let currentEventNo = 0;
+        let beamRunActive = false;
+        let sawInterEventWhitespace = false;
+        let beamCursorDiv = 0;
+        let activeEndingMarker = String(activeEndingByVoice[entry.voiceId] || "");
         let idx = 0;
         const text = entry.text;
+        const isBeamableAbcNote = (note) => Boolean(note &&
+            !note.isRest &&
+            !note.grace &&
+            ["eighth", "16th", "32nd", "64th"].includes(String(note.type || "").trim().toLowerCase()));
+        const applyBeamModeForEvent = (note, durationDiv) => {
+            const resolvedDurationDiv = Math.max(0, Math.round(Number(durationDiv) || 0));
+            const beatDiv = Math.max(1, Math.round((960 * 4) / Math.max(1, Math.round(Number(activeMeter === null || activeMeter === void 0 ? void 0 : activeMeter.beatType) || 4))));
+            const startsAtBeatBoundary = beamCursorDiv > 0 && beamCursorDiv % beatDiv === 0;
+            if (startsAtBeatBoundary) {
+                beamRunActive = false;
+            }
+            if (isBeamableAbcNote(note)) {
+                note.beamMode = !beamRunActive || sawInterEventWhitespace ? "begin" : "mid";
+                beamRunActive = true;
+            }
+            else {
+                beamRunActive = false;
+            }
+            sawInterEventWhitespace = false;
+            beamCursorDiv += resolvedDurationDiv;
+        };
         while (idx < text.length) {
             const ch = text[idx];
             if (ch === " " || ch === "\t") {
+                sawInterEventWhitespace = true;
                 idx += 1;
                 continue;
             }
@@ -29808,17 +30234,46 @@ function parseForMusicXml(source, settings) {
                 continue;
             }
             if (ch === "|" || ch === ":") {
-                if (ch === "|" && (currentMeasure.length > 0 || measures.length === 0)) {
+                const barlineToken = parseBarlineTokenAt(text, idx);
+                if (!barlineToken) {
+                    idx += 1;
+                    continue;
+                }
+                const bareRepeatEndingMarker = barlineToken.endsMeasure ? parseBareRepeatEndingMarkerAt(text, barlineToken.nextIdx) : null;
+                if (barlineToken.repeatEnd) {
+                    ensureNotationMeasureMeta(entry.voiceId, currentMeasureNo).repeatEnd = true;
+                }
+                if ((barlineToken.endingStop || bareRepeatEndingMarker) && activeEndingMarker) {
+                    const measureMeta = ensureNotationMeasureMeta(entry.voiceId, currentMeasureNo);
+                    measureMeta.endingStop = activeEndingMarker;
+                    measureMeta.endingStopType = "stop";
+                    activeEndingMarker = "";
+                }
+                if (barlineToken.endsMeasure && (currentMeasure.length > 0 || measures.length === 0)) {
                     currentMeasure = [];
                     measures.push(currentMeasure);
                     currentMeasureNo = Math.max(1, measures.length);
                     currentEventNo = 0;
+                    beamCursorDiv = 0;
                 }
-                if (ch === "|") {
+                if (barlineToken.endsMeasure) {
                     measureAccidentals = {};
                     lastNote = null;
                 }
-                idx += 1;
+                if (barlineToken.repeatStart) {
+                    ensureNotationMeasureMeta(entry.voiceId, currentMeasureNo).repeatStart = true;
+                }
+                if (bareRepeatEndingMarker) {
+                    const measureMeta = ensureNotationMeasureMeta(entry.voiceId, currentMeasureNo);
+                    measureMeta.endingStart = bareRepeatEndingMarker.marker;
+                    activeEndingMarker = bareRepeatEndingMarker.marker;
+                    idx = bareRepeatEndingMarker.nextIdx;
+                }
+                else {
+                    idx = barlineToken.nextIdx;
+                }
+                beamRunActive = false;
+                sawInterEventWhitespace = false;
                 continue;
             }
             if (ch === ">" || ch === "<") {
@@ -29856,9 +30311,63 @@ function parseForMusicXml(source, settings) {
                 idx += 1;
                 continue;
             }
+            if (ch === "~") {
+                pendingArpeggiate = true;
+                idx += 1;
+                continue;
+            }
+            if (ch === "H") {
+                pendingFermata = "normal";
+                idx += 1;
+                continue;
+            }
+            if (ch === "L") {
+                pendingAccent = true;
+                idx += 1;
+                continue;
+            }
+            if (ch === "M") {
+                pendingMordent = "mordent";
+                idx += 1;
+                continue;
+            }
+            if (ch === "O") {
+                pendingCoda = true;
+                idx += 1;
+                continue;
+            }
+            if (ch === "P") {
+                pendingMordent = "inverted-mordent";
+                idx += 1;
+                continue;
+            }
+            if (ch === "S") {
+                pendingSegno = true;
+                idx += 1;
+                continue;
+            }
+            if (ch === "T") {
+                pendingTrill = true;
+                idx += 1;
+                continue;
+            }
+            if (ch === "u") {
+                pendingUpBow = true;
+                idx += 1;
+                continue;
+            }
+            if (ch === "v") {
+                pendingDownBow = true;
+                idx += 1;
+                continue;
+            }
             if (ch === "-") {
-                if (lastNote && !lastNote.isRest) {
-                    lastNote.tieStart = true;
+                if (lastEventNotes && lastEventNotes.length > 0 && lastEventNotes.some((n) => !n.isRest)) {
+                    for (const eventNote of lastEventNotes) {
+                        if (!eventNote.isRest) {
+                            eventNote.tieStart = true;
+                        }
+                    }
                     pendingTieToNext = true;
                 }
                 else {
@@ -29870,12 +30379,22 @@ function parseForMusicXml(source, settings) {
             if (ch === "\"") {
                 const endQuote = text.indexOf("\"", idx + 1);
                 if (endQuote >= 0) {
+                    const rawAnnotation = text.slice(idx + 1, endQuote);
+                    const normalizedAnnotation = rawAnnotation.replace(/^[\^_<>@]/, "").trim();
+                    if (normalizedAnnotation) {
+                        if (isLikelyAbcChordSymbol(normalizedAnnotation)) {
+                            pendingChordSymbols.push(normalizedAnnotation);
+                        }
+                        else {
+                            pendingAnnotations.push(normalizedAnnotation);
+                        }
+                    }
                     idx = endQuote + 1;
                 }
                 else {
                     idx = text.length;
+                    warnings.push("line " + entry.lineNo + ': Unterminated inline string ("...").');
                 }
-                warnings.push("line " + entry.lineNo + ': Skipped inline string ("...").');
                 continue;
             }
             if (ch === "!" || ch === "+") {
@@ -29885,9 +30404,24 @@ function parseForMusicXml(source, settings) {
                     warnings.push("line " + entry.lineNo + ": Unterminated decoration marker: " + ch);
                     continue;
                 }
-                const decoration = text.slice(idx + 1, endMark).trim().toLowerCase();
+                const rawDecoration = text.slice(idx + 1, endMark).trim();
+                const decoration = rawDecoration.toLowerCase();
                 if (decoration === "trill" || decoration === "tr" || decoration === "triller") {
                     pendingTrill = true;
+                }
+                else if (decoration.startsWith("rehearsal:")) {
+                    const rehearsalText = rawDecoration.slice("rehearsal:".length).trim();
+                    if (rehearsalText) {
+                        pendingRehearsalMark = rehearsalText;
+                    }
+                }
+                else if (decoration === "delayedturn" || decoration === "delayed-turn") {
+                    pendingTurn = pendingTurn || "turn";
+                    pendingDelayedTurn = true;
+                }
+                else if (decoration === "delayedinvertedturn" || decoration === "delayed-inverted-turn") {
+                    pendingTurn = "inverted-turn";
+                    pendingDelayedTurn = true;
                 }
                 else if (decoration === "turn") {
                     pendingTurn = "turn";
@@ -29895,11 +30429,209 @@ function parseForMusicXml(source, settings) {
                 else if (decoration === "invertedturn" || decoration === "inverted-turn" || decoration === "lowerturn") {
                     pendingTurn = "inverted-turn";
                 }
+                else if (decoration === "mordent" || decoration === "lowermordent") {
+                    pendingMordent = "mordent";
+                }
+                else if (decoration === "pralltriller" ||
+                    decoration === "pralltrill" ||
+                    decoration === "prall" ||
+                    decoration === "uppermordent" ||
+                    decoration === "invertedmordent" ||
+                    decoration === "inverted-mordent") {
+                    pendingMordent = "inverted-mordent";
+                }
+                else if (/^tremolo-(single|start|stop)-([1-9]\d*)$/.test(decoration)) {
+                    const m = decoration.match(/^tremolo-(single|start|stop)-([1-9]\d*)$/);
+                    if (m) {
+                        pendingTremolo = {
+                            type: m[1],
+                            marks: Math.max(1, Math.min(8, Number.parseInt(m[2], 10) || 1))
+                        };
+                    }
+                }
+                else if (decoration === "gliss-start" || decoration === "glissando-start") {
+                    pendingGlissandoStart = true;
+                }
+                else if (decoration === "gliss-stop" || decoration === "glissando-stop") {
+                    pendingGlissandoStop = true;
+                }
+                else if (decoration === "slide-start") {
+                    pendingSlideStart = true;
+                }
+                else if (decoration === "slide-stop") {
+                    pendingSlideStop = true;
+                }
+                else if (decoration === "schleifer") {
+                    pendingSchleifer = true;
+                }
+                else if (decoration === "shake") {
+                    pendingShake = true;
+                }
+                else if (decoration === "roll" || decoration === "arpeggio" || decoration === "arpeggiate") {
+                    pendingArpeggiate = true;
+                }
                 else if (decoration === "staccato" ||
                     decoration === "stacc" ||
-                    decoration === "stac" ||
-                    decoration === "staccatissimo") {
+                    decoration === "stac") {
                     pendingStaccato = true;
+                }
+                else if (decoration === "staccatissimo" || decoration === "wedge" || decoration === "spiccato") {
+                    pendingStaccatissimo = true;
+                }
+                else if (decoration === "accent") {
+                    pendingAccent = true;
+                }
+                else if (decoration === "tenuto") {
+                    pendingTenuto = true;
+                }
+                else if (decoration === "stress") {
+                    pendingStress = true;
+                }
+                else if (decoration === "unstress") {
+                    pendingUnstress = true;
+                }
+                else if (decoration === "fermata") {
+                    pendingFermata = "normal";
+                }
+                else if (decoration === "invertedfermata" ||
+                    decoration === "inverted-fermata" ||
+                    decoration === "inverted fermata") {
+                    pendingFermata = "inverted";
+                }
+                else if (decoration === "marcato" ||
+                    decoration === "strongaccent" ||
+                    decoration === "strong-accent" ||
+                    decoration === "strong accent") {
+                    pendingStrongAccent = true;
+                }
+                else if (decoration === "breath" ||
+                    decoration === "breath-mark" ||
+                    decoration === "breathmark" ||
+                    decoration === "breath mark") {
+                    pendingBreathMark = true;
+                }
+                else if (decoration === "caesura") {
+                    pendingCaesura = true;
+                }
+                else if (decoration === "segno") {
+                    pendingSegno = true;
+                }
+                else if (decoration === "coda") {
+                    pendingCoda = true;
+                }
+                else if (decoration === "fine") {
+                    pendingFine = true;
+                }
+                else if (decoration === "dacapo" || decoration === "da-capo" || decoration === "da capo") {
+                    pendingDaCapo = true;
+                }
+                else if (decoration === "dalsegno" || decoration === "dal-segno" || decoration === "dal segno") {
+                    pendingDalSegno = true;
+                }
+                else if (decoration === "tocoda" || decoration === "to-coda" || decoration === "to coda") {
+                    pendingToCoda = true;
+                }
+                else if (decoration === "crescendo(" || decoration === "cresc(") {
+                    pendingCrescendoStart = true;
+                }
+                else if (decoration === "crescendo)" || decoration === "cresc)") {
+                    pendingCrescendoStop = true;
+                }
+                else if (decoration === "diminuendo(" ||
+                    decoration === "decrescendo(" ||
+                    decoration === "dim(" ||
+                    decoration === "decresc(") {
+                    pendingDiminuendoStart = true;
+                }
+                else if (decoration === "diminuendo)" ||
+                    decoration === "decrescendo)" ||
+                    decoration === "dim)" ||
+                    decoration === "decresc)") {
+                    pendingDiminuendoStop = true;
+                }
+                else if (decoration === "ppp" ||
+                    decoration === "p" ||
+                    decoration === "pp" ||
+                    decoration === "mp" ||
+                    decoration === "mf" ||
+                    decoration === "f" ||
+                    decoration === "ff" ||
+                    decoration === "fff" ||
+                    decoration === "fp" ||
+                    decoration === "fz" ||
+                    decoration === "rfz" ||
+                    decoration === "sf" ||
+                    decoration === "sfp") {
+                    pendingDynamicMark = decoration;
+                }
+                else if (decoration === "sfz") {
+                    pendingSfz = true;
+                }
+                else if (decoration === "upbow" || decoration === "up-bow" || decoration === "up bow") {
+                    pendingUpBow = true;
+                }
+                else if (decoration === "downbow" || decoration === "down-bow" || decoration === "down bow") {
+                    pendingDownBow = true;
+                }
+                else if (decoration === "doubletongue" ||
+                    decoration === "double-tongue" ||
+                    decoration === "double tongue") {
+                    pendingDoubleTongue = true;
+                }
+                else if (decoration === "tripletongue" ||
+                    decoration === "triple-tongue" ||
+                    decoration === "triple tongue") {
+                    pendingTripleTongue = true;
+                }
+                else if (decoration === "heel" || decoration === "heel mark") {
+                    pendingHeel = true;
+                }
+                else if (decoration === "toe" || decoration === "toe mark") {
+                    pendingToe = true;
+                }
+                else if (decoration.startsWith("fingering:")) {
+                    const fingeringText = rawDecoration.slice("fingering:".length).trim();
+                    if (fingeringText)
+                        pendingFingerings.push(fingeringText);
+                }
+                else if (decoration.startsWith("string:")) {
+                    const stringText = rawDecoration.slice("string:".length).trim();
+                    if (stringText)
+                        pendingStrings.push(stringText);
+                }
+                else if (decoration.startsWith("pluck:")) {
+                    const pluckText = rawDecoration.slice("pluck:".length).trim();
+                    if (pluckText)
+                        pendingPlucks.push(pluckText);
+                }
+                else if (decoration === "open" ||
+                    decoration === "open-string" ||
+                    decoration === "openstring" ||
+                    decoration === "open string") {
+                    pendingOpenString = true;
+                }
+                else if (decoration === "snap" ||
+                    decoration === "snap-pizzicato" ||
+                    decoration === "snappizzicato" ||
+                    decoration === "snap pizzicato") {
+                    pendingSnapPizzicato = true;
+                }
+                else if (decoration === "harmonic") {
+                    pendingHarmonic = true;
+                }
+                else if (decoration === "stopped" ||
+                    decoration === "plus" ||
+                    decoration === "stopped horn" ||
+                    decoration === "stopped-horn") {
+                    pendingStopped = true;
+                }
+                else if (decoration === "thumb" ||
+                    decoration === "thumbposition" ||
+                    decoration === "thumb-position" ||
+                    decoration === "thumbpos" ||
+                    decoration === "thumb pos" ||
+                    decoration === "thumb position") {
+                    pendingThumbPosition = true;
                 }
                 else if (decoration) {
                     warnings.push("line " + entry.lineNo + ": Skipped decoration: " + ch + decoration + ch);
@@ -29908,7 +30640,7 @@ function parseForMusicXml(source, settings) {
                 continue;
             }
             if (ch === "{") {
-                const graceResult = parseGraceGroupAt(text, idx, entry.lineNo, unitLength, keySignatureAccidentals, measureAccidentals, entry.voiceId);
+                const graceResult = parseGraceGroupAt(text, idx, entry.lineNo, activeUnitLength, activeKeySignatureAccidentals, measureAccidentals, entry.voiceId);
                 if (!graceResult) {
                     warnings.push("line " + entry.lineNo + ": Failed to parse grace group; skipped.");
                     idx += 1;
@@ -29927,6 +30659,56 @@ function parseForMusicXml(source, settings) {
                 continue;
             }
             if (ch === "[") {
+                const inlineField = parseInlineFieldAt(text, idx);
+                if (inlineField) {
+                    if (inlineField.fieldName === "K") {
+                        const inlineKeyInfo = parseKey(inlineField.fieldValue || "C", warnings);
+                        activeKeyFifths = inlineKeyInfo.fifths;
+                        activeKeySignatureAccidentals = keySignatureAlterByStep(activeKeyFifths);
+                        currentKeyFifthsByVoice[entry.voiceId] = activeKeyFifths;
+                        keyHintFifthsByKey.set(`${entry.voiceId}#${currentMeasureNo}`, activeKeyFifths);
+                        measureAccidentals = {};
+                    }
+                    else if (inlineField.fieldName === "L") {
+                        activeUnitLength = parseFraction(inlineField.fieldValue || "1/8", "L", warnings);
+                    }
+                    else if (inlineField.fieldName === "M") {
+                        activeMeter = parseMeter(inlineField.fieldValue || "4/4", warnings);
+                        ensureMeterByMeasure(entry.voiceId)[currentMeasureNo] = {
+                            beats: activeMeter.beats,
+                            beatType: activeMeter.beatType,
+                        };
+                    }
+                    else if (inlineField.fieldName === "Q") {
+                        activeTempoBpm = parseTempoFromQ(inlineField.fieldValue || "", warnings);
+                        if (Number.isFinite(activeTempoBpm)) {
+                            ensureTempoByMeasure(entry.voiceId)[currentMeasureNo] = Math.max(20, Math.min(300, Math.round(Number(activeTempoBpm))));
+                        }
+                    }
+                    else {
+                        warnings.push("line " + entry.lineNo + ": Skipped unsupported inline field: [" + inlineField.fieldName + ":" + inlineField.fieldValue + "]");
+                    }
+                    idx = inlineField.nextIdx;
+                    continue;
+                }
+                const repeatEndingMarker = parseRepeatEndingMarkerAt(text, idx);
+                if (repeatEndingMarker) {
+                    if (activeEndingMarker) {
+                        const stopMeasureNo = currentMeasure.length === 0 ? currentMeasureNo - 1 : currentMeasureNo;
+                        if (stopMeasureNo >= 1) {
+                            const prevMeta = ensureNotationMeasureMeta(entry.voiceId, stopMeasureNo);
+                            prevMeta.endingStop = activeEndingMarker;
+                            prevMeta.endingStopType = "stop";
+                        }
+                    }
+                    const measureMeta = ensureNotationMeasureMeta(entry.voiceId, currentMeasureNo);
+                    measureMeta.endingStart = repeatEndingMarker.marker;
+                    activeEndingMarker = repeatEndingMarker.marker;
+                    idx = repeatEndingMarker.nextIdx;
+                    beamRunActive = false;
+                    sawInterEventWhitespace = false;
+                    continue;
+                }
                 const chordResult = parseChordAt(text, idx, entry.lineNo);
                 if (!chordResult) {
                     warnings.push("line " + entry.lineNo + ": Failed to parse chord notation; skipped.");
@@ -29938,7 +30720,7 @@ function parseForMusicXml(source, settings) {
                 if (!chordResult.lengthToken && chordResult.notes.length > 0 && chordResult.notes[0].lengthToken) {
                     chordLength = parseLengthToken(chordResult.notes[0].lengthToken, entry.lineNo);
                 }
-                let absoluteLength = multiplyFractions(unitLength, chordLength);
+                let absoluteLength = multiplyFractions(activeUnitLength, chordLength);
                 if (pendingRhythmScale) {
                     absoluteLength = multiplyFractions(absoluteLength, pendingRhythmScale);
                     pendingRhythmScale = null;
@@ -29978,15 +30760,57 @@ function parseForMusicXml(source, settings) {
                 const trillHint = trillWidthHintByKey.get(`${entry.voiceId}#${currentMeasureNo}#${currentEventNo}`) || "";
                 for (let chordIndex = 0; chordIndex < chordResult.notes.length; chordIndex += 1) {
                     const chordNote = chordResult.notes[chordIndex];
-                    const note = buildNoteData(chordNote.pitchChar, chordNote.accidentalText, chordNote.octaveShift, absoluteLength, dur, entry.lineNo, keySignatureAccidentals, measureAccidentals);
+                    const note = buildNoteData(chordNote.pitchChar, chordNote.accidentalText, chordNote.octaveShift, absoluteLength, dur, entry.lineNo, activeKeySignatureAccidentals, measureAccidentals);
                     note.voice = entry.voiceId;
+                    if (chordIndex === 0) {
+                        applyBeamModeForEvent(note, dur);
+                    }
                     if (chordIndex === 0 && pendingTrill && !note.isRest) {
                         note.trill = true;
                         pendingTrill = false;
                     }
                     if (chordIndex === 0 && pendingTurn && !note.isRest) {
                         note.turnType = pendingTurn;
+                        note.delayedTurn = pendingDelayedTurn;
                         pendingTurn = "";
+                        pendingDelayedTurn = false;
+                    }
+                    if (chordIndex === 0 && pendingMordent && !note.isRest) {
+                        note.mordentType = pendingMordent;
+                        pendingMordent = "";
+                    }
+                    if (chordIndex === 0 && pendingTremolo && !note.isRest) {
+                        note.tremoloType = pendingTremolo.type;
+                        note.tremoloMarks = pendingTremolo.marks;
+                        pendingTremolo = null;
+                    }
+                    if (chordIndex === 0 && pendingGlissandoStart && !note.isRest) {
+                        note.glissandoStart = true;
+                        pendingGlissandoStart = false;
+                    }
+                    if (chordIndex === 0 && pendingGlissandoStop && !note.isRest) {
+                        note.glissandoStop = true;
+                        pendingGlissandoStop = false;
+                    }
+                    if (chordIndex === 0 && pendingSlideStart && !note.isRest) {
+                        note.slideStart = true;
+                        pendingSlideStart = false;
+                    }
+                    if (chordIndex === 0 && pendingSlideStop && !note.isRest) {
+                        note.slideStop = true;
+                        pendingSlideStop = false;
+                    }
+                    if (chordIndex === 0 && pendingSchleifer && !note.isRest) {
+                        note.schleifer = true;
+                        pendingSchleifer = false;
+                    }
+                    if (chordIndex === 0 && pendingShake && !note.isRest) {
+                        note.shake = true;
+                        pendingShake = false;
+                    }
+                    if (chordIndex === 0 && pendingArpeggiate && !note.isRest) {
+                        note.arpeggiate = true;
+                        pendingArpeggiate = false;
                     }
                     if (chordIndex === 0 && pendingSlurStart > 0 && !note.isRest) {
                         note.slurStart = true;
@@ -29998,6 +30822,158 @@ function parseForMusicXml(source, settings) {
                     if (chordIndex === 0 && pendingStaccato && !note.isRest) {
                         note.staccato = true;
                         pendingStaccato = false;
+                    }
+                    if (chordIndex === 0 && pendingStaccatissimo && !note.isRest) {
+                        note.staccatissimo = true;
+                        pendingStaccatissimo = false;
+                    }
+                    if (chordIndex === 0 && pendingAccent && !note.isRest) {
+                        note.accent = true;
+                        pendingAccent = false;
+                    }
+                    if (chordIndex === 0 && pendingTenuto && !note.isRest) {
+                        note.tenuto = true;
+                        pendingTenuto = false;
+                    }
+                    if (chordIndex === 0 && pendingStress && !note.isRest) {
+                        note.stress = true;
+                        pendingStress = false;
+                    }
+                    if (chordIndex === 0 && pendingUnstress && !note.isRest) {
+                        note.unstress = true;
+                        pendingUnstress = false;
+                    }
+                    if (chordIndex === 0 && pendingFermata && !note.isRest) {
+                        note.fermataType = pendingFermata;
+                        pendingFermata = "";
+                    }
+                    if (chordIndex === 0 && pendingStrongAccent && !note.isRest) {
+                        note.strongAccent = true;
+                        pendingStrongAccent = false;
+                    }
+                    if (chordIndex === 0 && pendingBreathMark && !note.isRest) {
+                        note.breathMark = true;
+                        pendingBreathMark = false;
+                    }
+                    if (chordIndex === 0 && pendingCaesura && !note.isRest) {
+                        note.caesura = true;
+                        pendingCaesura = false;
+                    }
+                    if (chordIndex === 0 && pendingSegno && !note.isRest) {
+                        note.segno = true;
+                        pendingSegno = false;
+                    }
+                    if (chordIndex === 0 && pendingCoda && !note.isRest) {
+                        note.coda = true;
+                        pendingCoda = false;
+                    }
+                    if (chordIndex === 0 && pendingFine && !note.isRest) {
+                        note.fine = true;
+                        pendingFine = false;
+                    }
+                    if (chordIndex === 0 && pendingDaCapo && !note.isRest) {
+                        note.daCapo = true;
+                        pendingDaCapo = false;
+                    }
+                    if (chordIndex === 0 && pendingDalSegno && !note.isRest) {
+                        note.dalSegno = true;
+                        pendingDalSegno = false;
+                    }
+                    if (chordIndex === 0 && pendingToCoda && !note.isRest) {
+                        note.toCoda = true;
+                        pendingToCoda = false;
+                    }
+                    if (chordIndex === 0 && pendingCrescendoStart && !note.isRest) {
+                        note.crescendoStart = true;
+                        pendingCrescendoStart = false;
+                    }
+                    if (chordIndex === 0 && pendingCrescendoStop && !note.isRest) {
+                        note.crescendoStop = true;
+                        pendingCrescendoStop = false;
+                    }
+                    if (chordIndex === 0 && pendingDiminuendoStart && !note.isRest) {
+                        note.diminuendoStart = true;
+                        pendingDiminuendoStart = false;
+                    }
+                    if (chordIndex === 0 && pendingDiminuendoStop && !note.isRest) {
+                        note.diminuendoStop = true;
+                        pendingDiminuendoStop = false;
+                    }
+                    if (chordIndex === 0 && pendingDynamicMark && !note.isRest) {
+                        note.dynamicMark = pendingDynamicMark;
+                        pendingDynamicMark = "";
+                    }
+                    if (chordIndex === 0 && pendingSfz && !note.isRest) {
+                        note.sfz = true;
+                        pendingSfz = false;
+                    }
+                    if (chordIndex === 0 && pendingRehearsalMark && !note.isRest) {
+                        note.rehearsalMark = pendingRehearsalMark;
+                        pendingRehearsalMark = "";
+                    }
+                    if (chordIndex === 0 && pendingUpBow && !note.isRest) {
+                        note.upBow = true;
+                        pendingUpBow = false;
+                    }
+                    if (chordIndex === 0 && pendingDownBow && !note.isRest) {
+                        note.downBow = true;
+                        pendingDownBow = false;
+                    }
+                    if (chordIndex === 0 && pendingDoubleTongue && !note.isRest) {
+                        note.doubleTongue = true;
+                        pendingDoubleTongue = false;
+                    }
+                    if (chordIndex === 0 && pendingTripleTongue && !note.isRest) {
+                        note.tripleTongue = true;
+                        pendingTripleTongue = false;
+                    }
+                    if (chordIndex === 0 && pendingHeel && !note.isRest) {
+                        note.heel = true;
+                        pendingHeel = false;
+                    }
+                    if (chordIndex === 0 && pendingToe && !note.isRest) {
+                        note.toe = true;
+                        pendingToe = false;
+                    }
+                    if (chordIndex === 0 && pendingFingerings.length > 0 && !note.isRest) {
+                        note.fingerings = pendingFingerings.slice();
+                        pendingFingerings = [];
+                    }
+                    if (chordIndex === 0 && pendingStrings.length > 0 && !note.isRest) {
+                        note.strings = pendingStrings.slice();
+                        pendingStrings = [];
+                    }
+                    if (chordIndex === 0 && pendingPlucks.length > 0 && !note.isRest) {
+                        note.plucks = pendingPlucks.slice();
+                        pendingPlucks = [];
+                    }
+                    if (chordIndex === 0 && pendingChordSymbols.length > 0 && !note.isRest) {
+                        note.chordSymbols = pendingChordSymbols.slice();
+                        pendingChordSymbols = [];
+                    }
+                    if (chordIndex === 0 && pendingOpenString && !note.isRest) {
+                        note.openString = true;
+                        pendingOpenString = false;
+                    }
+                    if (chordIndex === 0 && pendingSnapPizzicato && !note.isRest) {
+                        note.snapPizzicato = true;
+                        pendingSnapPizzicato = false;
+                    }
+                    if (chordIndex === 0 && pendingHarmonic && !note.isRest) {
+                        note.harmonic = true;
+                        pendingHarmonic = false;
+                    }
+                    if (chordIndex === 0 && pendingStopped && !note.isRest) {
+                        note.stopped = true;
+                        pendingStopped = false;
+                    }
+                    if (chordIndex === 0 && pendingThumbPosition && !note.isRest) {
+                        note.thumbPosition = true;
+                        pendingThumbPosition = false;
+                    }
+                    if (chordIndex === 0 && pendingAnnotations.length > 0 && !note.isRest) {
+                        note.annotations = pendingAnnotations.slice();
+                        pendingAnnotations = [];
                     }
                     if (chordIndex > 0) {
                         note.chord = true;
@@ -30014,7 +30990,11 @@ function parseForMusicXml(source, settings) {
                     chordNotes.push(note);
                 }
                 if (pendingTieToNext && chordNotes.length > 0) {
-                    chordNotes[0].tieStop = true;
+                    for (const chordNote of chordNotes) {
+                        if (!chordNote.isRest) {
+                            chordNote.tieStop = true;
+                        }
+                    }
                     pendingTieToNext = false;
                 }
                 for (const note of chordNotes) {
@@ -30036,8 +31016,23 @@ function parseForMusicXml(source, settings) {
                 continue;
             }
             if (ch === "]" || ch === "}") {
+                if (ch === "]" && activeEndingMarker) {
+                    const stopMeasureNo = currentMeasure.length === 0 ? currentMeasureNo - 1 : currentMeasureNo;
+                    if (stopMeasureNo >= 1) {
+                        const measureMeta = ensureNotationMeasureMeta(entry.voiceId, stopMeasureNo);
+                        measureMeta.endingStop = activeEndingMarker;
+                        measureMeta.endingStopType = "stop";
+                        activeEndingMarker = "";
+                    }
+                    idx += 1;
+                    beamRunActive = false;
+                    sawInterEventWhitespace = false;
+                    continue;
+                }
                 warnings.push("line " + entry.lineNo + ": Skipped unsupported notation: " + ch);
                 idx += 1;
+                beamRunActive = false;
+                sawInterEventWhitespace = false;
                 continue;
             }
             let accidentalText = "";
@@ -30065,13 +31060,13 @@ function parseForMusicXml(source, settings) {
                 idx += 1;
             }
             let lengthToken = "";
-            const lengthMatch = text.slice(idx).match(/^(\d+\/\d+|\d+|\/\d+|\/)/);
+            const lengthMatch = text.slice(idx).match(/^(\d+\/\d+|\d+|\/\d+|\/+)/);
             if (lengthMatch) {
                 lengthToken = lengthMatch[1];
                 idx += lengthToken.length;
             }
             const len = parseLengthToken(lengthToken, entry.lineNo);
-            let absoluteLength = multiplyFractions(unitLength, len);
+            let absoluteLength = multiplyFractions(activeUnitLength, len);
             if (pendingRhythmScale) {
                 absoluteLength = multiplyFractions(absoluteLength, pendingRhythmScale);
                 pendingRhythmScale = null;
@@ -30106,14 +31101,54 @@ function parseForMusicXml(source, settings) {
             if (dur <= 0) {
                 throw new Error("line " + entry.lineNo + ": Invalid length");
             }
-            const note = buildNoteData(pitchChar, accidentalText, octaveShift, absoluteLength, dur, entry.lineNo, keySignatureAccidentals, measureAccidentals);
+            const note = buildNoteData(pitchChar, accidentalText, octaveShift, absoluteLength, dur, entry.lineNo, activeKeySignatureAccidentals, measureAccidentals);
+            applyBeamModeForEvent(note, dur);
             if (pendingTrill && !note.isRest) {
                 note.trill = true;
                 pendingTrill = false;
             }
             if (pendingTurn && !note.isRest) {
                 note.turnType = pendingTurn;
+                note.delayedTurn = pendingDelayedTurn;
                 pendingTurn = "";
+                pendingDelayedTurn = false;
+            }
+            if (pendingMordent && !note.isRest) {
+                note.mordentType = pendingMordent;
+                pendingMordent = "";
+            }
+            if (pendingTremolo && !note.isRest) {
+                note.tremoloType = pendingTremolo.type;
+                note.tremoloMarks = pendingTremolo.marks;
+                pendingTremolo = null;
+            }
+            if (pendingGlissandoStart && !note.isRest) {
+                note.glissandoStart = true;
+                pendingGlissandoStart = false;
+            }
+            if (pendingGlissandoStop && !note.isRest) {
+                note.glissandoStop = true;
+                pendingGlissandoStop = false;
+            }
+            if (pendingSlideStart && !note.isRest) {
+                note.slideStart = true;
+                pendingSlideStart = false;
+            }
+            if (pendingSlideStop && !note.isRest) {
+                note.slideStop = true;
+                pendingSlideStop = false;
+            }
+            if (pendingSchleifer && !note.isRest) {
+                note.schleifer = true;
+                pendingSchleifer = false;
+            }
+            if (pendingShake && !note.isRest) {
+                note.shake = true;
+                pendingShake = false;
+            }
+            if (pendingArpeggiate && !note.isRest) {
+                note.arpeggiate = true;
+                pendingArpeggiate = false;
             }
             if (pendingSlurStart > 0 && !note.isRest) {
                 note.slurStart = true;
@@ -30127,6 +31162,158 @@ function parseForMusicXml(source, settings) {
             if (pendingStaccato && !note.isRest) {
                 note.staccato = true;
                 pendingStaccato = false;
+            }
+            if (pendingStaccatissimo && !note.isRest) {
+                note.staccatissimo = true;
+                pendingStaccatissimo = false;
+            }
+            if (pendingAccent && !note.isRest) {
+                note.accent = true;
+                pendingAccent = false;
+            }
+            if (pendingTenuto && !note.isRest) {
+                note.tenuto = true;
+                pendingTenuto = false;
+            }
+            if (pendingStress && !note.isRest) {
+                note.stress = true;
+                pendingStress = false;
+            }
+            if (pendingUnstress && !note.isRest) {
+                note.unstress = true;
+                pendingUnstress = false;
+            }
+            if (pendingFermata && !note.isRest) {
+                note.fermataType = pendingFermata;
+                pendingFermata = "";
+            }
+            if (pendingStrongAccent && !note.isRest) {
+                note.strongAccent = true;
+                pendingStrongAccent = false;
+            }
+            if (pendingBreathMark && !note.isRest) {
+                note.breathMark = true;
+                pendingBreathMark = false;
+            }
+            if (pendingCaesura && !note.isRest) {
+                note.caesura = true;
+                pendingCaesura = false;
+            }
+            if (pendingSegno && !note.isRest) {
+                note.segno = true;
+                pendingSegno = false;
+            }
+            if (pendingCoda && !note.isRest) {
+                note.coda = true;
+                pendingCoda = false;
+            }
+            if (pendingFine && !note.isRest) {
+                note.fine = true;
+                pendingFine = false;
+            }
+            if (pendingDaCapo && !note.isRest) {
+                note.daCapo = true;
+                pendingDaCapo = false;
+            }
+            if (pendingDalSegno && !note.isRest) {
+                note.dalSegno = true;
+                pendingDalSegno = false;
+            }
+            if (pendingToCoda && !note.isRest) {
+                note.toCoda = true;
+                pendingToCoda = false;
+            }
+            if (pendingCrescendoStart && !note.isRest) {
+                note.crescendoStart = true;
+                pendingCrescendoStart = false;
+            }
+            if (pendingCrescendoStop && !note.isRest) {
+                note.crescendoStop = true;
+                pendingCrescendoStop = false;
+            }
+            if (pendingDiminuendoStart && !note.isRest) {
+                note.diminuendoStart = true;
+                pendingDiminuendoStart = false;
+            }
+            if (pendingDiminuendoStop && !note.isRest) {
+                note.diminuendoStop = true;
+                pendingDiminuendoStop = false;
+            }
+            if (pendingDynamicMark && !note.isRest) {
+                note.dynamicMark = pendingDynamicMark;
+                pendingDynamicMark = "";
+            }
+            if (pendingSfz && !note.isRest) {
+                note.sfz = true;
+                pendingSfz = false;
+            }
+            if (pendingRehearsalMark && !note.isRest) {
+                note.rehearsalMark = pendingRehearsalMark;
+                pendingRehearsalMark = "";
+            }
+            if (pendingUpBow && !note.isRest) {
+                note.upBow = true;
+                pendingUpBow = false;
+            }
+            if (pendingDownBow && !note.isRest) {
+                note.downBow = true;
+                pendingDownBow = false;
+            }
+            if (pendingDoubleTongue && !note.isRest) {
+                note.doubleTongue = true;
+                pendingDoubleTongue = false;
+            }
+            if (pendingTripleTongue && !note.isRest) {
+                note.tripleTongue = true;
+                pendingTripleTongue = false;
+            }
+            if (pendingHeel && !note.isRest) {
+                note.heel = true;
+                pendingHeel = false;
+            }
+            if (pendingToe && !note.isRest) {
+                note.toe = true;
+                pendingToe = false;
+            }
+            if (pendingFingerings.length > 0 && !note.isRest) {
+                note.fingerings = pendingFingerings.slice();
+                pendingFingerings = [];
+            }
+            if (pendingStrings.length > 0 && !note.isRest) {
+                note.strings = pendingStrings.slice();
+                pendingStrings = [];
+            }
+            if (pendingPlucks.length > 0 && !note.isRest) {
+                note.plucks = pendingPlucks.slice();
+                pendingPlucks = [];
+            }
+            if (pendingChordSymbols.length > 0 && !note.isRest) {
+                note.chordSymbols = pendingChordSymbols.slice();
+                pendingChordSymbols = [];
+            }
+            if (pendingOpenString && !note.isRest) {
+                note.openString = true;
+                pendingOpenString = false;
+            }
+            if (pendingSnapPizzicato && !note.isRest) {
+                note.snapPizzicato = true;
+                pendingSnapPizzicato = false;
+            }
+            if (pendingHarmonic && !note.isRest) {
+                note.harmonic = true;
+                pendingHarmonic = false;
+            }
+            if (pendingStopped && !note.isRest) {
+                note.stopped = true;
+                pendingStopped = false;
+            }
+            if (pendingThumbPosition && !note.isRest) {
+                note.thumbPosition = true;
+                pendingThumbPosition = false;
+            }
+            if (pendingAnnotations.length > 0 && !note.isRest) {
+                note.annotations = pendingAnnotations.slice();
+                pendingAnnotations = [];
             }
             if (pendingTieToNext && !note.isRest) {
                 note.tieStop = true;
@@ -30151,11 +31338,64 @@ function parseForMusicXml(source, settings) {
             lastEventNotes = [note];
             noteCount += 1;
         }
+        activeEndingByVoice[entry.voiceId] = activeEndingMarker;
+        currentKeyFifthsByVoice[entry.voiceId] = activeKeyFifths;
     }
     for (const voiceId of Object.keys(measuresByVoice)) {
         const measures = measuresByVoice[voiceId];
         while (measures.length > 1 && measures[measures.length - 1].length === 0) {
             measures.pop();
+        }
+        const activeEndingMarker = String(activeEndingByVoice[voiceId] || "");
+        if (activeEndingMarker) {
+            const lastMeasureNo = measures.length;
+            if (lastMeasureNo >= 1) {
+                const measureMeta = ensureNotationMeasureMeta(voiceId, lastMeasureNo);
+                if (!measureMeta.endingStop) {
+                    measureMeta.endingStop = activeEndingMarker;
+                    measureMeta.endingStopType = "stop";
+                }
+            }
+        }
+    }
+    for (const voiceId of Object.keys(lyricEntriesByVoice)) {
+        const measures = measuresByVoice[voiceId];
+        if (!Array.isArray(measures) || measures.length === 0)
+            continue;
+        const lyricTargets = [];
+        for (const measure of measures) {
+            for (const note of measure) {
+                if (note && !note.isRest && !note.grace && !note.chord) {
+                    lyricTargets.push(note);
+                }
+            }
+        }
+        if (lyricTargets.length === 0)
+            continue;
+        let cursor = 0;
+        for (const lyricEntry of lyricEntriesByVoice[voiceId]) {
+            const tokens = tokenizeAbcLyricLine(lyricEntry.text);
+            for (const token of tokens) {
+                if (cursor >= lyricTargets.length)
+                    break;
+                if (token.type === "skip") {
+                    cursor += 1;
+                    continue;
+                }
+                if (token.type === "extend") {
+                    const target = lyricTargets[Math.max(0, cursor - 1)];
+                    if (target) {
+                        target.lyricExtend = true;
+                    }
+                    continue;
+                }
+                const target = lyricTargets[cursor];
+                if (target) {
+                    target.lyricText = token.text;
+                    target.lyricSyllabic = token.syllabic;
+                }
+                cursor += 1;
+            }
         }
     }
     if (noteCount === 0) {
@@ -30166,6 +31406,7 @@ function parseForMusicXml(source, settings) {
     const importDiagnostics = [];
     const overfullCompatibilityMode = (settings === null || settings === void 0 ? void 0 : settings.overfullCompatibilityMode) !== false;
     const parts = orderedVoiceIds.map((voiceId, index) => {
+        var _a, _b, _c, _d, _e, _f, _g;
         const partName = voiceNameById[voiceId] || ("Voice " + voiceId);
         const transpose = transposeHintByVoiceId.get(voiceId) ||
             voiceTransposeById[voiceId] ||
@@ -30188,15 +31429,38 @@ function parseForMusicXml(source, settings) {
             }
         }
         const keyByMeasure = {};
+        const meterByMeasure = {};
+        const tempoByMeasure = {};
         const measureMetaByIndex = {};
         for (let m = 1; m <= normalizedMeasures.length; m += 1) {
             const hinted = keyHintFifthsByKey.get(`${voiceId}#${m}`);
             if (Number.isFinite(hinted)) {
                 keyByMeasure[m] = Number(hinted);
             }
-            const meta = measureMetaByKey.get(`${voiceId}#${m}`);
-            if (meta) {
-                measureMetaByIndex[m] = meta;
+            const notationMeta = ((_a = notationMeasureMetaByVoice[voiceId]) === null || _a === void 0 ? void 0 : _a[m]) || null;
+            const hintedMeta = measureMetaByKey.get(`${voiceId}#${m}`) || null;
+            const meterHint = ((_b = meterByMeasureByVoice[voiceId]) === null || _b === void 0 ? void 0 : _b[m]) || null;
+            const tempoHint = ((_c = tempoByMeasureByVoice[voiceId]) === null || _c === void 0 ? void 0 : _c[m]) || null;
+            if (notationMeta || hintedMeta) {
+                measureMetaByIndex[m] = {
+                    number: (hintedMeta === null || hintedMeta === void 0 ? void 0 : hintedMeta.number) || (notationMeta === null || notationMeta === void 0 ? void 0 : notationMeta.number) || String(m),
+                    implicit: (_e = (_d = hintedMeta === null || hintedMeta === void 0 ? void 0 : hintedMeta.implicit) !== null && _d !== void 0 ? _d : notationMeta === null || notationMeta === void 0 ? void 0 : notationMeta.implicit) !== null && _e !== void 0 ? _e : false,
+                    repeatStart: Boolean((notationMeta === null || notationMeta === void 0 ? void 0 : notationMeta.repeatStart) || (hintedMeta === null || hintedMeta === void 0 ? void 0 : hintedMeta.repeatStart)),
+                    repeatEnd: Boolean((notationMeta === null || notationMeta === void 0 ? void 0 : notationMeta.repeatEnd) || (hintedMeta === null || hintedMeta === void 0 ? void 0 : hintedMeta.repeatEnd)),
+                    repeatTimes: (_g = (_f = hintedMeta === null || hintedMeta === void 0 ? void 0 : hintedMeta.repeatTimes) !== null && _f !== void 0 ? _f : notationMeta === null || notationMeta === void 0 ? void 0 : notationMeta.repeatTimes) !== null && _g !== void 0 ? _g : null,
+                    endingStart: String((notationMeta === null || notationMeta === void 0 ? void 0 : notationMeta.endingStart) || (hintedMeta === null || hintedMeta === void 0 ? void 0 : hintedMeta.endingStart) || ""),
+                    endingStop: String((notationMeta === null || notationMeta === void 0 ? void 0 : notationMeta.endingStop) || (hintedMeta === null || hintedMeta === void 0 ? void 0 : hintedMeta.endingStop) || ""),
+                    endingStopType: (notationMeta === null || notationMeta === void 0 ? void 0 : notationMeta.endingStopType) || (hintedMeta === null || hintedMeta === void 0 ? void 0 : hintedMeta.endingStopType) || "",
+                };
+            }
+            if (meterHint) {
+                meterByMeasure[m] = {
+                    beats: meterHint.beats,
+                    beatType: meterHint.beatType,
+                };
+            }
+            if (Number.isFinite(tempoHint)) {
+                tempoByMeasure[m] = Math.max(20, Math.min(300, Math.round(Number(tempoHint))));
             }
         }
         return {
@@ -30206,6 +31470,8 @@ function parseForMusicXml(source, settings) {
             transpose,
             voiceId,
             keyByMeasure,
+            meterByMeasure,
+            tempoByMeasure,
             measureMetaByIndex,
             measures: normalizedMeasures
         };
@@ -30405,7 +31671,7 @@ function parseChordAt(text, startIdx, lineNo) {
         return null;
     }
     const after = text.slice(closeIdx + 1);
-    const lengthMatch = after.match(/^(\d+\/\d+|\d+|\/\d+|\/)/);
+    const lengthMatch = after.match(/^(\d+\/\d+|\d+|\/\d+|\/+)/);
     const lengthToken = lengthMatch ? lengthMatch[1] : "";
     const nextIdx = closeIdx + 1 + (lengthMatch ? lengthMatch[1].length : 0);
     return {
@@ -30453,7 +31719,7 @@ function parseGraceGroupAt(text, startIdx, lineNo, unitLength, keySignatureAccid
             idx += 1;
         }
         let lengthToken = "";
-        const lengthMatch = inner.slice(idx).match(/^(\d+\/\d+|\d+|\/\d+|\/)/);
+        const lengthMatch = inner.slice(idx).match(/^(\d+\/\d+|\d+|\/\d+|\/+)/);
         if (lengthMatch) {
             lengthToken = lengthMatch[1];
             idx += lengthToken.length;
@@ -30768,7 +32034,6 @@ const exportMusicXmlDomToAbc = (doc) => {
     ].filter(Boolean);
     const bodyLines = [];
     const metaLines = [];
-    const emittedKeyMetaByVoiceMeasure = new Set();
     const emitDiagMetaForMeasure = (normalizedVoiceId, measure, safeMeasureNumber) => {
         const fields = Array.from(measure.querySelectorAll(':scope > attributes > miscellaneous > miscellaneous-field[name^="mks:diag:"]'));
         if (!fields.length)
@@ -30797,7 +32062,7 @@ const exportMusicXmlDomToAbc = (doc) => {
     };
     const parts = Array.from(doc.querySelectorAll("score-partwise > part"));
     parts.forEach((part, partIndex) => {
-        var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p, _q, _r, _s, _t, _u, _v, _w, _x, _y, _z, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19;
+        var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p, _q, _r, _s, _t, _u, _v, _w, _x, _y, _z, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26;
         const partId = part.getAttribute("id") || `P${partIndex + 1}`;
         const partName = partNameById.get(partId) || partId;
         const measures = Array.from(part.querySelectorAll(":scope > measure"));
@@ -30894,10 +32159,12 @@ const exportMusicXmlDomToAbc = (doc) => {
                 : (Number.isFinite(fifths) ? Math.round(fifths) : 0);
             let currentDivisions = 480;
             let currentFifths = partInitialFifths;
-            let lastEmittedKeyFifths = null;
+            let lastEmittedKeyFifths = Number.isFinite(fifths) ? Math.round(fifths) : 0;
             let currentBeats = Number(meterBeats) || 4;
             let currentBeatType = Number(meterBeatType) || 4;
             const measureTexts = [];
+            const lyricTokens = [];
+            let pendingLyricExtension = false;
             for (const measure of measures) {
                 let activeTuplet = null;
                 let eventNo = 0;
@@ -30915,40 +32182,36 @@ const exportMusicXmlDomToAbc = (doc) => {
                 const isImplicit = implicitAttr === "yes" || implicitAttr === "true" || implicitAttr === "1";
                 const leftRepeatNode = measure.querySelector(':scope > barline[location="left"] > repeat');
                 const rightRepeatNode = measure.querySelector(':scope > barline[location="right"] > repeat');
+                const leftEndingNode = measure.querySelector(':scope > barline[location="left"] > ending');
+                const rightEndingNode = measure.querySelector(':scope > barline[location="right"] > ending');
                 const leftRepeatDir = ((leftRepeatNode === null || leftRepeatNode === void 0 ? void 0 : leftRepeatNode.getAttribute("direction")) || "").trim().toLowerCase();
                 const rightRepeatDir = ((rightRepeatNode === null || rightRepeatNode === void 0 ? void 0 : rightRepeatNode.getAttribute("direction")) || "").trim().toLowerCase();
-                const repeatDir = rightRepeatDir === "backward"
-                    ? "backward"
-                    : (leftRepeatDir === "forward" ? "forward" : "");
+                const hasLeftRepeat = leftRepeatDir === "forward";
+                const hasRightRepeat = rightRepeatDir === "backward";
                 const repeatTimes = Number.parseInt(String((rightRepeatNode === null || rightRepeatNode === void 0 ? void 0 : rightRepeatNode.getAttribute("times")) || ""), 10);
-                if (isImplicit || repeatDir || rawMeasureNumber !== String(safeMeasureNumber)) {
+                const leftEndingNumber = ((leftEndingNode === null || leftEndingNode === void 0 ? void 0 : leftEndingNode.getAttribute("number")) || "").trim();
+                const rightEndingNumber = ((rightEndingNode === null || rightEndingNode === void 0 ? void 0 : rightEndingNode.getAttribute("number")) || "").trim();
+                const rightEndingType = ((rightEndingNode === null || rightEndingNode === void 0 ? void 0 : rightEndingNode.getAttribute("type")) || "").trim().toLowerCase();
+                if (isImplicit ||
+                    rawMeasureNumber !== String(safeMeasureNumber) ||
+                    (hasRightRepeat && Number.isFinite(repeatTimes) && repeatTimes > 2) ||
+                    (rightEndingNumber && rightEndingType === "discontinue")) {
                     const metaChunks = [
                         `%@mks measure voice=${normalizedVoiceId} measure=${safeMeasureNumber}`,
                         `number=${rawMeasureNumber}`,
                         `implicit=${isImplicit ? 1 : 0}`,
                     ];
-                    if (repeatDir) {
-                        metaChunks.push(`repeat=${repeatDir}`);
-                    }
-                    if (repeatDir === "backward" && Number.isFinite(repeatTimes) && repeatTimes > 1) {
+                    if (hasRightRepeat && Number.isFinite(repeatTimes) && repeatTimes > 2) {
                         metaChunks.push(`times=${Math.round(repeatTimes)}`);
+                    }
+                    if (rightEndingNumber && rightEndingType === "discontinue") {
+                        metaChunks.push(`ending-stop=${rightEndingNumber}`);
+                        metaChunks.push(`ending-type=${rightEndingType}`);
                     }
                     metaLines.push(metaChunks.join(" "));
                 }
                 emitDiagMetaForMeasure(normalizedVoiceId, measure, safeMeasureNumber);
-                const isFirstMeasureForLane = measureTexts.length === 0;
-                const hasExplicitKeyInMeasure = parsedFifths !== null;
-                const shouldEmitMeasureHint = hasExplicitKeyInMeasure || isFirstMeasureForLane;
-                if (shouldEmitMeasureHint) {
-                    if (lastEmittedKeyFifths === null || lastEmittedKeyFifths !== currentFifths) {
-                        const metaKey = `${normalizedVoiceId}#${safeMeasureNumber}`;
-                        if (!emittedKeyMetaByVoiceMeasure.has(metaKey)) {
-                            metaLines.push(`%@mks key voice=${normalizedVoiceId} measure=${safeMeasureNumber} fifths=${Math.max(-7, Math.min(7, Math.round(currentFifths)))}`);
-                            emittedKeyMetaByVoiceMeasure.add(metaKey);
-                        }
-                        lastEmittedKeyFifths = currentFifths;
-                    }
-                }
+                const needsInlineKeyChange = lastEmittedKeyFifths === null || lastEmittedKeyFifths !== currentFifths;
                 const parsedBeats = parseOptionalNumber((_p = measure.querySelector("attributes > time > beats")) === null || _p === void 0 ? void 0 : _p.textContent);
                 if (parsedBeats !== null && parsedBeats > 0) {
                     currentBeats = parsedBeats;
@@ -30961,6 +32224,10 @@ const exportMusicXmlDomToAbc = (doc) => {
                 const measureAccidentalByStepOctave = new Map();
                 let pending = null;
                 const pendingGraceTokens = [];
+                const pendingHarmonySymbols = [];
+                const pendingDirectionWords = [];
+                const pendingDirectionDecorations = [];
+                let activeWedgeType = "";
                 const tokens = [];
                 const flush = () => {
                     if (!pending)
@@ -30974,6 +32241,64 @@ const exportMusicXmlDomToAbc = (doc) => {
                     pending = null;
                 };
                 for (const child of Array.from(measure.children)) {
+                    if (child.tagName === "harmony") {
+                        const chordSymbol = abcChordSymbolFromHarmony(child);
+                        if (chordSymbol) {
+                            pendingHarmonySymbols.push(chordSymbol);
+                        }
+                        continue;
+                    }
+                    if (child.tagName === "direction") {
+                        const rehearsalTexts = Array.from(child.querySelectorAll(":scope > direction-type > rehearsal"))
+                            .map((node) => abcQuotedTextEscape(node.textContent || ""))
+                            .filter(Boolean);
+                        for (const rehearsalText of rehearsalTexts) {
+                            pendingDirectionDecorations.push(`!rehearsal:${rehearsalText}!`);
+                        }
+                        const words = Array.from(child.querySelectorAll(":scope > direction-type > words"))
+                            .map((node) => abcQuotedTextEscape(node.textContent || ""))
+                            .filter(Boolean);
+                        pendingDirectionWords.push(...words);
+                        if (child.querySelector(":scope > direction-type > segno")) {
+                            pendingDirectionDecorations.push("!segno!");
+                        }
+                        if (child.querySelector(":scope > direction-type > coda")) {
+                            pendingDirectionDecorations.push("!coda!");
+                        }
+                        if (child.querySelector(':scope > sound[fine="yes"]')) {
+                            pendingDirectionDecorations.push("!fine!");
+                        }
+                        if (child.querySelector(':scope > sound[dacapo="yes"]')) {
+                            pendingDirectionDecorations.push("!dacapo!");
+                        }
+                        if (child.querySelector(":scope > sound[dalsegno]")) {
+                            pendingDirectionDecorations.push("!dalsegno!");
+                        }
+                        if (child.querySelector(":scope > sound[tocoda]")) {
+                            pendingDirectionDecorations.push("!tocoda!");
+                        }
+                        for (const wedgeNode of Array.from(child.querySelectorAll(":scope > direction-type > wedge"))) {
+                            const wedgeType = (wedgeNode.getAttribute("type") || "").trim().toLowerCase();
+                            if (wedgeType === "crescendo") {
+                                pendingDirectionDecorations.push("!crescendo(!");
+                                activeWedgeType = "crescendo";
+                            }
+                            else if (wedgeType === "diminuendo") {
+                                pendingDirectionDecorations.push("!diminuendo(!");
+                                activeWedgeType = "diminuendo";
+                            }
+                            else if (wedgeType === "stop") {
+                                pendingDirectionDecorations.push(activeWedgeType === "diminuendo" ? "!diminuendo)!" : "!crescendo)!");
+                                activeWedgeType = "";
+                            }
+                        }
+                        for (const dynamicName of ["ppp", "pp", "p", "mp", "mf", "f", "ff", "fff", "fp", "fz", "rfz", "sf", "sfp", "sfz"]) {
+                            if (child.querySelector(`:scope > direction-type > dynamics > ${dynamicName}`)) {
+                                pendingDirectionDecorations.push(`!${dynamicName}!`);
+                            }
+                        }
+                        continue;
+                    }
                     if (child.tagName !== "note")
                         continue;
                     if (lane.staff) {
@@ -30999,6 +32324,17 @@ const exportMusicXmlDomToAbc = (doc) => {
                     const hasTrillMark = Boolean(child.querySelector(":scope > notations > ornaments > trill-mark"));
                     const hasTurn = Boolean(child.querySelector(":scope > notations > ornaments > turn"));
                     const hasInvertedTurn = Boolean(child.querySelector(":scope > notations > ornaments > inverted-turn"));
+                    const hasDelayedTurn = Boolean(child.querySelector(":scope > notations > ornaments > delayed-turn"));
+                    const hasMordent = Boolean(child.querySelector(":scope > notations > ornaments > mordent"));
+                    const hasInvertedMordent = Boolean(child.querySelector(":scope > notations > ornaments > inverted-mordent"));
+                    const tremoloNode = child.querySelector(":scope > notations > ornaments > tremolo");
+                    const hasSchleifer = Boolean(child.querySelector(":scope > notations > ornaments > schleifer"));
+                    const hasShake = Boolean(child.querySelector(":scope > notations > ornaments > shake"));
+                    const hasGlissandoStart = Boolean(child.querySelector(':scope > notations > glissando[type="start"]'));
+                    const hasGlissandoStop = Boolean(child.querySelector(':scope > notations > glissando[type="stop"]'));
+                    const hasSlideStart = Boolean(child.querySelector(':scope > notations > slide[type="start"]'));
+                    const hasSlideStop = Boolean(child.querySelector(':scope > notations > slide[type="stop"]'));
+                    const hasArpeggiate = Boolean(child.querySelector(":scope > notations > arpeggiate"));
                     const hasWavyLineStart = Array.from(child.querySelectorAll(":scope > notations > ornaments > wavy-line")).some((node) => {
                         var _a;
                         const type = ((_a = node.getAttribute("type")) !== null && _a !== void 0 ? _a : "").trim().toLowerCase();
@@ -31006,14 +32342,54 @@ const exportMusicXmlDomToAbc = (doc) => {
                     });
                     const hasTrill = hasTrillMark || hasWavyLineStart;
                     const turnType = hasInvertedTurn ? "inverted-turn" : (hasTurn ? "turn" : "");
-                    const trillAccidentalText = ((_0 = (_z = child.querySelector(":scope > notations > ornaments > accidental-mark")) === null || _z === void 0 ? void 0 : _z.textContent) === null || _0 === void 0 ? void 0 : _0.trim()) || "";
+                    const mordentType = hasInvertedMordent ? "inverted-mordent" : (hasMordent ? "mordent" : "");
+                    const tremoloTypeRaw = ((tremoloNode === null || tremoloNode === void 0 ? void 0 : tremoloNode.getAttribute("type")) || "").trim().toLowerCase();
+                    const tremoloType = tremoloTypeRaw === "single" || tremoloTypeRaw === "start" || tremoloTypeRaw === "stop"
+                        ? tremoloTypeRaw
+                        : "";
+                    const tremoloMarks = Math.max(1, Math.min(8, Number.parseInt(((_z = tremoloNode === null || tremoloNode === void 0 ? void 0 : tremoloNode.textContent) === null || _z === void 0 ? void 0 : _z.trim()) || "", 10) || 0));
+                    const trillAccidentalText = ((_1 = (_0 = child.querySelector(":scope > notations > ornaments > accidental-mark")) === null || _0 === void 0 ? void 0 : _0.textContent) === null || _1 === void 0 ? void 0 : _1.trim()) || "";
                     const hasStaccato = Boolean(child.querySelector(":scope > notations > articulations > staccato"));
+                    const hasStaccatissimo = Boolean(child.querySelector(":scope > notations > articulations > staccatissimo"));
+                    const hasAccent = Boolean(child.querySelector(":scope > notations > articulations > accent"));
+                    const hasTenuto = Boolean(child.querySelector(":scope > notations > articulations > tenuto"));
+                    const hasStress = Boolean(child.querySelector(":scope > notations > articulations > stress"));
+                    const hasUnstress = Boolean(child.querySelector(":scope > notations > articulations > unstress"));
+                    const hasStrongAccent = Boolean(child.querySelector(":scope > notations > articulations > strong-accent"));
+                    const hasBreathMark = Boolean(child.querySelector(":scope > notations > articulations > breath-mark"));
+                    const hasCaesura = Boolean(child.querySelector(":scope > notations > articulations > caesura"));
+                    const hasUpBow = Boolean(child.querySelector(":scope > notations > technical > up-bow"));
+                    const hasDownBow = Boolean(child.querySelector(":scope > notations > technical > down-bow"));
+                    const hasDoubleTongue = Boolean(child.querySelector(":scope > notations > technical > double-tongue"));
+                    const hasTripleTongue = Boolean(child.querySelector(":scope > notations > technical > triple-tongue"));
+                    const hasHeel = Boolean(child.querySelector(":scope > notations > technical > heel"));
+                    const hasToe = Boolean(child.querySelector(":scope > notations > technical > toe"));
+                    const fingeringTexts = Array.from(child.querySelectorAll(":scope > notations > technical > fingering"))
+                        .map((node) => (node.textContent || "").trim())
+                        .filter(Boolean);
+                    const stringTexts = Array.from(child.querySelectorAll(":scope > notations > technical > string"))
+                        .map((node) => (node.textContent || "").trim())
+                        .filter(Boolean);
+                    const pluckTexts = Array.from(child.querySelectorAll(":scope > notations > technical > pluck"))
+                        .map((node) => (node.textContent || "").trim())
+                        .filter(Boolean);
+                    const hasOpenString = Boolean(child.querySelector(":scope > notations > technical > open-string"));
+                    const hasSnapPizzicato = Boolean(child.querySelector(":scope > notations > technical > snap-pizzicato"));
+                    const hasHarmonic = Boolean(child.querySelector(":scope > notations > technical > harmonic"));
+                    const hasStopped = Boolean(child.querySelector(":scope > notations > technical > stopped"));
+                    const hasThumbPosition = Boolean(child.querySelector(":scope > notations > technical > thumb-position"));
+                    const fermataNode = child.querySelector(":scope > notations > fermata");
+                    const fermataTypeRaw = ((_2 = fermataNode === null || fermataNode === void 0 ? void 0 : fermataNode.getAttribute("type")) === null || _2 === void 0 ? void 0 : _2.trim().toLowerCase()) || "";
+                    const fermataShapeRaw = ((_3 = fermataNode === null || fermataNode === void 0 ? void 0 : fermataNode.textContent) === null || _3 === void 0 ? void 0 : _3.trim().toLowerCase()) || "";
+                    const fermataType = !fermataNode
+                        ? ""
+                        : (fermataTypeRaw === "inverted" || fermataShapeRaw === "inverted" ? "inverted" : "normal");
                     const hasSlurStart = Boolean(child.querySelector(':scope > notations > slur[type="start"]'));
                     const hasSlurStop = Boolean(child.querySelector(':scope > notations > slur[type="stop"]'));
-                    const hasGraceSlash = ((_2 = (_1 = child.querySelector(":scope > grace")) === null || _1 === void 0 ? void 0 : _1.getAttribute("slash")) !== null && _2 !== void 0 ? _2 : "").trim().toLowerCase() === "yes";
+                    const hasGraceSlash = ((_5 = (_4 = child.querySelector(":scope > grace")) === null || _4 === void 0 ? void 0 : _4.getAttribute("slash")) !== null && _5 !== void 0 ? _5 : "").trim().toLowerCase() === "yes";
                     const hasTupletStart = Boolean(child.querySelector(':scope > notations > tuplet[type="start"]'));
-                    const tmActual = Number(((_4 = (_3 = child.querySelector(":scope > time-modification > actual-notes")) === null || _3 === void 0 ? void 0 : _3.textContent) === null || _4 === void 0 ? void 0 : _4.trim()) || "");
-                    const tmNormal = Number(((_6 = (_5 = child.querySelector(":scope > time-modification > normal-notes")) === null || _5 === void 0 ? void 0 : _5.textContent) === null || _6 === void 0 ? void 0 : _6.trim()) || "");
+                    const tmActual = Number(((_7 = (_6 = child.querySelector(":scope > time-modification > actual-notes")) === null || _6 === void 0 ? void 0 : _6.textContent) === null || _7 === void 0 ? void 0 : _7.trim()) || "");
+                    const tmNormal = Number(((_9 = (_8 = child.querySelector(":scope > time-modification > normal-notes")) === null || _8 === void 0 ? void 0 : _8.textContent) === null || _9 === void 0 ? void 0 : _9.trim()) || "");
                     const hasTimeModification = Number.isFinite(tmActual) && tmActual > 0 && Number.isFinite(tmNormal) && tmNormal > 0;
                     const rawWholeFraction = exports.AbcCommon.reduceFraction(noteDuration, currentDivisions * 4, { num: 1, den: 4 });
                     const abcBaseWholeFraction = hasTimeModification
@@ -31026,18 +32402,18 @@ const exportMusicXmlDomToAbc = (doc) => {
                     const len = exports.AbcCommon.abcLengthTokenFromFraction(lenRatio);
                     let pitchToken = "z";
                     if (!child.querySelector(":scope > rest")) {
-                        const step = ((_8 = (_7 = child.querySelector(":scope > pitch > step")) === null || _7 === void 0 ? void 0 : _7.textContent) === null || _8 === void 0 ? void 0 : _8.trim()) || "C";
-                        const octave = Number(((_10 = (_9 = child.querySelector(":scope > pitch > octave")) === null || _9 === void 0 ? void 0 : _9.textContent) === null || _10 === void 0 ? void 0 : _10.trim()) || "4");
+                        const step = ((_11 = (_10 = child.querySelector(":scope > pitch > step")) === null || _10 === void 0 ? void 0 : _10.textContent) === null || _11 === void 0 ? void 0 : _11.trim()) || "C";
+                        const octave = Number(((_13 = (_12 = child.querySelector(":scope > pitch > octave")) === null || _12 === void 0 ? void 0 : _12.textContent) === null || _13 === void 0 ? void 0 : _13.trim()) || "4");
                         const upperStep = /^[A-G]$/.test(step.toUpperCase()) ? step.toUpperCase() : "C";
                         const safeOctave = Number.isFinite(octave) ? Math.max(0, Math.min(9, Math.round(octave))) : 4;
                         const stepOctaveKey = `${upperStep}${safeOctave}`;
-                        const alterRaw = (_13 = (_12 = (_11 = child.querySelector(":scope > pitch > alter")) === null || _11 === void 0 ? void 0 : _11.textContent) === null || _12 === void 0 ? void 0 : _12.trim()) !== null && _13 !== void 0 ? _13 : "";
+                        const alterRaw = (_16 = (_15 = (_14 = child.querySelector(":scope > pitch > alter")) === null || _14 === void 0 ? void 0 : _14.textContent) === null || _15 === void 0 ? void 0 : _15.trim()) !== null && _16 !== void 0 ? _16 : "";
                         const explicitAlter = alterRaw !== "" && Number.isFinite(Number(alterRaw)) ? Math.round(Number(alterRaw)) : null;
-                        const accidentalText = (_16 = (_15 = (_14 = child.querySelector(":scope > accidental")) === null || _14 === void 0 ? void 0 : _14.textContent) === null || _15 === void 0 ? void 0 : _15.trim()) !== null && _16 !== void 0 ? _16 : "";
+                        const accidentalText = (_19 = (_18 = (_17 = child.querySelector(":scope > accidental")) === null || _17 === void 0 ? void 0 : _17.textContent) === null || _18 === void 0 ? void 0 : _18.trim()) !== null && _19 !== void 0 ? _19 : "";
                         const accidentalAlter = accidentalTextToAlter(accidentalText);
-                        const keyAlter = (_17 = keyAlterMap[upperStep]) !== null && _17 !== void 0 ? _17 : 0;
+                        const keyAlter = (_20 = keyAlterMap[upperStep]) !== null && _20 !== void 0 ? _20 : 0;
                         const currentAlter = measureAccidentalByStepOctave.has(stepOctaveKey)
-                            ? (_18 = measureAccidentalByStepOctave.get(stepOctaveKey)) !== null && _18 !== void 0 ? _18 : 0
+                            ? (_21 = measureAccidentalByStepOctave.get(stepOctaveKey)) !== null && _21 !== void 0 ? _21 : 0
                             : keyAlter;
                         // In MusicXML pitch, omitted <alter> means natural (0), not "follow key accidental".
                         // Key signature context is only used to decide whether an explicit accidental token is needed.
@@ -31060,7 +32436,7 @@ const exportMusicXmlDomToAbc = (doc) => {
                             pendingGraceTokens.push(`${graceSlashPrefix}${pitchToken}${len}${hasTieStart ? "-" : ""}`);
                         }
                         else {
-                            const last = (_19 = pendingGraceTokens.pop()) !== null && _19 !== void 0 ? _19 : "";
+                            const last = (_22 = pendingGraceTokens.pop()) !== null && _22 !== void 0 ? _22 : "";
                             const merged = last.startsWith("[")
                                 ? last.replace("]", `${graceSlashPrefix}${pitchToken}]`)
                                 : `[${last}${graceSlashPrefix}${pitchToken}]`;
@@ -31083,10 +32459,57 @@ const exportMusicXmlDomToAbc = (doc) => {
                             : "")
                         : "";
                     const trillPrefix = hasTrill ? "!trill!" : "";
-                    const turnPrefix = turnType === "inverted-turn" ? "!invertedturn!" : (turnType === "turn" ? "!turn!" : "");
-                    const staccatoPrefix = hasStaccato ? "!staccato!" : "";
+                    const turnPrefix = turnType === "inverted-turn"
+                        ? (hasDelayedTurn ? "!delayedinvertedturn!" : "!invertedturn!")
+                        : (turnType === "turn" ? (hasDelayedTurn ? "!delayedturn!" : "!turn!") : "");
+                    const mordentPrefix = mordentType === "inverted-mordent" ? "!pralltriller!" : (mordentType === "mordent" ? "!mordent!" : "");
+                    const tremoloPrefix = tremoloType ? `!tremolo-${tremoloType}-${tremoloMarks}!` : "";
+                    const glissandoPrefix = hasGlissandoStart ? "!gliss-start!" : (hasGlissandoStop ? "!gliss-stop!" : "");
+                    const slidePrefix = hasSlideStart ? "!slide-start!" : (hasSlideStop ? "!slide-stop!" : "");
+                    const schleiferPrefix = hasSchleifer ? "!schleifer!" : "";
+                    const shakePrefix = hasShake ? "!shake!" : "";
+                    const arpeggiatePrefix = hasArpeggiate ? "!roll!" : "";
+                    const staccatoPrefix = hasStaccatissimo ? "!wedge!" : (hasStaccato ? "!staccato!" : "");
+                    const accentPrefix = hasAccent ? "!accent!" : "";
+                    const tenutoPrefix = hasTenuto ? "!tenuto!" : "";
+                    const stressPrefix = hasStress ? "!stress!" : "";
+                    const unstressPrefix = hasUnstress ? "!unstress!" : "";
+                    const strongAccentPrefix = hasStrongAccent ? "!marcato!" : "";
+                    const breathMarkPrefix = hasBreathMark ? "!breath!" : "";
+                    const caesuraPrefix = hasCaesura ? "!caesura!" : "";
+                    const upBowPrefix = hasUpBow ? "!upbow!" : "";
+                    const downBowPrefix = hasDownBow ? "!downbow!" : "";
+                    const doubleTonguePrefix = hasDoubleTongue ? "!doubletongue!" : "";
+                    const tripleTonguePrefix = hasTripleTongue ? "!tripletongue!" : "";
+                    const heelPrefix = hasHeel ? "!heel!" : "";
+                    const toePrefix = hasToe ? "!toe!" : "";
+                    const fingeringPrefix = fingeringTexts.map((value) => `!fingering:${value}!`).join("");
+                    const stringPrefix = stringTexts.map((value) => `!string:${value}!`).join("");
+                    const pluckPrefix = pluckTexts.map((value) => `!pluck:${value}!`).join("");
+                    const openStringPrefix = hasOpenString ? "!open!" : "";
+                    const snapPizzicatoPrefix = hasSnapPizzicato ? "!snap!" : "";
+                    const harmonicPrefix = hasHarmonic ? "!harmonic!" : "";
+                    const stoppedPrefix = hasStopped ? "!stopped!" : "";
+                    const thumbPrefix = hasThumbPosition ? "!thumb!" : "";
+                    const fermataPrefix = fermataType === "inverted" ? "!invertedfermata!" : (fermataType === "normal" ? "!fermata!" : "");
                     const slurStartPrefix = hasSlurStart ? "(" : "";
-                    const eventPrefix = `${tupletPrefix}${slurStartPrefix}${gracePrefix}${trillPrefix}${turnPrefix}${staccatoPrefix}`;
+                    const wordsPrefix = !isChord && pendingDirectionWords.length > 0
+                        ? `${pendingDirectionWords.map((word) => `"${word}"`).join("")}`
+                        : "";
+                    const harmonyPrefix = !isChord && pendingHarmonySymbols.length > 0
+                        ? `${pendingHarmonySymbols.map((symbol) => `"${abcQuotedTextEscape(symbol)}"`).join("")}`
+                        : "";
+                    const directionDecorationPrefix = !isChord && pendingDirectionDecorations.length > 0 ? pendingDirectionDecorations.join("") : "";
+                    const eventPrefix = `${harmonyPrefix}${wordsPrefix}${directionDecorationPrefix}${tupletPrefix}${slurStartPrefix}${gracePrefix}${trillPrefix}${turnPrefix}${mordentPrefix}${tremoloPrefix}${glissandoPrefix}${slidePrefix}${schleiferPrefix}${shakePrefix}${arpeggiatePrefix}${staccatoPrefix}${accentPrefix}${tenutoPrefix}${stressPrefix}${unstressPrefix}${strongAccentPrefix}${breathMarkPrefix}${caesuraPrefix}${upBowPrefix}${downBowPrefix}${doubleTonguePrefix}${tripleTonguePrefix}${heelPrefix}${toePrefix}${fingeringPrefix}${stringPrefix}${pluckPrefix}${openStringPrefix}${snapPizzicatoPrefix}${harmonicPrefix}${stoppedPrefix}${thumbPrefix}${fermataPrefix}`;
+                    if (!isChord && pendingHarmonySymbols.length > 0) {
+                        pendingHarmonySymbols.length = 0;
+                    }
+                    if (!isChord && pendingDirectionWords.length > 0) {
+                        pendingDirectionWords.length = 0;
+                    }
+                    if (!isChord && pendingDirectionDecorations.length > 0) {
+                        pendingDirectionDecorations.length = 0;
+                    }
                     if (pendingGraceTokens.length > 0) {
                         pendingGraceTokens.length = 0;
                     }
@@ -31116,6 +32539,25 @@ const exportMusicXmlDomToAbc = (doc) => {
                             activeTuplet = null;
                         }
                     }
+                    if (!isGrace && !isChord && !child.querySelector(":scope > rest")) {
+                        const lyric = child.querySelector(":scope > lyric");
+                        const lyricText = ((_24 = (_23 = lyric === null || lyric === void 0 ? void 0 : lyric.querySelector(":scope > text")) === null || _23 === void 0 ? void 0 : _23.textContent) === null || _24 === void 0 ? void 0 : _24.trim()) || "";
+                        const lyricSyllabic = ((_26 = (_25 = lyric === null || lyric === void 0 ? void 0 : lyric.querySelector(":scope > syllabic")) === null || _25 === void 0 ? void 0 : _25.textContent) === null || _26 === void 0 ? void 0 : _26.trim()) || "single";
+                        const lyricExtend = Boolean(lyric === null || lyric === void 0 ? void 0 : lyric.querySelector(":scope > extend"));
+                        if (lyricText) {
+                            lyricTokens.push(abcLyricTokenFromMusicXml(lyricText, lyricSyllabic));
+                            pendingLyricExtension = lyricExtend;
+                        }
+                        else if (pendingLyricExtension) {
+                            lyricTokens.push("_");
+                        }
+                        else {
+                            lyricTokens.push("*");
+                        }
+                        if (lyricText && !lyricExtend) {
+                            pendingLyricExtension = false;
+                        }
+                    }
                 }
                 if (pendingGraceTokens.length > 0) {
                     tokens.push(`{${pendingGraceTokens.join("")}}`);
@@ -31128,10 +32570,29 @@ const exportMusicXmlDomToAbc = (doc) => {
                     const lenRatio = exports.AbcCommon.divideFractions(wholeFraction, unitLength, { num: 1, den: 1 });
                     tokens.push(`z${exports.AbcCommon.abcLengthTokenFromFraction(lenRatio)}`);
                 }
-                measureTexts.push(tokens.join(" "));
+                const measureTokenText = tokens.join(" ");
+                const keyPrefix = needsInlineKeyChange
+                    ? `[K:${exports.AbcCommon.keyFromFifthsMode(Math.max(-7, Math.min(7, Math.round(currentFifths))), "major")}]`
+                    : "";
+                const leftPrefix = `${hasLeftRepeat ? "|:" : ""}${leftEndingNumber ? `[${leftEndingNumber}` : ""}`;
+                let rightSuffix = "|";
+                if (hasRightRepeat && rightEndingNumber) {
+                    rightSuffix = `:|]`;
+                }
+                else if (hasRightRepeat) {
+                    rightSuffix = ":|";
+                }
+                else if (rightEndingNumber) {
+                    rightSuffix = "]|";
+                }
+                measureTexts.push(`${leftPrefix}${leftPrefix ? " " : ""}${keyPrefix}${keyPrefix ? " " : ""}${measureTokenText} ${rightSuffix}`.trim());
+                lastEmittedKeyFifths = currentFifths;
             }
             bodyLines.push(`V:${normalizedVoiceId}`);
-            bodyLines.push(`${measureTexts.join(" | ")} |`);
+            bodyLines.push(measureTexts.join(" "));
+            if (lyricTokens.some((token) => token !== "*")) {
+                bodyLines.push(`w: ${lyricTokens.join(" ")}`);
+            }
         }
     });
     const metaBlock = metaLines.length > 0 ? `\n${metaLines.join("\n")}\n` : "\n";
@@ -31144,6 +32605,146 @@ const xmlEscape = (text) => text
     .replace(/>/g, "&gt;")
     .replace(/"/g, "&quot;")
     .replace(/'/g, "&apos;");
+const abcQuotedTextEscape = (text) => String(text || "")
+    .replace(/"/g, "'")
+    .replace(/\s+/g, " ")
+    .trim();
+const normalizeChordToken = (raw) => String(raw || "")
+    .trim()
+    .replace(/♯/g, "#")
+    .replace(/♭/g, "b")
+    .replace(/\s+/g, "");
+const isLikelyAbcChordSymbol = (raw) => {
+    const text = normalizeChordToken(raw);
+    return /^[A-G](?:#|b)?(?:[^/\s"]*)?(?:\/[A-G](?:#|b)?)?$/.test(text);
+};
+const xmlHarmonyKindFromChordSuffix = (suffixRaw) => {
+    const suffix = String(suffixRaw || "").trim().toLowerCase();
+    if (!suffix)
+        return "major";
+    if (suffix === "m" || suffix === "min")
+        return "minor";
+    if (suffix === "6")
+        return "major-sixth";
+    if (suffix === "m6" || suffix === "min6")
+        return "minor-sixth";
+    if (suffix === "7")
+        return "dominant";
+    if (suffix === "7sus4")
+        return "suspended-fourth";
+    if (suffix === "9")
+        return "dominant-ninth";
+    if (suffix === "11")
+        return "dominant-11th";
+    if (suffix === "13")
+        return "dominant-13th";
+    if (suffix === "maj7")
+        return "major-seventh";
+    if (suffix === "maj9")
+        return "major-ninth";
+    if (suffix === "m9" || suffix === "min9")
+        return "minor-ninth";
+    if (suffix === "m7" || suffix === "min7")
+        return "minor-seventh";
+    if (suffix === "dim")
+        return "diminished";
+    if (suffix === "dim7")
+        return "diminished-seventh";
+    if (suffix === "aug" || suffix === "+")
+        return "augmented";
+    if (suffix === "sus4")
+        return "suspended-fourth";
+    if (suffix === "sus2")
+        return "suspended-second";
+    if (suffix === "m7b5" || suffix === "min7b5" || suffix === "ø")
+        return "half-diminished";
+    return null;
+};
+const xmlHarmonyRootFromChordToken = (token) => {
+    const m = String(token || "").match(/^([A-G])(#|b)?$/);
+    if (!m)
+        return null;
+    return {
+        step: m[1],
+        alter: m[2] === "#" ? 1 : (m[2] === "b" ? -1 : 0),
+    };
+};
+const buildHarmonyXmlFromChordSymbol = (raw) => {
+    const normalized = normalizeChordToken(raw);
+    const match = normalized.match(/^([A-G](?:#|b)?)([^/]*)?(?:\/([A-G](?:#|b)?))?$/);
+    if (!match)
+        return "";
+    const root = xmlHarmonyRootFromChordToken(match[1] || "");
+    if (!root)
+        return "";
+    const suffix = String(match[2] || "");
+    const bass = match[3] ? xmlHarmonyRootFromChordToken(match[3]) : null;
+    const kind = xmlHarmonyKindFromChordSuffix(suffix);
+    if (!kind)
+        return "";
+    return [
+        "<harmony>",
+        "<root>",
+        `<root-step>${xmlEscape(root.step)}</root-step>`,
+        root.alter !== 0 ? `<root-alter>${root.alter}</root-alter>` : "",
+        "</root>",
+        bass
+            ? `<bass><bass-step>${xmlEscape(bass.step)}</bass-step>${bass.alter !== 0 ? `<bass-alter>${bass.alter}</bass-alter>` : ""}</bass>`
+            : "",
+        `<kind text="${xmlEscape(normalized)}">${kind}</kind>`,
+        "</harmony>",
+    ].join("");
+};
+const abcChordSymbolFromHarmony = (harmony) => {
+    var _a, _b, _c, _d;
+    if (!harmony)
+        return "";
+    const rootStep = (((_a = harmony.querySelector(":scope > root > root-step")) === null || _a === void 0 ? void 0 : _a.textContent) || "").trim().toUpperCase();
+    if (!/^[A-G]$/.test(rootStep))
+        return "";
+    const rootAlter = Number(((_b = harmony.querySelector(":scope > root > root-alter")) === null || _b === void 0 ? void 0 : _b.textContent) || "0");
+    const kindNode = harmony.querySelector(":scope > kind");
+    const kindTextAttr = ((kindNode === null || kindNode === void 0 ? void 0 : kindNode.getAttribute("text")) || "").trim();
+    if (kindTextAttr)
+        return abcQuotedTextEscape(kindTextAttr);
+    const kindValue = ((kindNode === null || kindNode === void 0 ? void 0 : kindNode.textContent) || "").trim().toLowerCase();
+    const rootToken = `${rootStep}${rootAlter === 1 ? "#" : (rootAlter === -1 ? "b" : "")}`;
+    const suffix = kindValue === "major" ? "" :
+        kindValue === "minor" ? "m" :
+            kindValue === "major-sixth" ? "6" :
+                kindValue === "minor-sixth" ? "m6" :
+                    kindValue === "dominant" ? "7" :
+                        kindValue === "dominant-11th" ? "11" :
+                            kindValue === "dominant-13th" ? "13" :
+                                kindValue === "dominant-ninth" ? "9" :
+                                    kindValue === "major-seventh" ? "maj7" :
+                                        kindValue === "major-ninth" ? "maj9" :
+                                            kindValue === "minor-ninth" ? "m9" :
+                                                kindValue === "minor-seventh" ? "m7" :
+                                                    kindValue === "diminished" ? "dim" :
+                                                        kindValue === "diminished-seventh" ? "dim7" :
+                                                            kindValue === "augmented" ? "aug" :
+                                                                kindValue === "suspended-fourth" ? "sus4" :
+                                                                    kindValue === "suspended-second" ? "sus2" :
+                                                                        kindValue === "half-diminished" ? "m7b5" :
+                                                                            "";
+    const bassStep = (((_c = harmony.querySelector(":scope > bass > bass-step")) === null || _c === void 0 ? void 0 : _c.textContent) || "").trim().toUpperCase();
+    const bassAlter = Number(((_d = harmony.querySelector(":scope > bass > bass-alter")) === null || _d === void 0 ? void 0 : _d.textContent) || "0");
+    const bassToken = /^[A-G]$/.test(bassStep)
+        ? `/${bassStep}${bassAlter === 1 ? "#" : (bassAlter === -1 ? "b" : "")}`
+        : "";
+    return `${rootToken}${suffix}${bassToken}`;
+};
+const abcLyricTokenFromMusicXml = (text, syllabic) => {
+    const normalized = String(text || "").trim().replace(/\s+/g, "~");
+    const mode = String(syllabic || "single").trim().toLowerCase();
+    if (!normalized)
+        return "*";
+    if (mode === "begin" || mode === "middle") {
+        return `${normalized}-`;
+    }
+    return normalized;
+};
 const normalizeTypeForMusicXml = (t) => {
     const raw = String(t || "").trim();
     if (!raw)
@@ -31365,9 +32966,11 @@ const buildMusicXmlFromAbcParsed = (parsed, abcSource, options = {}) => {
         .join("");
     const partBodyXml = resolvedParts
         .map((part, partIndex) => {
-        var _a, _b, _c, _d, _e, _f;
+        var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k;
         const measuresXml = [];
         let currentPartFifths = Math.max(-7, Math.min(7, Math.round(defaultFifths)));
+        let currentPartMeter = { beats: Math.round(beats), beatType: Math.round(beatType) };
+        let currentPartTempo = tempoBpm;
         for (let i = 0; i < measureCount; i += 1) {
             const measureNo = i + 1;
             const notes = (_a = part.measures[i]) !== null && _a !== void 0 ? _a : [];
@@ -31375,15 +32978,28 @@ const buildMusicXmlFromAbcParsed = (parsed, abcSource, options = {}) => {
             const hintedFifths = Number.isFinite((_d = part.keyByMeasure) === null || _d === void 0 ? void 0 : _d[measureNo])
                 ? Math.max(-7, Math.min(7, Math.round(Number((_e = part.keyByMeasure) === null || _e === void 0 ? void 0 : _e[measureNo]))))
                 : null;
+            const hintedMeter = (_g = (_f = part.meterByMeasure) === null || _f === void 0 ? void 0 : _f[measureNo]) !== null && _g !== void 0 ? _g : null;
+            const hintedTempo = Number.isFinite((_h = part.tempoByMeasure) === null || _h === void 0 ? void 0 : _h[measureNo])
+                ? Math.max(20, Math.min(300, Math.round(Number((_j = part.tempoByMeasure) === null || _j === void 0 ? void 0 : _j[measureNo]))))
+                : null;
             if (hintedFifths !== null) {
                 currentPartFifths = hintedFifths;
+            }
+            if (hintedMeter) {
+                currentPartMeter = {
+                    beats: Math.max(1, Math.round(Number(hintedMeter.beats) || beats)),
+                    beatType: Math.max(1, Math.round(Number(hintedMeter.beatType) || beatType)),
+                };
+            }
+            if (hintedTempo !== null) {
+                currentPartTempo = hintedTempo;
             }
             const header = i === 0
                 ? [
                     "<attributes>",
                     "<divisions>960</divisions>",
                     `<key><fifths>${Math.round(currentPartFifths)}</fifths></key>`,
-                    `<time><beats>${Math.round(beats)}</beats><beat-type>${Math.round(beatType)}</beat-type></time>`,
+                    `<time><beats>${Math.round(currentPartMeter.beats)}</beats><beat-type>${Math.round(currentPartMeter.beatType)}</beat-type></time>`,
                     part.transpose && (Number.isFinite(part.transpose.chromatic) || Number.isFinite(part.transpose.diatonic))
                         ? [
                             "<transpose>",
@@ -31398,13 +33014,18 @@ const buildMusicXmlFromAbcParsed = (parsed, abcSource, options = {}) => {
                         : "",
                     (0, exports.clefXmlFromAbcClef)(part.clef),
                     "</attributes>",
-                    tempoBpm !== null && partIndex === 0
-                        ? `<direction><direction-type><metronome><beat-unit>quarter</beat-unit><per-minute>${tempoBpm}</per-minute></metronome></direction-type><sound tempo="${tempoBpm}"/></direction>`
+                    currentPartTempo !== null && partIndex === 0
+                        ? `<direction><direction-type><metronome><beat-unit>quarter</beat-unit><per-minute>${currentPartTempo}</per-minute></metronome></direction-type><sound tempo="${currentPartTempo}"/></direction>`
                         : "",
                 ].join("")
-                : hintedFifths !== null
-                    ? `<attributes><key><fifths>${Math.round(currentPartFifths)}</fifths></key></attributes>`
+                : (hintedFifths !== null || hintedMeter)
+                    ? `<attributes>${hintedFifths !== null ? `<key><fifths>${Math.round(currentPartFifths)}</fifths></key>` : ""}${hintedMeter
+                        ? `<time><beats>${Math.round(currentPartMeter.beats)}</beats><beat-type>${Math.round(currentPartMeter.beatType)}</beat-type></time>`
+                        : ""}</attributes>`
                     : "";
+            const tempoDirectionXml = i > 0 && hintedTempo !== null && partIndex === 0
+                ? `<direction><direction-type><metronome><beat-unit>quarter</beat-unit><per-minute>${hintedTempo}</per-minute></metronome></direction-type><sound tempo="${hintedTempo}"/></direction>`
+                : "";
             const notesXml = notes.length > 0
                 ? (() => {
                     const beamXmlByNoteIndex = (() => {
@@ -31437,7 +33058,7 @@ const buildMusicXmlFromAbcParsed = (parsed, abcSource, options = {}) => {
                             if (!primary.length)
                                 continue;
                             const assignments = (0, beam_common_1.computeBeamAssignments)(primary, beatDiv, (ev) => {
-                                var _a, _b, _c, _d, _e;
+                                var _a, _b, _c, _d, _e, _f;
                                 const type = normalizeTypeForMusicXml((_a = ev.note) === null || _a === void 0 ? void 0 : _a.type);
                                 return {
                                     timed: true,
@@ -31445,6 +33066,7 @@ const buildMusicXmlFromAbcParsed = (parsed, abcSource, options = {}) => {
                                     grace: Boolean((_c = ev.note) === null || _c === void 0 ? void 0 : _c.grace),
                                     durationDiv: ((_d = ev.note) === null || _d === void 0 ? void 0 : _d.grace) ? 0 : Math.max(1, Math.round(Number((_e = ev.note) === null || _e === void 0 ? void 0 : _e.duration) || 1)),
                                     levels: levelFromType(type),
+                                    explicitMode: (_f = ev.note) === null || _f === void 0 ? void 0 : _f.beamMode,
                                 };
                             }, { splitAtBeatBoundaryWhenImplicit: true });
                             for (const [eventIndex, assignment] of assignments.entries()) {
@@ -31466,7 +33088,62 @@ const buildMusicXmlFromAbcParsed = (parsed, abcSource, options = {}) => {
                     })();
                     return notes
                         .map((note, noteIndex) => {
-                        const chunks = ["<note>"];
+                        const chunks = [];
+                        if (!note.chord && Array.isArray(note.chordSymbols) && note.chordSymbols.length > 0) {
+                            for (const chordSymbol of note.chordSymbols) {
+                                const harmonyXml = buildHarmonyXmlFromChordSymbol(chordSymbol);
+                                if (harmonyXml) {
+                                    chunks.push(harmonyXml);
+                                }
+                                else {
+                                    chunks.push(`<direction><direction-type><words>${xmlEscape(String(chordSymbol))}</words></direction-type></direction>`);
+                                }
+                            }
+                        }
+                        if (!note.chord && Array.isArray(note.annotations) && note.annotations.length > 0) {
+                            for (const annotation of note.annotations) {
+                                if (!annotation)
+                                    continue;
+                                chunks.push(`<direction><direction-type><words>${xmlEscape(String(annotation))}</words></direction-type></direction>`);
+                            }
+                        }
+                        if (!note.chord && note.segno) {
+                            chunks.push("<direction><direction-type><segno/></direction-type></direction>");
+                        }
+                        if (!note.chord && note.coda) {
+                            chunks.push("<direction><direction-type><coda/></direction-type></direction>");
+                        }
+                        if (!note.chord && note.rehearsalMark) {
+                            chunks.push(`<direction><direction-type><rehearsal>${xmlEscape(String(note.rehearsalMark))}</rehearsal></direction-type></direction>`);
+                        }
+                        if (!note.chord && note.fine) {
+                            chunks.push('<direction><sound fine="yes"/></direction>');
+                        }
+                        if (!note.chord && note.daCapo) {
+                            chunks.push('<direction><sound dacapo="yes"/></direction>');
+                        }
+                        if (!note.chord && note.dalSegno) {
+                            chunks.push('<direction><sound dalsegno="segno"/></direction>');
+                        }
+                        if (!note.chord && note.toCoda) {
+                            chunks.push('<direction><sound tocoda="coda"/></direction>');
+                        }
+                        if (!note.chord && note.crescendoStart) {
+                            chunks.push('<direction><direction-type><wedge type="crescendo"/></direction-type></direction>');
+                        }
+                        if (!note.chord && note.diminuendoStart) {
+                            chunks.push('<direction><direction-type><wedge type="diminuendo"/></direction-type></direction>');
+                        }
+                        if (!note.chord && (note.crescendoStop || note.diminuendoStop)) {
+                            chunks.push('<direction><direction-type><wedge type="stop"/></direction-type></direction>');
+                        }
+                        if (!note.chord && note.dynamicMark) {
+                            chunks.push(`<direction><direction-type><dynamics><${xmlEscape(String(note.dynamicMark))}/></dynamics></direction-type></direction>`);
+                        }
+                        if (!note.chord && note.sfz) {
+                            chunks.push("<direction><direction-type><dynamics><sfz/></dynamics></direction-type></direction>");
+                        }
+                        chunks.push("<note>");
                         if (note.chord)
                             chunks.push("<chord/>");
                         if (note.grace) {
@@ -31495,6 +33172,9 @@ const buildMusicXmlFromAbcParsed = (parsed, abcSource, options = {}) => {
                             chunks.push(`<duration>${duration}</duration>`);
                         }
                         chunks.push(`<voice>${xmlEscape(normalizeVoiceForMusicXml(note.voice))}</voice>`);
+                        if (note.lyricText) {
+                            chunks.push(`<lyric><syllabic>${xmlEscape(String(note.lyricSyllabic || "single"))}</syllabic><text>${xmlEscape(String(note.lyricText))}</text>${note.lyricExtend ? "<extend/>" : ""}</lyric>`);
+                        }
                         chunks.push(`<type>${normalizeTypeForMusicXml(note.type)}</type>`);
                         if (!note.chord && beamXmlByNoteIndex.has(noteIndex)) {
                             chunks.push(String(beamXmlByNoteIndex.get(noteIndex)));
@@ -31519,7 +33199,40 @@ const buildMusicXmlFromAbcParsed = (parsed, abcSource, options = {}) => {
                             note.slurStop ||
                             note.trill ||
                             note.turnType ||
+                            note.delayedTurn ||
+                            note.mordentType ||
+                            note.tremoloType ||
+                            note.glissandoStart ||
+                            note.glissandoStop ||
+                            note.slideStart ||
+                            note.slideStop ||
+                            note.schleifer ||
+                            note.shake ||
+                            note.arpeggiate ||
                             note.staccato ||
+                            note.staccatissimo ||
+                            note.accent ||
+                            note.tenuto ||
+                            note.stress ||
+                            note.unstress ||
+                            note.fermataType ||
+                            note.strongAccent ||
+                            note.breathMark ||
+                            note.caesura ||
+                            note.upBow ||
+                            note.downBow ||
+                            note.doubleTongue ||
+                            note.tripleTongue ||
+                            note.heel ||
+                            note.toe ||
+                            (Array.isArray(note.fingerings) && note.fingerings.length > 0) ||
+                            (Array.isArray(note.strings) && note.strings.length > 0) ||
+                            (Array.isArray(note.plucks) && note.plucks.length > 0) ||
+                            note.openString ||
+                            note.snapPizzicato ||
+                            note.harmonic ||
+                            note.stopped ||
+                            note.thumbPosition ||
                             note.tupletStart ||
                             note.tupletStop) {
                             chunks.push("<notations>");
@@ -31538,6 +33251,7 @@ const buildMusicXmlFromAbcParsed = (parsed, abcSource, options = {}) => {
                             if (note.trill) {
                                 const trillParts = [];
                                 trillParts.push("<trill-mark/>");
+                                trillParts.push('<wavy-line type="start"/>');
                                 if (note.trillAccidentalText) {
                                     trillParts.push(`<accidental-mark>${xmlEscape(String(note.trillAccidentalText))}</accidental-mark>`);
                                 }
@@ -31545,10 +33259,107 @@ const buildMusicXmlFromAbcParsed = (parsed, abcSource, options = {}) => {
                             }
                             if (note.turnType) {
                                 const tag = note.turnType === "inverted-turn" ? "inverted-turn" : "turn";
+                                chunks.push(`<ornaments><${tag}/>${note.delayedTurn ? "<delayed-turn/>" : ""}</ornaments>`);
+                            }
+                            if (note.mordentType) {
+                                const tag = note.mordentType === "inverted-mordent" ? "inverted-mordent" : "mordent";
                                 chunks.push(`<ornaments><${tag}/></ornaments>`);
                             }
+                            if (note.tremoloType) {
+                                const marks = Math.max(1, Math.min(8, Math.round(Number(note.tremoloMarks) || 1)));
+                                chunks.push(`<ornaments><tremolo type="${xmlEscape(String(note.tremoloType))}">${marks}</tremolo></ornaments>`);
+                            }
+                            if (note.glissandoStart) {
+                                chunks.push('<glissando type="start" number="1">wavy</glissando>');
+                            }
+                            if (note.glissandoStop) {
+                                chunks.push('<glissando type="stop" number="1">wavy</glissando>');
+                            }
+                            if (note.slideStart) {
+                                chunks.push('<slide type="start" number="1"/>');
+                            }
+                            if (note.slideStop) {
+                                chunks.push('<slide type="stop" number="1"/>');
+                            }
+                            if (note.schleifer) {
+                                chunks.push("<ornaments><schleifer/></ornaments>");
+                            }
+                            if (note.shake) {
+                                chunks.push("<ornaments><shake/></ornaments>");
+                            }
+                            if (note.arpeggiate) {
+                                chunks.push("<arpeggiate/>");
+                            }
+                            const articulationParts = [];
                             if (note.staccato)
-                                chunks.push("<articulations><staccato/></articulations>");
+                                articulationParts.push("<staccato/>");
+                            if (note.staccatissimo)
+                                articulationParts.push("<staccatissimo/>");
+                            if (note.accent)
+                                articulationParts.push("<accent/>");
+                            if (note.tenuto)
+                                articulationParts.push("<tenuto/>");
+                            if (note.stress)
+                                articulationParts.push("<stress/>");
+                            if (note.unstress)
+                                articulationParts.push("<unstress/>");
+                            if (note.strongAccent)
+                                articulationParts.push("<strong-accent/>");
+                            if (note.breathMark)
+                                articulationParts.push("<breath-mark/>");
+                            if (note.caesura)
+                                articulationParts.push("<caesura/>");
+                            if (articulationParts.length > 0) {
+                                chunks.push(`<articulations>${articulationParts.join("")}</articulations>`);
+                            }
+                            const technicalParts = [];
+                            if (note.upBow)
+                                technicalParts.push("<up-bow/>");
+                            if (note.downBow)
+                                technicalParts.push("<down-bow/>");
+                            if (note.doubleTongue)
+                                technicalParts.push("<double-tongue/>");
+                            if (note.tripleTongue)
+                                technicalParts.push("<triple-tongue/>");
+                            if (note.heel)
+                                technicalParts.push("<heel/>");
+                            if (note.toe)
+                                technicalParts.push("<toe/>");
+                            if (Array.isArray(note.fingerings) && note.fingerings.length > 0) {
+                                for (const fingering of note.fingerings) {
+                                    if (fingering)
+                                        technicalParts.push(`<fingering>${xmlEscape(String(fingering))}</fingering>`);
+                                }
+                            }
+                            if (Array.isArray(note.strings) && note.strings.length > 0) {
+                                for (const stringText of note.strings) {
+                                    if (stringText)
+                                        technicalParts.push(`<string>${xmlEscape(String(stringText))}</string>`);
+                                }
+                            }
+                            if (Array.isArray(note.plucks) && note.plucks.length > 0) {
+                                for (const pluckText of note.plucks) {
+                                    if (pluckText)
+                                        technicalParts.push(`<pluck>${xmlEscape(String(pluckText))}</pluck>`);
+                                }
+                            }
+                            if (note.openString)
+                                technicalParts.push("<open-string/>");
+                            if (note.snapPizzicato)
+                                technicalParts.push("<snap-pizzicato/>");
+                            if (note.harmonic)
+                                technicalParts.push("<harmonic/>");
+                            if (note.stopped)
+                                technicalParts.push("<stopped/>");
+                            if (note.thumbPosition)
+                                technicalParts.push("<thumb-position/>");
+                            if (technicalParts.length > 0) {
+                                chunks.push(`<technical>${technicalParts.join("")}</technical>`);
+                            }
+                            if (note.fermataType) {
+                                const fermataText = note.fermataType === "inverted" ? "inverted" : "normal";
+                                chunks.push(`<fermata>${fermataText}</fermata>`);
+                            }
                             chunks.push("</notations>");
                         }
                         chunks.push("</note>");
@@ -31559,22 +33370,36 @@ const buildMusicXmlFromAbcParsed = (parsed, abcSource, options = {}) => {
                 : `<note><rest/><duration>${measureDurationDiv}</duration><voice>1</voice><type>${emptyMeasureRestType}</type></note>`;
             const xmlMeasureNumber = xmlEscape(String((measureMeta === null || measureMeta === void 0 ? void 0 : measureMeta.number) || measureNo));
             const implicitAttr = (measureMeta === null || measureMeta === void 0 ? void 0 : measureMeta.implicit) ? ' implicit="yes"' : "";
-            const repeatStartXml = (measureMeta === null || measureMeta === void 0 ? void 0 : measureMeta.repeat) === "forward"
-                ? '<barline location="left"><repeat direction="forward" winged="none"/></barline>'
+            const leftBarlineChunks = [];
+            if (measureMeta === null || measureMeta === void 0 ? void 0 : measureMeta.endingStart) {
+                leftBarlineChunks.push(`<ending number="${xmlEscape(String(measureMeta.endingStart))}" type="start"/>`);
+            }
+            if (measureMeta === null || measureMeta === void 0 ? void 0 : measureMeta.repeatStart) {
+                leftBarlineChunks.push('<repeat direction="forward" winged="none"/>');
+            }
+            const repeatStartXml = leftBarlineChunks.length > 0
+                ? `<barline location="left">${leftBarlineChunks.join("")}</barline>`
                 : "";
-            const repeatEndXml = (measureMeta === null || measureMeta === void 0 ? void 0 : measureMeta.repeat) === "backward"
-                ? `<barline location="right"><repeat direction="backward" winged="none"${Number.isFinite(measureMeta.repeatTimes) && Number(measureMeta.repeatTimes) > 1
+            const rightBarlineChunks = [];
+            if (measureMeta === null || measureMeta === void 0 ? void 0 : measureMeta.endingStop) {
+                rightBarlineChunks.push(`<ending number="${xmlEscape(String(measureMeta.endingStop))}" type="${measureMeta.endingStopType || "stop"}"/>`);
+            }
+            if (measureMeta === null || measureMeta === void 0 ? void 0 : measureMeta.repeatEnd) {
+                rightBarlineChunks.push(`<repeat direction="backward" winged="none"${Number.isFinite(measureMeta.repeatTimes) && Number(measureMeta.repeatTimes) > 1
                     ? ` times="${Math.round(Number(measureMeta.repeatTimes))}"`
-                    : ""}/></barline>`
+                    : ""}/>`);
+            }
+            const repeatEndXml = rightBarlineChunks.length > 0
+                ? `<barline location="right">${rightBarlineChunks.join("")}</barline>`
                 : "";
             const debugMiscXml = debugMetadata ? buildAbcMeasureDebugMiscXml(notes, measureNo) : "";
             const diagMiscXml = partIndex === 0 && measureNo === 1
-                ? buildAbcDiagMiscXml(((_f = parsed.diagnostics) !== null && _f !== void 0 ? _f : []).filter((diag) => !diag.voiceId || diag.voiceId === (part.voiceId || "")))
+                ? buildAbcDiagMiscXml(((_k = parsed.diagnostics) !== null && _k !== void 0 ? _k : []).filter((diag) => !diag.voiceId || diag.voiceId === (part.voiceId || "")))
                 : "";
             const sourceMiscXml = sourceMetadata && partIndex === 0 && measureNo === 1
                 ? buildAbcSourceMiscXml(abcSource)
                 : "";
-            measuresXml.push(`<measure number="${xmlMeasureNumber}"${implicitAttr}>${repeatStartXml}${header}${debugMiscXml}${diagMiscXml}${sourceMiscXml}${notesXml}${repeatEndXml}</measure>`);
+            measuresXml.push(`<measure number="${xmlMeasureNumber}"${implicitAttr}>${repeatStartXml}${header}${tempoDirectionXml}${debugMiscXml}${diagMiscXml}${sourceMiscXml}${notesXml}${repeatEndXml}</measure>`);
         }
         return `<part id="${xmlEscape(part.partId)}">${measuresXml.join("")}</part>`;
     })

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -21391,6 +21391,9 @@ const parseAbcLengthToken = (token, lineNo) => {
     if (!token) {
         return { num: 1, den: 1 };
     }
+    if (/^\/+$/.test(token)) {
+        return { num: 1, den: 2 ** token.length };
+    }
     if (token === "/") {
         return { num: 1, den: 2 };
     }
@@ -21504,6 +21507,247 @@ if (typeof window !== "undefined") {
     window.AbcCommon = exports.AbcCommon;
 }
 const abcCommon = exports.AbcCommon;
+function parseRepeatEndingMarkerAt(text, idx) {
+    const match = String(text || "").slice(idx).match(/^\[(\d+(?:[,-]\d+)*)/);
+    if (!match) {
+        return null;
+    }
+    return {
+        marker: match[1],
+        nextIdx: idx + match[0].length,
+    };
+}
+function parseBareRepeatEndingMarkerAt(text, idx) {
+    const match = String(text || "").slice(idx).match(/^(\d+(?:[,-]\d+)*)/);
+    if (!match) {
+        return null;
+    }
+    return {
+        marker: match[1],
+        nextIdx: idx + match[0].length,
+    };
+}
+function parseInlineFieldAt(text, idx) {
+    const match = String(text || "").slice(idx).match(/^\[([A-Za-z]):([^\]]*)\]/);
+    if (!match) {
+        return null;
+    }
+    return {
+        fieldName: String(match[1] || "").toUpperCase(),
+        fieldValue: String(match[2] || "").trim(),
+        nextIdx: idx + match[0].length,
+    };
+}
+function tokenizeAbcLyricLine(text) {
+    const raw = String(text || "").trim();
+    if (!raw)
+        return [];
+    const chunks = raw
+        .replace(/\|/g, " ")
+        .split(/\s+/)
+        .map((token) => token.trim())
+        .filter(Boolean);
+    const tokens = [];
+    for (const chunk of chunks) {
+        if (chunk === "*") {
+            tokens.push({ type: "skip" });
+            continue;
+        }
+        if (chunk === "_") {
+            tokens.push({ type: "extend" });
+            continue;
+        }
+        const normalized = chunk.replace(/~/g, " ");
+        const parts = normalized.split("-").filter((part) => part.length > 0);
+        if (parts.length <= 1) {
+            tokens.push({ type: "text", text: normalized, syllabic: "single" });
+            continue;
+        }
+        for (let i = 0; i < parts.length; i += 1) {
+            const syllabic = i === 0
+                ? "begin"
+                : (i === parts.length - 1 ? "end" : "middle");
+            tokens.push({ type: "text", text: parts[i], syllabic });
+        }
+    }
+    return tokens;
+}
+function splitBodyTextByInlineVoice(text, initialVoiceId) {
+    const segments = [];
+    let activeVoiceId = String(initialVoiceId || "1").trim() || "1";
+    let buffer = "";
+    const raw = String(text || "");
+    let idx = 0;
+    while (idx < raw.length) {
+        if (raw[idx] === "[") {
+            const inlineField = parseInlineFieldAt(raw, idx);
+            if (inlineField && inlineField.fieldName === "V") {
+                if (buffer.trim()) {
+                    segments.push({ voiceId: activeVoiceId, text: buffer });
+                }
+                buffer = "";
+                const voiceMatch = String(inlineField.fieldValue || "").match(/^(\S+)/);
+                if (voiceMatch) {
+                    activeVoiceId = voiceMatch[1];
+                }
+                else {
+                    buffer += raw.slice(idx, inlineField.nextIdx);
+                }
+                idx = inlineField.nextIdx;
+                continue;
+            }
+        }
+        buffer += raw[idx];
+        idx += 1;
+    }
+    if (buffer.trim()) {
+        segments.push({ voiceId: activeVoiceId, text: buffer });
+    }
+    return segments;
+}
+function splitBodyTextByOverlay(text, baseVoiceId) {
+    const raw = String(text || "");
+    const normalizedBaseVoiceId = String(baseVoiceId || "1").trim() || "1";
+    const overlayBuffers = [""];
+    let completedMeasureSkeleton = "";
+    let activeOverlayIndex = 0;
+    let idx = 0;
+    const ensureOverlayBuffer = (overlayIndex) => {
+        while (overlayBuffers.length <= overlayIndex) {
+            overlayBuffers.push(completedMeasureSkeleton);
+        }
+    };
+    while (idx < raw.length) {
+        const ch = raw[idx];
+        if (ch === '"') {
+            let endIdx = idx + 1;
+            while (endIdx < raw.length && raw[endIdx] !== '"') {
+                endIdx += 1;
+            }
+            const token = raw.slice(idx, Math.min(raw.length, endIdx + 1));
+            ensureOverlayBuffer(activeOverlayIndex);
+            overlayBuffers[activeOverlayIndex] += token;
+            idx = Math.min(raw.length, endIdx + 1);
+            continue;
+        }
+        if (ch === "!" || ch === "+") {
+            let endIdx = idx + 1;
+            while (endIdx < raw.length && raw[endIdx] !== ch) {
+                endIdx += 1;
+            }
+            const token = raw.slice(idx, Math.min(raw.length, endIdx + 1));
+            ensureOverlayBuffer(activeOverlayIndex);
+            overlayBuffers[activeOverlayIndex] += token;
+            idx = Math.min(raw.length, endIdx + 1);
+            continue;
+        }
+        const barlineToken = parseBarlineTokenAt(raw, idx);
+        if (barlineToken) {
+            const tokenText = raw.slice(idx, barlineToken.nextIdx);
+            if (barlineToken.endsMeasure) {
+                for (let overlayIndex = 0; overlayIndex < overlayBuffers.length; overlayIndex += 1) {
+                    ensureOverlayBuffer(overlayIndex);
+                    overlayBuffers[overlayIndex] += tokenText;
+                }
+                completedMeasureSkeleton += tokenText;
+                activeOverlayIndex = 0;
+            }
+            else {
+                ensureOverlayBuffer(activeOverlayIndex);
+                overlayBuffers[activeOverlayIndex] += tokenText;
+            }
+            idx = barlineToken.nextIdx;
+            continue;
+        }
+        if (ch === "&") {
+            activeOverlayIndex += 1;
+            ensureOverlayBuffer(activeOverlayIndex);
+            idx += 1;
+            continue;
+        }
+        ensureOverlayBuffer(activeOverlayIndex);
+        overlayBuffers[activeOverlayIndex] += ch;
+        idx += 1;
+    }
+    return overlayBuffers
+        .map((segmentText, overlayIndex) => ({
+        voiceId: overlayIndex === 0 ? normalizedBaseVoiceId : `${normalizedBaseVoiceId}_ov${overlayIndex + 1}`,
+        overlayIndex,
+        text: segmentText,
+    }))
+        .filter((segment) => segment.text.trim().length > 0);
+}
+function parseUserDefinedDecoration(rawValue) {
+    const text = String(rawValue || "").trim();
+    const match = text.match(/^(\S)(?:\s*=\s*|\s+)(.+)$/);
+    if (!match)
+        return null;
+    const symbol = String(match[1] || "");
+    const rhs = String(match[2] || "").trim();
+    if (!symbol || !rhs)
+        return null;
+    const wrapped = rhs.match(/^[!+](.+)[!+]$/);
+    const decoration = String(wrapped ? wrapped[1] : rhs).trim();
+    if (!decoration)
+        return null;
+    return { symbol, decoration };
+}
+function expandUserDefinedDecorationSymbols(text, userDefinedDecorationBySymbol) {
+    const raw = String(text || "");
+    const symbolMap = userDefinedDecorationBySymbol || {};
+    if (!raw || Object.keys(symbolMap).length === 0) {
+        return raw;
+    }
+    let out = "";
+    let idx = 0;
+    while (idx < raw.length) {
+        const ch = raw[idx];
+        if (ch === '"' || ch === "!" || ch === "+") {
+            let endIdx = idx + 1;
+            while (endIdx < raw.length && raw[endIdx] !== ch) {
+                endIdx += 1;
+            }
+            out += raw.slice(idx, Math.min(raw.length, endIdx + 1));
+            idx = Math.min(raw.length, endIdx + 1);
+            continue;
+        }
+        if (Object.prototype.hasOwnProperty.call(symbolMap, ch)) {
+            out += `!${String(symbolMap[ch])}!`;
+            idx += 1;
+            continue;
+        }
+        out += ch;
+        idx += 1;
+    }
+    return out;
+}
+function parseBarlineTokenAt(text, idx) {
+    const slice = String(text || "").slice(idx);
+    const candidates = [
+        { token: ":|]", endsMeasure: true, repeatEnd: true, repeatStart: false, endingStop: true },
+        { token: ":|:", endsMeasure: true, repeatEnd: true, repeatStart: true, endingStop: false },
+        { token: "|:", endsMeasure: true, repeatEnd: false, repeatStart: true, endingStop: false },
+        { token: ":|", endsMeasure: true, repeatEnd: true, repeatStart: false, endingStop: false },
+        { token: "::", endsMeasure: true, repeatEnd: true, repeatStart: true, endingStop: false },
+        { token: "[|", endsMeasure: true, repeatEnd: false, repeatStart: false, endingStop: false },
+        { token: "|]", endsMeasure: true, repeatEnd: false, repeatStart: false, endingStop: false },
+        { token: "||", endsMeasure: true, repeatEnd: false, repeatStart: false, endingStop: false },
+        { token: "|", endsMeasure: true, repeatEnd: false, repeatStart: false, endingStop: false },
+        { token: ":", endsMeasure: false, repeatEnd: false, repeatStart: false, endingStop: false },
+    ];
+    for (const candidate of candidates) {
+        if (slice.startsWith(candidate.token)) {
+            return {
+                nextIdx: idx + candidate.token.length,
+                endsMeasure: candidate.endsMeasure,
+                repeatEnd: candidate.repeatEnd,
+                repeatStart: candidate.repeatStart,
+                endingStop: candidate.endingStop,
+            };
+        }
+    }
+    return null;
+}
 function parseTempoFromQ(rawQ, warnings) {
     const raw = String(rawQ || "").trim();
     if (!raw) {
@@ -21546,10 +21790,12 @@ function parseForMusicXml(source, settings) {
     const transposeHintByVoiceId = new Map();
     const headers = {};
     const bodyEntries = [];
+    const lyricEntriesByVoice = {};
     const declaredVoiceIds = [];
     const voiceNameById = {};
     const voiceClefById = {};
     const voiceTransposeById = {};
+    const userDefinedDecorationBySymbol = {};
     let currentVoiceId = "1";
     let scoreDirective = "";
     for (let i = 0; i < lines.length; i += 1) {
@@ -21606,14 +21852,23 @@ function parseForMusicXml(source, settings) {
                 const measureNumberText = String(params.number || "").trim();
                 const implicitRaw = String(params.implicit || "").trim().toLowerCase();
                 const repeatRaw = String(params.repeat || "").trim().toLowerCase();
+                const leftRepeatRaw = String(params["left-repeat"] || "").trim().toLowerCase();
+                const rightRepeatRaw = String(params["right-repeat"] || "").trim().toLowerCase();
                 const repeatTimesRaw = Number.parseInt(String(params.times || ""), 10);
+                const endingStart = String(params["ending-start"] || "").trim();
+                const endingStop = String(params["ending-stop"] || "").trim();
+                const endingStopTypeRaw = String(params["ending-type"] || "").trim().toLowerCase();
                 measureMetaByKey.set(`${voiceId}#${measureNo}`, {
                     number: measureNumberText || String(measureNo),
                     implicit: implicitRaw === "1" || implicitRaw === "true" || implicitRaw === "yes",
-                    repeat: repeatRaw === "forward" || repeatRaw === "backward"
-                        ? repeatRaw
-                        : "",
-                    repeatTimes: Number.isFinite(repeatTimesRaw) && repeatTimesRaw > 1 ? repeatTimesRaw : null
+                    repeatStart: leftRepeatRaw === "1" || leftRepeatRaw === "true" || leftRepeatRaw === "yes" || repeatRaw === "forward",
+                    repeatEnd: rightRepeatRaw === "1" || rightRepeatRaw === "true" || rightRepeatRaw === "yes" || repeatRaw === "backward",
+                    repeatTimes: Number.isFinite(repeatTimesRaw) && repeatTimesRaw > 1 ? repeatTimesRaw : null,
+                    endingStart,
+                    endingStop,
+                    endingStopType: endingStopTypeRaw === "discontinue" || endingStopTypeRaw === "stop"
+                        ? endingStopTypeRaw
+                        : (endingStop ? "stop" : "")
                 });
             }
             continue;
@@ -21655,6 +21910,13 @@ function parseForMusicXml(source, settings) {
         if (headerMatch && /^[A-Za-z]$/.test(headerMatch[1])) {
             const key = headerMatch[1];
             const value = headerMatch[2].trim();
+            if (key === "w") {
+                if (!Object.prototype.hasOwnProperty.call(lyricEntriesByVoice, currentVoiceId)) {
+                    lyricEntriesByVoice[currentVoiceId] = [];
+                }
+                lyricEntriesByVoice[currentVoiceId].push({ text: value, lineNo });
+                continue;
+            }
             if (key === "V") {
                 const m = value.match(/^(\S+)\s*(.*)$/);
                 if (!m) {
@@ -21676,17 +21938,65 @@ function parseForMusicXml(source, settings) {
                     voiceTransposeById[currentVoiceId] = parsedVoice.transpose;
                 }
                 if (parsedVoice.bodyText) {
-                    bodyEntries.push({ text: parsedVoice.bodyText, lineNo, voiceId: currentVoiceId });
+                    const expandedBodyText = expandUserDefinedDecorationSymbols(parsedVoice.bodyText, userDefinedDecorationBySymbol);
+                    const inlineVoiceSegments = splitBodyTextByInlineVoice(expandedBodyText, currentVoiceId);
+                    for (const segment of inlineVoiceSegments) {
+                        const overlaySegments = splitBodyTextByOverlay(segment.text, segment.voiceId);
+                        for (const overlaySegment of overlaySegments) {
+                            if (!declaredVoiceIds.includes(overlaySegment.voiceId)) {
+                                declaredVoiceIds.push(overlaySegment.voiceId);
+                            }
+                            if (overlaySegment.overlayIndex > 0) {
+                                const overlayLabel = `overlay ${overlaySegment.overlayIndex + 1}`;
+                                voiceNameById[overlaySegment.voiceId] = voiceNameById[segment.voiceId]
+                                    ? `${voiceNameById[segment.voiceId]} ${overlayLabel}`
+                                    : `Voice ${segment.voiceId} ${overlayLabel}`;
+                                if (voiceClefById[segment.voiceId] && !voiceClefById[overlaySegment.voiceId]) {
+                                    voiceClefById[overlaySegment.voiceId] = voiceClefById[segment.voiceId];
+                                }
+                                if (voiceTransposeById[segment.voiceId] && !voiceTransposeById[overlaySegment.voiceId]) {
+                                    voiceTransposeById[overlaySegment.voiceId] = { ...voiceTransposeById[segment.voiceId] };
+                                }
+                            }
+                            bodyEntries.push({ text: overlaySegment.text, lineNo, voiceId: overlaySegment.voiceId });
+                        }
+                    }
+                }
+                continue;
+            }
+            if (key === "U") {
+                const parsedUserDefinedDecoration = parseUserDefinedDecoration(value);
+                if (parsedUserDefinedDecoration) {
+                    userDefinedDecorationBySymbol[parsedUserDefinedDecoration.symbol] = parsedUserDefinedDecoration.decoration;
                 }
                 continue;
             }
             headers[key] = value;
             continue;
         }
-        if (!declaredVoiceIds.includes(currentVoiceId)) {
-            declaredVoiceIds.push(currentVoiceId);
+        const expandedBodyText = expandUserDefinedDecorationSymbols(noComment, userDefinedDecorationBySymbol);
+        const inlineVoiceSegments = splitBodyTextByInlineVoice(expandedBodyText, currentVoiceId);
+        for (const segment of inlineVoiceSegments) {
+            const overlaySegments = splitBodyTextByOverlay(segment.text, segment.voiceId);
+            for (const overlaySegment of overlaySegments) {
+                if (!declaredVoiceIds.includes(overlaySegment.voiceId)) {
+                    declaredVoiceIds.push(overlaySegment.voiceId);
+                }
+                if (overlaySegment.overlayIndex > 0) {
+                    const overlayLabel = `overlay ${overlaySegment.overlayIndex + 1}`;
+                    voiceNameById[overlaySegment.voiceId] = voiceNameById[segment.voiceId]
+                        ? `${voiceNameById[segment.voiceId]} ${overlayLabel}`
+                        : `Voice ${segment.voiceId} ${overlayLabel}`;
+                    if (voiceClefById[segment.voiceId] && !voiceClefById[overlaySegment.voiceId]) {
+                        voiceClefById[overlaySegment.voiceId] = voiceClefById[segment.voiceId];
+                    }
+                    if (voiceTransposeById[segment.voiceId] && !voiceTransposeById[overlaySegment.voiceId]) {
+                        voiceTransposeById[overlaySegment.voiceId] = { ...voiceTransposeById[segment.voiceId] };
+                    }
+                }
+                bodyEntries.push({ text: overlaySegment.text, lineNo, voiceId: overlaySegment.voiceId });
+            }
         }
-        bodyEntries.push({ text: noComment, lineNo, voiceId: currentVoiceId });
     }
     if (bodyEntries.length === 0) {
         throw new Error("Body not found. Please provide ABC note content. (line 1)");
@@ -21697,6 +22007,11 @@ function parseForMusicXml(source, settings) {
     const tempoBpm = parseTempoFromQ(headers.Q || "", warnings);
     const keySignatureAccidentals = keySignatureAlterByStep(keyInfo.fifths);
     const measuresByVoice = {};
+    const notationMeasureMetaByVoice = {};
+    const activeEndingByVoice = {};
+    const currentKeyFifthsByVoice = {};
+    const meterByMeasureByVoice = {};
+    const tempoByMeasureByVoice = {};
     let noteCount = 0;
     function ensureVoice(voiceId) {
         if (!Object.prototype.hasOwnProperty.call(measuresByVoice, voiceId)) {
@@ -21704,16 +22019,101 @@ function parseForMusicXml(source, settings) {
         }
         return measuresByVoice[voiceId];
     }
+    function ensureNotationMeasureMeta(voiceId, measureNo) {
+        if (!Object.prototype.hasOwnProperty.call(notationMeasureMetaByVoice, voiceId)) {
+            notationMeasureMetaByVoice[voiceId] = {};
+        }
+        if (!Object.prototype.hasOwnProperty.call(notationMeasureMetaByVoice[voiceId], measureNo)) {
+            notationMeasureMetaByVoice[voiceId][measureNo] = {
+                number: String(measureNo),
+                implicit: false,
+                repeatStart: false,
+                repeatEnd: false,
+                repeatTimes: null,
+                endingStart: "",
+                endingStop: "",
+                endingStopType: "",
+            };
+        }
+        return notationMeasureMetaByVoice[voiceId][measureNo];
+    }
+    function ensureMeterByMeasure(voiceId) {
+        if (!Object.prototype.hasOwnProperty.call(meterByMeasureByVoice, voiceId)) {
+            meterByMeasureByVoice[voiceId] = {};
+        }
+        return meterByMeasureByVoice[voiceId];
+    }
+    function ensureTempoByMeasure(voiceId) {
+        if (!Object.prototype.hasOwnProperty.call(tempoByMeasureByVoice, voiceId)) {
+            tempoByMeasureByVoice[voiceId] = {};
+        }
+        return tempoByMeasureByVoice[voiceId];
+    }
     for (const entry of bodyEntries) {
         const measures = ensureVoice(entry.voiceId);
         let currentMeasure = measures[measures.length - 1];
         let measureAccidentals = {};
+        let activeUnitLength = unitLength;
+        let activeMeter = meter;
+        let activeTempoBpm = Number.isFinite(tempoBpm) ? Number(tempoBpm) : null;
+        let activeKeyFifths = Number.isFinite(currentKeyFifthsByVoice[entry.voiceId])
+            ? Number(currentKeyFifthsByVoice[entry.voiceId])
+            : keyInfo.fifths;
+        let activeKeySignatureAccidentals = keySignatureAlterByStep(activeKeyFifths);
         let lastNote = null;
         let lastEventNotes = [];
         let pendingTieToNext = false;
         let pendingTrill = false;
         let pendingTurn = "";
+        let pendingDelayedTurn = false;
+        let pendingMordent = "";
+        let pendingTremolo = null;
+        let pendingGlissandoStart = false;
+        let pendingGlissandoStop = false;
+        let pendingSlideStart = false;
+        let pendingSlideStop = false;
+        let pendingSchleifer = false;
+        let pendingShake = false;
+        let pendingArpeggiate = false;
         let pendingStaccato = false;
+        let pendingStaccatissimo = false;
+        let pendingAccent = false;
+        let pendingTenuto = false;
+        let pendingStress = false;
+        let pendingUnstress = false;
+        let pendingFermata = "";
+        let pendingStrongAccent = false;
+        let pendingBreathMark = false;
+        let pendingCaesura = false;
+        let pendingSegno = false;
+        let pendingCoda = false;
+        let pendingFine = false;
+        let pendingDaCapo = false;
+        let pendingDalSegno = false;
+        let pendingToCoda = false;
+        let pendingCrescendoStart = false;
+        let pendingCrescendoStop = false;
+        let pendingDiminuendoStart = false;
+        let pendingDiminuendoStop = false;
+        let pendingDynamicMark = "";
+        let pendingSfz = false;
+        let pendingRehearsalMark = "";
+        let pendingUpBow = false;
+        let pendingDownBow = false;
+        let pendingOpenString = false;
+        let pendingSnapPizzicato = false;
+        let pendingHarmonic = false;
+        let pendingStopped = false;
+        let pendingThumbPosition = false;
+        let pendingDoubleTongue = false;
+        let pendingTripleTongue = false;
+        let pendingHeel = false;
+        let pendingToe = false;
+        let pendingFingerings = [];
+        let pendingStrings = [];
+        let pendingPlucks = [];
+        let pendingChordSymbols = [];
+        let pendingAnnotations = [];
         let pendingSlurStart = 0;
         let pendingRhythmScale = null;
         let tupletRemaining = 0;
@@ -21721,11 +22121,37 @@ function parseForMusicXml(source, settings) {
         let tupletSpec = null;
         let currentMeasureNo = Math.max(1, measures.length);
         let currentEventNo = 0;
+        let beamRunActive = false;
+        let sawInterEventWhitespace = false;
+        let beamCursorDiv = 0;
+        let activeEndingMarker = String(activeEndingByVoice[entry.voiceId] || "");
         let idx = 0;
         const text = entry.text;
+        const isBeamableAbcNote = (note) => Boolean(note &&
+            !note.isRest &&
+            !note.grace &&
+            ["eighth", "16th", "32nd", "64th"].includes(String(note.type || "").trim().toLowerCase()));
+        const applyBeamModeForEvent = (note, durationDiv) => {
+            const resolvedDurationDiv = Math.max(0, Math.round(Number(durationDiv) || 0));
+            const beatDiv = Math.max(1, Math.round((960 * 4) / Math.max(1, Math.round(Number(activeMeter === null || activeMeter === void 0 ? void 0 : activeMeter.beatType) || 4))));
+            const startsAtBeatBoundary = beamCursorDiv > 0 && beamCursorDiv % beatDiv === 0;
+            if (startsAtBeatBoundary) {
+                beamRunActive = false;
+            }
+            if (isBeamableAbcNote(note)) {
+                note.beamMode = !beamRunActive || sawInterEventWhitespace ? "begin" : "mid";
+                beamRunActive = true;
+            }
+            else {
+                beamRunActive = false;
+            }
+            sawInterEventWhitespace = false;
+            beamCursorDiv += resolvedDurationDiv;
+        };
         while (idx < text.length) {
             const ch = text[idx];
             if (ch === " " || ch === "\t") {
+                sawInterEventWhitespace = true;
                 idx += 1;
                 continue;
             }
@@ -21736,17 +22162,46 @@ function parseForMusicXml(source, settings) {
                 continue;
             }
             if (ch === "|" || ch === ":") {
-                if (ch === "|" && (currentMeasure.length > 0 || measures.length === 0)) {
+                const barlineToken = parseBarlineTokenAt(text, idx);
+                if (!barlineToken) {
+                    idx += 1;
+                    continue;
+                }
+                const bareRepeatEndingMarker = barlineToken.endsMeasure ? parseBareRepeatEndingMarkerAt(text, barlineToken.nextIdx) : null;
+                if (barlineToken.repeatEnd) {
+                    ensureNotationMeasureMeta(entry.voiceId, currentMeasureNo).repeatEnd = true;
+                }
+                if ((barlineToken.endingStop || bareRepeatEndingMarker) && activeEndingMarker) {
+                    const measureMeta = ensureNotationMeasureMeta(entry.voiceId, currentMeasureNo);
+                    measureMeta.endingStop = activeEndingMarker;
+                    measureMeta.endingStopType = "stop";
+                    activeEndingMarker = "";
+                }
+                if (barlineToken.endsMeasure && (currentMeasure.length > 0 || measures.length === 0)) {
                     currentMeasure = [];
                     measures.push(currentMeasure);
                     currentMeasureNo = Math.max(1, measures.length);
                     currentEventNo = 0;
+                    beamCursorDiv = 0;
                 }
-                if (ch === "|") {
+                if (barlineToken.endsMeasure) {
                     measureAccidentals = {};
                     lastNote = null;
                 }
-                idx += 1;
+                if (barlineToken.repeatStart) {
+                    ensureNotationMeasureMeta(entry.voiceId, currentMeasureNo).repeatStart = true;
+                }
+                if (bareRepeatEndingMarker) {
+                    const measureMeta = ensureNotationMeasureMeta(entry.voiceId, currentMeasureNo);
+                    measureMeta.endingStart = bareRepeatEndingMarker.marker;
+                    activeEndingMarker = bareRepeatEndingMarker.marker;
+                    idx = bareRepeatEndingMarker.nextIdx;
+                }
+                else {
+                    idx = barlineToken.nextIdx;
+                }
+                beamRunActive = false;
+                sawInterEventWhitespace = false;
                 continue;
             }
             if (ch === ">" || ch === "<") {
@@ -21784,9 +22239,63 @@ function parseForMusicXml(source, settings) {
                 idx += 1;
                 continue;
             }
+            if (ch === "~") {
+                pendingArpeggiate = true;
+                idx += 1;
+                continue;
+            }
+            if (ch === "H") {
+                pendingFermata = "normal";
+                idx += 1;
+                continue;
+            }
+            if (ch === "L") {
+                pendingAccent = true;
+                idx += 1;
+                continue;
+            }
+            if (ch === "M") {
+                pendingMordent = "mordent";
+                idx += 1;
+                continue;
+            }
+            if (ch === "O") {
+                pendingCoda = true;
+                idx += 1;
+                continue;
+            }
+            if (ch === "P") {
+                pendingMordent = "inverted-mordent";
+                idx += 1;
+                continue;
+            }
+            if (ch === "S") {
+                pendingSegno = true;
+                idx += 1;
+                continue;
+            }
+            if (ch === "T") {
+                pendingTrill = true;
+                idx += 1;
+                continue;
+            }
+            if (ch === "u") {
+                pendingUpBow = true;
+                idx += 1;
+                continue;
+            }
+            if (ch === "v") {
+                pendingDownBow = true;
+                idx += 1;
+                continue;
+            }
             if (ch === "-") {
-                if (lastNote && !lastNote.isRest) {
-                    lastNote.tieStart = true;
+                if (lastEventNotes && lastEventNotes.length > 0 && lastEventNotes.some((n) => !n.isRest)) {
+                    for (const eventNote of lastEventNotes) {
+                        if (!eventNote.isRest) {
+                            eventNote.tieStart = true;
+                        }
+                    }
                     pendingTieToNext = true;
                 }
                 else {
@@ -21798,12 +22307,22 @@ function parseForMusicXml(source, settings) {
             if (ch === "\"") {
                 const endQuote = text.indexOf("\"", idx + 1);
                 if (endQuote >= 0) {
+                    const rawAnnotation = text.slice(idx + 1, endQuote);
+                    const normalizedAnnotation = rawAnnotation.replace(/^[\^_<>@]/, "").trim();
+                    if (normalizedAnnotation) {
+                        if (isLikelyAbcChordSymbol(normalizedAnnotation)) {
+                            pendingChordSymbols.push(normalizedAnnotation);
+                        }
+                        else {
+                            pendingAnnotations.push(normalizedAnnotation);
+                        }
+                    }
                     idx = endQuote + 1;
                 }
                 else {
                     idx = text.length;
+                    warnings.push("line " + entry.lineNo + ': Unterminated inline string ("...").');
                 }
-                warnings.push("line " + entry.lineNo + ': Skipped inline string ("...").');
                 continue;
             }
             if (ch === "!" || ch === "+") {
@@ -21813,9 +22332,24 @@ function parseForMusicXml(source, settings) {
                     warnings.push("line " + entry.lineNo + ": Unterminated decoration marker: " + ch);
                     continue;
                 }
-                const decoration = text.slice(idx + 1, endMark).trim().toLowerCase();
+                const rawDecoration = text.slice(idx + 1, endMark).trim();
+                const decoration = rawDecoration.toLowerCase();
                 if (decoration === "trill" || decoration === "tr" || decoration === "triller") {
                     pendingTrill = true;
+                }
+                else if (decoration.startsWith("rehearsal:")) {
+                    const rehearsalText = rawDecoration.slice("rehearsal:".length).trim();
+                    if (rehearsalText) {
+                        pendingRehearsalMark = rehearsalText;
+                    }
+                }
+                else if (decoration === "delayedturn" || decoration === "delayed-turn") {
+                    pendingTurn = pendingTurn || "turn";
+                    pendingDelayedTurn = true;
+                }
+                else if (decoration === "delayedinvertedturn" || decoration === "delayed-inverted-turn") {
+                    pendingTurn = "inverted-turn";
+                    pendingDelayedTurn = true;
                 }
                 else if (decoration === "turn") {
                     pendingTurn = "turn";
@@ -21823,11 +22357,209 @@ function parseForMusicXml(source, settings) {
                 else if (decoration === "invertedturn" || decoration === "inverted-turn" || decoration === "lowerturn") {
                     pendingTurn = "inverted-turn";
                 }
+                else if (decoration === "mordent" || decoration === "lowermordent") {
+                    pendingMordent = "mordent";
+                }
+                else if (decoration === "pralltriller" ||
+                    decoration === "pralltrill" ||
+                    decoration === "prall" ||
+                    decoration === "uppermordent" ||
+                    decoration === "invertedmordent" ||
+                    decoration === "inverted-mordent") {
+                    pendingMordent = "inverted-mordent";
+                }
+                else if (/^tremolo-(single|start|stop)-([1-9]\d*)$/.test(decoration)) {
+                    const m = decoration.match(/^tremolo-(single|start|stop)-([1-9]\d*)$/);
+                    if (m) {
+                        pendingTremolo = {
+                            type: m[1],
+                            marks: Math.max(1, Math.min(8, Number.parseInt(m[2], 10) || 1))
+                        };
+                    }
+                }
+                else if (decoration === "gliss-start" || decoration === "glissando-start") {
+                    pendingGlissandoStart = true;
+                }
+                else if (decoration === "gliss-stop" || decoration === "glissando-stop") {
+                    pendingGlissandoStop = true;
+                }
+                else if (decoration === "slide-start") {
+                    pendingSlideStart = true;
+                }
+                else if (decoration === "slide-stop") {
+                    pendingSlideStop = true;
+                }
+                else if (decoration === "schleifer") {
+                    pendingSchleifer = true;
+                }
+                else if (decoration === "shake") {
+                    pendingShake = true;
+                }
+                else if (decoration === "roll" || decoration === "arpeggio" || decoration === "arpeggiate") {
+                    pendingArpeggiate = true;
+                }
                 else if (decoration === "staccato" ||
                     decoration === "stacc" ||
-                    decoration === "stac" ||
-                    decoration === "staccatissimo") {
+                    decoration === "stac") {
                     pendingStaccato = true;
+                }
+                else if (decoration === "staccatissimo" || decoration === "wedge" || decoration === "spiccato") {
+                    pendingStaccatissimo = true;
+                }
+                else if (decoration === "accent") {
+                    pendingAccent = true;
+                }
+                else if (decoration === "tenuto") {
+                    pendingTenuto = true;
+                }
+                else if (decoration === "stress") {
+                    pendingStress = true;
+                }
+                else if (decoration === "unstress") {
+                    pendingUnstress = true;
+                }
+                else if (decoration === "fermata") {
+                    pendingFermata = "normal";
+                }
+                else if (decoration === "invertedfermata" ||
+                    decoration === "inverted-fermata" ||
+                    decoration === "inverted fermata") {
+                    pendingFermata = "inverted";
+                }
+                else if (decoration === "marcato" ||
+                    decoration === "strongaccent" ||
+                    decoration === "strong-accent" ||
+                    decoration === "strong accent") {
+                    pendingStrongAccent = true;
+                }
+                else if (decoration === "breath" ||
+                    decoration === "breath-mark" ||
+                    decoration === "breathmark" ||
+                    decoration === "breath mark") {
+                    pendingBreathMark = true;
+                }
+                else if (decoration === "caesura") {
+                    pendingCaesura = true;
+                }
+                else if (decoration === "segno") {
+                    pendingSegno = true;
+                }
+                else if (decoration === "coda") {
+                    pendingCoda = true;
+                }
+                else if (decoration === "fine") {
+                    pendingFine = true;
+                }
+                else if (decoration === "dacapo" || decoration === "da-capo" || decoration === "da capo") {
+                    pendingDaCapo = true;
+                }
+                else if (decoration === "dalsegno" || decoration === "dal-segno" || decoration === "dal segno") {
+                    pendingDalSegno = true;
+                }
+                else if (decoration === "tocoda" || decoration === "to-coda" || decoration === "to coda") {
+                    pendingToCoda = true;
+                }
+                else if (decoration === "crescendo(" || decoration === "cresc(") {
+                    pendingCrescendoStart = true;
+                }
+                else if (decoration === "crescendo)" || decoration === "cresc)") {
+                    pendingCrescendoStop = true;
+                }
+                else if (decoration === "diminuendo(" ||
+                    decoration === "decrescendo(" ||
+                    decoration === "dim(" ||
+                    decoration === "decresc(") {
+                    pendingDiminuendoStart = true;
+                }
+                else if (decoration === "diminuendo)" ||
+                    decoration === "decrescendo)" ||
+                    decoration === "dim)" ||
+                    decoration === "decresc)") {
+                    pendingDiminuendoStop = true;
+                }
+                else if (decoration === "ppp" ||
+                    decoration === "p" ||
+                    decoration === "pp" ||
+                    decoration === "mp" ||
+                    decoration === "mf" ||
+                    decoration === "f" ||
+                    decoration === "ff" ||
+                    decoration === "fff" ||
+                    decoration === "fp" ||
+                    decoration === "fz" ||
+                    decoration === "rfz" ||
+                    decoration === "sf" ||
+                    decoration === "sfp") {
+                    pendingDynamicMark = decoration;
+                }
+                else if (decoration === "sfz") {
+                    pendingSfz = true;
+                }
+                else if (decoration === "upbow" || decoration === "up-bow" || decoration === "up bow") {
+                    pendingUpBow = true;
+                }
+                else if (decoration === "downbow" || decoration === "down-bow" || decoration === "down bow") {
+                    pendingDownBow = true;
+                }
+                else if (decoration === "doubletongue" ||
+                    decoration === "double-tongue" ||
+                    decoration === "double tongue") {
+                    pendingDoubleTongue = true;
+                }
+                else if (decoration === "tripletongue" ||
+                    decoration === "triple-tongue" ||
+                    decoration === "triple tongue") {
+                    pendingTripleTongue = true;
+                }
+                else if (decoration === "heel" || decoration === "heel mark") {
+                    pendingHeel = true;
+                }
+                else if (decoration === "toe" || decoration === "toe mark") {
+                    pendingToe = true;
+                }
+                else if (decoration.startsWith("fingering:")) {
+                    const fingeringText = rawDecoration.slice("fingering:".length).trim();
+                    if (fingeringText)
+                        pendingFingerings.push(fingeringText);
+                }
+                else if (decoration.startsWith("string:")) {
+                    const stringText = rawDecoration.slice("string:".length).trim();
+                    if (stringText)
+                        pendingStrings.push(stringText);
+                }
+                else if (decoration.startsWith("pluck:")) {
+                    const pluckText = rawDecoration.slice("pluck:".length).trim();
+                    if (pluckText)
+                        pendingPlucks.push(pluckText);
+                }
+                else if (decoration === "open" ||
+                    decoration === "open-string" ||
+                    decoration === "openstring" ||
+                    decoration === "open string") {
+                    pendingOpenString = true;
+                }
+                else if (decoration === "snap" ||
+                    decoration === "snap-pizzicato" ||
+                    decoration === "snappizzicato" ||
+                    decoration === "snap pizzicato") {
+                    pendingSnapPizzicato = true;
+                }
+                else if (decoration === "harmonic") {
+                    pendingHarmonic = true;
+                }
+                else if (decoration === "stopped" ||
+                    decoration === "plus" ||
+                    decoration === "stopped horn" ||
+                    decoration === "stopped-horn") {
+                    pendingStopped = true;
+                }
+                else if (decoration === "thumb" ||
+                    decoration === "thumbposition" ||
+                    decoration === "thumb-position" ||
+                    decoration === "thumbpos" ||
+                    decoration === "thumb pos" ||
+                    decoration === "thumb position") {
+                    pendingThumbPosition = true;
                 }
                 else if (decoration) {
                     warnings.push("line " + entry.lineNo + ": Skipped decoration: " + ch + decoration + ch);
@@ -21836,7 +22568,7 @@ function parseForMusicXml(source, settings) {
                 continue;
             }
             if (ch === "{") {
-                const graceResult = parseGraceGroupAt(text, idx, entry.lineNo, unitLength, keySignatureAccidentals, measureAccidentals, entry.voiceId);
+                const graceResult = parseGraceGroupAt(text, idx, entry.lineNo, activeUnitLength, activeKeySignatureAccidentals, measureAccidentals, entry.voiceId);
                 if (!graceResult) {
                     warnings.push("line " + entry.lineNo + ": Failed to parse grace group; skipped.");
                     idx += 1;
@@ -21855,6 +22587,56 @@ function parseForMusicXml(source, settings) {
                 continue;
             }
             if (ch === "[") {
+                const inlineField = parseInlineFieldAt(text, idx);
+                if (inlineField) {
+                    if (inlineField.fieldName === "K") {
+                        const inlineKeyInfo = parseKey(inlineField.fieldValue || "C", warnings);
+                        activeKeyFifths = inlineKeyInfo.fifths;
+                        activeKeySignatureAccidentals = keySignatureAlterByStep(activeKeyFifths);
+                        currentKeyFifthsByVoice[entry.voiceId] = activeKeyFifths;
+                        keyHintFifthsByKey.set(`${entry.voiceId}#${currentMeasureNo}`, activeKeyFifths);
+                        measureAccidentals = {};
+                    }
+                    else if (inlineField.fieldName === "L") {
+                        activeUnitLength = parseFraction(inlineField.fieldValue || "1/8", "L", warnings);
+                    }
+                    else if (inlineField.fieldName === "M") {
+                        activeMeter = parseMeter(inlineField.fieldValue || "4/4", warnings);
+                        ensureMeterByMeasure(entry.voiceId)[currentMeasureNo] = {
+                            beats: activeMeter.beats,
+                            beatType: activeMeter.beatType,
+                        };
+                    }
+                    else if (inlineField.fieldName === "Q") {
+                        activeTempoBpm = parseTempoFromQ(inlineField.fieldValue || "", warnings);
+                        if (Number.isFinite(activeTempoBpm)) {
+                            ensureTempoByMeasure(entry.voiceId)[currentMeasureNo] = Math.max(20, Math.min(300, Math.round(Number(activeTempoBpm))));
+                        }
+                    }
+                    else {
+                        warnings.push("line " + entry.lineNo + ": Skipped unsupported inline field: [" + inlineField.fieldName + ":" + inlineField.fieldValue + "]");
+                    }
+                    idx = inlineField.nextIdx;
+                    continue;
+                }
+                const repeatEndingMarker = parseRepeatEndingMarkerAt(text, idx);
+                if (repeatEndingMarker) {
+                    if (activeEndingMarker) {
+                        const stopMeasureNo = currentMeasure.length === 0 ? currentMeasureNo - 1 : currentMeasureNo;
+                        if (stopMeasureNo >= 1) {
+                            const prevMeta = ensureNotationMeasureMeta(entry.voiceId, stopMeasureNo);
+                            prevMeta.endingStop = activeEndingMarker;
+                            prevMeta.endingStopType = "stop";
+                        }
+                    }
+                    const measureMeta = ensureNotationMeasureMeta(entry.voiceId, currentMeasureNo);
+                    measureMeta.endingStart = repeatEndingMarker.marker;
+                    activeEndingMarker = repeatEndingMarker.marker;
+                    idx = repeatEndingMarker.nextIdx;
+                    beamRunActive = false;
+                    sawInterEventWhitespace = false;
+                    continue;
+                }
                 const chordResult = parseChordAt(text, idx, entry.lineNo);
                 if (!chordResult) {
                     warnings.push("line " + entry.lineNo + ": Failed to parse chord notation; skipped.");
@@ -21866,7 +22648,7 @@ function parseForMusicXml(source, settings) {
                 if (!chordResult.lengthToken && chordResult.notes.length > 0 && chordResult.notes[0].lengthToken) {
                     chordLength = parseLengthToken(chordResult.notes[0].lengthToken, entry.lineNo);
                 }
-                let absoluteLength = multiplyFractions(unitLength, chordLength);
+                let absoluteLength = multiplyFractions(activeUnitLength, chordLength);
                 if (pendingRhythmScale) {
                     absoluteLength = multiplyFractions(absoluteLength, pendingRhythmScale);
                     pendingRhythmScale = null;
@@ -21906,15 +22688,57 @@ function parseForMusicXml(source, settings) {
                 const trillHint = trillWidthHintByKey.get(`${entry.voiceId}#${currentMeasureNo}#${currentEventNo}`) || "";
                 for (let chordIndex = 0; chordIndex < chordResult.notes.length; chordIndex += 1) {
                     const chordNote = chordResult.notes[chordIndex];
-                    const note = buildNoteData(chordNote.pitchChar, chordNote.accidentalText, chordNote.octaveShift, absoluteLength, dur, entry.lineNo, keySignatureAccidentals, measureAccidentals);
+                    const note = buildNoteData(chordNote.pitchChar, chordNote.accidentalText, chordNote.octaveShift, absoluteLength, dur, entry.lineNo, activeKeySignatureAccidentals, measureAccidentals);
                     note.voice = entry.voiceId;
+                    if (chordIndex === 0) {
+                        applyBeamModeForEvent(note, dur);
+                    }
                     if (chordIndex === 0 && pendingTrill && !note.isRest) {
                         note.trill = true;
                         pendingTrill = false;
                     }
                     if (chordIndex === 0 && pendingTurn && !note.isRest) {
                         note.turnType = pendingTurn;
+                        note.delayedTurn = pendingDelayedTurn;
                         pendingTurn = "";
+                        pendingDelayedTurn = false;
+                    }
+                    if (chordIndex === 0 && pendingMordent && !note.isRest) {
+                        note.mordentType = pendingMordent;
+                        pendingMordent = "";
+                    }
+                    if (chordIndex === 0 && pendingTremolo && !note.isRest) {
+                        note.tremoloType = pendingTremolo.type;
+                        note.tremoloMarks = pendingTremolo.marks;
+                        pendingTremolo = null;
+                    }
+                    if (chordIndex === 0 && pendingGlissandoStart && !note.isRest) {
+                        note.glissandoStart = true;
+                        pendingGlissandoStart = false;
+                    }
+                    if (chordIndex === 0 && pendingGlissandoStop && !note.isRest) {
+                        note.glissandoStop = true;
+                        pendingGlissandoStop = false;
+                    }
+                    if (chordIndex === 0 && pendingSlideStart && !note.isRest) {
+                        note.slideStart = true;
+                        pendingSlideStart = false;
+                    }
+                    if (chordIndex === 0 && pendingSlideStop && !note.isRest) {
+                        note.slideStop = true;
+                        pendingSlideStop = false;
+                    }
+                    if (chordIndex === 0 && pendingSchleifer && !note.isRest) {
+                        note.schleifer = true;
+                        pendingSchleifer = false;
+                    }
+                    if (chordIndex === 0 && pendingShake && !note.isRest) {
+                        note.shake = true;
+                        pendingShake = false;
+                    }
+                    if (chordIndex === 0 && pendingArpeggiate && !note.isRest) {
+                        note.arpeggiate = true;
+                        pendingArpeggiate = false;
                     }
                     if (chordIndex === 0 && pendingSlurStart > 0 && !note.isRest) {
                         note.slurStart = true;
@@ -21926,6 +22750,158 @@ function parseForMusicXml(source, settings) {
                     if (chordIndex === 0 && pendingStaccato && !note.isRest) {
                         note.staccato = true;
                         pendingStaccato = false;
+                    }
+                    if (chordIndex === 0 && pendingStaccatissimo && !note.isRest) {
+                        note.staccatissimo = true;
+                        pendingStaccatissimo = false;
+                    }
+                    if (chordIndex === 0 && pendingAccent && !note.isRest) {
+                        note.accent = true;
+                        pendingAccent = false;
+                    }
+                    if (chordIndex === 0 && pendingTenuto && !note.isRest) {
+                        note.tenuto = true;
+                        pendingTenuto = false;
+                    }
+                    if (chordIndex === 0 && pendingStress && !note.isRest) {
+                        note.stress = true;
+                        pendingStress = false;
+                    }
+                    if (chordIndex === 0 && pendingUnstress && !note.isRest) {
+                        note.unstress = true;
+                        pendingUnstress = false;
+                    }
+                    if (chordIndex === 0 && pendingFermata && !note.isRest) {
+                        note.fermataType = pendingFermata;
+                        pendingFermata = "";
+                    }
+                    if (chordIndex === 0 && pendingStrongAccent && !note.isRest) {
+                        note.strongAccent = true;
+                        pendingStrongAccent = false;
+                    }
+                    if (chordIndex === 0 && pendingBreathMark && !note.isRest) {
+                        note.breathMark = true;
+                        pendingBreathMark = false;
+                    }
+                    if (chordIndex === 0 && pendingCaesura && !note.isRest) {
+                        note.caesura = true;
+                        pendingCaesura = false;
+                    }
+                    if (chordIndex === 0 && pendingSegno && !note.isRest) {
+                        note.segno = true;
+                        pendingSegno = false;
+                    }
+                    if (chordIndex === 0 && pendingCoda && !note.isRest) {
+                        note.coda = true;
+                        pendingCoda = false;
+                    }
+                    if (chordIndex === 0 && pendingFine && !note.isRest) {
+                        note.fine = true;
+                        pendingFine = false;
+                    }
+                    if (chordIndex === 0 && pendingDaCapo && !note.isRest) {
+                        note.daCapo = true;
+                        pendingDaCapo = false;
+                    }
+                    if (chordIndex === 0 && pendingDalSegno && !note.isRest) {
+                        note.dalSegno = true;
+                        pendingDalSegno = false;
+                    }
+                    if (chordIndex === 0 && pendingToCoda && !note.isRest) {
+                        note.toCoda = true;
+                        pendingToCoda = false;
+                    }
+                    if (chordIndex === 0 && pendingCrescendoStart && !note.isRest) {
+                        note.crescendoStart = true;
+                        pendingCrescendoStart = false;
+                    }
+                    if (chordIndex === 0 && pendingCrescendoStop && !note.isRest) {
+                        note.crescendoStop = true;
+                        pendingCrescendoStop = false;
+                    }
+                    if (chordIndex === 0 && pendingDiminuendoStart && !note.isRest) {
+                        note.diminuendoStart = true;
+                        pendingDiminuendoStart = false;
+                    }
+                    if (chordIndex === 0 && pendingDiminuendoStop && !note.isRest) {
+                        note.diminuendoStop = true;
+                        pendingDiminuendoStop = false;
+                    }
+                    if (chordIndex === 0 && pendingDynamicMark && !note.isRest) {
+                        note.dynamicMark = pendingDynamicMark;
+                        pendingDynamicMark = "";
+                    }
+                    if (chordIndex === 0 && pendingSfz && !note.isRest) {
+                        note.sfz = true;
+                        pendingSfz = false;
+                    }
+                    if (chordIndex === 0 && pendingRehearsalMark && !note.isRest) {
+                        note.rehearsalMark = pendingRehearsalMark;
+                        pendingRehearsalMark = "";
+                    }
+                    if (chordIndex === 0 && pendingUpBow && !note.isRest) {
+                        note.upBow = true;
+                        pendingUpBow = false;
+                    }
+                    if (chordIndex === 0 && pendingDownBow && !note.isRest) {
+                        note.downBow = true;
+                        pendingDownBow = false;
+                    }
+                    if (chordIndex === 0 && pendingDoubleTongue && !note.isRest) {
+                        note.doubleTongue = true;
+                        pendingDoubleTongue = false;
+                    }
+                    if (chordIndex === 0 && pendingTripleTongue && !note.isRest) {
+                        note.tripleTongue = true;
+                        pendingTripleTongue = false;
+                    }
+                    if (chordIndex === 0 && pendingHeel && !note.isRest) {
+                        note.heel = true;
+                        pendingHeel = false;
+                    }
+                    if (chordIndex === 0 && pendingToe && !note.isRest) {
+                        note.toe = true;
+                        pendingToe = false;
+                    }
+                    if (chordIndex === 0 && pendingFingerings.length > 0 && !note.isRest) {
+                        note.fingerings = pendingFingerings.slice();
+                        pendingFingerings = [];
+                    }
+                    if (chordIndex === 0 && pendingStrings.length > 0 && !note.isRest) {
+                        note.strings = pendingStrings.slice();
+                        pendingStrings = [];
+                    }
+                    if (chordIndex === 0 && pendingPlucks.length > 0 && !note.isRest) {
+                        note.plucks = pendingPlucks.slice();
+                        pendingPlucks = [];
+                    }
+                    if (chordIndex === 0 && pendingChordSymbols.length > 0 && !note.isRest) {
+                        note.chordSymbols = pendingChordSymbols.slice();
+                        pendingChordSymbols = [];
+                    }
+                    if (chordIndex === 0 && pendingOpenString && !note.isRest) {
+                        note.openString = true;
+                        pendingOpenString = false;
+                    }
+                    if (chordIndex === 0 && pendingSnapPizzicato && !note.isRest) {
+                        note.snapPizzicato = true;
+                        pendingSnapPizzicato = false;
+                    }
+                    if (chordIndex === 0 && pendingHarmonic && !note.isRest) {
+                        note.harmonic = true;
+                        pendingHarmonic = false;
+                    }
+                    if (chordIndex === 0 && pendingStopped && !note.isRest) {
+                        note.stopped = true;
+                        pendingStopped = false;
+                    }
+                    if (chordIndex === 0 && pendingThumbPosition && !note.isRest) {
+                        note.thumbPosition = true;
+                        pendingThumbPosition = false;
+                    }
+                    if (chordIndex === 0 && pendingAnnotations.length > 0 && !note.isRest) {
+                        note.annotations = pendingAnnotations.slice();
+                        pendingAnnotations = [];
                     }
                     if (chordIndex > 0) {
                         note.chord = true;
@@ -21942,7 +22918,11 @@ function parseForMusicXml(source, settings) {
                     chordNotes.push(note);
                 }
                 if (pendingTieToNext && chordNotes.length > 0) {
-                    chordNotes[0].tieStop = true;
+                    for (const chordNote of chordNotes) {
+                        if (!chordNote.isRest) {
+                            chordNote.tieStop = true;
+                        }
+                    }
                     pendingTieToNext = false;
                 }
                 for (const note of chordNotes) {
@@ -21964,8 +22944,23 @@ function parseForMusicXml(source, settings) {
                 continue;
             }
             if (ch === "]" || ch === "}") {
+                if (ch === "]" && activeEndingMarker) {
+                    const stopMeasureNo = currentMeasure.length === 0 ? currentMeasureNo - 1 : currentMeasureNo;
+                    if (stopMeasureNo >= 1) {
+                        const measureMeta = ensureNotationMeasureMeta(entry.voiceId, stopMeasureNo);
+                        measureMeta.endingStop = activeEndingMarker;
+                        measureMeta.endingStopType = "stop";
+                        activeEndingMarker = "";
+                    }
+                    idx += 1;
+                    beamRunActive = false;
+                    sawInterEventWhitespace = false;
+                    continue;
+                }
                 warnings.push("line " + entry.lineNo + ": Skipped unsupported notation: " + ch);
                 idx += 1;
+                beamRunActive = false;
+                sawInterEventWhitespace = false;
                 continue;
             }
             let accidentalText = "";
@@ -21993,13 +22988,13 @@ function parseForMusicXml(source, settings) {
                 idx += 1;
             }
             let lengthToken = "";
-            const lengthMatch = text.slice(idx).match(/^(\d+\/\d+|\d+|\/\d+|\/)/);
+            const lengthMatch = text.slice(idx).match(/^(\d+\/\d+|\d+|\/\d+|\/+)/);
             if (lengthMatch) {
                 lengthToken = lengthMatch[1];
                 idx += lengthToken.length;
             }
             const len = parseLengthToken(lengthToken, entry.lineNo);
-            let absoluteLength = multiplyFractions(unitLength, len);
+            let absoluteLength = multiplyFractions(activeUnitLength, len);
             if (pendingRhythmScale) {
                 absoluteLength = multiplyFractions(absoluteLength, pendingRhythmScale);
                 pendingRhythmScale = null;
@@ -22034,14 +23029,54 @@ function parseForMusicXml(source, settings) {
             if (dur <= 0) {
                 throw new Error("line " + entry.lineNo + ": Invalid length");
             }
-            const note = buildNoteData(pitchChar, accidentalText, octaveShift, absoluteLength, dur, entry.lineNo, keySignatureAccidentals, measureAccidentals);
+            const note = buildNoteData(pitchChar, accidentalText, octaveShift, absoluteLength, dur, entry.lineNo, activeKeySignatureAccidentals, measureAccidentals);
+            applyBeamModeForEvent(note, dur);
             if (pendingTrill && !note.isRest) {
                 note.trill = true;
                 pendingTrill = false;
             }
             if (pendingTurn && !note.isRest) {
                 note.turnType = pendingTurn;
+                note.delayedTurn = pendingDelayedTurn;
                 pendingTurn = "";
+                pendingDelayedTurn = false;
+            }
+            if (pendingMordent && !note.isRest) {
+                note.mordentType = pendingMordent;
+                pendingMordent = "";
+            }
+            if (pendingTremolo && !note.isRest) {
+                note.tremoloType = pendingTremolo.type;
+                note.tremoloMarks = pendingTremolo.marks;
+                pendingTremolo = null;
+            }
+            if (pendingGlissandoStart && !note.isRest) {
+                note.glissandoStart = true;
+                pendingGlissandoStart = false;
+            }
+            if (pendingGlissandoStop && !note.isRest) {
+                note.glissandoStop = true;
+                pendingGlissandoStop = false;
+            }
+            if (pendingSlideStart && !note.isRest) {
+                note.slideStart = true;
+                pendingSlideStart = false;
+            }
+            if (pendingSlideStop && !note.isRest) {
+                note.slideStop = true;
+                pendingSlideStop = false;
+            }
+            if (pendingSchleifer && !note.isRest) {
+                note.schleifer = true;
+                pendingSchleifer = false;
+            }
+            if (pendingShake && !note.isRest) {
+                note.shake = true;
+                pendingShake = false;
+            }
+            if (pendingArpeggiate && !note.isRest) {
+                note.arpeggiate = true;
+                pendingArpeggiate = false;
             }
             if (pendingSlurStart > 0 && !note.isRest) {
                 note.slurStart = true;
@@ -22055,6 +23090,158 @@ function parseForMusicXml(source, settings) {
             if (pendingStaccato && !note.isRest) {
                 note.staccato = true;
                 pendingStaccato = false;
+            }
+            if (pendingStaccatissimo && !note.isRest) {
+                note.staccatissimo = true;
+                pendingStaccatissimo = false;
+            }
+            if (pendingAccent && !note.isRest) {
+                note.accent = true;
+                pendingAccent = false;
+            }
+            if (pendingTenuto && !note.isRest) {
+                note.tenuto = true;
+                pendingTenuto = false;
+            }
+            if (pendingStress && !note.isRest) {
+                note.stress = true;
+                pendingStress = false;
+            }
+            if (pendingUnstress && !note.isRest) {
+                note.unstress = true;
+                pendingUnstress = false;
+            }
+            if (pendingFermata && !note.isRest) {
+                note.fermataType = pendingFermata;
+                pendingFermata = "";
+            }
+            if (pendingStrongAccent && !note.isRest) {
+                note.strongAccent = true;
+                pendingStrongAccent = false;
+            }
+            if (pendingBreathMark && !note.isRest) {
+                note.breathMark = true;
+                pendingBreathMark = false;
+            }
+            if (pendingCaesura && !note.isRest) {
+                note.caesura = true;
+                pendingCaesura = false;
+            }
+            if (pendingSegno && !note.isRest) {
+                note.segno = true;
+                pendingSegno = false;
+            }
+            if (pendingCoda && !note.isRest) {
+                note.coda = true;
+                pendingCoda = false;
+            }
+            if (pendingFine && !note.isRest) {
+                note.fine = true;
+                pendingFine = false;
+            }
+            if (pendingDaCapo && !note.isRest) {
+                note.daCapo = true;
+                pendingDaCapo = false;
+            }
+            if (pendingDalSegno && !note.isRest) {
+                note.dalSegno = true;
+                pendingDalSegno = false;
+            }
+            if (pendingToCoda && !note.isRest) {
+                note.toCoda = true;
+                pendingToCoda = false;
+            }
+            if (pendingCrescendoStart && !note.isRest) {
+                note.crescendoStart = true;
+                pendingCrescendoStart = false;
+            }
+            if (pendingCrescendoStop && !note.isRest) {
+                note.crescendoStop = true;
+                pendingCrescendoStop = false;
+            }
+            if (pendingDiminuendoStart && !note.isRest) {
+                note.diminuendoStart = true;
+                pendingDiminuendoStart = false;
+            }
+            if (pendingDiminuendoStop && !note.isRest) {
+                note.diminuendoStop = true;
+                pendingDiminuendoStop = false;
+            }
+            if (pendingDynamicMark && !note.isRest) {
+                note.dynamicMark = pendingDynamicMark;
+                pendingDynamicMark = "";
+            }
+            if (pendingSfz && !note.isRest) {
+                note.sfz = true;
+                pendingSfz = false;
+            }
+            if (pendingRehearsalMark && !note.isRest) {
+                note.rehearsalMark = pendingRehearsalMark;
+                pendingRehearsalMark = "";
+            }
+            if (pendingUpBow && !note.isRest) {
+                note.upBow = true;
+                pendingUpBow = false;
+            }
+            if (pendingDownBow && !note.isRest) {
+                note.downBow = true;
+                pendingDownBow = false;
+            }
+            if (pendingDoubleTongue && !note.isRest) {
+                note.doubleTongue = true;
+                pendingDoubleTongue = false;
+            }
+            if (pendingTripleTongue && !note.isRest) {
+                note.tripleTongue = true;
+                pendingTripleTongue = false;
+            }
+            if (pendingHeel && !note.isRest) {
+                note.heel = true;
+                pendingHeel = false;
+            }
+            if (pendingToe && !note.isRest) {
+                note.toe = true;
+                pendingToe = false;
+            }
+            if (pendingFingerings.length > 0 && !note.isRest) {
+                note.fingerings = pendingFingerings.slice();
+                pendingFingerings = [];
+            }
+            if (pendingStrings.length > 0 && !note.isRest) {
+                note.strings = pendingStrings.slice();
+                pendingStrings = [];
+            }
+            if (pendingPlucks.length > 0 && !note.isRest) {
+                note.plucks = pendingPlucks.slice();
+                pendingPlucks = [];
+            }
+            if (pendingChordSymbols.length > 0 && !note.isRest) {
+                note.chordSymbols = pendingChordSymbols.slice();
+                pendingChordSymbols = [];
+            }
+            if (pendingOpenString && !note.isRest) {
+                note.openString = true;
+                pendingOpenString = false;
+            }
+            if (pendingSnapPizzicato && !note.isRest) {
+                note.snapPizzicato = true;
+                pendingSnapPizzicato = false;
+            }
+            if (pendingHarmonic && !note.isRest) {
+                note.harmonic = true;
+                pendingHarmonic = false;
+            }
+            if (pendingStopped && !note.isRest) {
+                note.stopped = true;
+                pendingStopped = false;
+            }
+            if (pendingThumbPosition && !note.isRest) {
+                note.thumbPosition = true;
+                pendingThumbPosition = false;
+            }
+            if (pendingAnnotations.length > 0 && !note.isRest) {
+                note.annotations = pendingAnnotations.slice();
+                pendingAnnotations = [];
             }
             if (pendingTieToNext && !note.isRest) {
                 note.tieStop = true;
@@ -22079,11 +23266,64 @@ function parseForMusicXml(source, settings) {
             lastEventNotes = [note];
             noteCount += 1;
         }
+        activeEndingByVoice[entry.voiceId] = activeEndingMarker;
+        currentKeyFifthsByVoice[entry.voiceId] = activeKeyFifths;
     }
     for (const voiceId of Object.keys(measuresByVoice)) {
         const measures = measuresByVoice[voiceId];
         while (measures.length > 1 && measures[measures.length - 1].length === 0) {
             measures.pop();
+        }
+        const activeEndingMarker = String(activeEndingByVoice[voiceId] || "");
+        if (activeEndingMarker) {
+            const lastMeasureNo = measures.length;
+            if (lastMeasureNo >= 1) {
+                const measureMeta = ensureNotationMeasureMeta(voiceId, lastMeasureNo);
+                if (!measureMeta.endingStop) {
+                    measureMeta.endingStop = activeEndingMarker;
+                    measureMeta.endingStopType = "stop";
+                }
+            }
+        }
+    }
+    for (const voiceId of Object.keys(lyricEntriesByVoice)) {
+        const measures = measuresByVoice[voiceId];
+        if (!Array.isArray(measures) || measures.length === 0)
+            continue;
+        const lyricTargets = [];
+        for (const measure of measures) {
+            for (const note of measure) {
+                if (note && !note.isRest && !note.grace && !note.chord) {
+                    lyricTargets.push(note);
+                }
+            }
+        }
+        if (lyricTargets.length === 0)
+            continue;
+        let cursor = 0;
+        for (const lyricEntry of lyricEntriesByVoice[voiceId]) {
+            const tokens = tokenizeAbcLyricLine(lyricEntry.text);
+            for (const token of tokens) {
+                if (cursor >= lyricTargets.length)
+                    break;
+                if (token.type === "skip") {
+                    cursor += 1;
+                    continue;
+                }
+                if (token.type === "extend") {
+                    const target = lyricTargets[Math.max(0, cursor - 1)];
+                    if (target) {
+                        target.lyricExtend = true;
+                    }
+                    continue;
+                }
+                const target = lyricTargets[cursor];
+                if (target) {
+                    target.lyricText = token.text;
+                    target.lyricSyllabic = token.syllabic;
+                }
+                cursor += 1;
+            }
         }
     }
     if (noteCount === 0) {
@@ -22094,6 +23334,7 @@ function parseForMusicXml(source, settings) {
     const importDiagnostics = [];
     const overfullCompatibilityMode = (settings === null || settings === void 0 ? void 0 : settings.overfullCompatibilityMode) !== false;
     const parts = orderedVoiceIds.map((voiceId, index) => {
+        var _a, _b, _c, _d, _e, _f, _g;
         const partName = voiceNameById[voiceId] || ("Voice " + voiceId);
         const transpose = transposeHintByVoiceId.get(voiceId) ||
             voiceTransposeById[voiceId] ||
@@ -22116,15 +23357,38 @@ function parseForMusicXml(source, settings) {
             }
         }
         const keyByMeasure = {};
+        const meterByMeasure = {};
+        const tempoByMeasure = {};
         const measureMetaByIndex = {};
         for (let m = 1; m <= normalizedMeasures.length; m += 1) {
             const hinted = keyHintFifthsByKey.get(`${voiceId}#${m}`);
             if (Number.isFinite(hinted)) {
                 keyByMeasure[m] = Number(hinted);
             }
-            const meta = measureMetaByKey.get(`${voiceId}#${m}`);
-            if (meta) {
-                measureMetaByIndex[m] = meta;
+            const notationMeta = ((_a = notationMeasureMetaByVoice[voiceId]) === null || _a === void 0 ? void 0 : _a[m]) || null;
+            const hintedMeta = measureMetaByKey.get(`${voiceId}#${m}`) || null;
+            const meterHint = ((_b = meterByMeasureByVoice[voiceId]) === null || _b === void 0 ? void 0 : _b[m]) || null;
+            const tempoHint = ((_c = tempoByMeasureByVoice[voiceId]) === null || _c === void 0 ? void 0 : _c[m]) || null;
+            if (notationMeta || hintedMeta) {
+                measureMetaByIndex[m] = {
+                    number: (hintedMeta === null || hintedMeta === void 0 ? void 0 : hintedMeta.number) || (notationMeta === null || notationMeta === void 0 ? void 0 : notationMeta.number) || String(m),
+                    implicit: (_e = (_d = hintedMeta === null || hintedMeta === void 0 ? void 0 : hintedMeta.implicit) !== null && _d !== void 0 ? _d : notationMeta === null || notationMeta === void 0 ? void 0 : notationMeta.implicit) !== null && _e !== void 0 ? _e : false,
+                    repeatStart: Boolean((notationMeta === null || notationMeta === void 0 ? void 0 : notationMeta.repeatStart) || (hintedMeta === null || hintedMeta === void 0 ? void 0 : hintedMeta.repeatStart)),
+                    repeatEnd: Boolean((notationMeta === null || notationMeta === void 0 ? void 0 : notationMeta.repeatEnd) || (hintedMeta === null || hintedMeta === void 0 ? void 0 : hintedMeta.repeatEnd)),
+                    repeatTimes: (_g = (_f = hintedMeta === null || hintedMeta === void 0 ? void 0 : hintedMeta.repeatTimes) !== null && _f !== void 0 ? _f : notationMeta === null || notationMeta === void 0 ? void 0 : notationMeta.repeatTimes) !== null && _g !== void 0 ? _g : null,
+                    endingStart: String((notationMeta === null || notationMeta === void 0 ? void 0 : notationMeta.endingStart) || (hintedMeta === null || hintedMeta === void 0 ? void 0 : hintedMeta.endingStart) || ""),
+                    endingStop: String((notationMeta === null || notationMeta === void 0 ? void 0 : notationMeta.endingStop) || (hintedMeta === null || hintedMeta === void 0 ? void 0 : hintedMeta.endingStop) || ""),
+                    endingStopType: (notationMeta === null || notationMeta === void 0 ? void 0 : notationMeta.endingStopType) || (hintedMeta === null || hintedMeta === void 0 ? void 0 : hintedMeta.endingStopType) || "",
+                };
+            }
+            if (meterHint) {
+                meterByMeasure[m] = {
+                    beats: meterHint.beats,
+                    beatType: meterHint.beatType,
+                };
+            }
+            if (Number.isFinite(tempoHint)) {
+                tempoByMeasure[m] = Math.max(20, Math.min(300, Math.round(Number(tempoHint))));
             }
         }
         return {
@@ -22134,6 +23398,8 @@ function parseForMusicXml(source, settings) {
             transpose,
             voiceId,
             keyByMeasure,
+            meterByMeasure,
+            tempoByMeasure,
             measureMetaByIndex,
             measures: normalizedMeasures
         };
@@ -22333,7 +23599,7 @@ function parseChordAt(text, startIdx, lineNo) {
         return null;
     }
     const after = text.slice(closeIdx + 1);
-    const lengthMatch = after.match(/^(\d+\/\d+|\d+|\/\d+|\/)/);
+    const lengthMatch = after.match(/^(\d+\/\d+|\d+|\/\d+|\/+)/);
     const lengthToken = lengthMatch ? lengthMatch[1] : "";
     const nextIdx = closeIdx + 1 + (lengthMatch ? lengthMatch[1].length : 0);
     return {
@@ -22381,7 +23647,7 @@ function parseGraceGroupAt(text, startIdx, lineNo, unitLength, keySignatureAccid
             idx += 1;
         }
         let lengthToken = "";
-        const lengthMatch = inner.slice(idx).match(/^(\d+\/\d+|\d+|\/\d+|\/)/);
+        const lengthMatch = inner.slice(idx).match(/^(\d+\/\d+|\d+|\/\d+|\/+)/);
         if (lengthMatch) {
             lengthToken = lengthMatch[1];
             idx += lengthToken.length;
@@ -22696,7 +23962,6 @@ const exportMusicXmlDomToAbc = (doc) => {
     ].filter(Boolean);
     const bodyLines = [];
     const metaLines = [];
-    const emittedKeyMetaByVoiceMeasure = new Set();
     const emitDiagMetaForMeasure = (normalizedVoiceId, measure, safeMeasureNumber) => {
         const fields = Array.from(measure.querySelectorAll(':scope > attributes > miscellaneous > miscellaneous-field[name^="mks:diag:"]'));
         if (!fields.length)
@@ -22725,7 +23990,7 @@ const exportMusicXmlDomToAbc = (doc) => {
     };
     const parts = Array.from(doc.querySelectorAll("score-partwise > part"));
     parts.forEach((part, partIndex) => {
-        var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p, _q, _r, _s, _t, _u, _v, _w, _x, _y, _z, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19;
+        var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p, _q, _r, _s, _t, _u, _v, _w, _x, _y, _z, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26;
         const partId = part.getAttribute("id") || `P${partIndex + 1}`;
         const partName = partNameById.get(partId) || partId;
         const measures = Array.from(part.querySelectorAll(":scope > measure"));
@@ -22822,10 +24087,12 @@ const exportMusicXmlDomToAbc = (doc) => {
                 : (Number.isFinite(fifths) ? Math.round(fifths) : 0);
             let currentDivisions = 480;
             let currentFifths = partInitialFifths;
-            let lastEmittedKeyFifths = null;
+            let lastEmittedKeyFifths = Number.isFinite(fifths) ? Math.round(fifths) : 0;
             let currentBeats = Number(meterBeats) || 4;
             let currentBeatType = Number(meterBeatType) || 4;
             const measureTexts = [];
+            const lyricTokens = [];
+            let pendingLyricExtension = false;
             for (const measure of measures) {
                 let activeTuplet = null;
                 let eventNo = 0;
@@ -22843,40 +24110,36 @@ const exportMusicXmlDomToAbc = (doc) => {
                 const isImplicit = implicitAttr === "yes" || implicitAttr === "true" || implicitAttr === "1";
                 const leftRepeatNode = measure.querySelector(':scope > barline[location="left"] > repeat');
                 const rightRepeatNode = measure.querySelector(':scope > barline[location="right"] > repeat');
+                const leftEndingNode = measure.querySelector(':scope > barline[location="left"] > ending');
+                const rightEndingNode = measure.querySelector(':scope > barline[location="right"] > ending');
                 const leftRepeatDir = ((leftRepeatNode === null || leftRepeatNode === void 0 ? void 0 : leftRepeatNode.getAttribute("direction")) || "").trim().toLowerCase();
                 const rightRepeatDir = ((rightRepeatNode === null || rightRepeatNode === void 0 ? void 0 : rightRepeatNode.getAttribute("direction")) || "").trim().toLowerCase();
-                const repeatDir = rightRepeatDir === "backward"
-                    ? "backward"
-                    : (leftRepeatDir === "forward" ? "forward" : "");
+                const hasLeftRepeat = leftRepeatDir === "forward";
+                const hasRightRepeat = rightRepeatDir === "backward";
                 const repeatTimes = Number.parseInt(String((rightRepeatNode === null || rightRepeatNode === void 0 ? void 0 : rightRepeatNode.getAttribute("times")) || ""), 10);
-                if (isImplicit || repeatDir || rawMeasureNumber !== String(safeMeasureNumber)) {
+                const leftEndingNumber = ((leftEndingNode === null || leftEndingNode === void 0 ? void 0 : leftEndingNode.getAttribute("number")) || "").trim();
+                const rightEndingNumber = ((rightEndingNode === null || rightEndingNode === void 0 ? void 0 : rightEndingNode.getAttribute("number")) || "").trim();
+                const rightEndingType = ((rightEndingNode === null || rightEndingNode === void 0 ? void 0 : rightEndingNode.getAttribute("type")) || "").trim().toLowerCase();
+                if (isImplicit ||
+                    rawMeasureNumber !== String(safeMeasureNumber) ||
+                    (hasRightRepeat && Number.isFinite(repeatTimes) && repeatTimes > 2) ||
+                    (rightEndingNumber && rightEndingType === "discontinue")) {
                     const metaChunks = [
                         `%@mks measure voice=${normalizedVoiceId} measure=${safeMeasureNumber}`,
                         `number=${rawMeasureNumber}`,
                         `implicit=${isImplicit ? 1 : 0}`,
                     ];
-                    if (repeatDir) {
-                        metaChunks.push(`repeat=${repeatDir}`);
-                    }
-                    if (repeatDir === "backward" && Number.isFinite(repeatTimes) && repeatTimes > 1) {
+                    if (hasRightRepeat && Number.isFinite(repeatTimes) && repeatTimes > 2) {
                         metaChunks.push(`times=${Math.round(repeatTimes)}`);
+                    }
+                    if (rightEndingNumber && rightEndingType === "discontinue") {
+                        metaChunks.push(`ending-stop=${rightEndingNumber}`);
+                        metaChunks.push(`ending-type=${rightEndingType}`);
                     }
                     metaLines.push(metaChunks.join(" "));
                 }
                 emitDiagMetaForMeasure(normalizedVoiceId, measure, safeMeasureNumber);
-                const isFirstMeasureForLane = measureTexts.length === 0;
-                const hasExplicitKeyInMeasure = parsedFifths !== null;
-                const shouldEmitMeasureHint = hasExplicitKeyInMeasure || isFirstMeasureForLane;
-                if (shouldEmitMeasureHint) {
-                    if (lastEmittedKeyFifths === null || lastEmittedKeyFifths !== currentFifths) {
-                        const metaKey = `${normalizedVoiceId}#${safeMeasureNumber}`;
-                        if (!emittedKeyMetaByVoiceMeasure.has(metaKey)) {
-                            metaLines.push(`%@mks key voice=${normalizedVoiceId} measure=${safeMeasureNumber} fifths=${Math.max(-7, Math.min(7, Math.round(currentFifths)))}`);
-                            emittedKeyMetaByVoiceMeasure.add(metaKey);
-                        }
-                        lastEmittedKeyFifths = currentFifths;
-                    }
-                }
+                const needsInlineKeyChange = lastEmittedKeyFifths === null || lastEmittedKeyFifths !== currentFifths;
                 const parsedBeats = parseOptionalNumber((_p = measure.querySelector("attributes > time > beats")) === null || _p === void 0 ? void 0 : _p.textContent);
                 if (parsedBeats !== null && parsedBeats > 0) {
                     currentBeats = parsedBeats;
@@ -22889,6 +24152,10 @@ const exportMusicXmlDomToAbc = (doc) => {
                 const measureAccidentalByStepOctave = new Map();
                 let pending = null;
                 const pendingGraceTokens = [];
+                const pendingHarmonySymbols = [];
+                const pendingDirectionWords = [];
+                const pendingDirectionDecorations = [];
+                let activeWedgeType = "";
                 const tokens = [];
                 const flush = () => {
                     if (!pending)
@@ -22902,6 +24169,64 @@ const exportMusicXmlDomToAbc = (doc) => {
                     pending = null;
                 };
                 for (const child of Array.from(measure.children)) {
+                    if (child.tagName === "harmony") {
+                        const chordSymbol = abcChordSymbolFromHarmony(child);
+                        if (chordSymbol) {
+                            pendingHarmonySymbols.push(chordSymbol);
+                        }
+                        continue;
+                    }
+                    if (child.tagName === "direction") {
+                        const rehearsalTexts = Array.from(child.querySelectorAll(":scope > direction-type > rehearsal"))
+                            .map((node) => abcQuotedTextEscape(node.textContent || ""))
+                            .filter(Boolean);
+                        for (const rehearsalText of rehearsalTexts) {
+                            pendingDirectionDecorations.push(`!rehearsal:${rehearsalText}!`);
+                        }
+                        const words = Array.from(child.querySelectorAll(":scope > direction-type > words"))
+                            .map((node) => abcQuotedTextEscape(node.textContent || ""))
+                            .filter(Boolean);
+                        pendingDirectionWords.push(...words);
+                        if (child.querySelector(":scope > direction-type > segno")) {
+                            pendingDirectionDecorations.push("!segno!");
+                        }
+                        if (child.querySelector(":scope > direction-type > coda")) {
+                            pendingDirectionDecorations.push("!coda!");
+                        }
+                        if (child.querySelector(':scope > sound[fine="yes"]')) {
+                            pendingDirectionDecorations.push("!fine!");
+                        }
+                        if (child.querySelector(':scope > sound[dacapo="yes"]')) {
+                            pendingDirectionDecorations.push("!dacapo!");
+                        }
+                        if (child.querySelector(":scope > sound[dalsegno]")) {
+                            pendingDirectionDecorations.push("!dalsegno!");
+                        }
+                        if (child.querySelector(":scope > sound[tocoda]")) {
+                            pendingDirectionDecorations.push("!tocoda!");
+                        }
+                        for (const wedgeNode of Array.from(child.querySelectorAll(":scope > direction-type > wedge"))) {
+                            const wedgeType = (wedgeNode.getAttribute("type") || "").trim().toLowerCase();
+                            if (wedgeType === "crescendo") {
+                                pendingDirectionDecorations.push("!crescendo(!");
+                                activeWedgeType = "crescendo";
+                            }
+                            else if (wedgeType === "diminuendo") {
+                                pendingDirectionDecorations.push("!diminuendo(!");
+                                activeWedgeType = "diminuendo";
+                            }
+                            else if (wedgeType === "stop") {
+                                pendingDirectionDecorations.push(activeWedgeType === "diminuendo" ? "!diminuendo)!" : "!crescendo)!");
+                                activeWedgeType = "";
+                            }
+                        }
+                        for (const dynamicName of ["ppp", "pp", "p", "mp", "mf", "f", "ff", "fff", "fp", "fz", "rfz", "sf", "sfp", "sfz"]) {
+                            if (child.querySelector(`:scope > direction-type > dynamics > ${dynamicName}`)) {
+                                pendingDirectionDecorations.push(`!${dynamicName}!`);
+                            }
+                        }
+                        continue;
+                    }
                     if (child.tagName !== "note")
                         continue;
                     if (lane.staff) {
@@ -22927,6 +24252,17 @@ const exportMusicXmlDomToAbc = (doc) => {
                     const hasTrillMark = Boolean(child.querySelector(":scope > notations > ornaments > trill-mark"));
                     const hasTurn = Boolean(child.querySelector(":scope > notations > ornaments > turn"));
                     const hasInvertedTurn = Boolean(child.querySelector(":scope > notations > ornaments > inverted-turn"));
+                    const hasDelayedTurn = Boolean(child.querySelector(":scope > notations > ornaments > delayed-turn"));
+                    const hasMordent = Boolean(child.querySelector(":scope > notations > ornaments > mordent"));
+                    const hasInvertedMordent = Boolean(child.querySelector(":scope > notations > ornaments > inverted-mordent"));
+                    const tremoloNode = child.querySelector(":scope > notations > ornaments > tremolo");
+                    const hasSchleifer = Boolean(child.querySelector(":scope > notations > ornaments > schleifer"));
+                    const hasShake = Boolean(child.querySelector(":scope > notations > ornaments > shake"));
+                    const hasGlissandoStart = Boolean(child.querySelector(':scope > notations > glissando[type="start"]'));
+                    const hasGlissandoStop = Boolean(child.querySelector(':scope > notations > glissando[type="stop"]'));
+                    const hasSlideStart = Boolean(child.querySelector(':scope > notations > slide[type="start"]'));
+                    const hasSlideStop = Boolean(child.querySelector(':scope > notations > slide[type="stop"]'));
+                    const hasArpeggiate = Boolean(child.querySelector(":scope > notations > arpeggiate"));
                     const hasWavyLineStart = Array.from(child.querySelectorAll(":scope > notations > ornaments > wavy-line")).some((node) => {
                         var _a;
                         const type = ((_a = node.getAttribute("type")) !== null && _a !== void 0 ? _a : "").trim().toLowerCase();
@@ -22934,14 +24270,54 @@ const exportMusicXmlDomToAbc = (doc) => {
                     });
                     const hasTrill = hasTrillMark || hasWavyLineStart;
                     const turnType = hasInvertedTurn ? "inverted-turn" : (hasTurn ? "turn" : "");
-                    const trillAccidentalText = ((_0 = (_z = child.querySelector(":scope > notations > ornaments > accidental-mark")) === null || _z === void 0 ? void 0 : _z.textContent) === null || _0 === void 0 ? void 0 : _0.trim()) || "";
+                    const mordentType = hasInvertedMordent ? "inverted-mordent" : (hasMordent ? "mordent" : "");
+                    const tremoloTypeRaw = ((tremoloNode === null || tremoloNode === void 0 ? void 0 : tremoloNode.getAttribute("type")) || "").trim().toLowerCase();
+                    const tremoloType = tremoloTypeRaw === "single" || tremoloTypeRaw === "start" || tremoloTypeRaw === "stop"
+                        ? tremoloTypeRaw
+                        : "";
+                    const tremoloMarks = Math.max(1, Math.min(8, Number.parseInt(((_z = tremoloNode === null || tremoloNode === void 0 ? void 0 : tremoloNode.textContent) === null || _z === void 0 ? void 0 : _z.trim()) || "", 10) || 0));
+                    const trillAccidentalText = ((_1 = (_0 = child.querySelector(":scope > notations > ornaments > accidental-mark")) === null || _0 === void 0 ? void 0 : _0.textContent) === null || _1 === void 0 ? void 0 : _1.trim()) || "";
                     const hasStaccato = Boolean(child.querySelector(":scope > notations > articulations > staccato"));
+                    const hasStaccatissimo = Boolean(child.querySelector(":scope > notations > articulations > staccatissimo"));
+                    const hasAccent = Boolean(child.querySelector(":scope > notations > articulations > accent"));
+                    const hasTenuto = Boolean(child.querySelector(":scope > notations > articulations > tenuto"));
+                    const hasStress = Boolean(child.querySelector(":scope > notations > articulations > stress"));
+                    const hasUnstress = Boolean(child.querySelector(":scope > notations > articulations > unstress"));
+                    const hasStrongAccent = Boolean(child.querySelector(":scope > notations > articulations > strong-accent"));
+                    const hasBreathMark = Boolean(child.querySelector(":scope > notations > articulations > breath-mark"));
+                    const hasCaesura = Boolean(child.querySelector(":scope > notations > articulations > caesura"));
+                    const hasUpBow = Boolean(child.querySelector(":scope > notations > technical > up-bow"));
+                    const hasDownBow = Boolean(child.querySelector(":scope > notations > technical > down-bow"));
+                    const hasDoubleTongue = Boolean(child.querySelector(":scope > notations > technical > double-tongue"));
+                    const hasTripleTongue = Boolean(child.querySelector(":scope > notations > technical > triple-tongue"));
+                    const hasHeel = Boolean(child.querySelector(":scope > notations > technical > heel"));
+                    const hasToe = Boolean(child.querySelector(":scope > notations > technical > toe"));
+                    const fingeringTexts = Array.from(child.querySelectorAll(":scope > notations > technical > fingering"))
+                        .map((node) => (node.textContent || "").trim())
+                        .filter(Boolean);
+                    const stringTexts = Array.from(child.querySelectorAll(":scope > notations > technical > string"))
+                        .map((node) => (node.textContent || "").trim())
+                        .filter(Boolean);
+                    const pluckTexts = Array.from(child.querySelectorAll(":scope > notations > technical > pluck"))
+                        .map((node) => (node.textContent || "").trim())
+                        .filter(Boolean);
+                    const hasOpenString = Boolean(child.querySelector(":scope > notations > technical > open-string"));
+                    const hasSnapPizzicato = Boolean(child.querySelector(":scope > notations > technical > snap-pizzicato"));
+                    const hasHarmonic = Boolean(child.querySelector(":scope > notations > technical > harmonic"));
+                    const hasStopped = Boolean(child.querySelector(":scope > notations > technical > stopped"));
+                    const hasThumbPosition = Boolean(child.querySelector(":scope > notations > technical > thumb-position"));
+                    const fermataNode = child.querySelector(":scope > notations > fermata");
+                    const fermataTypeRaw = ((_2 = fermataNode === null || fermataNode === void 0 ? void 0 : fermataNode.getAttribute("type")) === null || _2 === void 0 ? void 0 : _2.trim().toLowerCase()) || "";
+                    const fermataShapeRaw = ((_3 = fermataNode === null || fermataNode === void 0 ? void 0 : fermataNode.textContent) === null || _3 === void 0 ? void 0 : _3.trim().toLowerCase()) || "";
+                    const fermataType = !fermataNode
+                        ? ""
+                        : (fermataTypeRaw === "inverted" || fermataShapeRaw === "inverted" ? "inverted" : "normal");
                     const hasSlurStart = Boolean(child.querySelector(':scope > notations > slur[type="start"]'));
                     const hasSlurStop = Boolean(child.querySelector(':scope > notations > slur[type="stop"]'));
-                    const hasGraceSlash = ((_2 = (_1 = child.querySelector(":scope > grace")) === null || _1 === void 0 ? void 0 : _1.getAttribute("slash")) !== null && _2 !== void 0 ? _2 : "").trim().toLowerCase() === "yes";
+                    const hasGraceSlash = ((_5 = (_4 = child.querySelector(":scope > grace")) === null || _4 === void 0 ? void 0 : _4.getAttribute("slash")) !== null && _5 !== void 0 ? _5 : "").trim().toLowerCase() === "yes";
                     const hasTupletStart = Boolean(child.querySelector(':scope > notations > tuplet[type="start"]'));
-                    const tmActual = Number(((_4 = (_3 = child.querySelector(":scope > time-modification > actual-notes")) === null || _3 === void 0 ? void 0 : _3.textContent) === null || _4 === void 0 ? void 0 : _4.trim()) || "");
-                    const tmNormal = Number(((_6 = (_5 = child.querySelector(":scope > time-modification > normal-notes")) === null || _5 === void 0 ? void 0 : _5.textContent) === null || _6 === void 0 ? void 0 : _6.trim()) || "");
+                    const tmActual = Number(((_7 = (_6 = child.querySelector(":scope > time-modification > actual-notes")) === null || _6 === void 0 ? void 0 : _6.textContent) === null || _7 === void 0 ? void 0 : _7.trim()) || "");
+                    const tmNormal = Number(((_9 = (_8 = child.querySelector(":scope > time-modification > normal-notes")) === null || _8 === void 0 ? void 0 : _8.textContent) === null || _9 === void 0 ? void 0 : _9.trim()) || "");
                     const hasTimeModification = Number.isFinite(tmActual) && tmActual > 0 && Number.isFinite(tmNormal) && tmNormal > 0;
                     const rawWholeFraction = exports.AbcCommon.reduceFraction(noteDuration, currentDivisions * 4, { num: 1, den: 4 });
                     const abcBaseWholeFraction = hasTimeModification
@@ -22954,18 +24330,18 @@ const exportMusicXmlDomToAbc = (doc) => {
                     const len = exports.AbcCommon.abcLengthTokenFromFraction(lenRatio);
                     let pitchToken = "z";
                     if (!child.querySelector(":scope > rest")) {
-                        const step = ((_8 = (_7 = child.querySelector(":scope > pitch > step")) === null || _7 === void 0 ? void 0 : _7.textContent) === null || _8 === void 0 ? void 0 : _8.trim()) || "C";
-                        const octave = Number(((_10 = (_9 = child.querySelector(":scope > pitch > octave")) === null || _9 === void 0 ? void 0 : _9.textContent) === null || _10 === void 0 ? void 0 : _10.trim()) || "4");
+                        const step = ((_11 = (_10 = child.querySelector(":scope > pitch > step")) === null || _10 === void 0 ? void 0 : _10.textContent) === null || _11 === void 0 ? void 0 : _11.trim()) || "C";
+                        const octave = Number(((_13 = (_12 = child.querySelector(":scope > pitch > octave")) === null || _12 === void 0 ? void 0 : _12.textContent) === null || _13 === void 0 ? void 0 : _13.trim()) || "4");
                         const upperStep = /^[A-G]$/.test(step.toUpperCase()) ? step.toUpperCase() : "C";
                         const safeOctave = Number.isFinite(octave) ? Math.max(0, Math.min(9, Math.round(octave))) : 4;
                         const stepOctaveKey = `${upperStep}${safeOctave}`;
-                        const alterRaw = (_13 = (_12 = (_11 = child.querySelector(":scope > pitch > alter")) === null || _11 === void 0 ? void 0 : _11.textContent) === null || _12 === void 0 ? void 0 : _12.trim()) !== null && _13 !== void 0 ? _13 : "";
+                        const alterRaw = (_16 = (_15 = (_14 = child.querySelector(":scope > pitch > alter")) === null || _14 === void 0 ? void 0 : _14.textContent) === null || _15 === void 0 ? void 0 : _15.trim()) !== null && _16 !== void 0 ? _16 : "";
                         const explicitAlter = alterRaw !== "" && Number.isFinite(Number(alterRaw)) ? Math.round(Number(alterRaw)) : null;
-                        const accidentalText = (_16 = (_15 = (_14 = child.querySelector(":scope > accidental")) === null || _14 === void 0 ? void 0 : _14.textContent) === null || _15 === void 0 ? void 0 : _15.trim()) !== null && _16 !== void 0 ? _16 : "";
+                        const accidentalText = (_19 = (_18 = (_17 = child.querySelector(":scope > accidental")) === null || _17 === void 0 ? void 0 : _17.textContent) === null || _18 === void 0 ? void 0 : _18.trim()) !== null && _19 !== void 0 ? _19 : "";
                         const accidentalAlter = accidentalTextToAlter(accidentalText);
-                        const keyAlter = (_17 = keyAlterMap[upperStep]) !== null && _17 !== void 0 ? _17 : 0;
+                        const keyAlter = (_20 = keyAlterMap[upperStep]) !== null && _20 !== void 0 ? _20 : 0;
                         const currentAlter = measureAccidentalByStepOctave.has(stepOctaveKey)
-                            ? (_18 = measureAccidentalByStepOctave.get(stepOctaveKey)) !== null && _18 !== void 0 ? _18 : 0
+                            ? (_21 = measureAccidentalByStepOctave.get(stepOctaveKey)) !== null && _21 !== void 0 ? _21 : 0
                             : keyAlter;
                         // In MusicXML pitch, omitted <alter> means natural (0), not "follow key accidental".
                         // Key signature context is only used to decide whether an explicit accidental token is needed.
@@ -22988,7 +24364,7 @@ const exportMusicXmlDomToAbc = (doc) => {
                             pendingGraceTokens.push(`${graceSlashPrefix}${pitchToken}${len}${hasTieStart ? "-" : ""}`);
                         }
                         else {
-                            const last = (_19 = pendingGraceTokens.pop()) !== null && _19 !== void 0 ? _19 : "";
+                            const last = (_22 = pendingGraceTokens.pop()) !== null && _22 !== void 0 ? _22 : "";
                             const merged = last.startsWith("[")
                                 ? last.replace("]", `${graceSlashPrefix}${pitchToken}]`)
                                 : `[${last}${graceSlashPrefix}${pitchToken}]`;
@@ -23011,10 +24387,57 @@ const exportMusicXmlDomToAbc = (doc) => {
                             : "")
                         : "";
                     const trillPrefix = hasTrill ? "!trill!" : "";
-                    const turnPrefix = turnType === "inverted-turn" ? "!invertedturn!" : (turnType === "turn" ? "!turn!" : "");
-                    const staccatoPrefix = hasStaccato ? "!staccato!" : "";
+                    const turnPrefix = turnType === "inverted-turn"
+                        ? (hasDelayedTurn ? "!delayedinvertedturn!" : "!invertedturn!")
+                        : (turnType === "turn" ? (hasDelayedTurn ? "!delayedturn!" : "!turn!") : "");
+                    const mordentPrefix = mordentType === "inverted-mordent" ? "!pralltriller!" : (mordentType === "mordent" ? "!mordent!" : "");
+                    const tremoloPrefix = tremoloType ? `!tremolo-${tremoloType}-${tremoloMarks}!` : "";
+                    const glissandoPrefix = hasGlissandoStart ? "!gliss-start!" : (hasGlissandoStop ? "!gliss-stop!" : "");
+                    const slidePrefix = hasSlideStart ? "!slide-start!" : (hasSlideStop ? "!slide-stop!" : "");
+                    const schleiferPrefix = hasSchleifer ? "!schleifer!" : "";
+                    const shakePrefix = hasShake ? "!shake!" : "";
+                    const arpeggiatePrefix = hasArpeggiate ? "!roll!" : "";
+                    const staccatoPrefix = hasStaccatissimo ? "!wedge!" : (hasStaccato ? "!staccato!" : "");
+                    const accentPrefix = hasAccent ? "!accent!" : "";
+                    const tenutoPrefix = hasTenuto ? "!tenuto!" : "";
+                    const stressPrefix = hasStress ? "!stress!" : "";
+                    const unstressPrefix = hasUnstress ? "!unstress!" : "";
+                    const strongAccentPrefix = hasStrongAccent ? "!marcato!" : "";
+                    const breathMarkPrefix = hasBreathMark ? "!breath!" : "";
+                    const caesuraPrefix = hasCaesura ? "!caesura!" : "";
+                    const upBowPrefix = hasUpBow ? "!upbow!" : "";
+                    const downBowPrefix = hasDownBow ? "!downbow!" : "";
+                    const doubleTonguePrefix = hasDoubleTongue ? "!doubletongue!" : "";
+                    const tripleTonguePrefix = hasTripleTongue ? "!tripletongue!" : "";
+                    const heelPrefix = hasHeel ? "!heel!" : "";
+                    const toePrefix = hasToe ? "!toe!" : "";
+                    const fingeringPrefix = fingeringTexts.map((value) => `!fingering:${value}!`).join("");
+                    const stringPrefix = stringTexts.map((value) => `!string:${value}!`).join("");
+                    const pluckPrefix = pluckTexts.map((value) => `!pluck:${value}!`).join("");
+                    const openStringPrefix = hasOpenString ? "!open!" : "";
+                    const snapPizzicatoPrefix = hasSnapPizzicato ? "!snap!" : "";
+                    const harmonicPrefix = hasHarmonic ? "!harmonic!" : "";
+                    const stoppedPrefix = hasStopped ? "!stopped!" : "";
+                    const thumbPrefix = hasThumbPosition ? "!thumb!" : "";
+                    const fermataPrefix = fermataType === "inverted" ? "!invertedfermata!" : (fermataType === "normal" ? "!fermata!" : "");
                     const slurStartPrefix = hasSlurStart ? "(" : "";
-                    const eventPrefix = `${tupletPrefix}${slurStartPrefix}${gracePrefix}${trillPrefix}${turnPrefix}${staccatoPrefix}`;
+                    const wordsPrefix = !isChord && pendingDirectionWords.length > 0
+                        ? `${pendingDirectionWords.map((word) => `"${word}"`).join("")}`
+                        : "";
+                    const harmonyPrefix = !isChord && pendingHarmonySymbols.length > 0
+                        ? `${pendingHarmonySymbols.map((symbol) => `"${abcQuotedTextEscape(symbol)}"`).join("")}`
+                        : "";
+                    const directionDecorationPrefix = !isChord && pendingDirectionDecorations.length > 0 ? pendingDirectionDecorations.join("") : "";
+                    const eventPrefix = `${harmonyPrefix}${wordsPrefix}${directionDecorationPrefix}${tupletPrefix}${slurStartPrefix}${gracePrefix}${trillPrefix}${turnPrefix}${mordentPrefix}${tremoloPrefix}${glissandoPrefix}${slidePrefix}${schleiferPrefix}${shakePrefix}${arpeggiatePrefix}${staccatoPrefix}${accentPrefix}${tenutoPrefix}${stressPrefix}${unstressPrefix}${strongAccentPrefix}${breathMarkPrefix}${caesuraPrefix}${upBowPrefix}${downBowPrefix}${doubleTonguePrefix}${tripleTonguePrefix}${heelPrefix}${toePrefix}${fingeringPrefix}${stringPrefix}${pluckPrefix}${openStringPrefix}${snapPizzicatoPrefix}${harmonicPrefix}${stoppedPrefix}${thumbPrefix}${fermataPrefix}`;
+                    if (!isChord && pendingHarmonySymbols.length > 0) {
+                        pendingHarmonySymbols.length = 0;
+                    }
+                    if (!isChord && pendingDirectionWords.length > 0) {
+                        pendingDirectionWords.length = 0;
+                    }
+                    if (!isChord && pendingDirectionDecorations.length > 0) {
+                        pendingDirectionDecorations.length = 0;
+                    }
                     if (pendingGraceTokens.length > 0) {
                         pendingGraceTokens.length = 0;
                     }
@@ -23044,6 +24467,25 @@ const exportMusicXmlDomToAbc = (doc) => {
                             activeTuplet = null;
                         }
                     }
+                    if (!isGrace && !isChord && !child.querySelector(":scope > rest")) {
+                        const lyric = child.querySelector(":scope > lyric");
+                        const lyricText = ((_24 = (_23 = lyric === null || lyric === void 0 ? void 0 : lyric.querySelector(":scope > text")) === null || _23 === void 0 ? void 0 : _23.textContent) === null || _24 === void 0 ? void 0 : _24.trim()) || "";
+                        const lyricSyllabic = ((_26 = (_25 = lyric === null || lyric === void 0 ? void 0 : lyric.querySelector(":scope > syllabic")) === null || _25 === void 0 ? void 0 : _25.textContent) === null || _26 === void 0 ? void 0 : _26.trim()) || "single";
+                        const lyricExtend = Boolean(lyric === null || lyric === void 0 ? void 0 : lyric.querySelector(":scope > extend"));
+                        if (lyricText) {
+                            lyricTokens.push(abcLyricTokenFromMusicXml(lyricText, lyricSyllabic));
+                            pendingLyricExtension = lyricExtend;
+                        }
+                        else if (pendingLyricExtension) {
+                            lyricTokens.push("_");
+                        }
+                        else {
+                            lyricTokens.push("*");
+                        }
+                        if (lyricText && !lyricExtend) {
+                            pendingLyricExtension = false;
+                        }
+                    }
                 }
                 if (pendingGraceTokens.length > 0) {
                     tokens.push(`{${pendingGraceTokens.join("")}}`);
@@ -23056,10 +24498,29 @@ const exportMusicXmlDomToAbc = (doc) => {
                     const lenRatio = exports.AbcCommon.divideFractions(wholeFraction, unitLength, { num: 1, den: 1 });
                     tokens.push(`z${exports.AbcCommon.abcLengthTokenFromFraction(lenRatio)}`);
                 }
-                measureTexts.push(tokens.join(" "));
+                const measureTokenText = tokens.join(" ");
+                const keyPrefix = needsInlineKeyChange
+                    ? `[K:${exports.AbcCommon.keyFromFifthsMode(Math.max(-7, Math.min(7, Math.round(currentFifths))), "major")}]`
+                    : "";
+                const leftPrefix = `${hasLeftRepeat ? "|:" : ""}${leftEndingNumber ? `[${leftEndingNumber}` : ""}`;
+                let rightSuffix = "|";
+                if (hasRightRepeat && rightEndingNumber) {
+                    rightSuffix = `:|]`;
+                }
+                else if (hasRightRepeat) {
+                    rightSuffix = ":|";
+                }
+                else if (rightEndingNumber) {
+                    rightSuffix = "]|";
+                }
+                measureTexts.push(`${leftPrefix}${leftPrefix ? " " : ""}${keyPrefix}${keyPrefix ? " " : ""}${measureTokenText} ${rightSuffix}`.trim());
+                lastEmittedKeyFifths = currentFifths;
             }
             bodyLines.push(`V:${normalizedVoiceId}`);
-            bodyLines.push(`${measureTexts.join(" | ")} |`);
+            bodyLines.push(measureTexts.join(" "));
+            if (lyricTokens.some((token) => token !== "*")) {
+                bodyLines.push(`w: ${lyricTokens.join(" ")}`);
+            }
         }
     });
     const metaBlock = metaLines.length > 0 ? `\n${metaLines.join("\n")}\n` : "\n";
@@ -23072,6 +24533,146 @@ const xmlEscape = (text) => text
     .replace(/>/g, "&gt;")
     .replace(/"/g, "&quot;")
     .replace(/'/g, "&apos;");
+const abcQuotedTextEscape = (text) => String(text || "")
+    .replace(/"/g, "'")
+    .replace(/\s+/g, " ")
+    .trim();
+const normalizeChordToken = (raw) => String(raw || "")
+    .trim()
+    .replace(/♯/g, "#")
+    .replace(/♭/g, "b")
+    .replace(/\s+/g, "");
+const isLikelyAbcChordSymbol = (raw) => {
+    const text = normalizeChordToken(raw);
+    return /^[A-G](?:#|b)?(?:[^/\s"]*)?(?:\/[A-G](?:#|b)?)?$/.test(text);
+};
+const xmlHarmonyKindFromChordSuffix = (suffixRaw) => {
+    const suffix = String(suffixRaw || "").trim().toLowerCase();
+    if (!suffix)
+        return "major";
+    if (suffix === "m" || suffix === "min")
+        return "minor";
+    if (suffix === "6")
+        return "major-sixth";
+    if (suffix === "m6" || suffix === "min6")
+        return "minor-sixth";
+    if (suffix === "7")
+        return "dominant";
+    if (suffix === "7sus4")
+        return "suspended-fourth";
+    if (suffix === "9")
+        return "dominant-ninth";
+    if (suffix === "11")
+        return "dominant-11th";
+    if (suffix === "13")
+        return "dominant-13th";
+    if (suffix === "maj7")
+        return "major-seventh";
+    if (suffix === "maj9")
+        return "major-ninth";
+    if (suffix === "m9" || suffix === "min9")
+        return "minor-ninth";
+    if (suffix === "m7" || suffix === "min7")
+        return "minor-seventh";
+    if (suffix === "dim")
+        return "diminished";
+    if (suffix === "dim7")
+        return "diminished-seventh";
+    if (suffix === "aug" || suffix === "+")
+        return "augmented";
+    if (suffix === "sus4")
+        return "suspended-fourth";
+    if (suffix === "sus2")
+        return "suspended-second";
+    if (suffix === "m7b5" || suffix === "min7b5" || suffix === "ø")
+        return "half-diminished";
+    return null;
+};
+const xmlHarmonyRootFromChordToken = (token) => {
+    const m = String(token || "").match(/^([A-G])(#|b)?$/);
+    if (!m)
+        return null;
+    return {
+        step: m[1],
+        alter: m[2] === "#" ? 1 : (m[2] === "b" ? -1 : 0),
+    };
+};
+const buildHarmonyXmlFromChordSymbol = (raw) => {
+    const normalized = normalizeChordToken(raw);
+    const match = normalized.match(/^([A-G](?:#|b)?)([^/]*)?(?:\/([A-G](?:#|b)?))?$/);
+    if (!match)
+        return "";
+    const root = xmlHarmonyRootFromChordToken(match[1] || "");
+    if (!root)
+        return "";
+    const suffix = String(match[2] || "");
+    const bass = match[3] ? xmlHarmonyRootFromChordToken(match[3]) : null;
+    const kind = xmlHarmonyKindFromChordSuffix(suffix);
+    if (!kind)
+        return "";
+    return [
+        "<harmony>",
+        "<root>",
+        `<root-step>${xmlEscape(root.step)}</root-step>`,
+        root.alter !== 0 ? `<root-alter>${root.alter}</root-alter>` : "",
+        "</root>",
+        bass
+            ? `<bass><bass-step>${xmlEscape(bass.step)}</bass-step>${bass.alter !== 0 ? `<bass-alter>${bass.alter}</bass-alter>` : ""}</bass>`
+            : "",
+        `<kind text="${xmlEscape(normalized)}">${kind}</kind>`,
+        "</harmony>",
+    ].join("");
+};
+const abcChordSymbolFromHarmony = (harmony) => {
+    var _a, _b, _c, _d;
+    if (!harmony)
+        return "";
+    const rootStep = (((_a = harmony.querySelector(":scope > root > root-step")) === null || _a === void 0 ? void 0 : _a.textContent) || "").trim().toUpperCase();
+    if (!/^[A-G]$/.test(rootStep))
+        return "";
+    const rootAlter = Number(((_b = harmony.querySelector(":scope > root > root-alter")) === null || _b === void 0 ? void 0 : _b.textContent) || "0");
+    const kindNode = harmony.querySelector(":scope > kind");
+    const kindTextAttr = ((kindNode === null || kindNode === void 0 ? void 0 : kindNode.getAttribute("text")) || "").trim();
+    if (kindTextAttr)
+        return abcQuotedTextEscape(kindTextAttr);
+    const kindValue = ((kindNode === null || kindNode === void 0 ? void 0 : kindNode.textContent) || "").trim().toLowerCase();
+    const rootToken = `${rootStep}${rootAlter === 1 ? "#" : (rootAlter === -1 ? "b" : "")}`;
+    const suffix = kindValue === "major" ? "" :
+        kindValue === "minor" ? "m" :
+            kindValue === "major-sixth" ? "6" :
+                kindValue === "minor-sixth" ? "m6" :
+                    kindValue === "dominant" ? "7" :
+                        kindValue === "dominant-11th" ? "11" :
+                            kindValue === "dominant-13th" ? "13" :
+                                kindValue === "dominant-ninth" ? "9" :
+                                    kindValue === "major-seventh" ? "maj7" :
+                                        kindValue === "major-ninth" ? "maj9" :
+                                            kindValue === "minor-ninth" ? "m9" :
+                                                kindValue === "minor-seventh" ? "m7" :
+                                                    kindValue === "diminished" ? "dim" :
+                                                        kindValue === "diminished-seventh" ? "dim7" :
+                                                            kindValue === "augmented" ? "aug" :
+                                                                kindValue === "suspended-fourth" ? "sus4" :
+                                                                    kindValue === "suspended-second" ? "sus2" :
+                                                                        kindValue === "half-diminished" ? "m7b5" :
+                                                                            "";
+    const bassStep = (((_c = harmony.querySelector(":scope > bass > bass-step")) === null || _c === void 0 ? void 0 : _c.textContent) || "").trim().toUpperCase();
+    const bassAlter = Number(((_d = harmony.querySelector(":scope > bass > bass-alter")) === null || _d === void 0 ? void 0 : _d.textContent) || "0");
+    const bassToken = /^[A-G]$/.test(bassStep)
+        ? `/${bassStep}${bassAlter === 1 ? "#" : (bassAlter === -1 ? "b" : "")}`
+        : "";
+    return `${rootToken}${suffix}${bassToken}`;
+};
+const abcLyricTokenFromMusicXml = (text, syllabic) => {
+    const normalized = String(text || "").trim().replace(/\s+/g, "~");
+    const mode = String(syllabic || "single").trim().toLowerCase();
+    if (!normalized)
+        return "*";
+    if (mode === "begin" || mode === "middle") {
+        return `${normalized}-`;
+    }
+    return normalized;
+};
 const normalizeTypeForMusicXml = (t) => {
     const raw = String(t || "").trim();
     if (!raw)
@@ -23293,9 +24894,11 @@ const buildMusicXmlFromAbcParsed = (parsed, abcSource, options = {}) => {
         .join("");
     const partBodyXml = resolvedParts
         .map((part, partIndex) => {
-        var _a, _b, _c, _d, _e, _f;
+        var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k;
         const measuresXml = [];
         let currentPartFifths = Math.max(-7, Math.min(7, Math.round(defaultFifths)));
+        let currentPartMeter = { beats: Math.round(beats), beatType: Math.round(beatType) };
+        let currentPartTempo = tempoBpm;
         for (let i = 0; i < measureCount; i += 1) {
             const measureNo = i + 1;
             const notes = (_a = part.measures[i]) !== null && _a !== void 0 ? _a : [];
@@ -23303,15 +24906,28 @@ const buildMusicXmlFromAbcParsed = (parsed, abcSource, options = {}) => {
             const hintedFifths = Number.isFinite((_d = part.keyByMeasure) === null || _d === void 0 ? void 0 : _d[measureNo])
                 ? Math.max(-7, Math.min(7, Math.round(Number((_e = part.keyByMeasure) === null || _e === void 0 ? void 0 : _e[measureNo]))))
                 : null;
+            const hintedMeter = (_g = (_f = part.meterByMeasure) === null || _f === void 0 ? void 0 : _f[measureNo]) !== null && _g !== void 0 ? _g : null;
+            const hintedTempo = Number.isFinite((_h = part.tempoByMeasure) === null || _h === void 0 ? void 0 : _h[measureNo])
+                ? Math.max(20, Math.min(300, Math.round(Number((_j = part.tempoByMeasure) === null || _j === void 0 ? void 0 : _j[measureNo]))))
+                : null;
             if (hintedFifths !== null) {
                 currentPartFifths = hintedFifths;
+            }
+            if (hintedMeter) {
+                currentPartMeter = {
+                    beats: Math.max(1, Math.round(Number(hintedMeter.beats) || beats)),
+                    beatType: Math.max(1, Math.round(Number(hintedMeter.beatType) || beatType)),
+                };
+            }
+            if (hintedTempo !== null) {
+                currentPartTempo = hintedTempo;
             }
             const header = i === 0
                 ? [
                     "<attributes>",
                     "<divisions>960</divisions>",
                     `<key><fifths>${Math.round(currentPartFifths)}</fifths></key>`,
-                    `<time><beats>${Math.round(beats)}</beats><beat-type>${Math.round(beatType)}</beat-type></time>`,
+                    `<time><beats>${Math.round(currentPartMeter.beats)}</beats><beat-type>${Math.round(currentPartMeter.beatType)}</beat-type></time>`,
                     part.transpose && (Number.isFinite(part.transpose.chromatic) || Number.isFinite(part.transpose.diatonic))
                         ? [
                             "<transpose>",
@@ -23326,13 +24942,18 @@ const buildMusicXmlFromAbcParsed = (parsed, abcSource, options = {}) => {
                         : "",
                     (0, exports.clefXmlFromAbcClef)(part.clef),
                     "</attributes>",
-                    tempoBpm !== null && partIndex === 0
-                        ? `<direction><direction-type><metronome><beat-unit>quarter</beat-unit><per-minute>${tempoBpm}</per-minute></metronome></direction-type><sound tempo="${tempoBpm}"/></direction>`
+                    currentPartTempo !== null && partIndex === 0
+                        ? `<direction><direction-type><metronome><beat-unit>quarter</beat-unit><per-minute>${currentPartTempo}</per-minute></metronome></direction-type><sound tempo="${currentPartTempo}"/></direction>`
                         : "",
                 ].join("")
-                : hintedFifths !== null
-                    ? `<attributes><key><fifths>${Math.round(currentPartFifths)}</fifths></key></attributes>`
+                : (hintedFifths !== null || hintedMeter)
+                    ? `<attributes>${hintedFifths !== null ? `<key><fifths>${Math.round(currentPartFifths)}</fifths></key>` : ""}${hintedMeter
+                        ? `<time><beats>${Math.round(currentPartMeter.beats)}</beats><beat-type>${Math.round(currentPartMeter.beatType)}</beat-type></time>`
+                        : ""}</attributes>`
                     : "";
+            const tempoDirectionXml = i > 0 && hintedTempo !== null && partIndex === 0
+                ? `<direction><direction-type><metronome><beat-unit>quarter</beat-unit><per-minute>${hintedTempo}</per-minute></metronome></direction-type><sound tempo="${hintedTempo}"/></direction>`
+                : "";
             const notesXml = notes.length > 0
                 ? (() => {
                     const beamXmlByNoteIndex = (() => {
@@ -23365,7 +24986,7 @@ const buildMusicXmlFromAbcParsed = (parsed, abcSource, options = {}) => {
                             if (!primary.length)
                                 continue;
                             const assignments = (0, beam_common_1.computeBeamAssignments)(primary, beatDiv, (ev) => {
-                                var _a, _b, _c, _d, _e;
+                                var _a, _b, _c, _d, _e, _f;
                                 const type = normalizeTypeForMusicXml((_a = ev.note) === null || _a === void 0 ? void 0 : _a.type);
                                 return {
                                     timed: true,
@@ -23373,6 +24994,7 @@ const buildMusicXmlFromAbcParsed = (parsed, abcSource, options = {}) => {
                                     grace: Boolean((_c = ev.note) === null || _c === void 0 ? void 0 : _c.grace),
                                     durationDiv: ((_d = ev.note) === null || _d === void 0 ? void 0 : _d.grace) ? 0 : Math.max(1, Math.round(Number((_e = ev.note) === null || _e === void 0 ? void 0 : _e.duration) || 1)),
                                     levels: levelFromType(type),
+                                    explicitMode: (_f = ev.note) === null || _f === void 0 ? void 0 : _f.beamMode,
                                 };
                             }, { splitAtBeatBoundaryWhenImplicit: true });
                             for (const [eventIndex, assignment] of assignments.entries()) {
@@ -23394,7 +25016,62 @@ const buildMusicXmlFromAbcParsed = (parsed, abcSource, options = {}) => {
                     })();
                     return notes
                         .map((note, noteIndex) => {
-                        const chunks = ["<note>"];
+                        const chunks = [];
+                        if (!note.chord && Array.isArray(note.chordSymbols) && note.chordSymbols.length > 0) {
+                            for (const chordSymbol of note.chordSymbols) {
+                                const harmonyXml = buildHarmonyXmlFromChordSymbol(chordSymbol);
+                                if (harmonyXml) {
+                                    chunks.push(harmonyXml);
+                                }
+                                else {
+                                    chunks.push(`<direction><direction-type><words>${xmlEscape(String(chordSymbol))}</words></direction-type></direction>`);
+                                }
+                            }
+                        }
+                        if (!note.chord && Array.isArray(note.annotations) && note.annotations.length > 0) {
+                            for (const annotation of note.annotations) {
+                                if (!annotation)
+                                    continue;
+                                chunks.push(`<direction><direction-type><words>${xmlEscape(String(annotation))}</words></direction-type></direction>`);
+                            }
+                        }
+                        if (!note.chord && note.segno) {
+                            chunks.push("<direction><direction-type><segno/></direction-type></direction>");
+                        }
+                        if (!note.chord && note.coda) {
+                            chunks.push("<direction><direction-type><coda/></direction-type></direction>");
+                        }
+                        if (!note.chord && note.rehearsalMark) {
+                            chunks.push(`<direction><direction-type><rehearsal>${xmlEscape(String(note.rehearsalMark))}</rehearsal></direction-type></direction>`);
+                        }
+                        if (!note.chord && note.fine) {
+                            chunks.push('<direction><sound fine="yes"/></direction>');
+                        }
+                        if (!note.chord && note.daCapo) {
+                            chunks.push('<direction><sound dacapo="yes"/></direction>');
+                        }
+                        if (!note.chord && note.dalSegno) {
+                            chunks.push('<direction><sound dalsegno="segno"/></direction>');
+                        }
+                        if (!note.chord && note.toCoda) {
+                            chunks.push('<direction><sound tocoda="coda"/></direction>');
+                        }
+                        if (!note.chord && note.crescendoStart) {
+                            chunks.push('<direction><direction-type><wedge type="crescendo"/></direction-type></direction>');
+                        }
+                        if (!note.chord && note.diminuendoStart) {
+                            chunks.push('<direction><direction-type><wedge type="diminuendo"/></direction-type></direction>');
+                        }
+                        if (!note.chord && (note.crescendoStop || note.diminuendoStop)) {
+                            chunks.push('<direction><direction-type><wedge type="stop"/></direction-type></direction>');
+                        }
+                        if (!note.chord && note.dynamicMark) {
+                            chunks.push(`<direction><direction-type><dynamics><${xmlEscape(String(note.dynamicMark))}/></dynamics></direction-type></direction>`);
+                        }
+                        if (!note.chord && note.sfz) {
+                            chunks.push("<direction><direction-type><dynamics><sfz/></dynamics></direction-type></direction>");
+                        }
+                        chunks.push("<note>");
                         if (note.chord)
                             chunks.push("<chord/>");
                         if (note.grace) {
@@ -23423,6 +25100,9 @@ const buildMusicXmlFromAbcParsed = (parsed, abcSource, options = {}) => {
                             chunks.push(`<duration>${duration}</duration>`);
                         }
                         chunks.push(`<voice>${xmlEscape(normalizeVoiceForMusicXml(note.voice))}</voice>`);
+                        if (note.lyricText) {
+                            chunks.push(`<lyric><syllabic>${xmlEscape(String(note.lyricSyllabic || "single"))}</syllabic><text>${xmlEscape(String(note.lyricText))}</text>${note.lyricExtend ? "<extend/>" : ""}</lyric>`);
+                        }
                         chunks.push(`<type>${normalizeTypeForMusicXml(note.type)}</type>`);
                         if (!note.chord && beamXmlByNoteIndex.has(noteIndex)) {
                             chunks.push(String(beamXmlByNoteIndex.get(noteIndex)));
@@ -23447,7 +25127,40 @@ const buildMusicXmlFromAbcParsed = (parsed, abcSource, options = {}) => {
                             note.slurStop ||
                             note.trill ||
                             note.turnType ||
+                            note.delayedTurn ||
+                            note.mordentType ||
+                            note.tremoloType ||
+                            note.glissandoStart ||
+                            note.glissandoStop ||
+                            note.slideStart ||
+                            note.slideStop ||
+                            note.schleifer ||
+                            note.shake ||
+                            note.arpeggiate ||
                             note.staccato ||
+                            note.staccatissimo ||
+                            note.accent ||
+                            note.tenuto ||
+                            note.stress ||
+                            note.unstress ||
+                            note.fermataType ||
+                            note.strongAccent ||
+                            note.breathMark ||
+                            note.caesura ||
+                            note.upBow ||
+                            note.downBow ||
+                            note.doubleTongue ||
+                            note.tripleTongue ||
+                            note.heel ||
+                            note.toe ||
+                            (Array.isArray(note.fingerings) && note.fingerings.length > 0) ||
+                            (Array.isArray(note.strings) && note.strings.length > 0) ||
+                            (Array.isArray(note.plucks) && note.plucks.length > 0) ||
+                            note.openString ||
+                            note.snapPizzicato ||
+                            note.harmonic ||
+                            note.stopped ||
+                            note.thumbPosition ||
                             note.tupletStart ||
                             note.tupletStop) {
                             chunks.push("<notations>");
@@ -23466,6 +25179,7 @@ const buildMusicXmlFromAbcParsed = (parsed, abcSource, options = {}) => {
                             if (note.trill) {
                                 const trillParts = [];
                                 trillParts.push("<trill-mark/>");
+                                trillParts.push('<wavy-line type="start"/>');
                                 if (note.trillAccidentalText) {
                                     trillParts.push(`<accidental-mark>${xmlEscape(String(note.trillAccidentalText))}</accidental-mark>`);
                                 }
@@ -23473,10 +25187,107 @@ const buildMusicXmlFromAbcParsed = (parsed, abcSource, options = {}) => {
                             }
                             if (note.turnType) {
                                 const tag = note.turnType === "inverted-turn" ? "inverted-turn" : "turn";
+                                chunks.push(`<ornaments><${tag}/>${note.delayedTurn ? "<delayed-turn/>" : ""}</ornaments>`);
+                            }
+                            if (note.mordentType) {
+                                const tag = note.mordentType === "inverted-mordent" ? "inverted-mordent" : "mordent";
                                 chunks.push(`<ornaments><${tag}/></ornaments>`);
                             }
+                            if (note.tremoloType) {
+                                const marks = Math.max(1, Math.min(8, Math.round(Number(note.tremoloMarks) || 1)));
+                                chunks.push(`<ornaments><tremolo type="${xmlEscape(String(note.tremoloType))}">${marks}</tremolo></ornaments>`);
+                            }
+                            if (note.glissandoStart) {
+                                chunks.push('<glissando type="start" number="1">wavy</glissando>');
+                            }
+                            if (note.glissandoStop) {
+                                chunks.push('<glissando type="stop" number="1">wavy</glissando>');
+                            }
+                            if (note.slideStart) {
+                                chunks.push('<slide type="start" number="1"/>');
+                            }
+                            if (note.slideStop) {
+                                chunks.push('<slide type="stop" number="1"/>');
+                            }
+                            if (note.schleifer) {
+                                chunks.push("<ornaments><schleifer/></ornaments>");
+                            }
+                            if (note.shake) {
+                                chunks.push("<ornaments><shake/></ornaments>");
+                            }
+                            if (note.arpeggiate) {
+                                chunks.push("<arpeggiate/>");
+                            }
+                            const articulationParts = [];
                             if (note.staccato)
-                                chunks.push("<articulations><staccato/></articulations>");
+                                articulationParts.push("<staccato/>");
+                            if (note.staccatissimo)
+                                articulationParts.push("<staccatissimo/>");
+                            if (note.accent)
+                                articulationParts.push("<accent/>");
+                            if (note.tenuto)
+                                articulationParts.push("<tenuto/>");
+                            if (note.stress)
+                                articulationParts.push("<stress/>");
+                            if (note.unstress)
+                                articulationParts.push("<unstress/>");
+                            if (note.strongAccent)
+                                articulationParts.push("<strong-accent/>");
+                            if (note.breathMark)
+                                articulationParts.push("<breath-mark/>");
+                            if (note.caesura)
+                                articulationParts.push("<caesura/>");
+                            if (articulationParts.length > 0) {
+                                chunks.push(`<articulations>${articulationParts.join("")}</articulations>`);
+                            }
+                            const technicalParts = [];
+                            if (note.upBow)
+                                technicalParts.push("<up-bow/>");
+                            if (note.downBow)
+                                technicalParts.push("<down-bow/>");
+                            if (note.doubleTongue)
+                                technicalParts.push("<double-tongue/>");
+                            if (note.tripleTongue)
+                                technicalParts.push("<triple-tongue/>");
+                            if (note.heel)
+                                technicalParts.push("<heel/>");
+                            if (note.toe)
+                                technicalParts.push("<toe/>");
+                            if (Array.isArray(note.fingerings) && note.fingerings.length > 0) {
+                                for (const fingering of note.fingerings) {
+                                    if (fingering)
+                                        technicalParts.push(`<fingering>${xmlEscape(String(fingering))}</fingering>`);
+                                }
+                            }
+                            if (Array.isArray(note.strings) && note.strings.length > 0) {
+                                for (const stringText of note.strings) {
+                                    if (stringText)
+                                        technicalParts.push(`<string>${xmlEscape(String(stringText))}</string>`);
+                                }
+                            }
+                            if (Array.isArray(note.plucks) && note.plucks.length > 0) {
+                                for (const pluckText of note.plucks) {
+                                    if (pluckText)
+                                        technicalParts.push(`<pluck>${xmlEscape(String(pluckText))}</pluck>`);
+                                }
+                            }
+                            if (note.openString)
+                                technicalParts.push("<open-string/>");
+                            if (note.snapPizzicato)
+                                technicalParts.push("<snap-pizzicato/>");
+                            if (note.harmonic)
+                                technicalParts.push("<harmonic/>");
+                            if (note.stopped)
+                                technicalParts.push("<stopped/>");
+                            if (note.thumbPosition)
+                                technicalParts.push("<thumb-position/>");
+                            if (technicalParts.length > 0) {
+                                chunks.push(`<technical>${technicalParts.join("")}</technical>`);
+                            }
+                            if (note.fermataType) {
+                                const fermataText = note.fermataType === "inverted" ? "inverted" : "normal";
+                                chunks.push(`<fermata>${fermataText}</fermata>`);
+                            }
                             chunks.push("</notations>");
                         }
                         chunks.push("</note>");
@@ -23487,22 +25298,36 @@ const buildMusicXmlFromAbcParsed = (parsed, abcSource, options = {}) => {
                 : `<note><rest/><duration>${measureDurationDiv}</duration><voice>1</voice><type>${emptyMeasureRestType}</type></note>`;
             const xmlMeasureNumber = xmlEscape(String((measureMeta === null || measureMeta === void 0 ? void 0 : measureMeta.number) || measureNo));
             const implicitAttr = (measureMeta === null || measureMeta === void 0 ? void 0 : measureMeta.implicit) ? ' implicit="yes"' : "";
-            const repeatStartXml = (measureMeta === null || measureMeta === void 0 ? void 0 : measureMeta.repeat) === "forward"
-                ? '<barline location="left"><repeat direction="forward" winged="none"/></barline>'
+            const leftBarlineChunks = [];
+            if (measureMeta === null || measureMeta === void 0 ? void 0 : measureMeta.endingStart) {
+                leftBarlineChunks.push(`<ending number="${xmlEscape(String(measureMeta.endingStart))}" type="start"/>`);
+            }
+            if (measureMeta === null || measureMeta === void 0 ? void 0 : measureMeta.repeatStart) {
+                leftBarlineChunks.push('<repeat direction="forward" winged="none"/>');
+            }
+            const repeatStartXml = leftBarlineChunks.length > 0
+                ? `<barline location="left">${leftBarlineChunks.join("")}</barline>`
                 : "";
-            const repeatEndXml = (measureMeta === null || measureMeta === void 0 ? void 0 : measureMeta.repeat) === "backward"
-                ? `<barline location="right"><repeat direction="backward" winged="none"${Number.isFinite(measureMeta.repeatTimes) && Number(measureMeta.repeatTimes) > 1
+            const rightBarlineChunks = [];
+            if (measureMeta === null || measureMeta === void 0 ? void 0 : measureMeta.endingStop) {
+                rightBarlineChunks.push(`<ending number="${xmlEscape(String(measureMeta.endingStop))}" type="${measureMeta.endingStopType || "stop"}"/>`);
+            }
+            if (measureMeta === null || measureMeta === void 0 ? void 0 : measureMeta.repeatEnd) {
+                rightBarlineChunks.push(`<repeat direction="backward" winged="none"${Number.isFinite(measureMeta.repeatTimes) && Number(measureMeta.repeatTimes) > 1
                     ? ` times="${Math.round(Number(measureMeta.repeatTimes))}"`
-                    : ""}/></barline>`
+                    : ""}/>`);
+            }
+            const repeatEndXml = rightBarlineChunks.length > 0
+                ? `<barline location="right">${rightBarlineChunks.join("")}</barline>`
                 : "";
             const debugMiscXml = debugMetadata ? buildAbcMeasureDebugMiscXml(notes, measureNo) : "";
             const diagMiscXml = partIndex === 0 && measureNo === 1
-                ? buildAbcDiagMiscXml(((_f = parsed.diagnostics) !== null && _f !== void 0 ? _f : []).filter((diag) => !diag.voiceId || diag.voiceId === (part.voiceId || "")))
+                ? buildAbcDiagMiscXml(((_k = parsed.diagnostics) !== null && _k !== void 0 ? _k : []).filter((diag) => !diag.voiceId || diag.voiceId === (part.voiceId || "")))
                 : "";
             const sourceMiscXml = sourceMetadata && partIndex === 0 && measureNo === 1
                 ? buildAbcSourceMiscXml(abcSource)
                 : "";
-            measuresXml.push(`<measure number="${xmlMeasureNumber}"${implicitAttr}>${repeatStartXml}${header}${debugMiscXml}${diagMiscXml}${sourceMiscXml}${notesXml}${repeatEndXml}</measure>`);
+            measuresXml.push(`<measure number="${xmlMeasureNumber}"${implicitAttr}>${repeatStartXml}${header}${tempoDirectionXml}${debugMiscXml}${diagMiscXml}${sourceMiscXml}${notesXml}${repeatEndXml}</measure>`);
         }
         return `<part id="${xmlEscape(part.partId)}">${measuresXml.join("")}</part>`;
     })

--- a/src/ts/abc-io.ts
+++ b/src/ts/abc-io.ts
@@ -54,6 +54,9 @@ const parseAbcLengthToken = (token: string, lineNo: number): Fraction => {
   if (!token) {
     return { num: 1, den: 1 };
   }
+  if (/^\/+$/.test(token)) {
+    return { num: 1, den: 2 ** token.length };
+  }
   if (token === "/") {
     return { num: 1, den: 2 };
   }
@@ -177,6 +180,259 @@ if (typeof window !== "undefined") {
 
 const abcCommon = AbcCommon;
 
+  function parseRepeatEndingMarkerAt(text, idx) {
+    const match = String(text || "").slice(idx).match(/^\[(\d+(?:[,-]\d+)*)/);
+    if (!match) {
+      return null;
+    }
+    return {
+      marker: match[1],
+      nextIdx: idx + match[0].length,
+    };
+  }
+
+  function parseBareRepeatEndingMarkerAt(text, idx) {
+    const match = String(text || "").slice(idx).match(/^(\d+(?:[,-]\d+)*)/);
+    if (!match) {
+      return null;
+    }
+    return {
+      marker: match[1],
+      nextIdx: idx + match[0].length,
+    };
+  }
+
+  function parseInlineFieldAt(text, idx) {
+    const match = String(text || "").slice(idx).match(/^\[([A-Za-z]):([^\]]*)\]/);
+    if (!match) {
+      return null;
+    }
+    return {
+      fieldName: String(match[1] || "").toUpperCase(),
+      fieldValue: String(match[2] || "").trim(),
+      nextIdx: idx + match[0].length,
+    };
+  }
+
+  function tokenizeAbcLyricLine(text) {
+    const raw = String(text || "").trim();
+    if (!raw) return [];
+    const chunks = raw
+      .replace(/\|/g, " ")
+      .split(/\s+/)
+      .map((token) => token.trim())
+      .filter(Boolean);
+    const tokens = [];
+    for (const chunk of chunks) {
+      if (chunk === "*") {
+        tokens.push({ type: "skip" });
+        continue;
+      }
+      if (chunk === "_") {
+        tokens.push({ type: "extend" });
+        continue;
+      }
+      const normalized = chunk.replace(/~/g, " ");
+      const parts = normalized.split("-").filter((part) => part.length > 0);
+      if (parts.length <= 1) {
+        tokens.push({ type: "text", text: normalized, syllabic: "single" });
+        continue;
+      }
+      for (let i = 0; i < parts.length; i += 1) {
+        const syllabic =
+          i === 0
+            ? "begin"
+            : (i === parts.length - 1 ? "end" : "middle");
+        tokens.push({ type: "text", text: parts[i], syllabic });
+      }
+    }
+    return tokens;
+  }
+
+  function splitBodyTextByInlineVoice(text, initialVoiceId) {
+    const segments = [];
+    let activeVoiceId = String(initialVoiceId || "1").trim() || "1";
+    let buffer = "";
+    const raw = String(text || "");
+    let idx = 0;
+    while (idx < raw.length) {
+      if (raw[idx] === "[") {
+        const inlineField = parseInlineFieldAt(raw, idx);
+        if (inlineField && inlineField.fieldName === "V") {
+          if (buffer.trim()) {
+            segments.push({ voiceId: activeVoiceId, text: buffer });
+          }
+          buffer = "";
+          const voiceMatch = String(inlineField.fieldValue || "").match(/^(\S+)/);
+          if (voiceMatch) {
+            activeVoiceId = voiceMatch[1];
+          } else {
+            buffer += raw.slice(idx, inlineField.nextIdx);
+          }
+          idx = inlineField.nextIdx;
+          continue;
+        }
+      }
+      buffer += raw[idx];
+      idx += 1;
+    }
+    if (buffer.trim()) {
+      segments.push({ voiceId: activeVoiceId, text: buffer });
+    }
+    return segments;
+  }
+
+  function splitBodyTextByOverlay(text, baseVoiceId) {
+    const raw = String(text || "");
+    const normalizedBaseVoiceId = String(baseVoiceId || "1").trim() || "1";
+    const overlayBuffers = [""];
+    let completedMeasureSkeleton = "";
+    let activeOverlayIndex = 0;
+    let idx = 0;
+
+    const ensureOverlayBuffer = (overlayIndex) => {
+      while (overlayBuffers.length <= overlayIndex) {
+        overlayBuffers.push(completedMeasureSkeleton);
+      }
+    };
+
+    while (idx < raw.length) {
+      const ch = raw[idx];
+
+      if (ch === '"') {
+        let endIdx = idx + 1;
+        while (endIdx < raw.length && raw[endIdx] !== '"') {
+          endIdx += 1;
+        }
+        const token = raw.slice(idx, Math.min(raw.length, endIdx + 1));
+        ensureOverlayBuffer(activeOverlayIndex);
+        overlayBuffers[activeOverlayIndex] += token;
+        idx = Math.min(raw.length, endIdx + 1);
+        continue;
+      }
+
+      if (ch === "!" || ch === "+") {
+        let endIdx = idx + 1;
+        while (endIdx < raw.length && raw[endIdx] !== ch) {
+          endIdx += 1;
+        }
+        const token = raw.slice(idx, Math.min(raw.length, endIdx + 1));
+        ensureOverlayBuffer(activeOverlayIndex);
+        overlayBuffers[activeOverlayIndex] += token;
+        idx = Math.min(raw.length, endIdx + 1);
+        continue;
+      }
+
+      const barlineToken = parseBarlineTokenAt(raw, idx);
+      if (barlineToken) {
+        const tokenText = raw.slice(idx, barlineToken.nextIdx);
+        if (barlineToken.endsMeasure) {
+          for (let overlayIndex = 0; overlayIndex < overlayBuffers.length; overlayIndex += 1) {
+            ensureOverlayBuffer(overlayIndex);
+            overlayBuffers[overlayIndex] += tokenText;
+          }
+          completedMeasureSkeleton += tokenText;
+          activeOverlayIndex = 0;
+        } else {
+          ensureOverlayBuffer(activeOverlayIndex);
+          overlayBuffers[activeOverlayIndex] += tokenText;
+        }
+        idx = barlineToken.nextIdx;
+        continue;
+      }
+
+      if (ch === "&") {
+        activeOverlayIndex += 1;
+        ensureOverlayBuffer(activeOverlayIndex);
+        idx += 1;
+        continue;
+      }
+
+      ensureOverlayBuffer(activeOverlayIndex);
+      overlayBuffers[activeOverlayIndex] += ch;
+      idx += 1;
+    }
+
+    return overlayBuffers
+      .map((segmentText, overlayIndex) => ({
+        voiceId: overlayIndex === 0 ? normalizedBaseVoiceId : `${normalizedBaseVoiceId}_ov${overlayIndex + 1}`,
+        overlayIndex,
+        text: segmentText,
+      }))
+      .filter((segment) => segment.text.trim().length > 0);
+  }
+
+  function parseUserDefinedDecoration(rawValue) {
+    const text = String(rawValue || "").trim();
+    const match = text.match(/^(\S)(?:\s*=\s*|\s+)(.+)$/);
+    if (!match) return null;
+    const symbol = String(match[1] || "");
+    const rhs = String(match[2] || "").trim();
+    if (!symbol || !rhs) return null;
+    const wrapped = rhs.match(/^[!+](.+)[!+]$/);
+    const decoration = String(wrapped ? wrapped[1] : rhs).trim();
+    if (!decoration) return null;
+    return { symbol, decoration };
+  }
+
+  function expandUserDefinedDecorationSymbols(text, userDefinedDecorationBySymbol) {
+    const raw = String(text || "");
+    const symbolMap = userDefinedDecorationBySymbol || {};
+    if (!raw || Object.keys(symbolMap).length === 0) {
+      return raw;
+    }
+    let out = "";
+    let idx = 0;
+    while (idx < raw.length) {
+      const ch = raw[idx];
+      if (ch === '"' || ch === "!" || ch === "+") {
+        let endIdx = idx + 1;
+        while (endIdx < raw.length && raw[endIdx] !== ch) {
+          endIdx += 1;
+        }
+        out += raw.slice(idx, Math.min(raw.length, endIdx + 1));
+        idx = Math.min(raw.length, endIdx + 1);
+        continue;
+      }
+      if (Object.prototype.hasOwnProperty.call(symbolMap, ch)) {
+        out += `!${String(symbolMap[ch])}!`;
+        idx += 1;
+        continue;
+      }
+      out += ch;
+      idx += 1;
+    }
+    return out;
+  }
+
+  function parseBarlineTokenAt(text, idx) {
+    const slice = String(text || "").slice(idx);
+    const candidates = [
+      { token: ":|]", endsMeasure: true, repeatEnd: true, repeatStart: false, endingStop: true },
+      { token: ":|:", endsMeasure: true, repeatEnd: true, repeatStart: true, endingStop: false },
+      { token: "|:", endsMeasure: true, repeatEnd: false, repeatStart: true, endingStop: false },
+      { token: ":|", endsMeasure: true, repeatEnd: true, repeatStart: false, endingStop: false },
+      { token: "::", endsMeasure: true, repeatEnd: true, repeatStart: true, endingStop: false },
+      { token: "[|", endsMeasure: true, repeatEnd: false, repeatStart: false, endingStop: false },
+      { token: "|]", endsMeasure: true, repeatEnd: false, repeatStart: false, endingStop: false },
+      { token: "||", endsMeasure: true, repeatEnd: false, repeatStart: false, endingStop: false },
+      { token: "|", endsMeasure: true, repeatEnd: false, repeatStart: false, endingStop: false },
+      { token: ":", endsMeasure: false, repeatEnd: false, repeatStart: false, endingStop: false },
+    ];
+    for (const candidate of candidates) {
+      if (slice.startsWith(candidate.token)) {
+        return {
+          nextIdx: idx + candidate.token.length,
+          endsMeasure: candidate.endsMeasure,
+          repeatEnd: candidate.repeatEnd,
+          repeatStart: candidate.repeatStart,
+          endingStop: candidate.endingStop,
+        };
+      }
+    }
+    return null;
+  }
+
   function parseTempoFromQ(rawQ, warnings) {
     const raw = String(rawQ || "").trim();
     if (!raw) {
@@ -223,10 +479,12 @@ const abcCommon = AbcCommon;
     const transposeHintByVoiceId = new Map();
     const headers = {};
     const bodyEntries = [];
+    const lyricEntriesByVoice = {};
     const declaredVoiceIds = [];
     const voiceNameById = {};
     const voiceClefById = {};
     const voiceTransposeById = {};
+    const userDefinedDecorationBySymbol = {};
     let currentVoiceId = "1";
     let scoreDirective = "";
 
@@ -284,15 +542,26 @@ const abcCommon = AbcCommon;
           const measureNumberText = String(params.number || "").trim();
           const implicitRaw = String(params.implicit || "").trim().toLowerCase();
           const repeatRaw = String(params.repeat || "").trim().toLowerCase();
+          const leftRepeatRaw = String(params["left-repeat"] || "").trim().toLowerCase();
+          const rightRepeatRaw = String(params["right-repeat"] || "").trim().toLowerCase();
           const repeatTimesRaw = Number.parseInt(String(params.times || ""), 10);
+          const endingStart = String(params["ending-start"] || "").trim();
+          const endingStop = String(params["ending-stop"] || "").trim();
+          const endingStopTypeRaw = String(params["ending-type"] || "").trim().toLowerCase();
           measureMetaByKey.set(`${voiceId}#${measureNo}`, {
             number: measureNumberText || String(measureNo),
             implicit: implicitRaw === "1" || implicitRaw === "true" || implicitRaw === "yes",
-            repeat:
-              repeatRaw === "forward" || repeatRaw === "backward"
-                ? repeatRaw
-                : "",
-            repeatTimes: Number.isFinite(repeatTimesRaw) && repeatTimesRaw > 1 ? repeatTimesRaw : null
+            repeatStart:
+              leftRepeatRaw === "1" || leftRepeatRaw === "true" || leftRepeatRaw === "yes" || repeatRaw === "forward",
+            repeatEnd:
+              rightRepeatRaw === "1" || rightRepeatRaw === "true" || rightRepeatRaw === "yes" || repeatRaw === "backward",
+            repeatTimes: Number.isFinite(repeatTimesRaw) && repeatTimesRaw > 1 ? repeatTimesRaw : null,
+            endingStart,
+            endingStop,
+            endingStopType:
+              endingStopTypeRaw === "discontinue" || endingStopTypeRaw === "stop"
+                ? endingStopTypeRaw
+                : (endingStop ? "stop" : "")
           });
         }
         continue;
@@ -335,6 +604,13 @@ const abcCommon = AbcCommon;
       if (headerMatch && /^[A-Za-z]$/.test(headerMatch[1])) {
         const key = headerMatch[1];
         const value = headerMatch[2].trim();
+        if (key === "w") {
+          if (!Object.prototype.hasOwnProperty.call(lyricEntriesByVoice, currentVoiceId)) {
+            lyricEntriesByVoice[currentVoiceId] = [];
+          }
+          lyricEntriesByVoice[currentVoiceId].push({ text: value, lineNo });
+          continue;
+        }
         if (key === "V") {
           const m = value.match(/^(\S+)\s*(.*)$/);
           if (!m) {
@@ -356,7 +632,36 @@ const abcCommon = AbcCommon;
             voiceTransposeById[currentVoiceId] = parsedVoice.transpose;
           }
           if (parsedVoice.bodyText) {
-            bodyEntries.push({ text: parsedVoice.bodyText, lineNo, voiceId: currentVoiceId });
+            const expandedBodyText = expandUserDefinedDecorationSymbols(parsedVoice.bodyText, userDefinedDecorationBySymbol);
+            const inlineVoiceSegments = splitBodyTextByInlineVoice(expandedBodyText, currentVoiceId);
+            for (const segment of inlineVoiceSegments) {
+              const overlaySegments = splitBodyTextByOverlay(segment.text, segment.voiceId);
+              for (const overlaySegment of overlaySegments) {
+                if (!declaredVoiceIds.includes(overlaySegment.voiceId)) {
+                  declaredVoiceIds.push(overlaySegment.voiceId);
+                }
+                if (overlaySegment.overlayIndex > 0) {
+                  const overlayLabel = `overlay ${overlaySegment.overlayIndex + 1}`;
+                  voiceNameById[overlaySegment.voiceId] = voiceNameById[segment.voiceId]
+                    ? `${voiceNameById[segment.voiceId]} ${overlayLabel}`
+                    : `Voice ${segment.voiceId} ${overlayLabel}`;
+                  if (voiceClefById[segment.voiceId] && !voiceClefById[overlaySegment.voiceId]) {
+                    voiceClefById[overlaySegment.voiceId] = voiceClefById[segment.voiceId];
+                  }
+                  if (voiceTransposeById[segment.voiceId] && !voiceTransposeById[overlaySegment.voiceId]) {
+                    voiceTransposeById[overlaySegment.voiceId] = { ...voiceTransposeById[segment.voiceId] };
+                  }
+                }
+                bodyEntries.push({ text: overlaySegment.text, lineNo, voiceId: overlaySegment.voiceId });
+              }
+            }
+          }
+          continue;
+        }
+        if (key === "U") {
+          const parsedUserDefinedDecoration = parseUserDefinedDecoration(value);
+          if (parsedUserDefinedDecoration) {
+            userDefinedDecorationBySymbol[parsedUserDefinedDecoration.symbol] = parsedUserDefinedDecoration.decoration;
           }
           continue;
         }
@@ -364,10 +669,29 @@ const abcCommon = AbcCommon;
         continue;
       }
 
-      if (!declaredVoiceIds.includes(currentVoiceId)) {
-        declaredVoiceIds.push(currentVoiceId);
+      const expandedBodyText = expandUserDefinedDecorationSymbols(noComment, userDefinedDecorationBySymbol);
+      const inlineVoiceSegments = splitBodyTextByInlineVoice(expandedBodyText, currentVoiceId);
+      for (const segment of inlineVoiceSegments) {
+        const overlaySegments = splitBodyTextByOverlay(segment.text, segment.voiceId);
+        for (const overlaySegment of overlaySegments) {
+          if (!declaredVoiceIds.includes(overlaySegment.voiceId)) {
+            declaredVoiceIds.push(overlaySegment.voiceId);
+          }
+          if (overlaySegment.overlayIndex > 0) {
+            const overlayLabel = `overlay ${overlaySegment.overlayIndex + 1}`;
+            voiceNameById[overlaySegment.voiceId] = voiceNameById[segment.voiceId]
+              ? `${voiceNameById[segment.voiceId]} ${overlayLabel}`
+              : `Voice ${segment.voiceId} ${overlayLabel}`;
+            if (voiceClefById[segment.voiceId] && !voiceClefById[overlaySegment.voiceId]) {
+              voiceClefById[overlaySegment.voiceId] = voiceClefById[segment.voiceId];
+            }
+            if (voiceTransposeById[segment.voiceId] && !voiceTransposeById[overlaySegment.voiceId]) {
+              voiceTransposeById[overlaySegment.voiceId] = { ...voiceTransposeById[segment.voiceId] };
+            }
+          }
+          bodyEntries.push({ text: overlaySegment.text, lineNo, voiceId: overlaySegment.voiceId });
+        }
       }
-      bodyEntries.push({ text: noComment, lineNo, voiceId: currentVoiceId });
     }
 
     if (bodyEntries.length === 0) {
@@ -380,6 +704,11 @@ const abcCommon = AbcCommon;
     const tempoBpm = parseTempoFromQ(headers.Q || "", warnings);
     const keySignatureAccidentals = keySignatureAlterByStep(keyInfo.fifths);
     const measuresByVoice = {};
+    const notationMeasureMetaByVoice = {};
+    const activeEndingByVoice = {};
+    const currentKeyFifthsByVoice = {};
+    const meterByMeasureByVoice = {};
+    const tempoByMeasureByVoice = {};
     let noteCount = 0;
 
     function ensureVoice(voiceId) {
@@ -389,16 +718,104 @@ const abcCommon = AbcCommon;
       return measuresByVoice[voiceId];
     }
 
+    function ensureNotationMeasureMeta(voiceId, measureNo) {
+      if (!Object.prototype.hasOwnProperty.call(notationMeasureMetaByVoice, voiceId)) {
+        notationMeasureMetaByVoice[voiceId] = {};
+      }
+      if (!Object.prototype.hasOwnProperty.call(notationMeasureMetaByVoice[voiceId], measureNo)) {
+        notationMeasureMetaByVoice[voiceId][measureNo] = {
+          number: String(measureNo),
+          implicit: false,
+          repeatStart: false,
+          repeatEnd: false,
+          repeatTimes: null,
+          endingStart: "",
+          endingStop: "",
+          endingStopType: "",
+        };
+      }
+      return notationMeasureMetaByVoice[voiceId][measureNo];
+    }
+
+    function ensureMeterByMeasure(voiceId) {
+      if (!Object.prototype.hasOwnProperty.call(meterByMeasureByVoice, voiceId)) {
+        meterByMeasureByVoice[voiceId] = {};
+      }
+      return meterByMeasureByVoice[voiceId];
+    }
+
+    function ensureTempoByMeasure(voiceId) {
+      if (!Object.prototype.hasOwnProperty.call(tempoByMeasureByVoice, voiceId)) {
+        tempoByMeasureByVoice[voiceId] = {};
+      }
+      return tempoByMeasureByVoice[voiceId];
+    }
+
     for (const entry of bodyEntries) {
       const measures = ensureVoice(entry.voiceId);
       let currentMeasure = measures[measures.length - 1];
       let measureAccidentals = {};
+      let activeUnitLength = unitLength;
+      let activeMeter = meter;
+      let activeTempoBpm = Number.isFinite(tempoBpm) ? Number(tempoBpm) : null;
+      let activeKeyFifths = Number.isFinite(currentKeyFifthsByVoice[entry.voiceId])
+        ? Number(currentKeyFifthsByVoice[entry.voiceId])
+        : keyInfo.fifths;
+      let activeKeySignatureAccidentals = keySignatureAlterByStep(activeKeyFifths);
       let lastNote = null;
       let lastEventNotes = [];
       let pendingTieToNext = false;
       let pendingTrill = false;
       let pendingTurn: "" | "turn" | "inverted-turn" = "";
+      let pendingDelayedTurn = false;
+      let pendingMordent: "" | "mordent" | "inverted-mordent" = "";
+      let pendingTremolo: { type: "single" | "start" | "stop"; marks: number } | null = null;
+      let pendingGlissandoStart = false;
+      let pendingGlissandoStop = false;
+      let pendingSlideStart = false;
+      let pendingSlideStop = false;
+      let pendingSchleifer = false;
+      let pendingShake = false;
+      let pendingArpeggiate = false;
       let pendingStaccato = false;
+      let pendingStaccatissimo = false;
+      let pendingAccent = false;
+      let pendingTenuto = false;
+      let pendingStress = false;
+      let pendingUnstress = false;
+      let pendingFermata: "" | "normal" | "inverted" = "";
+      let pendingStrongAccent = false;
+      let pendingBreathMark = false;
+      let pendingCaesura = false;
+      let pendingSegno = false;
+      let pendingCoda = false;
+      let pendingFine = false;
+      let pendingDaCapo = false;
+      let pendingDalSegno = false;
+      let pendingToCoda = false;
+      let pendingCrescendoStart = false;
+      let pendingCrescendoStop = false;
+      let pendingDiminuendoStart = false;
+      let pendingDiminuendoStop = false;
+      let pendingDynamicMark: "" | "ppp" | "pp" | "p" | "mp" | "mf" | "f" | "ff" | "fff" | "fp" | "fz" | "rfz" | "sf" | "sfp" = "";
+      let pendingSfz = false;
+      let pendingRehearsalMark = "";
+      let pendingUpBow = false;
+      let pendingDownBow = false;
+      let pendingOpenString = false;
+      let pendingSnapPizzicato = false;
+      let pendingHarmonic = false;
+      let pendingStopped = false;
+      let pendingThumbPosition = false;
+      let pendingDoubleTongue = false;
+      let pendingTripleTongue = false;
+      let pendingHeel = false;
+      let pendingToe = false;
+      let pendingFingerings: string[] = [];
+      let pendingStrings: string[] = [];
+      let pendingPlucks: string[] = [];
+      let pendingChordSymbols: string[] = [];
+      let pendingAnnotations: string[] = [];
       let pendingSlurStart = 0;
       let pendingRhythmScale = null;
       let tupletRemaining = 0;
@@ -406,13 +823,42 @@ const abcCommon = AbcCommon;
       let tupletSpec = null;
       let currentMeasureNo = Math.max(1, measures.length);
       let currentEventNo = 0;
+      let beamRunActive = false;
+      let sawInterEventWhitespace = false;
+      let beamCursorDiv = 0;
+      let activeEndingMarker = String(activeEndingByVoice[entry.voiceId] || "");
       let idx = 0;
       const text = entry.text;
+
+      const isBeamableAbcNote = (note) =>
+        Boolean(
+          note &&
+          !note.isRest &&
+          !note.grace &&
+          ["eighth", "16th", "32nd", "64th"].includes(String(note.type || "").trim().toLowerCase())
+        );
+      const applyBeamModeForEvent = (note, durationDiv) => {
+        const resolvedDurationDiv = Math.max(0, Math.round(Number(durationDiv) || 0));
+        const beatDiv = Math.max(1, Math.round((960 * 4) / Math.max(1, Math.round(Number(activeMeter?.beatType) || 4))));
+        const startsAtBeatBoundary = beamCursorDiv > 0 && beamCursorDiv % beatDiv === 0;
+        if (startsAtBeatBoundary) {
+          beamRunActive = false;
+        }
+        if (isBeamableAbcNote(note)) {
+          note.beamMode = !beamRunActive || sawInterEventWhitespace ? "begin" : "mid";
+          beamRunActive = true;
+        } else {
+          beamRunActive = false;
+        }
+        sawInterEventWhitespace = false;
+        beamCursorDiv += resolvedDurationDiv;
+      };
 
       while (idx < text.length) {
         const ch = text[idx];
 
         if (ch === " " || ch === "\t") {
+          sawInterEventWhitespace = true;
           idx += 1;
           continue;
         }
@@ -425,17 +871,46 @@ const abcCommon = AbcCommon;
         }
 
         if (ch === "|" || ch === ":") {
-          if (ch === "|" && (currentMeasure.length > 0 || measures.length === 0)) {
+          const barlineToken = parseBarlineTokenAt(text, idx);
+          if (!barlineToken) {
+            idx += 1;
+            continue;
+          }
+          const bareRepeatEndingMarker =
+            barlineToken.endsMeasure ? parseBareRepeatEndingMarkerAt(text, barlineToken.nextIdx) : null;
+          if (barlineToken.repeatEnd) {
+            ensureNotationMeasureMeta(entry.voiceId, currentMeasureNo).repeatEnd = true;
+          }
+          if ((barlineToken.endingStop || bareRepeatEndingMarker) && activeEndingMarker) {
+            const measureMeta = ensureNotationMeasureMeta(entry.voiceId, currentMeasureNo);
+            measureMeta.endingStop = activeEndingMarker;
+            measureMeta.endingStopType = "stop";
+            activeEndingMarker = "";
+          }
+          if (barlineToken.endsMeasure && (currentMeasure.length > 0 || measures.length === 0)) {
             currentMeasure = [];
             measures.push(currentMeasure);
             currentMeasureNo = Math.max(1, measures.length);
             currentEventNo = 0;
+            beamCursorDiv = 0;
           }
-          if (ch === "|") {
+          if (barlineToken.endsMeasure) {
             measureAccidentals = {};
             lastNote = null;
           }
-          idx += 1;
+          if (barlineToken.repeatStart) {
+            ensureNotationMeasureMeta(entry.voiceId, currentMeasureNo).repeatStart = true;
+          }
+          if (bareRepeatEndingMarker) {
+            const measureMeta = ensureNotationMeasureMeta(entry.voiceId, currentMeasureNo);
+            measureMeta.endingStart = bareRepeatEndingMarker.marker;
+            activeEndingMarker = bareRepeatEndingMarker.marker;
+            idx = bareRepeatEndingMarker.nextIdx;
+          } else {
+            idx = barlineToken.nextIdx;
+          }
+          beamRunActive = false;
+          sawInterEventWhitespace = false;
           continue;
         }
 
@@ -475,9 +950,73 @@ const abcCommon = AbcCommon;
           continue;
         }
 
+        if (ch === "~") {
+          pendingArpeggiate = true;
+          idx += 1;
+          continue;
+        }
+
+        if (ch === "H") {
+          pendingFermata = "normal";
+          idx += 1;
+          continue;
+        }
+
+        if (ch === "L") {
+          pendingAccent = true;
+          idx += 1;
+          continue;
+        }
+
+        if (ch === "M") {
+          pendingMordent = "mordent";
+          idx += 1;
+          continue;
+        }
+
+        if (ch === "O") {
+          pendingCoda = true;
+          idx += 1;
+          continue;
+        }
+
+        if (ch === "P") {
+          pendingMordent = "inverted-mordent";
+          idx += 1;
+          continue;
+        }
+
+        if (ch === "S") {
+          pendingSegno = true;
+          idx += 1;
+          continue;
+        }
+
+        if (ch === "T") {
+          pendingTrill = true;
+          idx += 1;
+          continue;
+        }
+
+        if (ch === "u") {
+          pendingUpBow = true;
+          idx += 1;
+          continue;
+        }
+
+        if (ch === "v") {
+          pendingDownBow = true;
+          idx += 1;
+          continue;
+        }
+
         if (ch === "-") {
-          if (lastNote && !lastNote.isRest) {
-            lastNote.tieStart = true;
+          if (lastEventNotes && lastEventNotes.length > 0 && lastEventNotes.some((n) => !n.isRest)) {
+            for (const eventNote of lastEventNotes) {
+              if (!eventNote.isRest) {
+                eventNote.tieStart = true;
+              }
+            }
             pendingTieToNext = true;
           } else {
             warnings.push("line " + entry.lineNo + ": tie(-)  has no preceding note; skipped.");
@@ -489,11 +1028,20 @@ const abcCommon = AbcCommon;
         if (ch === "\"") {
           const endQuote = text.indexOf("\"", idx + 1);
           if (endQuote >= 0) {
+            const rawAnnotation = text.slice(idx + 1, endQuote);
+            const normalizedAnnotation = rawAnnotation.replace(/^[\^_<>@]/, "").trim();
+            if (normalizedAnnotation) {
+              if (isLikelyAbcChordSymbol(normalizedAnnotation)) {
+                pendingChordSymbols.push(normalizedAnnotation);
+              } else {
+                pendingAnnotations.push(normalizedAnnotation);
+              }
+            }
             idx = endQuote + 1;
           } else {
             idx = text.length;
+            warnings.push("line " + entry.lineNo + ': Unterminated inline string ("...").');
           }
-          warnings.push("line " + entry.lineNo + ': Skipped inline string ("...").');
           continue;
         }
 
@@ -504,20 +1052,207 @@ const abcCommon = AbcCommon;
             warnings.push("line " + entry.lineNo + ": Unterminated decoration marker: " + ch);
             continue;
           }
-          const decoration = text.slice(idx + 1, endMark).trim().toLowerCase();
+          const rawDecoration = text.slice(idx + 1, endMark).trim();
+          const decoration = rawDecoration.toLowerCase();
           if (decoration === "trill" || decoration === "tr" || decoration === "triller") {
             pendingTrill = true;
+          } else if (decoration.startsWith("rehearsal:")) {
+            const rehearsalText = rawDecoration.slice("rehearsal:".length).trim();
+            if (rehearsalText) {
+              pendingRehearsalMark = rehearsalText;
+            }
+          } else if (decoration === "delayedturn" || decoration === "delayed-turn") {
+            pendingTurn = pendingTurn || "turn";
+            pendingDelayedTurn = true;
+          } else if (decoration === "delayedinvertedturn" || decoration === "delayed-inverted-turn") {
+            pendingTurn = "inverted-turn";
+            pendingDelayedTurn = true;
           } else if (decoration === "turn") {
             pendingTurn = "turn";
           } else if (decoration === "invertedturn" || decoration === "inverted-turn" || decoration === "lowerturn") {
             pendingTurn = "inverted-turn";
+          } else if (decoration === "mordent" || decoration === "lowermordent") {
+            pendingMordent = "mordent";
+          } else if (
+            decoration === "pralltriller" ||
+            decoration === "pralltrill" ||
+            decoration === "prall" ||
+            decoration === "uppermordent" ||
+            decoration === "invertedmordent" ||
+            decoration === "inverted-mordent"
+          ) {
+            pendingMordent = "inverted-mordent";
+          } else if (/^tremolo-(single|start|stop)-([1-9]\d*)$/.test(decoration)) {
+            const m = decoration.match(/^tremolo-(single|start|stop)-([1-9]\d*)$/);
+            if (m) {
+              pendingTremolo = {
+                type: m[1] as "single" | "start" | "stop",
+                marks: Math.max(1, Math.min(8, Number.parseInt(m[2], 10) || 1))
+              };
+            }
+          } else if (decoration === "gliss-start" || decoration === "glissando-start") {
+            pendingGlissandoStart = true;
+          } else if (decoration === "gliss-stop" || decoration === "glissando-stop") {
+            pendingGlissandoStop = true;
+          } else if (decoration === "slide-start") {
+            pendingSlideStart = true;
+          } else if (decoration === "slide-stop") {
+            pendingSlideStop = true;
+          } else if (decoration === "schleifer") {
+            pendingSchleifer = true;
+          } else if (decoration === "shake") {
+            pendingShake = true;
+          } else if (decoration === "roll" || decoration === "arpeggio" || decoration === "arpeggiate") {
+            pendingArpeggiate = true;
           } else if (
             decoration === "staccato" ||
             decoration === "stacc" ||
-            decoration === "stac" ||
-            decoration === "staccatissimo"
+            decoration === "stac"
           ) {
             pendingStaccato = true;
+          } else if (decoration === "staccatissimo" || decoration === "wedge" || decoration === "spiccato") {
+            pendingStaccatissimo = true;
+          } else if (decoration === "accent") {
+            pendingAccent = true;
+          } else if (decoration === "tenuto") {
+            pendingTenuto = true;
+          } else if (decoration === "stress") {
+            pendingStress = true;
+          } else if (decoration === "unstress") {
+            pendingUnstress = true;
+          } else if (decoration === "fermata") {
+            pendingFermata = "normal";
+          } else if (
+            decoration === "invertedfermata" ||
+            decoration === "inverted-fermata" ||
+            decoration === "inverted fermata"
+          ) {
+            pendingFermata = "inverted";
+          } else if (
+            decoration === "marcato" ||
+            decoration === "strongaccent" ||
+            decoration === "strong-accent" ||
+            decoration === "strong accent"
+          ) {
+            pendingStrongAccent = true;
+          } else if (
+            decoration === "breath" ||
+            decoration === "breath-mark" ||
+            decoration === "breathmark" ||
+            decoration === "breath mark"
+          ) {
+            pendingBreathMark = true;
+          } else if (decoration === "caesura") {
+            pendingCaesura = true;
+          } else if (decoration === "segno") {
+            pendingSegno = true;
+          } else if (decoration === "coda") {
+            pendingCoda = true;
+          } else if (decoration === "fine") {
+            pendingFine = true;
+          } else if (decoration === "dacapo" || decoration === "da-capo" || decoration === "da capo") {
+            pendingDaCapo = true;
+          } else if (decoration === "dalsegno" || decoration === "dal-segno" || decoration === "dal segno") {
+            pendingDalSegno = true;
+          } else if (decoration === "tocoda" || decoration === "to-coda" || decoration === "to coda") {
+            pendingToCoda = true;
+          } else if (decoration === "crescendo(" || decoration === "cresc(") {
+            pendingCrescendoStart = true;
+          } else if (decoration === "crescendo)" || decoration === "cresc)") {
+            pendingCrescendoStop = true;
+          } else if (
+            decoration === "diminuendo(" ||
+            decoration === "decrescendo(" ||
+            decoration === "dim(" ||
+            decoration === "decresc("
+          ) {
+            pendingDiminuendoStart = true;
+          } else if (
+            decoration === "diminuendo)" ||
+            decoration === "decrescendo)" ||
+            decoration === "dim)" ||
+            decoration === "decresc)"
+          ) {
+            pendingDiminuendoStop = true;
+          } else if (
+            decoration === "ppp" ||
+            decoration === "p" ||
+            decoration === "pp" ||
+            decoration === "mp" ||
+            decoration === "mf" ||
+            decoration === "f" ||
+            decoration === "ff" ||
+            decoration === "fff" ||
+            decoration === "fp" ||
+            decoration === "fz" ||
+            decoration === "rfz" ||
+            decoration === "sf" ||
+            decoration === "sfp"
+          ) {
+            pendingDynamicMark = decoration;
+          } else if (decoration === "sfz") {
+            pendingSfz = true;
+          } else if (decoration === "upbow" || decoration === "up-bow" || decoration === "up bow") {
+            pendingUpBow = true;
+          } else if (decoration === "downbow" || decoration === "down-bow" || decoration === "down bow") {
+            pendingDownBow = true;
+          } else if (
+            decoration === "doubletongue" ||
+            decoration === "double-tongue" ||
+            decoration === "double tongue"
+          ) {
+            pendingDoubleTongue = true;
+          } else if (
+            decoration === "tripletongue" ||
+            decoration === "triple-tongue" ||
+            decoration === "triple tongue"
+          ) {
+            pendingTripleTongue = true;
+          } else if (decoration === "heel" || decoration === "heel mark") {
+            pendingHeel = true;
+          } else if (decoration === "toe" || decoration === "toe mark") {
+            pendingToe = true;
+          } else if (decoration.startsWith("fingering:")) {
+            const fingeringText = rawDecoration.slice("fingering:".length).trim();
+            if (fingeringText) pendingFingerings.push(fingeringText);
+          } else if (decoration.startsWith("string:")) {
+            const stringText = rawDecoration.slice("string:".length).trim();
+            if (stringText) pendingStrings.push(stringText);
+          } else if (decoration.startsWith("pluck:")) {
+            const pluckText = rawDecoration.slice("pluck:".length).trim();
+            if (pluckText) pendingPlucks.push(pluckText);
+          } else if (
+            decoration === "open" ||
+            decoration === "open-string" ||
+            decoration === "openstring" ||
+            decoration === "open string"
+          ) {
+            pendingOpenString = true;
+          } else if (
+            decoration === "snap" ||
+            decoration === "snap-pizzicato" ||
+            decoration === "snappizzicato" ||
+            decoration === "snap pizzicato"
+          ) {
+            pendingSnapPizzicato = true;
+          } else if (decoration === "harmonic") {
+            pendingHarmonic = true;
+          } else if (
+            decoration === "stopped" ||
+            decoration === "plus" ||
+            decoration === "stopped horn" ||
+            decoration === "stopped-horn"
+          ) {
+            pendingStopped = true;
+          } else if (
+            decoration === "thumb" ||
+            decoration === "thumbposition" ||
+            decoration === "thumb-position" ||
+            decoration === "thumbpos" ||
+            decoration === "thumb pos" ||
+            decoration === "thumb position"
+          ) {
+            pendingThumbPosition = true;
           } else if (decoration) {
             warnings.push("line " + entry.lineNo + ": Skipped decoration: " + ch + decoration + ch);
           }
@@ -530,8 +1265,8 @@ const abcCommon = AbcCommon;
             text,
             idx,
             entry.lineNo,
-            unitLength,
-            keySignatureAccidentals,
+            activeUnitLength,
+            activeKeySignatureAccidentals,
             measureAccidentals,
             entry.voiceId
           );
@@ -555,6 +1290,54 @@ const abcCommon = AbcCommon;
         }
 
         if (ch === "[") {
+          const inlineField = parseInlineFieldAt(text, idx);
+          if (inlineField) {
+            if (inlineField.fieldName === "K") {
+              const inlineKeyInfo = parseKey(inlineField.fieldValue || "C", warnings);
+              activeKeyFifths = inlineKeyInfo.fifths;
+              activeKeySignatureAccidentals = keySignatureAlterByStep(activeKeyFifths);
+              currentKeyFifthsByVoice[entry.voiceId] = activeKeyFifths;
+              keyHintFifthsByKey.set(`${entry.voiceId}#${currentMeasureNo}`, activeKeyFifths);
+              measureAccidentals = {};
+            } else if (inlineField.fieldName === "L") {
+              activeUnitLength = parseFraction(inlineField.fieldValue || "1/8", "L", warnings);
+            } else if (inlineField.fieldName === "M") {
+              activeMeter = parseMeter(inlineField.fieldValue || "4/4", warnings);
+              ensureMeterByMeasure(entry.voiceId)[currentMeasureNo] = {
+                beats: activeMeter.beats,
+                beatType: activeMeter.beatType,
+              };
+            } else if (inlineField.fieldName === "Q") {
+              activeTempoBpm = parseTempoFromQ(inlineField.fieldValue || "", warnings);
+              if (Number.isFinite(activeTempoBpm)) {
+                ensureTempoByMeasure(entry.voiceId)[currentMeasureNo] = Math.max(20, Math.min(300, Math.round(Number(activeTempoBpm))));
+              }
+            } else {
+              warnings.push(
+                "line " + entry.lineNo + ": Skipped unsupported inline field: [" + inlineField.fieldName + ":" + inlineField.fieldValue + "]"
+              );
+            }
+            idx = inlineField.nextIdx;
+            continue;
+          }
+          const repeatEndingMarker = parseRepeatEndingMarkerAt(text, idx);
+          if (repeatEndingMarker) {
+            if (activeEndingMarker) {
+              const stopMeasureNo = currentMeasure.length === 0 ? currentMeasureNo - 1 : currentMeasureNo;
+              if (stopMeasureNo >= 1) {
+                const prevMeta = ensureNotationMeasureMeta(entry.voiceId, stopMeasureNo);
+                prevMeta.endingStop = activeEndingMarker;
+                prevMeta.endingStopType = "stop";
+              }
+            }
+            const measureMeta = ensureNotationMeasureMeta(entry.voiceId, currentMeasureNo);
+            measureMeta.endingStart = repeatEndingMarker.marker;
+            activeEndingMarker = repeatEndingMarker.marker;
+            idx = repeatEndingMarker.nextIdx;
+            beamRunActive = false;
+            sawInterEventWhitespace = false;
+            continue;
+          }
           const chordResult = parseChordAt(text, idx, entry.lineNo);
           if (!chordResult) {
             warnings.push("line " + entry.lineNo + ": Failed to parse chord notation; skipped.");
@@ -566,7 +1349,7 @@ const abcCommon = AbcCommon;
           if (!chordResult.lengthToken && chordResult.notes.length > 0 && chordResult.notes[0].lengthToken) {
             chordLength = parseLengthToken(chordResult.notes[0].lengthToken, entry.lineNo);
           }
-          let absoluteLength = multiplyFractions(unitLength, chordLength);
+          let absoluteLength = multiplyFractions(activeUnitLength, chordLength);
           if (pendingRhythmScale) {
             absoluteLength = multiplyFractions(absoluteLength, pendingRhythmScale);
             pendingRhythmScale = null;
@@ -613,17 +1396,59 @@ const abcCommon = AbcCommon;
               absoluteLength,
               dur,
               entry.lineNo,
-              keySignatureAccidentals,
+              activeKeySignatureAccidentals,
               measureAccidentals
             );
             note.voice = entry.voiceId;
+            if (chordIndex === 0) {
+              applyBeamModeForEvent(note, dur);
+            }
             if (chordIndex === 0 && pendingTrill && !note.isRest) {
               note.trill = true;
               pendingTrill = false;
             }
             if (chordIndex === 0 && pendingTurn && !note.isRest) {
               note.turnType = pendingTurn;
+              note.delayedTurn = pendingDelayedTurn;
               pendingTurn = "";
+              pendingDelayedTurn = false;
+            }
+            if (chordIndex === 0 && pendingMordent && !note.isRest) {
+              note.mordentType = pendingMordent;
+              pendingMordent = "";
+            }
+            if (chordIndex === 0 && pendingTremolo && !note.isRest) {
+              note.tremoloType = pendingTremolo.type;
+              note.tremoloMarks = pendingTremolo.marks;
+              pendingTremolo = null;
+            }
+            if (chordIndex === 0 && pendingGlissandoStart && !note.isRest) {
+              note.glissandoStart = true;
+              pendingGlissandoStart = false;
+            }
+            if (chordIndex === 0 && pendingGlissandoStop && !note.isRest) {
+              note.glissandoStop = true;
+              pendingGlissandoStop = false;
+            }
+            if (chordIndex === 0 && pendingSlideStart && !note.isRest) {
+              note.slideStart = true;
+              pendingSlideStart = false;
+            }
+            if (chordIndex === 0 && pendingSlideStop && !note.isRest) {
+              note.slideStop = true;
+              pendingSlideStop = false;
+            }
+            if (chordIndex === 0 && pendingSchleifer && !note.isRest) {
+              note.schleifer = true;
+              pendingSchleifer = false;
+            }
+            if (chordIndex === 0 && pendingShake && !note.isRest) {
+              note.shake = true;
+              pendingShake = false;
+            }
+            if (chordIndex === 0 && pendingArpeggiate && !note.isRest) {
+              note.arpeggiate = true;
+              pendingArpeggiate = false;
             }
             if (chordIndex === 0 && pendingSlurStart > 0 && !note.isRest) {
               note.slurStart = true;
@@ -635,6 +1460,158 @@ const abcCommon = AbcCommon;
             if (chordIndex === 0 && pendingStaccato && !note.isRest) {
               note.staccato = true;
               pendingStaccato = false;
+            }
+            if (chordIndex === 0 && pendingStaccatissimo && !note.isRest) {
+              note.staccatissimo = true;
+              pendingStaccatissimo = false;
+            }
+            if (chordIndex === 0 && pendingAccent && !note.isRest) {
+              note.accent = true;
+              pendingAccent = false;
+            }
+            if (chordIndex === 0 && pendingTenuto && !note.isRest) {
+              note.tenuto = true;
+              pendingTenuto = false;
+            }
+            if (chordIndex === 0 && pendingStress && !note.isRest) {
+              note.stress = true;
+              pendingStress = false;
+            }
+            if (chordIndex === 0 && pendingUnstress && !note.isRest) {
+              note.unstress = true;
+              pendingUnstress = false;
+            }
+            if (chordIndex === 0 && pendingFermata && !note.isRest) {
+              note.fermataType = pendingFermata;
+              pendingFermata = "";
+            }
+            if (chordIndex === 0 && pendingStrongAccent && !note.isRest) {
+              note.strongAccent = true;
+              pendingStrongAccent = false;
+            }
+            if (chordIndex === 0 && pendingBreathMark && !note.isRest) {
+              note.breathMark = true;
+              pendingBreathMark = false;
+            }
+            if (chordIndex === 0 && pendingCaesura && !note.isRest) {
+              note.caesura = true;
+              pendingCaesura = false;
+            }
+            if (chordIndex === 0 && pendingSegno && !note.isRest) {
+              note.segno = true;
+              pendingSegno = false;
+            }
+            if (chordIndex === 0 && pendingCoda && !note.isRest) {
+              note.coda = true;
+              pendingCoda = false;
+            }
+            if (chordIndex === 0 && pendingFine && !note.isRest) {
+              note.fine = true;
+              pendingFine = false;
+            }
+            if (chordIndex === 0 && pendingDaCapo && !note.isRest) {
+              note.daCapo = true;
+              pendingDaCapo = false;
+            }
+            if (chordIndex === 0 && pendingDalSegno && !note.isRest) {
+              note.dalSegno = true;
+              pendingDalSegno = false;
+            }
+            if (chordIndex === 0 && pendingToCoda && !note.isRest) {
+              note.toCoda = true;
+              pendingToCoda = false;
+            }
+            if (chordIndex === 0 && pendingCrescendoStart && !note.isRest) {
+              note.crescendoStart = true;
+              pendingCrescendoStart = false;
+            }
+            if (chordIndex === 0 && pendingCrescendoStop && !note.isRest) {
+              note.crescendoStop = true;
+              pendingCrescendoStop = false;
+            }
+            if (chordIndex === 0 && pendingDiminuendoStart && !note.isRest) {
+              note.diminuendoStart = true;
+              pendingDiminuendoStart = false;
+            }
+            if (chordIndex === 0 && pendingDiminuendoStop && !note.isRest) {
+              note.diminuendoStop = true;
+              pendingDiminuendoStop = false;
+            }
+            if (chordIndex === 0 && pendingDynamicMark && !note.isRest) {
+              note.dynamicMark = pendingDynamicMark;
+              pendingDynamicMark = "";
+            }
+            if (chordIndex === 0 && pendingSfz && !note.isRest) {
+              note.sfz = true;
+              pendingSfz = false;
+            }
+            if (chordIndex === 0 && pendingRehearsalMark && !note.isRest) {
+              note.rehearsalMark = pendingRehearsalMark;
+              pendingRehearsalMark = "";
+            }
+            if (chordIndex === 0 && pendingUpBow && !note.isRest) {
+              note.upBow = true;
+              pendingUpBow = false;
+            }
+            if (chordIndex === 0 && pendingDownBow && !note.isRest) {
+              note.downBow = true;
+              pendingDownBow = false;
+            }
+            if (chordIndex === 0 && pendingDoubleTongue && !note.isRest) {
+              note.doubleTongue = true;
+              pendingDoubleTongue = false;
+            }
+            if (chordIndex === 0 && pendingTripleTongue && !note.isRest) {
+              note.tripleTongue = true;
+              pendingTripleTongue = false;
+            }
+            if (chordIndex === 0 && pendingHeel && !note.isRest) {
+              note.heel = true;
+              pendingHeel = false;
+            }
+            if (chordIndex === 0 && pendingToe && !note.isRest) {
+              note.toe = true;
+              pendingToe = false;
+            }
+            if (chordIndex === 0 && pendingFingerings.length > 0 && !note.isRest) {
+              note.fingerings = pendingFingerings.slice();
+              pendingFingerings = [];
+            }
+            if (chordIndex === 0 && pendingStrings.length > 0 && !note.isRest) {
+              note.strings = pendingStrings.slice();
+              pendingStrings = [];
+            }
+            if (chordIndex === 0 && pendingPlucks.length > 0 && !note.isRest) {
+              note.plucks = pendingPlucks.slice();
+              pendingPlucks = [];
+            }
+            if (chordIndex === 0 && pendingChordSymbols.length > 0 && !note.isRest) {
+              note.chordSymbols = pendingChordSymbols.slice();
+              pendingChordSymbols = [];
+            }
+            if (chordIndex === 0 && pendingOpenString && !note.isRest) {
+              note.openString = true;
+              pendingOpenString = false;
+            }
+            if (chordIndex === 0 && pendingSnapPizzicato && !note.isRest) {
+              note.snapPizzicato = true;
+              pendingSnapPizzicato = false;
+            }
+            if (chordIndex === 0 && pendingHarmonic && !note.isRest) {
+              note.harmonic = true;
+              pendingHarmonic = false;
+            }
+            if (chordIndex === 0 && pendingStopped && !note.isRest) {
+              note.stopped = true;
+              pendingStopped = false;
+            }
+            if (chordIndex === 0 && pendingThumbPosition && !note.isRest) {
+              note.thumbPosition = true;
+              pendingThumbPosition = false;
+            }
+            if (chordIndex === 0 && pendingAnnotations.length > 0 && !note.isRest) {
+              note.annotations = pendingAnnotations.slice();
+              pendingAnnotations = [];
             }
             if (chordIndex > 0) {
               note.chord = true;
@@ -651,7 +1628,11 @@ const abcCommon = AbcCommon;
             chordNotes.push(note);
           }
           if (pendingTieToNext && chordNotes.length > 0) {
-            chordNotes[0].tieStop = true;
+            for (const chordNote of chordNotes) {
+              if (!chordNote.isRest) {
+                chordNote.tieStop = true;
+              }
+            }
             pendingTieToNext = false;
           }
           for (const note of chordNotes) {
@@ -674,8 +1655,23 @@ const abcCommon = AbcCommon;
         }
 
         if (ch === "]" || ch === "}") {
+          if (ch === "]" && activeEndingMarker) {
+            const stopMeasureNo = currentMeasure.length === 0 ? currentMeasureNo - 1 : currentMeasureNo;
+            if (stopMeasureNo >= 1) {
+              const measureMeta = ensureNotationMeasureMeta(entry.voiceId, stopMeasureNo);
+              measureMeta.endingStop = activeEndingMarker;
+              measureMeta.endingStopType = "stop";
+              activeEndingMarker = "";
+            }
+            idx += 1;
+            beamRunActive = false;
+            sawInterEventWhitespace = false;
+            continue;
+          }
           warnings.push("line " + entry.lineNo + ": Skipped unsupported notation: " + ch);
           idx += 1;
+          beamRunActive = false;
+          sawInterEventWhitespace = false;
           continue;
         }
 
@@ -707,14 +1703,14 @@ const abcCommon = AbcCommon;
         }
 
         let lengthToken = "";
-        const lengthMatch = text.slice(idx).match(/^(\d+\/\d+|\d+|\/\d+|\/)/);
+        const lengthMatch = text.slice(idx).match(/^(\d+\/\d+|\d+|\/\d+|\/+)/);
         if (lengthMatch) {
           lengthToken = lengthMatch[1];
           idx += lengthToken.length;
         }
 
         const len = parseLengthToken(lengthToken, entry.lineNo);
-        let absoluteLength = multiplyFractions(unitLength, len);
+        let absoluteLength = multiplyFractions(activeUnitLength, len);
         if (pendingRhythmScale) {
           absoluteLength = multiplyFractions(absoluteLength, pendingRhythmScale);
           pendingRhythmScale = null;
@@ -759,16 +1755,56 @@ const abcCommon = AbcCommon;
           absoluteLength,
           dur,
           entry.lineNo,
-          keySignatureAccidentals,
+          activeKeySignatureAccidentals,
           measureAccidentals
         );
+        applyBeamModeForEvent(note, dur);
         if (pendingTrill && !note.isRest) {
           note.trill = true;
           pendingTrill = false;
         }
         if (pendingTurn && !note.isRest) {
           note.turnType = pendingTurn;
+          note.delayedTurn = pendingDelayedTurn;
           pendingTurn = "";
+          pendingDelayedTurn = false;
+        }
+        if (pendingMordent && !note.isRest) {
+          note.mordentType = pendingMordent;
+          pendingMordent = "";
+        }
+        if (pendingTremolo && !note.isRest) {
+          note.tremoloType = pendingTremolo.type;
+          note.tremoloMarks = pendingTremolo.marks;
+          pendingTremolo = null;
+        }
+        if (pendingGlissandoStart && !note.isRest) {
+          note.glissandoStart = true;
+          pendingGlissandoStart = false;
+        }
+        if (pendingGlissandoStop && !note.isRest) {
+          note.glissandoStop = true;
+          pendingGlissandoStop = false;
+        }
+        if (pendingSlideStart && !note.isRest) {
+          note.slideStart = true;
+          pendingSlideStart = false;
+        }
+        if (pendingSlideStop && !note.isRest) {
+          note.slideStop = true;
+          pendingSlideStop = false;
+        }
+        if (pendingSchleifer && !note.isRest) {
+          note.schleifer = true;
+          pendingSchleifer = false;
+        }
+        if (pendingShake && !note.isRest) {
+          note.shake = true;
+          pendingShake = false;
+        }
+        if (pendingArpeggiate && !note.isRest) {
+          note.arpeggiate = true;
+          pendingArpeggiate = false;
         }
         if (pendingSlurStart > 0 && !note.isRest) {
           note.slurStart = true;
@@ -782,6 +1818,158 @@ const abcCommon = AbcCommon;
         if (pendingStaccato && !note.isRest) {
           note.staccato = true;
           pendingStaccato = false;
+        }
+        if (pendingStaccatissimo && !note.isRest) {
+          note.staccatissimo = true;
+          pendingStaccatissimo = false;
+        }
+        if (pendingAccent && !note.isRest) {
+          note.accent = true;
+          pendingAccent = false;
+        }
+        if (pendingTenuto && !note.isRest) {
+          note.tenuto = true;
+          pendingTenuto = false;
+        }
+        if (pendingStress && !note.isRest) {
+          note.stress = true;
+          pendingStress = false;
+        }
+        if (pendingUnstress && !note.isRest) {
+          note.unstress = true;
+          pendingUnstress = false;
+        }
+        if (pendingFermata && !note.isRest) {
+          note.fermataType = pendingFermata;
+          pendingFermata = "";
+        }
+        if (pendingStrongAccent && !note.isRest) {
+          note.strongAccent = true;
+          pendingStrongAccent = false;
+        }
+        if (pendingBreathMark && !note.isRest) {
+          note.breathMark = true;
+          pendingBreathMark = false;
+        }
+        if (pendingCaesura && !note.isRest) {
+          note.caesura = true;
+          pendingCaesura = false;
+        }
+        if (pendingSegno && !note.isRest) {
+          note.segno = true;
+          pendingSegno = false;
+        }
+        if (pendingCoda && !note.isRest) {
+          note.coda = true;
+          pendingCoda = false;
+        }
+        if (pendingFine && !note.isRest) {
+          note.fine = true;
+          pendingFine = false;
+        }
+        if (pendingDaCapo && !note.isRest) {
+          note.daCapo = true;
+          pendingDaCapo = false;
+        }
+        if (pendingDalSegno && !note.isRest) {
+          note.dalSegno = true;
+          pendingDalSegno = false;
+        }
+        if (pendingToCoda && !note.isRest) {
+          note.toCoda = true;
+          pendingToCoda = false;
+        }
+        if (pendingCrescendoStart && !note.isRest) {
+          note.crescendoStart = true;
+          pendingCrescendoStart = false;
+        }
+        if (pendingCrescendoStop && !note.isRest) {
+          note.crescendoStop = true;
+          pendingCrescendoStop = false;
+        }
+        if (pendingDiminuendoStart && !note.isRest) {
+          note.diminuendoStart = true;
+          pendingDiminuendoStart = false;
+        }
+        if (pendingDiminuendoStop && !note.isRest) {
+          note.diminuendoStop = true;
+          pendingDiminuendoStop = false;
+        }
+        if (pendingDynamicMark && !note.isRest) {
+          note.dynamicMark = pendingDynamicMark;
+          pendingDynamicMark = "";
+        }
+        if (pendingSfz && !note.isRest) {
+          note.sfz = true;
+          pendingSfz = false;
+        }
+        if (pendingRehearsalMark && !note.isRest) {
+          note.rehearsalMark = pendingRehearsalMark;
+          pendingRehearsalMark = "";
+        }
+        if (pendingUpBow && !note.isRest) {
+          note.upBow = true;
+          pendingUpBow = false;
+        }
+        if (pendingDownBow && !note.isRest) {
+          note.downBow = true;
+          pendingDownBow = false;
+        }
+        if (pendingDoubleTongue && !note.isRest) {
+          note.doubleTongue = true;
+          pendingDoubleTongue = false;
+        }
+        if (pendingTripleTongue && !note.isRest) {
+          note.tripleTongue = true;
+          pendingTripleTongue = false;
+        }
+        if (pendingHeel && !note.isRest) {
+          note.heel = true;
+          pendingHeel = false;
+        }
+        if (pendingToe && !note.isRest) {
+          note.toe = true;
+          pendingToe = false;
+        }
+        if (pendingFingerings.length > 0 && !note.isRest) {
+          note.fingerings = pendingFingerings.slice();
+          pendingFingerings = [];
+        }
+        if (pendingStrings.length > 0 && !note.isRest) {
+          note.strings = pendingStrings.slice();
+          pendingStrings = [];
+        }
+        if (pendingPlucks.length > 0 && !note.isRest) {
+          note.plucks = pendingPlucks.slice();
+          pendingPlucks = [];
+        }
+        if (pendingChordSymbols.length > 0 && !note.isRest) {
+          note.chordSymbols = pendingChordSymbols.slice();
+          pendingChordSymbols = [];
+        }
+        if (pendingOpenString && !note.isRest) {
+          note.openString = true;
+          pendingOpenString = false;
+        }
+        if (pendingSnapPizzicato && !note.isRest) {
+          note.snapPizzicato = true;
+          pendingSnapPizzicato = false;
+        }
+        if (pendingHarmonic && !note.isRest) {
+          note.harmonic = true;
+          pendingHarmonic = false;
+        }
+        if (pendingStopped && !note.isRest) {
+          note.stopped = true;
+          pendingStopped = false;
+        }
+        if (pendingThumbPosition && !note.isRest) {
+          note.thumbPosition = true;
+          pendingThumbPosition = false;
+        }
+        if (pendingAnnotations.length > 0 && !note.isRest) {
+          note.annotations = pendingAnnotations.slice();
+          pendingAnnotations = [];
         }
         if (pendingTieToNext && !note.isRest) {
           note.tieStop = true;
@@ -805,12 +1993,63 @@ const abcCommon = AbcCommon;
         lastEventNotes = [note];
         noteCount += 1;
       }
+      activeEndingByVoice[entry.voiceId] = activeEndingMarker;
+      currentKeyFifthsByVoice[entry.voiceId] = activeKeyFifths;
     }
 
     for (const voiceId of Object.keys(measuresByVoice)) {
       const measures = measuresByVoice[voiceId];
       while (measures.length > 1 && measures[measures.length - 1].length === 0) {
         measures.pop();
+      }
+      const activeEndingMarker = String(activeEndingByVoice[voiceId] || "");
+      if (activeEndingMarker) {
+        const lastMeasureNo = measures.length;
+        if (lastMeasureNo >= 1) {
+          const measureMeta = ensureNotationMeasureMeta(voiceId, lastMeasureNo);
+          if (!measureMeta.endingStop) {
+            measureMeta.endingStop = activeEndingMarker;
+            measureMeta.endingStopType = "stop";
+          }
+        }
+      }
+    }
+
+    for (const voiceId of Object.keys(lyricEntriesByVoice)) {
+      const measures = measuresByVoice[voiceId];
+      if (!Array.isArray(measures) || measures.length === 0) continue;
+      const lyricTargets = [];
+      for (const measure of measures) {
+        for (const note of measure) {
+          if (note && !note.isRest && !note.grace && !note.chord) {
+            lyricTargets.push(note);
+          }
+        }
+      }
+      if (lyricTargets.length === 0) continue;
+      let cursor = 0;
+      for (const lyricEntry of lyricEntriesByVoice[voiceId]) {
+        const tokens = tokenizeAbcLyricLine(lyricEntry.text);
+        for (const token of tokens) {
+          if (cursor >= lyricTargets.length) break;
+          if (token.type === "skip") {
+            cursor += 1;
+            continue;
+          }
+          if (token.type === "extend") {
+            const target = lyricTargets[Math.max(0, cursor - 1)];
+            if (target) {
+              target.lyricExtend = true;
+            }
+            continue;
+          }
+          const target = lyricTargets[cursor];
+          if (target) {
+            target.lyricText = token.text;
+            target.lyricSyllabic = token.syllabic;
+          }
+          cursor += 1;
+        }
       }
     }
 
@@ -849,15 +2088,47 @@ const abcCommon = AbcCommon;
         }
       }
       const keyByMeasure: Record<number, number> = {};
-      const measureMetaByIndex: Record<number, { number: string; implicit: boolean; repeat: string; repeatTimes: number | null }> = {};
+      const meterByMeasure: Record<number, { beats: number; beatType: number }> = {};
+      const tempoByMeasure: Record<number, number> = {};
+      const measureMetaByIndex: Record<number, {
+        number: string;
+        implicit: boolean;
+        repeatStart: boolean;
+        repeatEnd: boolean;
+        repeatTimes: number | null;
+        endingStart: string;
+        endingStop: string;
+        endingStopType: "" | "stop" | "discontinue";
+      }> = {};
       for (let m = 1; m <= normalizedMeasures.length; m += 1) {
         const hinted = keyHintFifthsByKey.get(`${voiceId}#${m}`);
         if (Number.isFinite(hinted)) {
           keyByMeasure[m] = Number(hinted);
         }
-        const meta = measureMetaByKey.get(`${voiceId}#${m}`);
-        if (meta) {
-          measureMetaByIndex[m] = meta;
+        const notationMeta = notationMeasureMetaByVoice[voiceId]?.[m] || null;
+        const hintedMeta = measureMetaByKey.get(`${voiceId}#${m}`) || null;
+        const meterHint = meterByMeasureByVoice[voiceId]?.[m] || null;
+        const tempoHint = tempoByMeasureByVoice[voiceId]?.[m] || null;
+        if (notationMeta || hintedMeta) {
+          measureMetaByIndex[m] = {
+            number: hintedMeta?.number || notationMeta?.number || String(m),
+            implicit: hintedMeta?.implicit ?? notationMeta?.implicit ?? false,
+            repeatStart: Boolean(notationMeta?.repeatStart || hintedMeta?.repeatStart),
+            repeatEnd: Boolean(notationMeta?.repeatEnd || hintedMeta?.repeatEnd),
+            repeatTimes: hintedMeta?.repeatTimes ?? notationMeta?.repeatTimes ?? null,
+            endingStart: String(notationMeta?.endingStart || hintedMeta?.endingStart || ""),
+            endingStop: String(notationMeta?.endingStop || hintedMeta?.endingStop || ""),
+            endingStopType: notationMeta?.endingStopType || hintedMeta?.endingStopType || "",
+          };
+        }
+        if (meterHint) {
+          meterByMeasure[m] = {
+            beats: meterHint.beats,
+            beatType: meterHint.beatType,
+          };
+        }
+        if (Number.isFinite(tempoHint)) {
+          tempoByMeasure[m] = Math.max(20, Math.min(300, Math.round(Number(tempoHint))));
         }
       }
       return {
@@ -867,6 +2138,8 @@ const abcCommon = AbcCommon;
         transpose,
         voiceId,
         keyByMeasure,
+        meterByMeasure,
+        tempoByMeasure,
         measureMetaByIndex,
         measures: normalizedMeasures
       };
@@ -1076,7 +2349,7 @@ const abcCommon = AbcCommon;
       return null;
     }
     const after = text.slice(closeIdx + 1);
-    const lengthMatch = after.match(/^(\d+\/\d+|\d+|\/\d+|\/)/);
+    const lengthMatch = after.match(/^(\d+\/\d+|\d+|\/\d+|\/+)/);
     const lengthToken = lengthMatch ? lengthMatch[1] : "";
     const nextIdx = closeIdx + 1 + (lengthMatch ? lengthMatch[1].length : 0);
     return {
@@ -1123,7 +2396,7 @@ const abcCommon = AbcCommon;
         idx += 1;
       }
       let lengthToken = "";
-      const lengthMatch = inner.slice(idx).match(/^(\d+\/\d+|\d+|\/\d+|\/)/);
+      const lengthMatch = inner.slice(idx).match(/^(\d+\/\d+|\d+|\/\d+|\/+)/);
       if (lengthMatch) {
         lengthToken = lengthMatch[1];
         idx += lengthToken.length;
@@ -1469,7 +2742,6 @@ export const exportMusicXmlDomToAbc = (doc: Document): string => {
 
   const bodyLines: string[] = [];
   const metaLines: string[] = [];
-  const emittedKeyMetaByVoiceMeasure = new Set<string>();
   const emitDiagMetaForMeasure = (
     normalizedVoiceId: string,
     measure: Element,
@@ -1596,10 +2868,12 @@ export const exportMusicXmlDomToAbc = (doc: Document): string => {
 
       let currentDivisions = 480;
       let currentFifths = partInitialFifths;
-      let lastEmittedKeyFifths: number | null = null;
+      let lastEmittedKeyFifths: number | null = Number.isFinite(fifths) ? Math.round(fifths) : 0;
       let currentBeats = Number(meterBeats) || 4;
       let currentBeatType = Number(meterBeatType) || 4;
       const measureTexts: string[] = [];
+      const lyricTokens: string[] = [];
+      let pendingLyricExtension = false;
       for (const measure of measures) {
         let activeTuplet: { actual: number; normal: number; remaining: number } | null = null;
         let eventNo = 0;
@@ -1617,43 +2891,38 @@ export const exportMusicXmlDomToAbc = (doc: Document): string => {
         const isImplicit = implicitAttr === "yes" || implicitAttr === "true" || implicitAttr === "1";
         const leftRepeatNode = measure.querySelector(':scope > barline[location="left"] > repeat');
         const rightRepeatNode = measure.querySelector(':scope > barline[location="right"] > repeat');
+        const leftEndingNode = measure.querySelector(':scope > barline[location="left"] > ending');
+        const rightEndingNode = measure.querySelector(':scope > barline[location="right"] > ending');
         const leftRepeatDir = (leftRepeatNode?.getAttribute("direction") || "").trim().toLowerCase();
         const rightRepeatDir = (rightRepeatNode?.getAttribute("direction") || "").trim().toLowerCase();
-        const repeatDir =
-          rightRepeatDir === "backward"
-            ? "backward"
-            : (leftRepeatDir === "forward" ? "forward" : "");
+        const hasLeftRepeat = leftRepeatDir === "forward";
+        const hasRightRepeat = rightRepeatDir === "backward";
         const repeatTimes = Number.parseInt(String(rightRepeatNode?.getAttribute("times") || ""), 10);
-        if (isImplicit || repeatDir || rawMeasureNumber !== String(safeMeasureNumber)) {
+        const leftEndingNumber = (leftEndingNode?.getAttribute("number") || "").trim();
+        const rightEndingNumber = (rightEndingNode?.getAttribute("number") || "").trim();
+        const rightEndingType = (rightEndingNode?.getAttribute("type") || "").trim().toLowerCase();
+        if (
+          isImplicit ||
+          rawMeasureNumber !== String(safeMeasureNumber) ||
+          (hasRightRepeat && Number.isFinite(repeatTimes) && repeatTimes > 2) ||
+          (rightEndingNumber && rightEndingType === "discontinue")
+        ) {
           const metaChunks = [
             `%@mks measure voice=${normalizedVoiceId} measure=${safeMeasureNumber}`,
             `number=${rawMeasureNumber}`,
             `implicit=${isImplicit ? 1 : 0}`,
           ];
-          if (repeatDir) {
-            metaChunks.push(`repeat=${repeatDir}`);
-          }
-          if (repeatDir === "backward" && Number.isFinite(repeatTimes) && repeatTimes > 1) {
+          if (hasRightRepeat && Number.isFinite(repeatTimes) && repeatTimes > 2) {
             metaChunks.push(`times=${Math.round(repeatTimes)}`);
+          }
+          if (rightEndingNumber && rightEndingType === "discontinue") {
+            metaChunks.push(`ending-stop=${rightEndingNumber}`);
+            metaChunks.push(`ending-type=${rightEndingType}`);
           }
           metaLines.push(metaChunks.join(" "));
         }
         emitDiagMetaForMeasure(normalizedVoiceId, measure, safeMeasureNumber);
-        const isFirstMeasureForLane = measureTexts.length === 0;
-        const hasExplicitKeyInMeasure = parsedFifths !== null;
-        const shouldEmitMeasureHint = hasExplicitKeyInMeasure || isFirstMeasureForLane;
-        if (shouldEmitMeasureHint) {
-          if (lastEmittedKeyFifths === null || lastEmittedKeyFifths !== currentFifths) {
-            const metaKey = `${normalizedVoiceId}#${safeMeasureNumber}`;
-            if (!emittedKeyMetaByVoiceMeasure.has(metaKey)) {
-              metaLines.push(
-                `%@mks key voice=${normalizedVoiceId} measure=${safeMeasureNumber} fifths=${Math.max(-7, Math.min(7, Math.round(currentFifths)))}`
-              );
-              emittedKeyMetaByVoiceMeasure.add(metaKey);
-            }
-            lastEmittedKeyFifths = currentFifths;
-          }
-        }
+        const needsInlineKeyChange = lastEmittedKeyFifths === null || lastEmittedKeyFifths !== currentFifths;
         const parsedBeats = parseOptionalNumber(measure.querySelector("attributes > time > beats")?.textContent);
         if (parsedBeats !== null && parsedBeats > 0) {
           currentBeats = parsedBeats;
@@ -1667,6 +2936,10 @@ export const exportMusicXmlDomToAbc = (doc: Document): string => {
 
         let pending: { pitches: string[]; len: string; tie: boolean; slurStop: boolean; prefix: string } | null = null;
         const pendingGraceTokens: string[] = [];
+        const pendingHarmonySymbols: string[] = [];
+        const pendingDirectionWords: string[] = [];
+        const pendingDirectionDecorations: string[] = [];
+        let activeWedgeType: "" | "crescendo" | "diminuendo" = "";
         const tokens: string[] = [];
         const flush = (): void => {
           if (!pending) return;
@@ -1679,6 +2952,62 @@ export const exportMusicXmlDomToAbc = (doc: Document): string => {
         };
 
         for (const child of Array.from(measure.children)) {
+          if (child.tagName === "harmony") {
+            const chordSymbol = abcChordSymbolFromHarmony(child);
+            if (chordSymbol) {
+              pendingHarmonySymbols.push(chordSymbol);
+            }
+            continue;
+          }
+          if (child.tagName === "direction") {
+            const rehearsalTexts = Array.from(child.querySelectorAll(":scope > direction-type > rehearsal"))
+              .map((node) => abcQuotedTextEscape(node.textContent || ""))
+              .filter(Boolean);
+            for (const rehearsalText of rehearsalTexts) {
+              pendingDirectionDecorations.push(`!rehearsal:${rehearsalText}!`);
+            }
+            const words = Array.from(child.querySelectorAll(":scope > direction-type > words"))
+              .map((node) => abcQuotedTextEscape(node.textContent || ""))
+              .filter(Boolean);
+            pendingDirectionWords.push(...words);
+            if (child.querySelector(":scope > direction-type > segno")) {
+              pendingDirectionDecorations.push("!segno!");
+            }
+            if (child.querySelector(":scope > direction-type > coda")) {
+              pendingDirectionDecorations.push("!coda!");
+            }
+            if (child.querySelector(':scope > sound[fine="yes"]')) {
+              pendingDirectionDecorations.push("!fine!");
+            }
+            if (child.querySelector(':scope > sound[dacapo="yes"]')) {
+              pendingDirectionDecorations.push("!dacapo!");
+            }
+            if (child.querySelector(":scope > sound[dalsegno]")) {
+              pendingDirectionDecorations.push("!dalsegno!");
+            }
+            if (child.querySelector(":scope > sound[tocoda]")) {
+              pendingDirectionDecorations.push("!tocoda!");
+            }
+            for (const wedgeNode of Array.from(child.querySelectorAll(":scope > direction-type > wedge"))) {
+              const wedgeType = (wedgeNode.getAttribute("type") || "").trim().toLowerCase();
+              if (wedgeType === "crescendo") {
+                pendingDirectionDecorations.push("!crescendo(!");
+                activeWedgeType = "crescendo";
+              } else if (wedgeType === "diminuendo") {
+                pendingDirectionDecorations.push("!diminuendo(!");
+                activeWedgeType = "diminuendo";
+              } else if (wedgeType === "stop") {
+                pendingDirectionDecorations.push(activeWedgeType === "diminuendo" ? "!diminuendo)!" : "!crescendo)!");
+                activeWedgeType = "";
+              }
+            }
+            for (const dynamicName of ["ppp", "pp", "p", "mp", "mf", "f", "ff", "fff", "fp", "fz", "rfz", "sf", "sfp", "sfz"]) {
+              if (child.querySelector(`:scope > direction-type > dynamics > ${dynamicName}`)) {
+                pendingDirectionDecorations.push(`!${dynamicName}!`);
+              }
+            }
+            continue;
+          }
           if (child.tagName !== "note") continue;
           if (lane.staff) {
             const noteStaff = child.querySelector(":scope > staff")?.textContent?.trim() ?? "";
@@ -1701,6 +3030,17 @@ export const exportMusicXmlDomToAbc = (doc: Document): string => {
           const hasTrillMark = Boolean(child.querySelector(":scope > notations > ornaments > trill-mark"));
           const hasTurn = Boolean(child.querySelector(":scope > notations > ornaments > turn"));
           const hasInvertedTurn = Boolean(child.querySelector(":scope > notations > ornaments > inverted-turn"));
+          const hasDelayedTurn = Boolean(child.querySelector(":scope > notations > ornaments > delayed-turn"));
+          const hasMordent = Boolean(child.querySelector(":scope > notations > ornaments > mordent"));
+          const hasInvertedMordent = Boolean(child.querySelector(":scope > notations > ornaments > inverted-mordent"));
+          const tremoloNode = child.querySelector(":scope > notations > ornaments > tremolo");
+          const hasSchleifer = Boolean(child.querySelector(":scope > notations > ornaments > schleifer"));
+          const hasShake = Boolean(child.querySelector(":scope > notations > ornaments > shake"));
+          const hasGlissandoStart = Boolean(child.querySelector(':scope > notations > glissando[type="start"]'));
+          const hasGlissandoStop = Boolean(child.querySelector(':scope > notations > glissando[type="stop"]'));
+          const hasSlideStart = Boolean(child.querySelector(':scope > notations > slide[type="start"]'));
+          const hasSlideStop = Boolean(child.querySelector(':scope > notations > slide[type="stop"]'));
+          const hasArpeggiate = Boolean(child.querySelector(":scope > notations > arpeggiate"));
           const hasWavyLineStart = Array.from(
             child.querySelectorAll(":scope > notations > ornaments > wavy-line")
           ).some((node) => {
@@ -1709,8 +3049,50 @@ export const exportMusicXmlDomToAbc = (doc: Document): string => {
           });
           const hasTrill = hasTrillMark || hasWavyLineStart;
           const turnType: "" | "turn" | "inverted-turn" = hasInvertedTurn ? "inverted-turn" : (hasTurn ? "turn" : "");
+          const mordentType: "" | "mordent" | "inverted-mordent" = hasInvertedMordent ? "inverted-mordent" : (hasMordent ? "mordent" : "");
+          const tremoloTypeRaw = (tremoloNode?.getAttribute("type") || "").trim().toLowerCase();
+          const tremoloType: "" | "single" | "start" | "stop" =
+            tremoloTypeRaw === "single" || tremoloTypeRaw === "start" || tremoloTypeRaw === "stop"
+              ? tremoloTypeRaw
+              : "";
+          const tremoloMarks = Math.max(1, Math.min(8, Number.parseInt(tremoloNode?.textContent?.trim() || "", 10) || 0));
           const trillAccidentalText = child.querySelector(":scope > notations > ornaments > accidental-mark")?.textContent?.trim() || "";
           const hasStaccato = Boolean(child.querySelector(":scope > notations > articulations > staccato"));
+          const hasStaccatissimo = Boolean(child.querySelector(":scope > notations > articulations > staccatissimo"));
+          const hasAccent = Boolean(child.querySelector(":scope > notations > articulations > accent"));
+          const hasTenuto = Boolean(child.querySelector(":scope > notations > articulations > tenuto"));
+          const hasStress = Boolean(child.querySelector(":scope > notations > articulations > stress"));
+          const hasUnstress = Boolean(child.querySelector(":scope > notations > articulations > unstress"));
+          const hasStrongAccent = Boolean(child.querySelector(":scope > notations > articulations > strong-accent"));
+          const hasBreathMark = Boolean(child.querySelector(":scope > notations > articulations > breath-mark"));
+          const hasCaesura = Boolean(child.querySelector(":scope > notations > articulations > caesura"));
+          const hasUpBow = Boolean(child.querySelector(":scope > notations > technical > up-bow"));
+          const hasDownBow = Boolean(child.querySelector(":scope > notations > technical > down-bow"));
+          const hasDoubleTongue = Boolean(child.querySelector(":scope > notations > technical > double-tongue"));
+          const hasTripleTongue = Boolean(child.querySelector(":scope > notations > technical > triple-tongue"));
+          const hasHeel = Boolean(child.querySelector(":scope > notations > technical > heel"));
+          const hasToe = Boolean(child.querySelector(":scope > notations > technical > toe"));
+          const fingeringTexts = Array.from(child.querySelectorAll(":scope > notations > technical > fingering"))
+            .map((node) => (node.textContent || "").trim())
+            .filter(Boolean);
+          const stringTexts = Array.from(child.querySelectorAll(":scope > notations > technical > string"))
+            .map((node) => (node.textContent || "").trim())
+            .filter(Boolean);
+          const pluckTexts = Array.from(child.querySelectorAll(":scope > notations > technical > pluck"))
+            .map((node) => (node.textContent || "").trim())
+            .filter(Boolean);
+          const hasOpenString = Boolean(child.querySelector(":scope > notations > technical > open-string"));
+          const hasSnapPizzicato = Boolean(child.querySelector(":scope > notations > technical > snap-pizzicato"));
+          const hasHarmonic = Boolean(child.querySelector(":scope > notations > technical > harmonic"));
+          const hasStopped = Boolean(child.querySelector(":scope > notations > technical > stopped"));
+          const hasThumbPosition = Boolean(child.querySelector(":scope > notations > technical > thumb-position"));
+          const fermataNode = child.querySelector(":scope > notations > fermata");
+          const fermataTypeRaw = fermataNode?.getAttribute("type")?.trim().toLowerCase() || "";
+          const fermataShapeRaw = fermataNode?.textContent?.trim().toLowerCase() || "";
+          const fermataType: "" | "normal" | "inverted" =
+            !fermataNode
+              ? ""
+              : (fermataTypeRaw === "inverted" || fermataShapeRaw === "inverted" ? "inverted" : "normal");
           const hasSlurStart = Boolean(child.querySelector(':scope > notations > slur[type="start"]'));
           const hasSlurStop = Boolean(child.querySelector(':scope > notations > slur[type="stop"]'));
           const hasGraceSlash = (child.querySelector(":scope > grace")?.getAttribute("slash") ?? "").trim().toLowerCase() === "yes";
@@ -1794,10 +3176,61 @@ export const exportMusicXmlDomToAbc = (doc: Document): string => {
                   : "")
               : "";
           const trillPrefix = hasTrill ? "!trill!" : "";
-          const turnPrefix = turnType === "inverted-turn" ? "!invertedturn!" : (turnType === "turn" ? "!turn!" : "");
-          const staccatoPrefix = hasStaccato ? "!staccato!" : "";
+          const turnPrefix =
+            turnType === "inverted-turn"
+              ? (hasDelayedTurn ? "!delayedinvertedturn!" : "!invertedturn!")
+              : (turnType === "turn" ? (hasDelayedTurn ? "!delayedturn!" : "!turn!") : "");
+          const mordentPrefix = mordentType === "inverted-mordent" ? "!pralltriller!" : (mordentType === "mordent" ? "!mordent!" : "");
+          const tremoloPrefix = tremoloType ? `!tremolo-${tremoloType}-${tremoloMarks}!` : "";
+          const glissandoPrefix = hasGlissandoStart ? "!gliss-start!" : (hasGlissandoStop ? "!gliss-stop!" : "");
+          const slidePrefix = hasSlideStart ? "!slide-start!" : (hasSlideStop ? "!slide-stop!" : "");
+          const schleiferPrefix = hasSchleifer ? "!schleifer!" : "";
+          const shakePrefix = hasShake ? "!shake!" : "";
+          const arpeggiatePrefix = hasArpeggiate ? "!roll!" : "";
+          const staccatoPrefix = hasStaccatissimo ? "!wedge!" : (hasStaccato ? "!staccato!" : "");
+          const accentPrefix = hasAccent ? "!accent!" : "";
+          const tenutoPrefix = hasTenuto ? "!tenuto!" : "";
+          const stressPrefix = hasStress ? "!stress!" : "";
+          const unstressPrefix = hasUnstress ? "!unstress!" : "";
+          const strongAccentPrefix = hasStrongAccent ? "!marcato!" : "";
+          const breathMarkPrefix = hasBreathMark ? "!breath!" : "";
+          const caesuraPrefix = hasCaesura ? "!caesura!" : "";
+          const upBowPrefix = hasUpBow ? "!upbow!" : "";
+          const downBowPrefix = hasDownBow ? "!downbow!" : "";
+          const doubleTonguePrefix = hasDoubleTongue ? "!doubletongue!" : "";
+          const tripleTonguePrefix = hasTripleTongue ? "!tripletongue!" : "";
+          const heelPrefix = hasHeel ? "!heel!" : "";
+          const toePrefix = hasToe ? "!toe!" : "";
+          const fingeringPrefix = fingeringTexts.map((value) => `!fingering:${value}!`).join("");
+          const stringPrefix = stringTexts.map((value) => `!string:${value}!`).join("");
+          const pluckPrefix = pluckTexts.map((value) => `!pluck:${value}!`).join("");
+          const openStringPrefix = hasOpenString ? "!open!" : "";
+          const snapPizzicatoPrefix = hasSnapPizzicato ? "!snap!" : "";
+          const harmonicPrefix = hasHarmonic ? "!harmonic!" : "";
+          const stoppedPrefix = hasStopped ? "!stopped!" : "";
+          const thumbPrefix = hasThumbPosition ? "!thumb!" : "";
+          const fermataPrefix = fermataType === "inverted" ? "!invertedfermata!" : (fermataType === "normal" ? "!fermata!" : "");
           const slurStartPrefix = hasSlurStart ? "(" : "";
-          const eventPrefix = `${tupletPrefix}${slurStartPrefix}${gracePrefix}${trillPrefix}${turnPrefix}${staccatoPrefix}`;
+          const wordsPrefix =
+            !isChord && pendingDirectionWords.length > 0
+              ? `${pendingDirectionWords.map((word) => `"${word}"`).join("")}`
+              : "";
+          const harmonyPrefix =
+            !isChord && pendingHarmonySymbols.length > 0
+              ? `${pendingHarmonySymbols.map((symbol) => `"${abcQuotedTextEscape(symbol)}"`).join("")}`
+              : "";
+          const directionDecorationPrefix =
+            !isChord && pendingDirectionDecorations.length > 0 ? pendingDirectionDecorations.join("") : "";
+          const eventPrefix = `${harmonyPrefix}${wordsPrefix}${directionDecorationPrefix}${tupletPrefix}${slurStartPrefix}${gracePrefix}${trillPrefix}${turnPrefix}${mordentPrefix}${tremoloPrefix}${glissandoPrefix}${slidePrefix}${schleiferPrefix}${shakePrefix}${arpeggiatePrefix}${staccatoPrefix}${accentPrefix}${tenutoPrefix}${stressPrefix}${unstressPrefix}${strongAccentPrefix}${breathMarkPrefix}${caesuraPrefix}${upBowPrefix}${downBowPrefix}${doubleTonguePrefix}${tripleTonguePrefix}${heelPrefix}${toePrefix}${fingeringPrefix}${stringPrefix}${pluckPrefix}${openStringPrefix}${snapPizzicatoPrefix}${harmonicPrefix}${stoppedPrefix}${thumbPrefix}${fermataPrefix}`;
+          if (!isChord && pendingHarmonySymbols.length > 0) {
+            pendingHarmonySymbols.length = 0;
+          }
+          if (!isChord && pendingDirectionWords.length > 0) {
+            pendingDirectionWords.length = 0;
+          }
+          if (!isChord && pendingDirectionDecorations.length > 0) {
+            pendingDirectionDecorations.length = 0;
+          }
           if (pendingGraceTokens.length > 0) {
             pendingGraceTokens.length = 0;
           }
@@ -1826,6 +3259,23 @@ export const exportMusicXmlDomToAbc = (doc: Document): string => {
               activeTuplet = null;
             }
           }
+          if (!isGrace && !isChord && !child.querySelector(":scope > rest")) {
+            const lyric = child.querySelector(":scope > lyric");
+            const lyricText = lyric?.querySelector(":scope > text")?.textContent?.trim() || "";
+            const lyricSyllabic = lyric?.querySelector(":scope > syllabic")?.textContent?.trim() || "single";
+            const lyricExtend = Boolean(lyric?.querySelector(":scope > extend"));
+            if (lyricText) {
+              lyricTokens.push(abcLyricTokenFromMusicXml(lyricText, lyricSyllabic));
+              pendingLyricExtension = lyricExtend;
+            } else if (pendingLyricExtension) {
+              lyricTokens.push("_");
+            } else {
+              lyricTokens.push("*");
+            }
+            if (lyricText && !lyricExtend) {
+              pendingLyricExtension = false;
+            }
+          }
         }
         if (pendingGraceTokens.length > 0) {
           tokens.push(`{${pendingGraceTokens.join("")}}`);
@@ -1841,11 +3291,28 @@ export const exportMusicXmlDomToAbc = (doc: Document): string => {
           const lenRatio = AbcCommon.divideFractions(wholeFraction, unitLength, { num: 1, den: 1 });
           tokens.push(`z${AbcCommon.abcLengthTokenFromFraction(lenRatio)}`);
         }
-        measureTexts.push(tokens.join(" "));
+        const measureTokenText = tokens.join(" ");
+        const keyPrefix = needsInlineKeyChange
+          ? `[K:${AbcCommon.keyFromFifthsMode(Math.max(-7, Math.min(7, Math.round(currentFifths))), "major")}]`
+          : "";
+        const leftPrefix = `${hasLeftRepeat ? "|:" : ""}${leftEndingNumber ? `[${leftEndingNumber}` : ""}`;
+        let rightSuffix = "|";
+        if (hasRightRepeat && rightEndingNumber) {
+          rightSuffix = `:|]`;
+        } else if (hasRightRepeat) {
+          rightSuffix = ":|";
+        } else if (rightEndingNumber) {
+          rightSuffix = "]|";
+        }
+        measureTexts.push(`${leftPrefix}${leftPrefix ? " " : ""}${keyPrefix}${keyPrefix ? " " : ""}${measureTokenText} ${rightSuffix}`.trim());
+        lastEmittedKeyFifths = currentFifths;
       }
 
       bodyLines.push(`V:${normalizedVoiceId}`);
-      bodyLines.push(`${measureTexts.join(" | ")} |`);
+      bodyLines.push(measureTexts.join(" "));
+      if (lyricTokens.some((token) => token !== "*")) {
+        bodyLines.push(`w: ${lyricTokens.join(" ")}`);
+      }
     }
   });
 
@@ -1860,6 +3327,132 @@ const xmlEscape = (text: string): string =>
     .replace(/>/g, "&gt;")
     .replace(/"/g, "&quot;")
     .replace(/'/g, "&apos;");
+
+const abcQuotedTextEscape = (text: string): string =>
+  String(text || "")
+    .replace(/"/g, "'")
+    .replace(/\s+/g, " ")
+    .trim();
+
+const normalizeChordToken = (raw: string): string =>
+  String(raw || "")
+    .trim()
+    .replace(/♯/g, "#")
+    .replace(/♭/g, "b")
+    .replace(/\s+/g, "");
+
+const isLikelyAbcChordSymbol = (raw: string): boolean => {
+  const text = normalizeChordToken(raw);
+  return /^[A-G](?:#|b)?(?:[^/\s"]*)?(?:\/[A-G](?:#|b)?)?$/.test(text);
+};
+
+const xmlHarmonyKindFromChordSuffix = (suffixRaw: string): string | null => {
+  const suffix = String(suffixRaw || "").trim().toLowerCase();
+  if (!suffix) return "major";
+  if (suffix === "m" || suffix === "min") return "minor";
+  if (suffix === "6") return "major-sixth";
+  if (suffix === "m6" || suffix === "min6") return "minor-sixth";
+  if (suffix === "7") return "dominant";
+  if (suffix === "7sus4") return "suspended-fourth";
+  if (suffix === "9") return "dominant-ninth";
+  if (suffix === "11") return "dominant-11th";
+  if (suffix === "13") return "dominant-13th";
+  if (suffix === "maj7") return "major-seventh";
+  if (suffix === "maj9") return "major-ninth";
+  if (suffix === "m9" || suffix === "min9") return "minor-ninth";
+  if (suffix === "m7" || suffix === "min7") return "minor-seventh";
+  if (suffix === "dim") return "diminished";
+  if (suffix === "dim7") return "diminished-seventh";
+  if (suffix === "aug" || suffix === "+") return "augmented";
+  if (suffix === "sus4") return "suspended-fourth";
+  if (suffix === "sus2") return "suspended-second";
+  if (suffix === "m7b5" || suffix === "min7b5" || suffix === "ø") return "half-diminished";
+  return null;
+};
+
+const xmlHarmonyRootFromChordToken = (token: string): { step: string; alter: number } | null => {
+  const m = String(token || "").match(/^([A-G])(#|b)?$/);
+  if (!m) return null;
+  return {
+    step: m[1],
+    alter: m[2] === "#" ? 1 : (m[2] === "b" ? -1 : 0),
+  };
+};
+
+const buildHarmonyXmlFromChordSymbol = (raw: string): string => {
+  const normalized = normalizeChordToken(raw);
+  const match = normalized.match(/^([A-G](?:#|b)?)([^/]*)?(?:\/([A-G](?:#|b)?))?$/);
+  if (!match) return "";
+  const root = xmlHarmonyRootFromChordToken(match[1] || "");
+  if (!root) return "";
+  const suffix = String(match[2] || "");
+  const bass = match[3] ? xmlHarmonyRootFromChordToken(match[3]) : null;
+  const kind = xmlHarmonyKindFromChordSuffix(suffix);
+  if (!kind) return "";
+  return [
+    "<harmony>",
+    "<root>",
+    `<root-step>${xmlEscape(root.step)}</root-step>`,
+    root.alter !== 0 ? `<root-alter>${root.alter}</root-alter>` : "",
+    "</root>",
+    bass
+      ? `<bass><bass-step>${xmlEscape(bass.step)}</bass-step>${bass.alter !== 0 ? `<bass-alter>${bass.alter}</bass-alter>` : ""}</bass>`
+      : "",
+    `<kind text="${xmlEscape(normalized)}">${kind}</kind>`,
+    "</harmony>",
+  ].join("");
+};
+
+const abcChordSymbolFromHarmony = (harmony: Element | null): string => {
+  if (!harmony) return "";
+  const rootStep = (harmony.querySelector(":scope > root > root-step")?.textContent || "").trim().toUpperCase();
+  if (!/^[A-G]$/.test(rootStep)) return "";
+  const rootAlter = Number(harmony.querySelector(":scope > root > root-alter")?.textContent || "0");
+  const kindNode = harmony.querySelector(":scope > kind");
+  const kindTextAttr = (kindNode?.getAttribute("text") || "").trim();
+  if (kindTextAttr) return abcQuotedTextEscape(kindTextAttr);
+  const kindValue = (kindNode?.textContent || "").trim().toLowerCase();
+  const rootToken = `${rootStep}${rootAlter === 1 ? "#" : (rootAlter === -1 ? "b" : "")}`;
+  const suffix =
+    kindValue === "major" ? "" :
+    kindValue === "minor" ? "m" :
+    kindValue === "major-sixth" ? "6" :
+    kindValue === "minor-sixth" ? "m6" :
+    kindValue === "dominant" ? "7" :
+    kindValue === "dominant-11th" ? "11" :
+    kindValue === "dominant-13th" ? "13" :
+    kindValue === "dominant-ninth" ? "9" :
+    kindValue === "major-seventh" ? "maj7" :
+    kindValue === "major-ninth" ? "maj9" :
+    kindValue === "minor-ninth" ? "m9" :
+    kindValue === "minor-seventh" ? "m7" :
+    kindValue === "diminished" ? "dim" :
+    kindValue === "diminished-seventh" ? "dim7" :
+    kindValue === "augmented" ? "aug" :
+    kindValue === "suspended-fourth" ? "sus4" :
+    kindValue === "suspended-second" ? "sus2" :
+    kindValue === "half-diminished" ? "m7b5" :
+    "";
+  const bassStep = (harmony.querySelector(":scope > bass > bass-step")?.textContent || "").trim().toUpperCase();
+  const bassAlter = Number(harmony.querySelector(":scope > bass > bass-alter")?.textContent || "0");
+  const bassToken = /^[A-G]$/.test(bassStep)
+    ? `/${bassStep}${bassAlter === 1 ? "#" : (bassAlter === -1 ? "b" : "")}`
+    : "";
+  return `${rootToken}${suffix}${bassToken}`;
+};
+
+const abcLyricTokenFromMusicXml = (
+  text: string,
+  syllabic?: "single" | "begin" | "middle" | "end" | string
+): string => {
+  const normalized = String(text || "").trim().replace(/\s+/g, "~");
+  const mode = String(syllabic || "single").trim().toLowerCase();
+  if (!normalized) return "*";
+  if (mode === "begin" || mode === "middle") {
+    return `${normalized}-`;
+  }
+  return normalized;
+};
 
 const normalizeTypeForMusicXml = (t?: string): string => {
   const raw = String(t || "").trim();
@@ -1943,6 +3536,7 @@ type AbcParsedNote = {
   isRest: boolean;
   duration: number;
   type?: string;
+  beamMode?: "begin" | "mid";
   step?: string;
   octave?: number;
   alter?: number | null;
@@ -1957,7 +3551,59 @@ type AbcParsedNote = {
   trill?: boolean;
   trillAccidentalText?: string;
   turnType?: "turn" | "inverted-turn";
+  delayedTurn?: boolean;
+  mordentType?: "mordent" | "inverted-mordent";
+  tremoloType?: "single" | "start" | "stop";
+  tremoloMarks?: number;
+  glissandoStart?: boolean;
+  glissandoStop?: boolean;
+  slideStart?: boolean;
+  slideStop?: boolean;
+  schleifer?: boolean;
+  shake?: boolean;
+  arpeggiate?: boolean;
   staccato?: boolean;
+  staccatissimo?: boolean;
+  accent?: boolean;
+  tenuto?: boolean;
+  stress?: boolean;
+  unstress?: boolean;
+  fermataType?: "normal" | "inverted";
+  strongAccent?: boolean;
+  breathMark?: boolean;
+  caesura?: boolean;
+  segno?: boolean;
+  coda?: boolean;
+  fine?: boolean;
+  daCapo?: boolean;
+  dalSegno?: boolean;
+  toCoda?: boolean;
+  crescendoStart?: boolean;
+  crescendoStop?: boolean;
+  diminuendoStart?: boolean;
+  diminuendoStop?: boolean;
+  rehearsalMark?: string;
+  dynamicMark?: "ppp" | "pp" | "p" | "mp" | "mf" | "f" | "ff" | "fff" | "fp" | "fz" | "rfz" | "sf" | "sfp";
+  sfz?: boolean;
+  upBow?: boolean;
+  downBow?: boolean;
+  doubleTongue?: boolean;
+  tripleTongue?: boolean;
+  heel?: boolean;
+  toe?: boolean;
+  fingerings?: string[];
+  strings?: string[];
+  plucks?: string[];
+  chordSymbols?: string[];
+  openString?: boolean;
+  snapPizzicato?: boolean;
+  harmonic?: boolean;
+  stopped?: boolean;
+  thumbPosition?: boolean;
+  annotations?: string[];
+  lyricText?: string;
+  lyricSyllabic?: "single" | "begin" | "middle" | "end";
+  lyricExtend?: boolean;
   timeModification?: { actual: number; normal: number };
   tupletStart?: boolean;
   tupletStop?: boolean;
@@ -1971,7 +3617,18 @@ type AbcParsedPart = {
   transpose?: { chromatic?: number; diatonic?: number } | null;
   voiceId?: string;
   keyByMeasure?: Record<number, number>;
-  measureMetaByIndex?: Record<number, { number: string; implicit: boolean; repeat: string; repeatTimes: number | null }>;
+  meterByMeasure?: Record<number, { beats: number; beatType: number }>;
+  tempoByMeasure?: Record<number, number>;
+  measureMetaByIndex?: Record<number, {
+    number: string;
+    implicit: boolean;
+    repeatStart: boolean;
+    repeatEnd: boolean;
+    repeatTimes: number | null;
+    endingStart: string;
+    endingStop: string;
+    endingStopType: "" | "stop" | "discontinue";
+  }>;
   measures: AbcParsedNote[][];
 };
 
@@ -2163,6 +3820,8 @@ const buildMusicXmlFromAbcParsed = (
     .map((part, partIndex) => {
       const measuresXml: string[] = [];
       let currentPartFifths = Math.max(-7, Math.min(7, Math.round(defaultFifths)));
+      let currentPartMeter = { beats: Math.round(beats), beatType: Math.round(beatType) };
+      let currentPartTempo = tempoBpm;
       for (let i = 0; i < measureCount; i += 1) {
         const measureNo = i + 1;
         const notes = part.measures[i] ?? [];
@@ -2170,8 +3829,21 @@ const buildMusicXmlFromAbcParsed = (
         const hintedFifths = Number.isFinite(part.keyByMeasure?.[measureNo])
           ? Math.max(-7, Math.min(7, Math.round(Number(part.keyByMeasure?.[measureNo]))))
           : null;
+        const hintedMeter = part.meterByMeasure?.[measureNo] ?? null;
+        const hintedTempo = Number.isFinite(part.tempoByMeasure?.[measureNo])
+          ? Math.max(20, Math.min(300, Math.round(Number(part.tempoByMeasure?.[measureNo]))))
+          : null;
         if (hintedFifths !== null) {
           currentPartFifths = hintedFifths;
+        }
+        if (hintedMeter) {
+          currentPartMeter = {
+            beats: Math.max(1, Math.round(Number(hintedMeter.beats) || beats)),
+            beatType: Math.max(1, Math.round(Number(hintedMeter.beatType) || beatType)),
+          };
+        }
+        if (hintedTempo !== null) {
+          currentPartTempo = hintedTempo;
         }
         const header =
           i === 0
@@ -2179,7 +3851,7 @@ const buildMusicXmlFromAbcParsed = (
                 "<attributes>",
                 "<divisions>960</divisions>",
                 `<key><fifths>${Math.round(currentPartFifths)}</fifths></key>`,
-                `<time><beats>${Math.round(beats)}</beats><beat-type>${Math.round(beatType)}</beat-type></time>`,
+                `<time><beats>${Math.round(currentPartMeter.beats)}</beats><beat-type>${Math.round(currentPartMeter.beatType)}</beat-type></time>`,
                 part.transpose && (Number.isFinite(part.transpose.chromatic) || Number.isFinite(part.transpose.diatonic))
                   ? [
                       "<transpose>",
@@ -2194,13 +3866,23 @@ const buildMusicXmlFromAbcParsed = (
                   : "",
                 clefXmlFromAbcClef(part.clef),
                 "</attributes>",
-                tempoBpm !== null && partIndex === 0
-                  ? `<direction><direction-type><metronome><beat-unit>quarter</beat-unit><per-minute>${tempoBpm}</per-minute></metronome></direction-type><sound tempo="${tempoBpm}"/></direction>`
+                currentPartTempo !== null && partIndex === 0
+                  ? `<direction><direction-type><metronome><beat-unit>quarter</beat-unit><per-minute>${currentPartTempo}</per-minute></metronome></direction-type><sound tempo="${currentPartTempo}"/></direction>`
                   : "",
               ].join("")
-            : hintedFifths !== null
-              ? `<attributes><key><fifths>${Math.round(currentPartFifths)}</fifths></key></attributes>`
+            : (hintedFifths !== null || hintedMeter)
+              ? `<attributes>${
+                  hintedFifths !== null ? `<key><fifths>${Math.round(currentPartFifths)}</fifths></key>` : ""
+                }${
+                  hintedMeter
+                    ? `<time><beats>${Math.round(currentPartMeter.beats)}</beats><beat-type>${Math.round(currentPartMeter.beatType)}</beat-type></time>`
+                    : ""
+                }</attributes>`
               : "";
+        const tempoDirectionXml =
+          i > 0 && hintedTempo !== null && partIndex === 0
+            ? `<direction><direction-type><metronome><beat-unit>quarter</beat-unit><per-minute>${hintedTempo}</per-minute></metronome></direction-type><sound tempo="${hintedTempo}"/></direction>`
+            : "";
 
         const notesXml =
           notes.length > 0
@@ -2243,6 +3925,7 @@ const buildMusicXmlFromAbcParsed = (
                           grace: Boolean(ev.note?.grace),
                           durationDiv: ev.note?.grace ? 0 : Math.max(1, Math.round(Number(ev.note?.duration) || 1)),
                           levels: levelFromType(type),
+                          explicitMode: ev.note?.beamMode,
                         };
                       },
                       { splitAtBeatBoundaryWhenImplicit: true }
@@ -2263,7 +3946,64 @@ const buildMusicXmlFromAbcParsed = (
                 })();
                 return notes
                   .map((note, noteIndex) => {
-                  const chunks: string[] = ["<note>"];
+                  const chunks: string[] = [];
+                  if (!note.chord && Array.isArray(note.chordSymbols) && note.chordSymbols.length > 0) {
+                    for (const chordSymbol of note.chordSymbols) {
+                      const harmonyXml = buildHarmonyXmlFromChordSymbol(chordSymbol);
+                      if (harmonyXml) {
+                        chunks.push(harmonyXml);
+                      } else {
+                        chunks.push(
+                          `<direction><direction-type><words>${xmlEscape(String(chordSymbol))}</words></direction-type></direction>`
+                        );
+                      }
+                    }
+                  }
+                  if (!note.chord && Array.isArray(note.annotations) && note.annotations.length > 0) {
+                    for (const annotation of note.annotations) {
+                      if (!annotation) continue;
+                      chunks.push(
+                        `<direction><direction-type><words>${xmlEscape(String(annotation))}</words></direction-type></direction>`
+                      );
+                    }
+                  }
+                  if (!note.chord && note.segno) {
+                    chunks.push("<direction><direction-type><segno/></direction-type></direction>");
+                  }
+                  if (!note.chord && note.coda) {
+                    chunks.push("<direction><direction-type><coda/></direction-type></direction>");
+                  }
+                  if (!note.chord && note.rehearsalMark) {
+                    chunks.push(`<direction><direction-type><rehearsal>${xmlEscape(String(note.rehearsalMark))}</rehearsal></direction-type></direction>`);
+                  }
+                  if (!note.chord && note.fine) {
+                    chunks.push('<direction><sound fine="yes"/></direction>');
+                  }
+                  if (!note.chord && note.daCapo) {
+                    chunks.push('<direction><sound dacapo="yes"/></direction>');
+                  }
+                  if (!note.chord && note.dalSegno) {
+                    chunks.push('<direction><sound dalsegno="segno"/></direction>');
+                  }
+                  if (!note.chord && note.toCoda) {
+                    chunks.push('<direction><sound tocoda="coda"/></direction>');
+                  }
+                  if (!note.chord && note.crescendoStart) {
+                    chunks.push('<direction><direction-type><wedge type="crescendo"/></direction-type></direction>');
+                  }
+                  if (!note.chord && note.diminuendoStart) {
+                    chunks.push('<direction><direction-type><wedge type="diminuendo"/></direction-type></direction>');
+                  }
+                  if (!note.chord && (note.crescendoStop || note.diminuendoStop)) {
+                    chunks.push('<direction><direction-type><wedge type="stop"/></direction-type></direction>');
+                  }
+                  if (!note.chord && note.dynamicMark) {
+                    chunks.push(`<direction><direction-type><dynamics><${xmlEscape(String(note.dynamicMark))}/></dynamics></direction-type></direction>`);
+                  }
+                  if (!note.chord && note.sfz) {
+                    chunks.push("<direction><direction-type><dynamics><sfz/></dynamics></direction-type></direction>");
+                  }
+                  chunks.push("<note>");
                   if (note.chord) chunks.push("<chord/>");
                   if (note.grace) {
                     chunks.push(note.graceSlash ? '<grace slash="yes"/>' : "<grace/>");
@@ -2290,6 +4030,13 @@ const buildMusicXmlFromAbcParsed = (
                     chunks.push(`<duration>${duration}</duration>`);
                   }
                   chunks.push(`<voice>${xmlEscape(normalizeVoiceForMusicXml(note.voice))}</voice>`);
+                  if (note.lyricText) {
+                    chunks.push(
+                      `<lyric><syllabic>${xmlEscape(String(note.lyricSyllabic || "single"))}</syllabic><text>${xmlEscape(String(note.lyricText))}</text>${
+                        note.lyricExtend ? "<extend/>" : ""
+                      }</lyric>`
+                    );
+                  }
                   chunks.push(`<type>${normalizeTypeForMusicXml(note.type)}</type>`);
                   if (!note.chord && beamXmlByNoteIndex.has(noteIndex)) {
                     chunks.push(String(beamXmlByNoteIndex.get(noteIndex)));
@@ -2317,7 +4064,40 @@ const buildMusicXmlFromAbcParsed = (
                     note.slurStop ||
                     note.trill ||
                     note.turnType ||
+                    note.delayedTurn ||
+                    note.mordentType ||
+                    note.tremoloType ||
+                    note.glissandoStart ||
+                    note.glissandoStop ||
+                    note.slideStart ||
+                    note.slideStop ||
+                    note.schleifer ||
+                    note.shake ||
+                    note.arpeggiate ||
                     note.staccato ||
+                    note.staccatissimo ||
+                    note.accent ||
+                    note.tenuto ||
+                    note.stress ||
+                    note.unstress ||
+                    note.fermataType ||
+                    note.strongAccent ||
+                    note.breathMark ||
+                    note.caesura ||
+                    note.upBow ||
+                    note.downBow ||
+                    note.doubleTongue ||
+                    note.tripleTongue ||
+                    note.heel ||
+                    note.toe ||
+                    (Array.isArray(note.fingerings) && note.fingerings.length > 0) ||
+                    (Array.isArray(note.strings) && note.strings.length > 0) ||
+                    (Array.isArray(note.plucks) && note.plucks.length > 0) ||
+                    note.openString ||
+                    note.snapPizzicato ||
+                    note.harmonic ||
+                    note.stopped ||
+                    note.thumbPosition ||
                     note.tupletStart ||
                     note.tupletStop
                   ) {
@@ -2331,6 +4111,7 @@ const buildMusicXmlFromAbcParsed = (
                     if (note.trill) {
                       const trillParts: string[] = [];
                       trillParts.push("<trill-mark/>");
+                      trillParts.push('<wavy-line type="start"/>');
                       if (note.trillAccidentalText) {
                         trillParts.push(`<accidental-mark>${xmlEscape(String(note.trillAccidentalText))}</accidental-mark>`);
                       }
@@ -2338,9 +4119,84 @@ const buildMusicXmlFromAbcParsed = (
                     }
                     if (note.turnType) {
                       const tag = note.turnType === "inverted-turn" ? "inverted-turn" : "turn";
+                      chunks.push(`<ornaments><${tag}/>${note.delayedTurn ? "<delayed-turn/>" : ""}</ornaments>`);
+                    }
+                    if (note.mordentType) {
+                      const tag = note.mordentType === "inverted-mordent" ? "inverted-mordent" : "mordent";
                       chunks.push(`<ornaments><${tag}/></ornaments>`);
                     }
-                    if (note.staccato) chunks.push("<articulations><staccato/></articulations>");
+                    if (note.tremoloType) {
+                      const marks = Math.max(1, Math.min(8, Math.round(Number(note.tremoloMarks) || 1)));
+                      chunks.push(`<ornaments><tremolo type="${xmlEscape(String(note.tremoloType))}">${marks}</tremolo></ornaments>`);
+                    }
+                    if (note.glissandoStart) {
+                      chunks.push('<glissando type="start" number="1">wavy</glissando>');
+                    }
+                    if (note.glissandoStop) {
+                      chunks.push('<glissando type="stop" number="1">wavy</glissando>');
+                    }
+                    if (note.slideStart) {
+                      chunks.push('<slide type="start" number="1"/>');
+                    }
+                    if (note.slideStop) {
+                      chunks.push('<slide type="stop" number="1"/>');
+                    }
+                    if (note.schleifer) {
+                      chunks.push("<ornaments><schleifer/></ornaments>");
+                    }
+                    if (note.shake) {
+                      chunks.push("<ornaments><shake/></ornaments>");
+                    }
+                    if (note.arpeggiate) {
+                      chunks.push("<arpeggiate/>");
+                    }
+                    const articulationParts: string[] = [];
+                    if (note.staccato) articulationParts.push("<staccato/>");
+                    if (note.staccatissimo) articulationParts.push("<staccatissimo/>");
+                    if (note.accent) articulationParts.push("<accent/>");
+                    if (note.tenuto) articulationParts.push("<tenuto/>");
+                    if (note.stress) articulationParts.push("<stress/>");
+                    if (note.unstress) articulationParts.push("<unstress/>");
+                    if (note.strongAccent) articulationParts.push("<strong-accent/>");
+                    if (note.breathMark) articulationParts.push("<breath-mark/>");
+                    if (note.caesura) articulationParts.push("<caesura/>");
+                    if (articulationParts.length > 0) {
+                      chunks.push(`<articulations>${articulationParts.join("")}</articulations>`);
+                    }
+                    const technicalParts: string[] = [];
+                    if (note.upBow) technicalParts.push("<up-bow/>");
+                    if (note.downBow) technicalParts.push("<down-bow/>");
+                    if (note.doubleTongue) technicalParts.push("<double-tongue/>");
+                    if (note.tripleTongue) technicalParts.push("<triple-tongue/>");
+                    if (note.heel) technicalParts.push("<heel/>");
+                    if (note.toe) technicalParts.push("<toe/>");
+                    if (Array.isArray(note.fingerings) && note.fingerings.length > 0) {
+                      for (const fingering of note.fingerings) {
+                        if (fingering) technicalParts.push(`<fingering>${xmlEscape(String(fingering))}</fingering>`);
+                      }
+                    }
+                    if (Array.isArray(note.strings) && note.strings.length > 0) {
+                      for (const stringText of note.strings) {
+                        if (stringText) technicalParts.push(`<string>${xmlEscape(String(stringText))}</string>`);
+                      }
+                    }
+                    if (Array.isArray(note.plucks) && note.plucks.length > 0) {
+                      for (const pluckText of note.plucks) {
+                        if (pluckText) technicalParts.push(`<pluck>${xmlEscape(String(pluckText))}</pluck>`);
+                      }
+                    }
+                    if (note.openString) technicalParts.push("<open-string/>");
+                    if (note.snapPizzicato) technicalParts.push("<snap-pizzicato/>");
+                    if (note.harmonic) technicalParts.push("<harmonic/>");
+                    if (note.stopped) technicalParts.push("<stopped/>");
+                    if (note.thumbPosition) technicalParts.push("<thumb-position/>");
+                    if (technicalParts.length > 0) {
+                      chunks.push(`<technical>${technicalParts.join("")}</technical>`);
+                    }
+                    if (note.fermataType) {
+                      const fermataText = note.fermataType === "inverted" ? "inverted" : "normal";
+                      chunks.push(`<fermata>${fermataText}</fermata>`);
+                    }
                     chunks.push("</notations>");
                   }
                   chunks.push("</note>");
@@ -2352,17 +4208,35 @@ const buildMusicXmlFromAbcParsed = (
 
         const xmlMeasureNumber = xmlEscape(String(measureMeta?.number || measureNo));
         const implicitAttr = measureMeta?.implicit ? ' implicit="yes"' : "";
+        const leftBarlineChunks: string[] = [];
+        if (measureMeta?.endingStart) {
+          leftBarlineChunks.push(`<ending number="${xmlEscape(String(measureMeta.endingStart))}" type="start"/>`);
+        }
+        if (measureMeta?.repeatStart) {
+          leftBarlineChunks.push('<repeat direction="forward" winged="none"/>');
+        }
         const repeatStartXml =
-          measureMeta?.repeat === "forward"
-            ? '<barline location="left"><repeat direction="forward" winged="none"/></barline>'
+          leftBarlineChunks.length > 0
+            ? `<barline location="left">${leftBarlineChunks.join("")}</barline>`
             : "";
+        const rightBarlineChunks: string[] = [];
+        if (measureMeta?.endingStop) {
+          rightBarlineChunks.push(
+            `<ending number="${xmlEscape(String(measureMeta.endingStop))}" type="${measureMeta.endingStopType || "stop"}"/>`
+          );
+        }
+        if (measureMeta?.repeatEnd) {
+          rightBarlineChunks.push(
+            `<repeat direction="backward" winged="none"${
+              Number.isFinite(measureMeta.repeatTimes) && Number(measureMeta.repeatTimes) > 1
+                ? ` times="${Math.round(Number(measureMeta.repeatTimes))}"`
+                : ""
+            }/>`
+          );
+        }
         const repeatEndXml =
-          measureMeta?.repeat === "backward"
-            ? `<barline location="right"><repeat direction="backward" winged="none"${
-                Number.isFinite(measureMeta.repeatTimes) && Number(measureMeta.repeatTimes) > 1
-                  ? ` times="${Math.round(Number(measureMeta.repeatTimes))}"`
-                  : ""
-              }/></barline>`
+          rightBarlineChunks.length > 0
+            ? `<barline location="right">${rightBarlineChunks.join("")}</barline>`
             : "";
         const debugMiscXml = debugMetadata ? buildAbcMeasureDebugMiscXml(notes, measureNo) : "";
         const diagMiscXml =
@@ -2378,7 +4252,7 @@ const buildMusicXmlFromAbcParsed = (
             ? buildAbcSourceMiscXml(abcSource)
             : "";
         measuresXml.push(
-          `<measure number="${xmlMeasureNumber}"${implicitAttr}>${repeatStartXml}${header}${debugMiscXml}${diagMiscXml}${sourceMiscXml}${notesXml}${repeatEndXml}</measure>`
+          `<measure number="${xmlMeasureNumber}"${implicitAttr}>${repeatStartXml}${header}${tempoDirectionXml}${debugMiscXml}${diagMiscXml}${sourceMiscXml}${notesXml}${repeatEndXml}</measure>`
         );
       }
       return `<part id="${xmlEscape(part.partId)}">${measuresXml.join("")}</part>`;

--- a/tests/unit/abc-io.spec.ts
+++ b/tests/unit/abc-io.spec.ts
@@ -94,6 +94,25 @@ C D E F |`;
     expect(xmlCompact.includes("\n")).toBe(false);
   });
 
+  it("ABC->MusicXML parses slash length shorthand including //", () => {
+    const abc = `X:1
+T:Slash shorthand
+M:4/4
+L:1/8
+K:C
+C/D/E/F/ G/F/E/D/ C//D//E//F// G//F//E//D// C2 |`;
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const notes = Array.from(outDoc.querySelectorAll("part > measure > note"));
+    expect(notes.length).toBe(17);
+    expect(notes[0]?.querySelector(":scope > duration")?.textContent?.trim()).toBe("240");
+    expect(notes[8]?.querySelector(":scope > duration")?.textContent?.trim()).toBe("120");
+    expect(notes[16]?.querySelector(":scope > duration")?.textContent?.trim()).toBe("960");
+  });
+
   it("roundtrip of grand staff score should not trigger MEASURE_OVERFULL", () => {
     const grandStaffXml = `<?xml version="1.0" encoding="UTF-8"?>
 <score-partwise version="3.1">
@@ -307,6 +326,640 @@ C D E F |`;
     );
   });
 
+  it("ABC->MusicXML supports inline [K:...] field changes", () => {
+    const abc = `X:1
+T:Inline key change
+M:4/4
+L:1/8
+K:C
+C D E F | [K:G] G A B c |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    expect(outDoc.querySelector('part > measure[number="2"] > attributes > key > fifths')?.textContent?.trim()).toBe("1");
+  });
+
+  it("ABC->MusicXML supports inline [M:...] field changes", () => {
+    const abc = `X:1
+T:Inline meter change
+M:4/4
+L:1/8
+K:C
+C D E F | [M:3/4] G A B |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    expect(outDoc.querySelector('part > measure[number="2"] > attributes > time > beats')?.textContent?.trim()).toBe("3");
+    expect(outDoc.querySelector('part > measure[number="2"] > attributes > time > beat-type')?.textContent?.trim()).toBe("4");
+  });
+
+  it("ABC->MusicXML applies inline [L:...] field changes to subsequent note durations", () => {
+    const abc = `X:1
+T:Inline unit length change
+M:4/4
+L:1/8
+K:C
+C D | [L:1/4] E F |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const firstMeasureFirstNote = outDoc.querySelector('part > measure[number="1"] > note:nth-of-type(1) > duration');
+    const secondMeasureFirstNote = outDoc.querySelector('part > measure[number="2"] > note:nth-of-type(1) > duration');
+    expect(firstMeasureFirstNote?.textContent?.trim()).toBe("480");
+    expect(secondMeasureFirstNote?.textContent?.trim()).toBe("960");
+  });
+
+  it("ABC->MusicXML supports inline [Q:...] field changes", () => {
+    const abc = `X:1
+T:Inline tempo change
+M:4/4
+L:1/8
+K:C
+C D E F | [Q:1/4=132] G A B c |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    expect(outDoc.querySelector('part > measure[number="2"] > direction > direction-type > metronome > per-minute')?.textContent?.trim()).toBe("132");
+    expect(outDoc.querySelector('part > measure[number="2"] > direction > sound')?.getAttribute("tempo")).toBe("132");
+  });
+
+  it("ABC->MusicXML preserves quoted annotations as direction words", () => {
+    const abc = `X:1
+T:Quoted annotation
+M:4/4
+L:1/8
+K:C
+"Am"C D "rit."E F |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const words = Array.from(outDoc.querySelectorAll("part > measure > direction > direction-type > words"))
+      .map((node) => node.textContent?.trim());
+    expect(words).toContain("rit.");
+    expect(outDoc.querySelector("part > measure > harmony")).not.toBeNull();
+    expect(outDoc.querySelectorAll("part > measure > note").length).toBeGreaterThanOrEqual(4);
+    expect(outDoc.querySelector('miscellaneous-field[name="mks:diag:count"]')).toBeNull();
+  });
+
+  it("ABC->MusicXML maps simple quoted chord symbols to MusicXML harmony", () => {
+    const abc = `X:1
+T:Quoted chord symbol
+M:4/4
+L:1/8
+K:C
+"Am"C D "rit."E F |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const harmony = outDoc.querySelector("part > measure > harmony");
+    expect(harmony).not.toBeNull();
+    expect(harmony?.querySelector(":scope > root > root-step")?.textContent?.trim()).toBe("A");
+    expect(harmony?.querySelector(":scope > kind")?.textContent?.trim()).toBe("minor");
+    expect(harmony?.querySelector(":scope > kind")?.getAttribute("text")).toBe("Am");
+
+    const words = Array.from(outDoc.querySelectorAll("part > measure > direction > direction-type > words"))
+      .map((node) => node.textContent?.trim());
+    expect(words).toContain("rit.");
+    expect(words).not.toContain("Am");
+  });
+
+  it("ABC->MusicXML maps common extended quoted chord symbols to MusicXML harmony", () => {
+    const abc = `X:1
+T:Extended chord symbols
+M:4/4
+L:1/8
+K:C
+"C6"C "Dm6"D "G9"E "Fmaj9"F |`;
+
+    const outDoc = parseMusicXmlDocument(convertAbcToMusicXml(abc));
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const harmonies = Array.from(outDoc.querySelectorAll("part > measure > harmony"));
+    expect(harmonies.map((node) => node.querySelector(":scope > kind")?.getAttribute("text"))).toEqual([
+      "C6",
+      "Dm6",
+      "G9",
+      "Fmaj9",
+    ]);
+    expect(harmonies.map((node) => node.querySelector(":scope > kind")?.textContent?.trim())).toEqual([
+      "major-sixth",
+      "minor-sixth",
+      "dominant-ninth",
+      "major-ninth",
+    ]);
+  });
+
+  it("ABC->MusicXML maps richer quoted chord symbols including slash chords to MusicXML harmony", () => {
+    const abc = `X:1
+T:Richer chord symbols
+M:4/4
+L:1/8
+K:C
+"Em9"C "G11/B"D "A13"E "D7sus4/F#"F |`;
+
+    const outDoc = parseMusicXmlDocument(convertAbcToMusicXml(abc));
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const harmonies = Array.from(outDoc.querySelectorAll("part > measure > harmony"));
+    expect(harmonies.map((node) => node.querySelector(":scope > kind")?.getAttribute("text"))).toEqual([
+      "Em9",
+      "G11/B",
+      "A13",
+      "D7sus4/F#",
+    ]);
+    expect(harmonies.map((node) => node.querySelector(":scope > kind")?.textContent?.trim())).toEqual([
+      "minor-ninth",
+      "dominant-11th",
+      "dominant-13th",
+      "suspended-fourth",
+    ]);
+    expect(harmonies[1]?.querySelector(":scope > bass > bass-step")?.textContent?.trim()).toBe("B");
+    expect(harmonies[3]?.querySelector(":scope > bass > bass-step")?.textContent?.trim()).toBe("F");
+    expect(harmonies[3]?.querySelector(":scope > bass > bass-alter")?.textContent?.trim()).toBe("1");
+  });
+
+  it("ABC->MusicXML parses mikuscore rehearsal decoration as rehearsal direction", () => {
+    const abc = `X:1
+T:Rehearsal
+M:4/4
+L:1/4
+K:C
+!rehearsal:A1!C D E F |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    expect(outDoc.querySelector("part > measure > direction > direction-type > rehearsal")?.textContent?.trim()).toBe("A1");
+  });
+
+  it("ABC->MusicXML accepts standard shorthand decoration symbols", () => {
+    const abc = `X:1
+T:Standard shorthand symbols
+M:4/4
+L:1/8
+K:C
+~C H D L E M F O G P A S B T c u d v e |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const notes = Array.from(outDoc.querySelectorAll("part > measure > note"));
+    const pitched = notes.filter((note) => note.querySelector(":scope > pitch") !== null);
+    expect(pitched.length).toBeGreaterThanOrEqual(10);
+
+    expect(pitched[0]?.querySelector(":scope > notations > arpeggiate")).not.toBeNull();
+    expect(pitched[1]?.querySelector(":scope > notations > fermata")?.textContent?.trim()).toBe("normal");
+    expect(pitched[2]?.querySelector(":scope > notations > articulations > accent")).not.toBeNull();
+    expect(pitched[3]?.querySelector(":scope > notations > ornaments > mordent")).not.toBeNull();
+    expect(pitched[5]?.querySelector(":scope > notations > ornaments > inverted-mordent")).not.toBeNull();
+    expect(pitched[7]?.querySelector(":scope > notations > ornaments > trill-mark")).not.toBeNull();
+    expect(pitched[8]?.querySelector(":scope > notations > technical > up-bow")).not.toBeNull();
+    expect(pitched[9]?.querySelector(":scope > notations > technical > down-bow")).not.toBeNull();
+
+    expect(outDoc.querySelectorAll("part > measure > direction > direction-type > coda").length).toBeGreaterThanOrEqual(1);
+    expect(outDoc.querySelectorAll("part > measure > direction > direction-type > segno").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("MusicXML->ABC exports direction words as quoted annotations", () => {
+    const xml = `<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>480</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <direction><direction-type><words>rit.</words></direction-type></direction>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>480</duration><voice>1</voice><type>eighth</type></note>
+      <note><pitch><step>D</step><octave>4</octave></pitch><duration>480</duration><voice>1</voice><type>eighth</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+
+    const doc = parseMusicXmlDocument(xml);
+    expect(doc).not.toBeNull();
+    if (!doc) return;
+
+    const abc = exportMusicXmlDomToAbc(doc);
+    expect(abc).toContain('"rit."C');
+  });
+
+  it("MusicXML->ABC exports harmony as quoted chord symbols", () => {
+    const xml = `<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>480</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <harmony><root><root-step>A</root-step></root><kind text="Am">minor</kind></harmony>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>480</duration><voice>1</voice><type>eighth</type></note>
+      <note><pitch><step>D</step><octave>4</octave></pitch><duration>480</duration><voice>1</voice><type>eighth</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+
+    const doc = parseMusicXmlDocument(xml);
+    expect(doc).not.toBeNull();
+    if (!doc) return;
+
+    const abc = exportMusicXmlDomToAbc(doc);
+    expect(abc).toContain('"Am"C');
+
+    const roundtrip = parseMusicXmlDocument(convertAbcToMusicXml(abc));
+    expect(roundtrip).not.toBeNull();
+    if (!roundtrip) return;
+    expect(roundtrip.querySelector("part > measure > harmony > root > root-step")?.textContent?.trim()).toBe("A");
+    expect(roundtrip.querySelector("part > measure > harmony > kind")?.textContent?.trim()).toBe("minor");
+  });
+
+  it("MusicXML->ABC exports common extended harmony kinds as quoted chord symbols", () => {
+    const xml = `<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>480</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <harmony><root><root-step>C</root-step></root><kind>major-sixth</kind></harmony>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>480</duration><voice>1</voice><type>eighth</type></note>
+      <harmony><root><root-step>D</root-step></root><kind>minor-sixth</kind></harmony>
+      <note><pitch><step>D</step><octave>4</octave></pitch><duration>480</duration><voice>1</voice><type>eighth</type></note>
+      <harmony><root><root-step>G</root-step></root><kind>dominant-ninth</kind></harmony>
+      <note><pitch><step>E</step><octave>4</octave></pitch><duration>480</duration><voice>1</voice><type>eighth</type></note>
+      <harmony><root><root-step>F</root-step></root><kind>major-ninth</kind></harmony>
+      <note><pitch><step>F</step><octave>4</octave></pitch><duration>480</duration><voice>1</voice><type>eighth</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+
+    const doc = parseMusicXmlDocument(xml);
+    expect(doc).not.toBeNull();
+    if (!doc) return;
+
+    const abc = exportMusicXmlDomToAbc(doc);
+    expect(abc).toContain('"C6"C');
+    expect(abc).toContain('"Dm6"D');
+    expect(abc).toContain('"G9"E');
+    expect(abc).toContain('"Fmaj9"F');
+  });
+
+  it("MusicXML->ABC exports richer harmony kinds and slash chords as quoted chord symbols", () => {
+    const xml = `<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>480</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <harmony><root><root-step>E</root-step></root><kind>minor-ninth</kind></harmony>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>480</duration><voice>1</voice><type>eighth</type></note>
+      <harmony><root><root-step>G</root-step></root><bass><bass-step>B</bass-step></bass><kind>dominant-11th</kind></harmony>
+      <note><pitch><step>D</step><octave>4</octave></pitch><duration>480</duration><voice>1</voice><type>eighth</type></note>
+      <harmony><root><root-step>A</root-step></root><kind>dominant-13th</kind></harmony>
+      <note><pitch><step>E</step><octave>4</octave></pitch><duration>480</duration><voice>1</voice><type>eighth</type></note>
+      <harmony><root><root-step>D</root-step></root><bass><bass-step>F</bass-step><bass-alter>1</bass-alter></bass><kind>suspended-fourth</kind></harmony>
+      <note><pitch><step>F</step><octave>4</octave></pitch><duration>480</duration><voice>1</voice><type>eighth</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+
+    const doc = parseMusicXmlDocument(xml);
+    expect(doc).not.toBeNull();
+    if (!doc) return;
+
+    const abc = exportMusicXmlDomToAbc(doc);
+    expect(abc).toContain('"Em9"C');
+    expect(abc).toContain('"G11/B"D');
+    expect(abc).toContain('"A13"E');
+    expect(abc).toContain('"Dsus4/F#"F');
+  });
+
+  it("MusicXML->ABC exports rehearsal direction as mikuscore rehearsal decoration and roundtrips it", () => {
+    const xml = `<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>480</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <direction><direction-type><rehearsal>A1</rehearsal></direction-type></direction>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>1920</duration><voice>1</voice><type>whole</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+
+    const doc = parseMusicXmlDocument(xml);
+    expect(doc).not.toBeNull();
+    if (!doc) return;
+
+    const abc = exportMusicXmlDomToAbc(doc);
+    expect(abc).toContain("!rehearsal:A1!");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector("part > measure > direction > direction-type > rehearsal")?.textContent?.trim()).toBe("A1");
+  });
+
+  it("ABC->MusicXML maps w: lyrics onto subsequent notes", () => {
+    const abc = `X:1
+T:Lyrics
+M:4/4
+L:1/8
+K:C
+C D E F |
+w: la la la la`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const lyrics = Array.from(outDoc.querySelectorAll("part > measure > note > lyric > text"))
+      .map((node) => node.textContent?.trim());
+    expect(lyrics).toEqual(["la", "la", "la", "la"]);
+    const syllabics = Array.from(outDoc.querySelectorAll("part > measure > note > lyric > syllabic"))
+      .map((node) => node.textContent?.trim());
+    expect(syllabics).toEqual(["single", "single", "single", "single"]);
+  });
+
+  it("MusicXML->ABC exports lyrics as w: lines", () => {
+    const xml = `<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>480</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch><duration>480</duration><voice>1</voice><type>eighth</type>
+        <lyric><syllabic>begin</syllabic><text>hal</text></lyric>
+      </note>
+      <note>
+        <pitch><step>D</step><octave>4</octave></pitch><duration>480</duration><voice>1</voice><type>eighth</type>
+        <lyric><syllabic>end</syllabic><text>lo</text></lyric>
+      </note>
+      <note>
+        <pitch><step>E</step><octave>4</octave></pitch><duration>480</duration><voice>1</voice><type>eighth</type>
+        <lyric><syllabic>single</syllabic><text>world</text></lyric>
+      </note>
+    </measure>
+  </part>
+</score-partwise>`;
+
+    const doc = parseMusicXmlDocument(xml);
+    expect(doc).not.toBeNull();
+    if (!doc) return;
+
+    const abc = exportMusicXmlDomToAbc(doc);
+    expect(abc).toContain("w: hal- lo world");
+  });
+
+  it("ABC->MusicXML supports hyphenated w: lyrics with syllabic markers", () => {
+    const abc = `X:1
+T:Lyrics hyphen
+M:4/4
+L:1/8
+K:C
+C D E |
+w: hal-le-lu`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const lyrics = Array.from(outDoc.querySelectorAll("part > measure > note > lyric > text"))
+      .map((node) => node.textContent?.trim());
+    expect(lyrics).toEqual(["hal", "le", "lu"]);
+    const syllabics = Array.from(outDoc.querySelectorAll("part > measure > note > lyric > syllabic"))
+      .map((node) => node.textContent?.trim());
+    expect(syllabics).toEqual(["begin", "middle", "end"]);
+  });
+
+  it("ABC->MusicXML supports inline [V:...] voice switches in body text", () => {
+    const abc = `X:1
+T:Inline voice switch
+M:4/4
+L:1/8
+K:C
+V:1 name="Upper"
+V:2 name="Lower"
+[V:1] C D | [V:2] E F |
+[V:1] G A | [V:2] B c |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const upperNotes = Array.from(outDoc.querySelectorAll('part[id="P1"] > measure > note > pitch > step'))
+      .map((node) => node.textContent?.trim());
+    const lowerNotes = Array.from(outDoc.querySelectorAll('part[id="P2"] > measure > note > pitch > step'))
+      .map((node) => node.textContent?.trim());
+    expect(upperNotes).toEqual(["C", "D", "G", "A"]);
+    expect(lowerNotes).toEqual(["E", "F", "B", "C"]);
+    expect(outDoc.querySelector('part-list > score-part[id="P1"] > part-name')?.textContent?.trim()).toBe("Upper");
+    expect(outDoc.querySelector('part-list > score-part[id="P2"] > part-name')?.textContent?.trim()).toBe("Lower");
+    expect(outDoc.querySelector('miscellaneous-field[name="mks:diag:count"]')).toBeNull();
+  });
+
+  it("ABC->MusicXML supports U: user-defined decoration symbols with punctuation", () => {
+    const abc = `X:1
+T:User defined decoration
+U:~=!trill!
+M:4/4
+L:1/8
+K:C
+~C D E F |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const firstNote = outDoc.querySelector("part > measure > note");
+    expect(firstNote?.querySelector(":scope > notations > ornaments > trill-mark")).not.toBeNull();
+    expect(outDoc.querySelector('miscellaneous-field[name="mks:diag:count"]')).toBeNull();
+  });
+
+  it("ABC->MusicXML supports U: user-defined decoration symbols with letters outside note names", () => {
+    const abc = `X:1
+T:User defined fermata
+U:H=!fermata!
+M:4/4
+L:1/8
+K:C
+HC D E F |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const firstNote = outDoc.querySelector("part > measure > note");
+    expect(firstNote?.querySelector(":scope > notations > fermata")).not.toBeNull();
+    expect(outDoc.querySelector('miscellaneous-field[name="mks:diag:count"]')).toBeNull();
+  });
+
+  it("ABC->MusicXML supports U: user-defined decoration symbols declared with +...+ wrappers", () => {
+    const abc = `X:1
+T:User defined accent
+U:Z=+accent+
+M:4/4
+L:1/8
+K:C
+ZC D E F |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const firstNote = outDoc.querySelector("part > measure > note");
+    expect(firstNote?.querySelector(":scope > notations > articulations > accent")).not.toBeNull();
+    expect(outDoc.querySelector('miscellaneous-field[name="mks:diag:count"]')).toBeNull();
+  });
+
+  it("ABC->MusicXML ignores malformed U: user-defined symbol syntax and continues", () => {
+    const abc = `X:1
+T:Broken user defined decoration
+U:~
+M:4/4
+L:1/8
+K:C
+C D E F |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const steps = Array.from(outDoc.querySelectorAll("part > measure > note > pitch > step"))
+      .map((node) => node.textContent?.trim());
+    expect(steps).toEqual(["C", "D", "E", "F"]);
+    expect(outDoc.querySelector('miscellaneous-field[name="mks:diag:count"]')).toBeNull();
+  });
+
+  it("ABC->MusicXML skips unsupported inline body fields with warning instead of failing", () => {
+    const abc = `X:1
+T:Inline unsupported field
+M:4/4
+L:1/8
+K:C
+[P:A] C D E F |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    expect(outDoc.querySelector('miscellaneous-field[name="mks:diag:count"]')).not.toBeNull();
+    expect(outDoc.querySelector('miscellaneous-field[name="mks:diag:0001"]')?.textContent).toContain(
+      "Skipped unsupported inline field: [P:A]"
+    );
+  });
+
+  it("ABC->MusicXML maps overlay syntax & into synthetic overlay voices", () => {
+    const abc = `X:1
+T:Overlay mapped
+M:4/4
+L:1/8
+K:C
+C D & E F |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const partNames = Array.from(outDoc.querySelectorAll("part-list > score-part > part-name")).map((node) => node.textContent?.trim());
+    expect(partNames).toEqual(["Voice 1", "Voice 1 overlay 2"]);
+    const part1Steps = Array.from(outDoc.querySelectorAll('part[id="P1"] > measure > note > pitch > step')).map((node) => node.textContent?.trim());
+    const part2Steps = Array.from(outDoc.querySelectorAll('part[id="P2"] > measure > note > pitch > step')).map((node) => node.textContent?.trim());
+    expect(part1Steps).toEqual(["C", "D"]);
+    expect(part2Steps).toEqual(["E", "F"]);
+    expect(outDoc.querySelector('miscellaneous-field[name="mks:diag:count"]')).toBeNull();
+  });
+
+  it("ABC->MusicXML keeps later-measure overlay notes when syntax & appears after earlier plain measures", () => {
+    const abc = `X:1
+T:Overlay later measure
+M:4/4
+L:1/8
+K:C
+C D E F | G A & B c |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const part1Measure1 = Array.from(outDoc.querySelectorAll('part[id="P1"] > measure[number="1"] > note > pitch > step')).map((node) => node.textContent?.trim());
+    const part1Measure2 = Array.from(outDoc.querySelectorAll('part[id="P1"] > measure[number="2"] > note > pitch > step')).map((node) => node.textContent?.trim());
+    const part2Steps = Array.from(outDoc.querySelectorAll('part[id="P2"] > measure > note > pitch > step')).map((node) => node.textContent?.trim());
+
+    expect(part1Measure1).toEqual(["C", "D", "E", "F"]);
+    expect(part1Measure2).toEqual(["G", "A"]);
+    expect(part2Steps).toEqual(["B", "C"]);
+    expect(outDoc.querySelector('miscellaneous-field[name="mks:diag:count"]')).toBeNull();
+  });
+
   it("ABC->MusicXML parses trill decoration and grace notes", () => {
     const abc = `X:1
 T:Ornament test
@@ -326,6 +979,124 @@ V:1
     expect(notes[0]?.querySelector(":scope > grace")).not.toBeNull();
     const principal = notes.find((n) => n.querySelector(":scope > grace") === null);
     expect(principal?.querySelector(":scope > notations > ornaments > trill-mark")).not.toBeNull();
+
+    const core = new ScoreCore();
+    core.load(xml);
+    const save = core.save();
+    expect(save.ok).toBe(true);
+  });
+
+  it("ABC->MusicXML accepts !tr! as trill alias", () => {
+    const abc = `X:1
+T:Trill alias
+M:4/4
+L:1/8
+K:C
+!tr!C D E F |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const firstNote = outDoc.querySelector("part > measure > note");
+    expect(firstNote?.querySelector(":scope > notations > ornaments > trill-mark")).not.toBeNull();
+  });
+
+  it("ABC->MusicXML accepts !triller! as trill alias", () => {
+    const abc = `X:1
+T:Triller alias
+M:4/4
+L:1/8
+K:C
+!triller!C D E F |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const firstNote = outDoc.querySelector("part > measure > note");
+    expect(firstNote?.querySelector(":scope > notations > ornaments > trill-mark")).not.toBeNull();
+  });
+
+  it("ABC->MusicXML restores standard repeat barlines from |: and :|", () => {
+    const abc = `X:1
+T:Repeat bars
+M:4/4
+L:1/8
+K:C
+|: C D E F | G A B c :|`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    expect(outDoc.querySelector('part > measure[number="1"] > barline[location="left"] > repeat')?.getAttribute("direction")).toBe("forward");
+    expect(outDoc.querySelector('part > measure[number="2"] > barline[location="right"] > repeat')?.getAttribute("direction")).toBe("backward");
+
+    const core = new ScoreCore();
+    core.load(xml);
+    const save = core.save();
+    expect(save.ok).toBe(true);
+  });
+
+  it("ABC->MusicXML restores alternate endings from standard ABC markers", () => {
+    const abc = `X:1
+T:Alternate endings
+M:4/4
+L:1/8
+K:C
+|: C D E F |
+[1 G A B c :|]
+[2 c B A G ||`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    expect(outDoc.querySelector('part > measure[number="1"] > barline[location="left"] > repeat')?.getAttribute("direction")).toBe("forward");
+    expect(outDoc.querySelector('part > measure[number="2"] > barline[location="left"] > ending')?.getAttribute("number")).toBe("1");
+    expect(outDoc.querySelector('part > measure[number="2"] > barline[location="left"] > ending')?.getAttribute("type")).toBe("start");
+    expect(outDoc.querySelector('part > measure[number="2"] > barline[location="right"] > repeat')?.getAttribute("direction")).toBe("backward");
+    expect(outDoc.querySelector('part > measure[number="2"] > barline[location="right"] > ending')?.getAttribute("number")).toBe("1");
+    expect(outDoc.querySelector('part > measure[number="2"] > barline[location="right"] > ending')?.getAttribute("type")).toBe("stop");
+    expect(outDoc.querySelector('part > measure[number="3"] > barline[location="left"] > ending')?.getAttribute("number")).toBe("2");
+    expect(outDoc.querySelector('part > measure[number="3"] > barline[location="right"] > ending')?.getAttribute("number")).toBe("2");
+
+    const notes = Array.from(outDoc.querySelectorAll("part > measure > note"));
+    expect(notes.length).toBeGreaterThanOrEqual(12);
+
+    const core = new ScoreCore();
+    core.load(xml);
+    const save = core.save();
+    expect(save.ok).toBe(true);
+  });
+
+  it("ABC->MusicXML restores alternate endings from |1 and :|2 style markers", () => {
+    const abc = `X:1
+T:Alternate endings barline style
+M:4/4
+L:1/8
+K:C
+|: C D E F |1 G A B c :|2 c B A G ||`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    expect(outDoc.querySelector('part > measure[number="1"] > barline[location="left"] > repeat')?.getAttribute("direction")).toBe("forward");
+    expect(outDoc.querySelector('part > measure[number="2"] > barline[location="left"] > ending')?.getAttribute("number")).toBe("1");
+    expect(outDoc.querySelector('part > measure[number="2"] > barline[location="right"] > repeat')?.getAttribute("direction")).toBe("backward");
+    expect(outDoc.querySelector('part > measure[number="2"] > barline[location="right"] > ending')?.getAttribute("number")).toBe("1");
+    expect(outDoc.querySelector('part > measure[number="3"] > barline[location="left"] > ending')?.getAttribute("number")).toBe("2");
+    expect(outDoc.querySelector('part > measure[number="3"] > barline[location="right"] > ending')?.getAttribute("number")).toBe("2");
+
+    const notes = Array.from(outDoc.querySelectorAll("part > measure > note"));
+    expect(notes.length).toBeGreaterThanOrEqual(12);
 
     const core = new ScoreCore();
     core.load(xml);
@@ -353,6 +1124,85 @@ V:1
     expect(principal?.querySelector(":scope > notations > ornaments > turn")).not.toBeNull();
   });
 
+  it("ABC->MusicXML accepts !lowerturn! as inverted-turn alias", () => {
+    const abc = `X:1
+T:Lower turn alias
+M:4/4
+L:1/8
+K:C
+!lowerturn!C D E F |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const firstNote = outDoc.querySelector("part > measure > note");
+    expect(firstNote?.querySelector(":scope > notations > ornaments > inverted-turn")).not.toBeNull();
+  });
+
+  it("ABC->MusicXML parses delayed turn variants", () => {
+    const abc = `X:1
+T:Delayed turn
+M:4/4
+L:1/4
+K:C
+!delayedturn!C !delayedinvertedturn!D |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const notes = Array.from(outDoc.querySelectorAll("part > measure > note"));
+    expect(notes[0]?.querySelector(":scope > notations > ornaments > turn")).not.toBeNull();
+    expect(notes[0]?.querySelector(":scope > notations > ornaments > delayed-turn")).not.toBeNull();
+    expect(notes[1]?.querySelector(":scope > notations > ornaments > inverted-turn")).not.toBeNull();
+    expect(notes[1]?.querySelector(":scope > notations > ornaments > delayed-turn")).not.toBeNull();
+  });
+
+  it("ABC->MusicXML parses mikuscore tremolo decorations", () => {
+    const abc = `X:1
+T:Tremolo
+M:4/4
+L:1/4
+K:C
+!tremolo-single-3!C !tremolo-start-2!D !tremolo-stop-2!E |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const tremolos = Array.from(outDoc.querySelectorAll("part > measure > note > notations > ornaments > tremolo"));
+    expect(tremolos[0]?.getAttribute("type")).toBe("single");
+    expect(tremolos[0]?.textContent?.trim()).toBe("3");
+    expect(tremolos[1]?.getAttribute("type")).toBe("start");
+    expect(tremolos[1]?.textContent?.trim()).toBe("2");
+    expect(tremolos[2]?.getAttribute("type")).toBe("stop");
+    expect(tremolos[2]?.textContent?.trim()).toBe("2");
+  });
+
+  it("ABC->MusicXML parses mikuscore glissando/slide decorations", () => {
+    const abc = `X:1
+T:Spanners
+M:4/4
+L:1/4
+K:C
+!gliss-start!C !gliss-stop!D !slide-start!E !slide-stop!F |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const notes = Array.from(outDoc.querySelectorAll("part > measure > note"));
+    expect(notes[0]?.querySelector(':scope > notations > glissando[type="start"]')).not.toBeNull();
+    expect(notes[1]?.querySelector(':scope > notations > glissando[type="stop"]')).not.toBeNull();
+    expect(notes[2]?.querySelector(':scope > notations > slide[type="start"]')).not.toBeNull();
+    expect(notes[3]?.querySelector(':scope > notations > slide[type="stop"]')).not.toBeNull();
+  });
+
   it("ABC->MusicXML parses staccato decoration", () => {
     const abc = `X:1
 T:Staccato test
@@ -371,6 +1221,1437 @@ V:1
     expect(firstNote?.querySelector(":scope > notations > articulations > staccato")).not.toBeNull();
   });
 
+  it("ABC->MusicXML accepts !stacc! and !stac! as staccato aliases", () => {
+    const abc = `X:1
+T:Staccato aliases
+M:4/4
+L:1/4
+K:C
+!stacc!C !stac!D |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const notes = Array.from(outDoc.querySelectorAll("part > measure > note"));
+    expect(notes[0]?.querySelector(":scope > notations > articulations > staccato")).not.toBeNull();
+    expect(notes[1]?.querySelector(":scope > notations > articulations > staccato")).not.toBeNull();
+  });
+
+  it("ABC->MusicXML parses accent, tenuto, and fermata decorations", () => {
+    const abc = `X:1
+T:Decoration expansion
+M:4/4
+L:1/4
+K:C
+!accent!C !tenuto!D !fermata!E F |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const notes = Array.from(outDoc.querySelectorAll("part > measure > note"));
+    expect(notes[0]?.querySelector(":scope > notations > articulations > accent")).not.toBeNull();
+    expect(notes[1]?.querySelector(":scope > notations > articulations > tenuto")).not.toBeNull();
+    expect(notes[2]?.querySelector(":scope > notations > fermata")).not.toBeNull();
+  });
+
+  it("ABC->MusicXML parses stress and unstress decorations", () => {
+    const abc = `X:1
+T:Stress
+M:4/4
+L:1/4
+K:C
+!stress!C !unstress!D |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const notes = Array.from(outDoc.querySelectorAll("part > measure > note"));
+    expect(notes[0]?.querySelector(":scope > notations > articulations > stress")).not.toBeNull();
+    expect(notes[1]?.querySelector(":scope > notations > articulations > unstress")).not.toBeNull();
+  });
+
+  it("ABC->MusicXML parses inverted fermata distinctly", () => {
+    const abc = `X:1
+T:Inverted fermata
+M:4/4
+L:1/4
+K:C
+!invertedfermata!C D |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const fermata = outDoc.querySelector("part > measure > note > notations > fermata");
+    expect(fermata?.textContent?.trim()).toBe("inverted");
+  });
+
+  it("ABC->MusicXML accepts !inverted fermata! as inverted-fermata alias", () => {
+    const abc = `X:1
+T:Inverted fermata alias
+M:4/4
+L:1/4
+K:C
+!inverted fermata!C D |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const fermata = outDoc.querySelector("part > measure > note > notations > fermata");
+    expect(fermata?.textContent?.trim()).toBe("inverted");
+  });
+
+  it("ABC->MusicXML parses marcato, breath, and caesura decorations", () => {
+    const abc = `X:1
+T:Decoration expansion 2
+M:4/4
+L:1/4
+K:C
+!marcato!C !breath!D !caesura!E F |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const notes = Array.from(outDoc.querySelectorAll("part > measure > note"));
+    expect(notes[0]?.querySelector(":scope > notations > articulations > strong-accent")).not.toBeNull();
+    expect(notes[1]?.querySelector(":scope > notations > articulations > breath-mark")).not.toBeNull();
+    expect(notes[2]?.querySelector(":scope > notations > articulations > caesura")).not.toBeNull();
+  });
+
+  it("ABC->MusicXML accepts !strong accent! as marcato alias", () => {
+    const abc = `X:1
+T:Marcato alias
+M:4/4
+L:1/4
+K:C
+!strong accent!C D |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const firstNote = outDoc.querySelector("part > measure > note");
+    expect(firstNote?.querySelector(":scope > notations > articulations > strong-accent")).not.toBeNull();
+  });
+
+  it("ABC->MusicXML accepts !strongaccent! as marcato alias", () => {
+    const abc = `X:1
+T:Marcato compact alias
+M:4/4
+L:1/4
+K:C
+!strongaccent!C D |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const firstNote = outDoc.querySelector("part > measure > note");
+    expect(firstNote?.querySelector(":scope > notations > articulations > strong-accent")).not.toBeNull();
+  });
+
+  it("ABC->MusicXML accepts !strong-accent! as marcato alias", () => {
+    const abc = `X:1
+T:Marcato hyphen alias
+M:4/4
+L:1/4
+K:C
+!strong-accent!C D |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const firstNote = outDoc.querySelector("part > measure > note");
+    expect(firstNote?.querySelector(":scope > notations > articulations > strong-accent")).not.toBeNull();
+  });
+
+  it("ABC->MusicXML accepts !breathmark! as breath-mark alias", () => {
+    const abc = `X:1
+T:Breath alias
+M:4/4
+L:1/4
+K:C
+!breathmark!C D |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const firstNote = outDoc.querySelector("part > measure > note");
+    expect(firstNote?.querySelector(":scope > notations > articulations > breath-mark")).not.toBeNull();
+  });
+
+  it("ABC->MusicXML accepts !breath mark! as breath-mark alias", () => {
+    const abc = `X:1
+T:Breath spaced alias
+M:4/4
+L:1/4
+K:C
+!breath mark!C D |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const firstNote = outDoc.querySelector("part > measure > note");
+    expect(firstNote?.querySelector(":scope > notations > articulations > breath-mark")).not.toBeNull();
+  });
+
+  it("ABC->MusicXML accepts !breath-mark! as breath-mark alias", () => {
+    const abc = `X:1
+T:Breath hyphen alias
+M:4/4
+L:1/4
+K:C
+!breath-mark!C D |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const firstNote = outDoc.querySelector("part > measure > note");
+    expect(firstNote?.querySelector(":scope > notations > articulations > breath-mark")).not.toBeNull();
+  });
+
+  it("ABC->MusicXML parses staccatissimo decoration distinctly from staccato", () => {
+    const abc = `X:1
+T:Staccatissimo
+M:4/4
+L:1/8
+K:C
+!wedge!c2 d2 |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const firstNote = outDoc.querySelector("part > measure > note");
+    expect(firstNote?.querySelector(":scope > notations > articulations > staccatissimo")).not.toBeNull();
+    expect(firstNote?.querySelector(":scope > notations > articulations > staccato")).toBeNull();
+  });
+
+  it("ABC->MusicXML accepts !spiccato! as staccatissimo alias", () => {
+    const abc = `X:1
+T:Spiccato alias
+M:4/4
+L:1/8
+K:C
+!spiccato!c2 d2 |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const firstNote = outDoc.querySelector("part > measure > note");
+    expect(firstNote?.querySelector(":scope > notations > articulations > staccatissimo")).not.toBeNull();
+    expect(firstNote?.querySelector(":scope > notations > articulations > staccato")).toBeNull();
+  });
+
+  it("ABC->MusicXML parses up-bow and down-bow decorations", () => {
+    const abc = `X:1
+T:Bowing
+M:4/4
+L:1/4
+K:C
+!upbow!C !downbow!D |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const notes = Array.from(outDoc.querySelectorAll("part > measure > note"));
+    expect(notes[0]?.querySelector(":scope > notations > technical > up-bow")).not.toBeNull();
+    expect(notes[1]?.querySelector(":scope > notations > technical > down-bow")).not.toBeNull();
+  });
+
+  it("ABC->MusicXML accepts !up bow! and !down bow! as bowing aliases", () => {
+    const abc = `X:1
+T:Bowing aliases
+M:4/4
+L:1/4
+K:C
+!up bow!C !down bow!D |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const notes = Array.from(outDoc.querySelectorAll("part > measure > note"));
+    expect(notes[0]?.querySelector(":scope > notations > technical > up-bow")).not.toBeNull();
+    expect(notes[1]?.querySelector(":scope > notations > technical > down-bow")).not.toBeNull();
+  });
+
+  it("ABC->MusicXML accepts !up-bow! and !down-bow! as bowing aliases", () => {
+    const abc = `X:1
+T:Bowing hyphen aliases
+M:4/4
+L:1/4
+K:C
+!up-bow!C !down-bow!D |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const notes = Array.from(outDoc.querySelectorAll("part > measure > note"));
+    expect(notes[0]?.querySelector(":scope > notations > technical > up-bow")).not.toBeNull();
+    expect(notes[1]?.querySelector(":scope > notations > technical > down-bow")).not.toBeNull();
+  });
+
+  it("ABC->MusicXML parses double-tongue, triple-tongue, heel, and toe decorations", () => {
+    const abc = `X:1
+T:Technical extensions
+M:4/4
+L:1/4
+K:C
+!doubletongue!C !tripletongue!D !heel!E !toe!F |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const notes = Array.from(outDoc.querySelectorAll("part > measure > note"));
+    expect(notes[0]?.querySelector(":scope > notations > technical > double-tongue")).not.toBeNull();
+    expect(notes[1]?.querySelector(":scope > notations > technical > triple-tongue")).not.toBeNull();
+    expect(notes[2]?.querySelector(":scope > notations > technical > heel")).not.toBeNull();
+    expect(notes[3]?.querySelector(":scope > notations > technical > toe")).not.toBeNull();
+  });
+
+  it("ABC->MusicXML accepts !heel mark! and !toe mark! as aliases", () => {
+    const abc = `X:1
+T:Heel toe aliases
+M:4/4
+L:1/4
+K:C
+!heel mark!C !toe mark!D |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const notes = Array.from(outDoc.querySelectorAll("part > measure > note"));
+    expect(notes[0]?.querySelector(":scope > notations > technical > heel")).not.toBeNull();
+    expect(notes[1]?.querySelector(":scope > notations > technical > toe")).not.toBeNull();
+  });
+
+  it("ABC->MusicXML accepts !double tongue! and !triple tongue! as tongue aliases", () => {
+    const abc = `X:1
+T:Tongue aliases
+M:4/4
+L:1/4
+K:C
+!double tongue!C !triple tongue!D |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const notes = Array.from(outDoc.querySelectorAll("part > measure > note"));
+    expect(notes[0]?.querySelector(":scope > notations > technical > double-tongue")).not.toBeNull();
+    expect(notes[1]?.querySelector(":scope > notations > technical > triple-tongue")).not.toBeNull();
+  });
+
+  it("ABC->MusicXML accepts !double-tongue! and !triple-tongue! as tongue aliases", () => {
+    const abc = `X:1
+T:Tongue hyphen aliases
+M:4/4
+L:1/4
+K:C
+!double-tongue!C !triple-tongue!D |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const notes = Array.from(outDoc.querySelectorAll("part > measure > note"));
+    expect(notes[0]?.querySelector(":scope > notations > technical > double-tongue")).not.toBeNull();
+    expect(notes[1]?.querySelector(":scope > notations > technical > triple-tongue")).not.toBeNull();
+  });
+
+  it("ABC->MusicXML parses mikuscore fingering and string decorations", () => {
+    const abc = `X:1
+T:Fingering and string
+M:4/4
+L:1/2
+K:C
+!fingering:1!!fingering:4!C !string:1!D !string:4!E |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const notes = Array.from(outDoc.querySelectorAll("part > measure > note"));
+    const fingerings = Array.from(notes[0]?.querySelectorAll(":scope > notations > technical > fingering") ?? []).map((n) => n.textContent?.trim());
+    expect(fingerings).toEqual(["1", "4"]);
+    expect(notes[1]?.querySelector(":scope > notations > technical > string")?.textContent?.trim()).toBe("1");
+    expect(notes[2]?.querySelector(":scope > notations > technical > string")?.textContent?.trim()).toBe("4");
+  });
+
+  it("ABC->MusicXML parses mikuscore pluck decorations", () => {
+    const abc = `X:1
+T:Pluck
+M:4/4
+L:1
+K:C
+!pluck:p!!pluck:i!!pluck:m!!pluck:a!C |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const plucks = Array.from(outDoc.querySelectorAll("part > measure > note > notations > technical > pluck")).map((n) => n.textContent?.trim());
+    expect(plucks).toEqual(["p", "i", "m", "a"]);
+  });
+
+  it("ABC->MusicXML parses open-string decoration", () => {
+    const abc = `X:1
+T:Open string
+M:4/4
+L:1/4
+K:C
+!open!C D |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const firstNote = outDoc.querySelector("part > measure > note");
+    expect(firstNote?.querySelector(":scope > notations > technical > open-string")).not.toBeNull();
+  });
+
+  it("ABC->MusicXML accepts !openstring! as open-string alias", () => {
+    const abc = `X:1
+T:Open string alias
+M:4/4
+L:1/4
+K:C
+!openstring!C D |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const firstNote = outDoc.querySelector("part > measure > note");
+    expect(firstNote?.querySelector(":scope > notations > technical > open-string")).not.toBeNull();
+  });
+
+  it("ABC->MusicXML accepts !open string! as open-string alias", () => {
+    const abc = `X:1
+T:Open string spaced alias
+M:4/4
+L:1/4
+K:C
+!open string!C D |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const firstNote = outDoc.querySelector("part > measure > note");
+    expect(firstNote?.querySelector(":scope > notations > technical > open-string")).not.toBeNull();
+  });
+
+  it("ABC->MusicXML accepts !open-string! as open-string alias", () => {
+    const abc = `X:1
+T:Open string hyphen alias
+M:4/4
+L:1/4
+K:C
+!open-string!C D |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const firstNote = outDoc.querySelector("part > measure > note");
+    expect(firstNote?.querySelector(":scope > notations > technical > open-string")).not.toBeNull();
+  });
+
+  it("ABC->MusicXML parses snap-pizzicato decoration", () => {
+    const abc = `X:1
+T:Snap pizzicato
+M:4/4
+L:1/4
+K:C
+!snap!C D |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const firstNote = outDoc.querySelector("part > measure > note");
+    expect(firstNote?.querySelector(":scope > notations > technical > snap-pizzicato")).not.toBeNull();
+  });
+
+  it("ABC->MusicXML accepts !snappizzicato! as snap-pizzicato alias", () => {
+    const abc = `X:1
+T:Snap pizzicato alias
+M:4/4
+L:1/4
+K:C
+!snappizzicato!C D |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const firstNote = outDoc.querySelector("part > measure > note");
+    expect(firstNote?.querySelector(":scope > notations > technical > snap-pizzicato")).not.toBeNull();
+  });
+
+  it("ABC->MusicXML accepts !snap pizzicato! as snap-pizzicato alias", () => {
+    const abc = `X:1
+T:Snap pizzicato spaced alias
+M:4/4
+L:1/4
+K:C
+!snap pizzicato!C D |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const firstNote = outDoc.querySelector("part > measure > note");
+    expect(firstNote?.querySelector(":scope > notations > technical > snap-pizzicato")).not.toBeNull();
+  });
+
+  it("ABC->MusicXML accepts !snap-pizzicato! as snap-pizzicato alias", () => {
+    const abc = `X:1
+T:Snap pizzicato hyphen alias
+M:4/4
+L:1/4
+K:C
+!snap-pizzicato!C D |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const firstNote = outDoc.querySelector("part > measure > note");
+    expect(firstNote?.querySelector(":scope > notations > technical > snap-pizzicato")).not.toBeNull();
+  });
+
+  it("ABC->MusicXML parses harmonic decoration", () => {
+    const abc = `X:1
+T:Harmonic
+M:4/4
+L:1/4
+K:C
+!harmonic!C D |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const firstNote = outDoc.querySelector("part > measure > note");
+    expect(firstNote?.querySelector(":scope > notations > technical > harmonic")).not.toBeNull();
+  });
+
+  it("ABC->MusicXML parses thumb decoration", () => {
+    const abc = `X:1
+T:Thumb position
+M:4/4
+L:1/4
+K:C
+!thumb!C D |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const firstNote = outDoc.querySelector("part > measure > note");
+    expect(firstNote?.querySelector(":scope > notations > technical > thumb-position")).not.toBeNull();
+  });
+
+  it("ABC->MusicXML accepts !thumbpos! as thumb-position alias", () => {
+    const abc = `X:1
+T:Thumb alias
+M:4/4
+L:1/4
+K:C
+!thumbpos!C D |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const firstNote = outDoc.querySelector("part > measure > note");
+    expect(firstNote?.querySelector(":scope > notations > technical > thumb-position")).not.toBeNull();
+  });
+
+  it("ABC->MusicXML accepts !thumb pos! as thumb-position alias", () => {
+    const abc = `X:1
+T:Thumb spaced alias
+M:4/4
+L:1/4
+K:C
+!thumb pos!C D |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const firstNote = outDoc.querySelector("part > measure > note");
+    expect(firstNote?.querySelector(":scope > notations > technical > thumb-position")).not.toBeNull();
+  });
+
+  it("ABC->MusicXML accepts !thumb position! as thumb-position alias", () => {
+    const abc = `X:1
+T:Thumb position alias
+M:4/4
+L:1/4
+K:C
+!thumb position!C D |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const firstNote = outDoc.querySelector("part > measure > note");
+    expect(firstNote?.querySelector(":scope > notations > technical > thumb-position")).not.toBeNull();
+  });
+
+  it("ABC->MusicXML accepts !thumbposition! as thumb-position alias", () => {
+    const abc = `X:1
+T:Thumbposition alias
+M:4/4
+L:1/4
+K:C
+!thumbposition!C D |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const firstNote = outDoc.querySelector("part > measure > note");
+    expect(firstNote?.querySelector(":scope > notations > technical > thumb-position")).not.toBeNull();
+  });
+
+  it("ABC->MusicXML accepts !thumb-position! as thumb-position alias", () => {
+    const abc = `X:1
+T:Thumb-position alias
+M:4/4
+L:1/4
+K:C
+!thumb-position!C D |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const firstNote = outDoc.querySelector("part > measure > note");
+    expect(firstNote?.querySelector(":scope > notations > technical > thumb-position")).not.toBeNull();
+  });
+
+  it("ABC->MusicXML parses mordent and pralltriller decorations", () => {
+    const abc = `X:1
+T:Mordent
+M:4/4
+L:1/4
+K:C
+!mordent!C !pralltriller!D |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const notes = Array.from(outDoc.querySelectorAll("part > measure > note"));
+    expect(notes[0]?.querySelector(":scope > notations > ornaments > mordent")).not.toBeNull();
+    expect(notes[1]?.querySelector(":scope > notations > ornaments > inverted-mordent")).not.toBeNull();
+  });
+
+  it("ABC->MusicXML parses roll decoration as arpeggiate", () => {
+    const abc = `X:1
+T:Arpeggiate
+M:4/4
+L:1/4
+K:C
+!roll![CEG]2 z2 |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const firstNote = outDoc.querySelector("part > measure > note");
+    expect(firstNote?.querySelector(":scope > notations > arpeggiate")).not.toBeNull();
+  });
+
+  it("ABC->MusicXML accepts !arpeggio! and !arpeggiate! as roll aliases", () => {
+    const abc = `X:1
+T:Arpeggiate aliases
+M:4/4
+L:1/4
+K:C
+!arpeggio![CEG]2 !arpeggiate![DFA]2 |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const notes = Array.from(outDoc.querySelectorAll("part > measure > note"));
+    expect(notes[0]?.querySelector(":scope > notations > arpeggiate")).not.toBeNull();
+    expect(notes[3]?.querySelector(":scope > notations > arpeggiate")).not.toBeNull();
+  });
+
+  it("ABC->MusicXML parses schleifer and shake decorations", () => {
+    const abc = `X:1
+T:More ornaments
+M:4/4
+L:1/4
+K:C
+!schleifer!C !shake!D |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const notes = Array.from(outDoc.querySelectorAll("part > measure > note"));
+    expect(notes[0]?.querySelector(":scope > notations > ornaments > schleifer")).not.toBeNull();
+    expect(notes[1]?.querySelector(":scope > notations > ornaments > shake")).not.toBeNull();
+  });
+
+  it("ABC->MusicXML parses segno and coda decorations as directions", () => {
+    const abc = `X:1
+T:Direction decorations
+M:4/4
+L:1/4
+K:C
+!segno!C !coda!D |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const directions = Array.from(outDoc.querySelectorAll("part > measure > direction > direction-type"));
+    expect(directions[0]?.querySelector(":scope > segno")).not.toBeNull();
+    expect(directions[1]?.querySelector(":scope > coda")).not.toBeNull();
+  });
+
+  it("ABC->MusicXML parses fine decoration as sound direction", () => {
+    const abc = `X:1
+T:Fine
+M:4/4
+L:1/4
+K:C
+!fine!C D |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    expect(outDoc.querySelector('part > measure > direction > sound[fine="yes"]')).not.toBeNull();
+  });
+
+  it("ABC->MusicXML parses dacapo decoration as sound direction", () => {
+    const abc = `X:1
+T:Da Capo
+M:4/4
+L:1/4
+K:C
+!dacapo!C D |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    expect(outDoc.querySelector('part > measure > direction > sound[dacapo="yes"]')).not.toBeNull();
+  });
+
+  it("ABC->MusicXML accepts !da capo! as dacapo alias", () => {
+    const abc = `X:1
+T:Da Capo alias
+M:4/4
+L:1/4
+K:C
+!da capo!C D |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    expect(outDoc.querySelector('part > measure > direction > sound[dacapo="yes"]')).not.toBeNull();
+  });
+
+  it("ABC->MusicXML accepts !da-capo! as dacapo alias", () => {
+    const abc = `X:1
+T:Da Capo hyphen alias
+M:4/4
+L:1/4
+K:C
+!da-capo!C D |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    expect(outDoc.querySelector('part > measure > direction > sound[dacapo="yes"]')).not.toBeNull();
+  });
+
+  it("ABC->MusicXML parses dalsegno decoration as sound direction", () => {
+    const abc = `X:1
+T:Dal Segno
+M:4/4
+L:1/4
+K:C
+!dalsegno!C D |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    expect(outDoc.querySelector('part > measure > direction > sound[dalsegno="segno"]')).not.toBeNull();
+  });
+
+  it("ABC->MusicXML accepts !dal segno! as dalsegno alias", () => {
+    const abc = `X:1
+T:Dal Segno alias
+M:4/4
+L:1/4
+K:C
+!dal segno!C D |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    expect(outDoc.querySelector('part > measure > direction > sound[dalsegno="segno"]')).not.toBeNull();
+  });
+
+  it("ABC->MusicXML accepts !dal-segno! as dalsegno alias", () => {
+    const abc = `X:1
+T:Dal Segno hyphen alias
+M:4/4
+L:1/4
+K:C
+!dal-segno!C D |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    expect(outDoc.querySelector('part > measure > direction > sound[dalsegno="segno"]')).not.toBeNull();
+  });
+
+  it("ABC->MusicXML parses tocoda decoration as sound direction", () => {
+    const abc = `X:1
+T:To Coda
+M:4/4
+L:1/4
+K:C
+!tocoda!C D |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    expect(outDoc.querySelector('part > measure > direction > sound[tocoda="coda"]')).not.toBeNull();
+  });
+
+  it("ABC->MusicXML accepts !to coda! as tocoda alias", () => {
+    const abc = `X:1
+T:To Coda alias
+M:4/4
+L:1/4
+K:C
+!to coda!C D |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    expect(outDoc.querySelector('part > measure > direction > sound[tocoda="coda"]')).not.toBeNull();
+  });
+
+  it("ABC->MusicXML accepts !to-coda! as tocoda alias", () => {
+    const abc = `X:1
+T:To Coda hyphen alias
+M:4/4
+L:1/4
+K:C
+!to-coda!C D |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    expect(outDoc.querySelector('part > measure > direction > sound[tocoda="coda"]')).not.toBeNull();
+  });
+
+  it("ABC->MusicXML parses crescendo and diminuendo wedge decorations as directions", () => {
+    const abc = `X:1
+T:Wedges
+M:4/4
+L:1/4
+K:C
+!crescendo(!C D !crescendo)!E !diminuendo(!F | !diminuendo)!G A B c |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const wedgeTypes = Array.from(outDoc.querySelectorAll("part > measure > direction > direction-type > wedge"))
+      .map((node) => node.getAttribute("type"));
+    expect(wedgeTypes).toEqual(["crescendo", "stop", "diminuendo", "stop"]);
+  });
+
+  it("ABC->MusicXML accepts wedge decoration aliases cresc/dim/decresc", () => {
+    const abc = `X:1
+T:Wedge aliases
+M:4/4
+L:1/4
+K:C
+!cresc(!C !cresc)!D !dim(!E !decresc)!F |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const wedgeTypes = Array.from(outDoc.querySelectorAll("part > measure > direction > direction-type > wedge"))
+      .map((node) => node.getAttribute("type"));
+    expect(wedgeTypes).toEqual(["crescendo", "stop", "diminuendo", "stop"]);
+  });
+
+  it("ABC->MusicXML accepts wedge decoration alias decrescendo", () => {
+    const abc = `X:1
+T:Decrescendo alias
+M:4/4
+L:1/4
+K:C
+!decrescendo(!C D !decrescendo)!E F |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const wedgeTypes = Array.from(outDoc.querySelectorAll("part > measure > direction > direction-type > wedge"))
+      .map((node) => node.getAttribute("type"));
+    expect(wedgeTypes).toEqual(["diminuendo", "stop"]);
+  });
+
+  it("ABC->MusicXML accepts !decresc(! as diminuendo-start alias", () => {
+    const abc = `X:1
+T:Decresc start alias
+M:4/4
+L:1/4
+K:C
+!decresc(!C D |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const wedge = outDoc.querySelector("part > measure > direction > direction-type > wedge");
+    expect(wedge?.getAttribute("type")).toBe("diminuendo");
+  });
+
+  it("ABC->MusicXML accepts !dim)! as diminuendo-stop alias", () => {
+    const abc = `X:1
+T:Dim stop alias
+M:4/4
+L:1/4
+K:C
+C !dim)!D |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const wedge = outDoc.querySelector("part > measure > direction > direction-type > wedge");
+    expect(wedge?.getAttribute("type")).toBe("stop");
+  });
+
+  it("ABC->MusicXML parses sfz decoration as dynamics direction", () => {
+    const abc = `X:1
+T:Sforzato
+M:4/4
+L:1/4
+K:C
+!sfz!C D |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const firstDirection = outDoc.querySelector("part > measure > direction > direction-type > dynamics > sfz");
+    expect(firstDirection).not.toBeNull();
+  });
+
+  it("ABC->MusicXML parses sf decoration as dynamics direction", () => {
+    const abc = `X:1
+T:Sforzando
+M:4/4
+L:1/4
+K:C
+!sf!C D |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const firstDirection = outDoc.querySelector("part > measure > direction > direction-type > dynamics > sf");
+    expect(firstDirection).not.toBeNull();
+  });
+
+  it("ABC->MusicXML parses sfp decoration as dynamics direction", () => {
+    const abc = `X:1
+T:Sforzando piano
+M:4/4
+L:1/4
+K:C
+!sfp!C D |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const firstDirection = outDoc.querySelector("part > measure > direction > direction-type > dynamics > sfp");
+    expect(firstDirection).not.toBeNull();
+  });
+
+  it("ABC->MusicXML parses rfz decoration as dynamics direction", () => {
+    const abc = `X:1
+T:Rinforzando
+M:4/4
+L:1/4
+K:C
+!rfz!C D |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const firstDirection = outDoc.querySelector("part > measure > direction > direction-type > dynamics > rfz");
+    expect(firstDirection).not.toBeNull();
+  });
+
+  it("ABC->MusicXML parses p decoration as dynamics direction", () => {
+    const abc = `X:1
+T:Piano
+M:4/4
+L:1/4
+K:C
+!p!C D |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const firstDirection = outDoc.querySelector("part > measure > direction > direction-type > dynamics > p");
+    expect(firstDirection).not.toBeNull();
+  });
+
+  it("ABC->MusicXML parses pp decoration as dynamics direction", () => {
+    const abc = `X:1
+T:Pianissimo
+M:4/4
+L:1/4
+K:C
+!pp!C D |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const firstDirection = outDoc.querySelector("part > measure > direction > direction-type > dynamics > pp");
+    expect(firstDirection).not.toBeNull();
+  });
+
+  it("ABC->MusicXML parses ff decoration as dynamics direction", () => {
+    const abc = `X:1
+T:Fortissimo
+M:4/4
+L:1/4
+K:C
+!ff!C D |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const firstDirection = outDoc.querySelector("part > measure > direction > direction-type > dynamics > ff");
+    expect(firstDirection).not.toBeNull();
+  });
+
+  it("ABC->MusicXML parses f decoration as dynamics direction", () => {
+    const abc = `X:1
+T:Forte
+M:4/4
+L:1/4
+K:C
+!f!C D |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const firstDirection = outDoc.querySelector("part > measure > direction > direction-type > dynamics > f");
+    expect(firstDirection).not.toBeNull();
+  });
+
+  it("ABC->MusicXML parses fff decoration as dynamics direction", () => {
+    const abc = `X:1
+T:Fortississimo
+M:4/4
+L:1/4
+K:C
+!fff!C D |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const firstDirection = outDoc.querySelector("part > measure > direction > direction-type > dynamics > fff");
+    expect(firstDirection).not.toBeNull();
+  });
+
+  it("ABC->MusicXML parses fp decoration as dynamics direction", () => {
+    const abc = `X:1
+T:Fortepiano
+M:4/4
+L:1/4
+K:C
+!fp!C D |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const firstDirection = outDoc.querySelector("part > measure > direction > direction-type > dynamics > fp");
+    expect(firstDirection).not.toBeNull();
+  });
+
+  it("ABC->MusicXML parses ppp decoration as dynamics direction", () => {
+    const abc = `X:1
+T:Pianississimo
+M:4/4
+L:1/4
+K:C
+!ppp!C D |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const firstDirection = outDoc.querySelector("part > measure > direction > direction-type > dynamics > ppp");
+    expect(firstDirection).not.toBeNull();
+  });
+
+  it("ABC->MusicXML parses mp decoration as dynamics direction", () => {
+    const abc = `X:1
+T:Mezzo piano
+M:4/4
+L:1/4
+K:C
+!mp!C D |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const firstDirection = outDoc.querySelector("part > measure > direction > direction-type > dynamics > mp");
+    expect(firstDirection).not.toBeNull();
+  });
+
+  it("ABC->MusicXML parses mf decoration as dynamics direction", () => {
+    const abc = `X:1
+T:Mezzo forte
+M:4/4
+L:1/4
+K:C
+!mf!C D |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const firstDirection = outDoc.querySelector("part > measure > direction > direction-type > dynamics > mf");
+    expect(firstDirection).not.toBeNull();
+  });
+
+  it("ABC->MusicXML parses fz decoration as dynamics direction", () => {
+    const abc = `X:1
+T:Forzando
+M:4/4
+L:1/4
+K:C
+!fz!C D |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const firstDirection = outDoc.querySelector("part > measure > direction > direction-type > dynamics > fz");
+    expect(firstDirection).not.toBeNull();
+  });
+
+  it("ABC->MusicXML parses common dynamic decorations as dynamics directions", () => {
+    const abc = `X:1
+T:Common dynamics
+M:4/4
+L:1/4
+K:C
+!ppp!C !mp!D !mf!E !ff!F | !fp!G !fz!A !rfz!B !sfp!c |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const dynamics = Array.from(outDoc.querySelectorAll("part > measure > direction > direction-type > dynamics"))
+      .map((node) => node.firstElementChild?.tagName?.toLowerCase());
+    expect(dynamics).toEqual(["ppp", "mp", "mf", "ff", "fp", "fz", "rfz", "sfp"]);
+  });
+
+  it("ABC->MusicXML accepts mordent aliases used in real-world ABC", () => {
+    const abc = `X:1
+T:Mordent aliases
+M:4/4
+L:1/4
+K:C
+!lowermordent!C !prall!D !uppermordent!E |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const notes = Array.from(outDoc.querySelectorAll("part > measure > note"));
+    expect(notes[0]?.querySelector(":scope > notations > ornaments > mordent")).not.toBeNull();
+    expect(notes[1]?.querySelector(":scope > notations > ornaments > inverted-mordent")).not.toBeNull();
+    expect(notes[2]?.querySelector(":scope > notations > ornaments > inverted-mordent")).not.toBeNull();
+  });
+
+  it("ABC->MusicXML accepts !lowermordent! as mordent alias", () => {
+    const abc = `X:1
+T:Lowermordent alias
+M:4/4
+L:1/4
+K:C
+!lowermordent!C D |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const firstNote = outDoc.querySelector("part > measure > note");
+    expect(firstNote?.querySelector(":scope > notations > ornaments > mordent")).not.toBeNull();
+  });
+
+  it("ABC->MusicXML accepts !uppermordent! as inverted-mordent alias", () => {
+    const abc = `X:1
+T:Uppermordent alias
+M:4/4
+L:1/4
+K:C
+!uppermordent!C D |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const firstNote = outDoc.querySelector("part > measure > note");
+    expect(firstNote?.querySelector(":scope > notations > ornaments > inverted-mordent")).not.toBeNull();
+  });
+
+  it("ABC->MusicXML accepts !pralltrill! as inverted-mordent alias", () => {
+    const abc = `X:1
+T:Pralltrill alias
+M:4/4
+L:1/4
+K:C
+!pralltrill!C D |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const firstNote = outDoc.querySelector("part > measure > note");
+    expect(firstNote?.querySelector(":scope > notations > ornaments > inverted-mordent")).not.toBeNull();
+  });
+
+  it("ABC->MusicXML accepts !invertedmordent! as inverted-mordent alias", () => {
+    const abc = `X:1
+T:Inverted mordent alias
+M:4/4
+L:1/4
+K:C
+!invertedmordent!C D |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const firstNote = outDoc.querySelector("part > measure > note");
+    expect(firstNote?.querySelector(":scope > notations > ornaments > inverted-mordent")).not.toBeNull();
+  });
+
+  it("ABC->MusicXML accepts !inverted-mordent! as inverted-mordent alias", () => {
+    const abc = `X:1
+T:Inverted-mordent alias
+M:4/4
+L:1/4
+K:C
+!inverted-mordent!C D |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const firstNote = outDoc.querySelector("part > measure > note");
+    expect(firstNote?.querySelector(":scope > notations > ornaments > inverted-mordent")).not.toBeNull();
+  });
+
+  it("ABC->MusicXML parses stopped decoration", () => {
+    const abc = `X:1
+T:Stopped
+M:4/4
+L:1/4
+K:C
+!stopped!C D |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const firstNote = outDoc.querySelector("part > measure > note");
+    expect(firstNote?.querySelector(":scope > notations > technical > stopped")).not.toBeNull();
+  });
+
+  it("ABC->MusicXML treats !plus! as stopped decoration alias", () => {
+    const abc = `X:1
+T:Stopped alias
+M:4/4
+L:1/4
+K:C
+!plus!C D |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const firstNote = outDoc.querySelector("part > measure > note");
+    expect(firstNote?.querySelector(":scope > notations > technical > stopped")).not.toBeNull();
+  });
+
+  it("ABC->MusicXML accepts !stopped horn! as stopped alias", () => {
+    const abc = `X:1
+T:Stopped horn alias
+M:4/4
+L:1/4
+K:C
+!stopped horn!C D |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const firstNote = outDoc.querySelector("part > measure > note");
+    expect(firstNote?.querySelector(":scope > notations > technical > stopped")).not.toBeNull();
+  });
+
+  it("ABC->MusicXML accepts !stopped-horn! as stopped alias", () => {
+    const abc = `X:1
+T:Stopped horn hyphen alias
+M:4/4
+L:1/4
+K:C
+!stopped-horn!C D |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const firstNote = outDoc.querySelector("part > measure > note");
+    expect(firstNote?.querySelector(":scope > notations > technical > stopped")).not.toBeNull();
+  });
+
   it("ABC->MusicXML applies beams and splits them at beat boundaries", () => {
     const abc = `X:1
 T:Beam test
@@ -378,7 +2659,7 @@ M:2/4
 L:1/8
 K:C
 V:1
-C D E F |`;
+CDEF |`;
     const xml = convertAbcToMusicXml(abc);
     const outDoc = parseMusicXmlDocument(xml);
     expect(outDoc).not.toBeNull();
@@ -391,6 +2672,25 @@ C D E F |`;
     expect(beams[1]).toBe("end");
     expect(beams[2]).toBe("begin");
     expect(beams[3]).toBe("end");
+  });
+
+  it("ABC->MusicXML treats whitespace as an explicit beam break hint", () => {
+    const abc = `X:1
+T:Whitespace beam test
+M:2/4
+L:1/16
+K:C
+V:1
+CD EF GA Bc |`;
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    const pitchedNotes = Array.from(outDoc.querySelectorAll("part > measure > note"))
+      .filter((note) => note.querySelector(":scope > pitch") !== null);
+    expect(pitchedNotes.length).toBe(8);
+    const beams = pitchedNotes.map((note) => note.querySelector(":scope > beam")?.textContent?.trim() ?? "");
+    expect(beams).toEqual(["begin", "end", "begin", "end", "begin", "end", "begin", "end"]);
   });
 
   it("ABC->MusicXML uses meter-sized empty-measure rests for missing voice measures", () => {
@@ -490,6 +2790,30 @@ V:1
     expect(secondPitched?.querySelector(':scope > notations > slur[type="stop"]')).not.toBeNull();
   });
 
+  it("ABC->MusicXML applies chord ties to all notes in the chord", () => {
+    const abc = `X:1
+T:Chord tie test
+M:4/4
+L:1/4
+K:C
+[CE]-[CE] z2 |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const notes = Array.from(outDoc.querySelectorAll("part > measure > note"));
+    const firstChord = notes.slice(0, 2);
+    const secondChord = notes.slice(2, 4);
+    expect(firstChord).toHaveLength(2);
+    expect(secondChord).toHaveLength(2);
+    expect(firstChord.every((note) => note.querySelector(':scope > tie[type="start"]') !== null)).toBe(true);
+    expect(firstChord.every((note) => note.querySelector(':scope > notations > tied[type="start"]') !== null)).toBe(true);
+    expect(secondChord.every((note) => note.querySelector(':scope > tie[type="stop"]') !== null)).toBe(true);
+    expect(secondChord.every((note) => note.querySelector(':scope > notations > tied[type="stop"]') !== null)).toBe(true);
+  });
+
   it("MusicXML->ABC exports trill decoration and grace notes", () => {
     const xmlWithOrnaments = `<?xml version="1.0" encoding="UTF-8"?>
 <score-partwise version="3.1">
@@ -535,6 +2859,96 @@ V:1
     if (!outDoc) return;
     expect(outDoc.querySelector("note > grace")).not.toBeNull();
     expect(outDoc.querySelector("note > notations > ornaments > trill-mark")).not.toBeNull();
+    expect(outDoc.querySelector('note > notations > ornaments > wavy-line[type="start"]')).not.toBeNull();
+  });
+
+  it("MusicXML->ABC preserves grace notes without ornaments", () => {
+    const xmlWithGrace = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note>
+        <grace/>
+        <pitch><step>G</step><octave>4</octave></pitch>
+        <voice>1</voice><type>eighth</type>
+      </note>
+      <note>
+        <pitch><step>A</step><octave>4</octave></pitch>
+        <duration>1920</duration>
+        <voice>1</voice><type>half</type>
+      </note>
+      <note>
+        <rest/><duration>1920</duration><voice>1</voice><type>half</type>
+      </note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithGrace);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toMatch(/\{[^}]+\}/);
+    expect(abc).not.toContain("!trill!");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector("note > grace")).not.toBeNull();
+    expect(outDoc.querySelector("note > notations > ornaments > trill-mark")).toBeNull();
+  });
+
+  it("MusicXML->ABC exports trill decoration without grace notes and roundtrips it", () => {
+    const xmlWithTrill = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note>
+        <pitch><step>A</step><octave>4</octave></pitch>
+        <duration>1920</duration>
+        <voice>1</voice><type>half</type>
+        <notations><ornaments><trill-mark/></ornaments></notations>
+      </note>
+      <note>
+        <rest/><duration>1920</duration><voice>1</voice><type>half</type>
+      </note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithTrill);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!trill!");
+    expect(abc).not.toMatch(/\{[^}]+\}/);
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector("note > grace")).toBeNull();
+    expect(outDoc.querySelector("note > notations > ornaments > trill-mark")).not.toBeNull();
+    expect(outDoc.querySelector('note > notations > ornaments > wavy-line[type="start"]')).not.toBeNull();
   });
 
   it("MusicXML->ABC exports turn and grace slash notes and roundtrips them", () => {
@@ -582,6 +2996,674 @@ V:1
     if (!outDoc) return;
     expect(outDoc.querySelector('note > grace[slash="yes"]')).not.toBeNull();
     expect(outDoc.querySelector("note > notations > ornaments > turn")).not.toBeNull();
+  });
+
+  it("MusicXML->ABC preserves slash grace notes without ornaments", () => {
+    const xmlWithSlashGrace = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note>
+        <grace slash="yes"/>
+        <pitch><step>G</step><octave>4</octave></pitch>
+        <voice>1</voice><type>eighth</type>
+      </note>
+      <note>
+        <pitch><step>A</step><octave>4</octave></pitch>
+        <duration>1920</duration>
+        <voice>1</voice><type>half</type>
+      </note>
+      <note><rest/><duration>1920</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithSlashGrace);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toMatch(/\{\/[^}]+\}/);
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector('note > grace[slash="yes"]')).not.toBeNull();
+    expect(outDoc.querySelector("note > notations > ornaments > turn")).toBeNull();
+  });
+
+  it("MusicXML->ABC preserves turn together with slash grace notes", () => {
+    const xmlWithTurnAndSlashGrace = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note>
+        <grace slash="yes"/>
+        <pitch><step>G</step><octave>4</octave></pitch>
+        <voice>1</voice><type>eighth</type>
+      </note>
+      <note>
+        <pitch><step>A</step><octave>4</octave></pitch>
+        <duration>1920</duration>
+        <voice>1</voice><type>half</type>
+        <notations><ornaments><turn/></ornaments></notations>
+      </note>
+      <note><rest/><duration>1920</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithTurnAndSlashGrace);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!turn!");
+    expect(abc).toMatch(/\{\/[^}]+\}/);
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector('note > grace[slash="yes"]')).not.toBeNull();
+    expect(outDoc.querySelector("note > notations > ornaments > turn")).not.toBeNull();
+  });
+
+  it("MusicXML->ABC exports turn and roundtrips it", () => {
+    const xmlWithTurn = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note>
+        <pitch><step>A</step><octave>4</octave></pitch>
+        <duration>1920</duration>
+        <voice>1</voice><type>half</type>
+        <notations><ornaments><turn/></ornaments></notations>
+      </note>
+      <note><rest/><duration>1920</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithTurn);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!turn!");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector("note > notations > ornaments > turn")).not.toBeNull();
+  });
+
+  it("MusicXML->ABC exports inverted-turn and roundtrips it", () => {
+    const xmlWithInvertedTurn = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note>
+        <pitch><step>A</step><octave>4</octave></pitch>
+        <duration>1920</duration>
+        <voice>1</voice><type>half</type>
+        <notations><ornaments><inverted-turn/></ornaments></notations>
+      </note>
+      <note><rest/><duration>1920</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithInvertedTurn);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!invertedturn!");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector("note > notations > ornaments > inverted-turn")).not.toBeNull();
+  });
+
+  it("MusicXML->ABC exports delayed turn variants and roundtrips them", () => {
+    const xmlWithDelayedTurns = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>960</duration><voice>1</voice><type>quarter</type>
+        <notations><ornaments><turn/><delayed-turn/></ornaments></notations>
+      </note>
+      <note>
+        <pitch><step>D</step><octave>4</octave></pitch>
+        <duration>960</duration><voice>1</voice><type>quarter</type>
+        <notations><ornaments><inverted-turn/><delayed-turn/></ornaments></notations>
+      </note>
+      <note><rest/><duration>1920</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithDelayedTurns);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!delayedturn!");
+    expect(abc).toContain("!delayedinvertedturn!");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const notes = Array.from(outDoc.querySelectorAll("part > measure > note"));
+    expect(notes[0]?.querySelector(":scope > notations > ornaments > turn")).not.toBeNull();
+    expect(notes[0]?.querySelector(":scope > notations > ornaments > delayed-turn")).not.toBeNull();
+    expect(notes[1]?.querySelector(":scope > notations > ornaments > inverted-turn")).not.toBeNull();
+    expect(notes[1]?.querySelector(":scope > notations > ornaments > delayed-turn")).not.toBeNull();
+  });
+
+  it("MusicXML->ABC exports delayed turn and roundtrips it", () => {
+    const xmlWithDelayedTurn = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>1920</duration><voice>1</voice><type>half</type>
+        <notations><ornaments><turn/><delayed-turn/></ornaments></notations>
+      </note>
+      <note><rest/><duration>1920</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithDelayedTurn);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!delayedturn!");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector("note > notations > ornaments > turn")).not.toBeNull();
+    expect(outDoc.querySelector("note > notations > ornaments > delayed-turn")).not.toBeNull();
+  });
+
+  it("MusicXML->ABC exports delayed inverted-turn and roundtrips it", () => {
+    const xmlWithDelayedInvertedTurn = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note>
+        <pitch><step>D</step><octave>4</octave></pitch>
+        <duration>1920</duration><voice>1</voice><type>half</type>
+        <notations><ornaments><inverted-turn/><delayed-turn/></ornaments></notations>
+      </note>
+      <note><rest/><duration>1920</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithDelayedInvertedTurn);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!delayedinvertedturn!");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector("note > notations > ornaments > inverted-turn")).not.toBeNull();
+    expect(outDoc.querySelector("note > notations > ornaments > delayed-turn")).not.toBeNull();
+  });
+
+  it("MusicXML->ABC exports tremolo as mikuscore decorations and roundtrips it", () => {
+    const xmlWithTremolo = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>960</duration><voice>1</voice><type>quarter</type>
+        <notations><ornaments><tremolo type="single">3</tremolo></ornaments></notations>
+      </note>
+      <note>
+        <pitch><step>D</step><octave>4</octave></pitch>
+        <duration>960</duration><voice>1</voice><type>quarter</type>
+        <notations><ornaments><tremolo type="start">2</tremolo></ornaments></notations>
+      </note>
+      <note>
+        <pitch><step>E</step><octave>4</octave></pitch>
+        <duration>960</duration><voice>1</voice><type>quarter</type>
+        <notations><ornaments><tremolo type="stop">2</tremolo></ornaments></notations>
+      </note>
+      <note><rest/><duration>960</duration><voice>1</voice><type>quarter</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithTremolo);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!tremolo-single-3!");
+    expect(abc).toContain("!tremolo-start-2!");
+    expect(abc).toContain("!tremolo-stop-2!");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const tremolos = Array.from(outDoc.querySelectorAll("part > measure > note > notations > ornaments > tremolo"));
+    expect(tremolos[0]?.getAttribute("type")).toBe("single");
+    expect(tremolos[0]?.textContent?.trim()).toBe("3");
+    expect(tremolos[1]?.getAttribute("type")).toBe("start");
+    expect(tremolos[1]?.textContent?.trim()).toBe("2");
+    expect(tremolos[2]?.getAttribute("type")).toBe("stop");
+    expect(tremolos[2]?.textContent?.trim()).toBe("2");
+  });
+
+  it("MusicXML->ABC exports single tremolo and roundtrips it", () => {
+    const xmlWithSingleTremolo = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>960</duration><voice>1</voice><type>quarter</type>
+        <notations><ornaments><tremolo type="single">3</tremolo></ornaments></notations>
+      </note>
+      <note><rest/><duration>2880</duration><voice>1</voice><type>half</type><dot/></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithSingleTremolo);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!tremolo-single-3!");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    const tremolo = outDoc.querySelector("part > measure > note > notations > ornaments > tremolo");
+    expect(tremolo?.getAttribute("type")).toBe("single");
+    expect(tremolo?.textContent?.trim()).toBe("3");
+  });
+
+  it("MusicXML->ABC exports tremolo start and roundtrips it", () => {
+    const xmlWithTremoloStart = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note>
+        <pitch><step>D</step><octave>4</octave></pitch>
+        <duration>960</duration><voice>1</voice><type>quarter</type>
+        <notations><ornaments><tremolo type="start">2</tremolo></ornaments></notations>
+      </note>
+      <note><rest/><duration>2880</duration><voice>1</voice><type>half</type><dot/></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithTremoloStart);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!tremolo-start-2!");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    const tremolo = outDoc.querySelector("part > measure > note > notations > ornaments > tremolo");
+    expect(tremolo?.getAttribute("type")).toBe("start");
+    expect(tremolo?.textContent?.trim()).toBe("2");
+  });
+
+  it("MusicXML->ABC exports tremolo stop and roundtrips it", () => {
+    const xmlWithTremoloStop = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note>
+        <pitch><step>E</step><octave>4</octave></pitch>
+        <duration>960</duration><voice>1</voice><type>quarter</type>
+        <notations><ornaments><tremolo type="stop">2</tremolo></ornaments></notations>
+      </note>
+      <note><rest/><duration>2880</duration><voice>1</voice><type>half</type><dot/></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithTremoloStop);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!tremolo-stop-2!");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    const tremolo = outDoc.querySelector("part > measure > note > notations > ornaments > tremolo");
+    expect(tremolo?.getAttribute("type")).toBe("stop");
+    expect(tremolo?.textContent?.trim()).toBe("2");
+  });
+
+  it("MusicXML->ABC exports glissando/slide as mikuscore decorations and roundtrips them", () => {
+    const xmlWithSpanners = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>960</duration><voice>1</voice><type>quarter</type>
+        <notations><glissando type="start" number="1">wavy</glissando></notations>
+      </note>
+      <note>
+        <pitch><step>D</step><octave>4</octave></pitch>
+        <duration>960</duration><voice>1</voice><type>quarter</type>
+        <notations><glissando type="stop" number="1">wavy</glissando></notations>
+      </note>
+      <note>
+        <pitch><step>E</step><octave>4</octave></pitch>
+        <duration>960</duration><voice>1</voice><type>quarter</type>
+        <notations><slide type="start" number="1"/></notations>
+      </note>
+      <note>
+        <pitch><step>F</step><octave>4</octave></pitch>
+        <duration>960</duration><voice>1</voice><type>quarter</type>
+        <notations><slide type="stop" number="1"/></notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithSpanners);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!gliss-start!");
+    expect(abc).toContain("!gliss-stop!");
+    expect(abc).toContain("!slide-start!");
+    expect(abc).toContain("!slide-stop!");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const notes = Array.from(outDoc.querySelectorAll("part > measure > note"));
+    expect(notes[0]?.querySelector(':scope > notations > glissando[type="start"]')).not.toBeNull();
+    expect(notes[1]?.querySelector(':scope > notations > glissando[type="stop"]')).not.toBeNull();
+    expect(notes[2]?.querySelector(':scope > notations > slide[type="start"]')).not.toBeNull();
+    expect(notes[3]?.querySelector(':scope > notations > slide[type="stop"]')).not.toBeNull();
+  });
+
+  it("MusicXML->ABC exports glissando start and roundtrips it", () => {
+    const xmlWithGlissStart = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>1920</duration><voice>1</voice><type>half</type>
+        <notations><glissando type="start" number="1">wavy</glissando></notations>
+      </note>
+      <note><rest/><duration>1920</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithGlissStart);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!gliss-start!");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector('note > notations > glissando[type="start"]')).not.toBeNull();
+  });
+
+  it("MusicXML->ABC exports glissando stop and roundtrips it", () => {
+    const xmlWithGlissStop = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>1920</duration><voice>1</voice><type>half</type>
+        <notations><glissando type="stop" number="1">wavy</glissando></notations>
+      </note>
+      <note><rest/><duration>1920</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithGlissStop);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!gliss-stop!");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector('note > notations > glissando[type="stop"]')).not.toBeNull();
+  });
+
+  it("MusicXML->ABC exports slide start and roundtrips it", () => {
+    const xmlWithSlideStart = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>1920</duration><voice>1</voice><type>half</type>
+        <notations><slide type="start" number="1"/></notations>
+      </note>
+      <note><rest/><duration>1920</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithSlideStart);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!slide-start!");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector('note > notations > slide[type="start"]')).not.toBeNull();
+  });
+
+  it("MusicXML->ABC exports slide stop and roundtrips it", () => {
+    const xmlWithSlideStop = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>1920</duration><voice>1</voice><type>half</type>
+        <notations><slide type="stop" number="1"/></notations>
+      </note>
+      <note><rest/><duration>1920</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithSlideStop);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!slide-stop!");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector('note > notations > slide[type="stop"]')).not.toBeNull();
   });
 
   it("MusicXML->ABC exports trill when encoded as ornaments wavy-line start", () => {
@@ -656,6 +3738,2954 @@ V:1
     expect(outDoc).not.toBeNull();
     if (!outDoc) return;
     expect(outDoc.querySelector("note > notations > articulations > staccato")).not.toBeNull();
+  });
+
+  it("MusicXML->ABC exports accent, tenuto, and fermata decorations and roundtrips them", () => {
+    const xmlWithDecorations = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>960</duration>
+        <voice>1</voice><type>quarter</type>
+        <notations><articulations><accent/></articulations></notations>
+      </note>
+      <note>
+        <pitch><step>D</step><octave>4</octave></pitch>
+        <duration>960</duration>
+        <voice>1</voice><type>quarter</type>
+        <notations><articulations><tenuto/></articulations></notations>
+      </note>
+      <note>
+        <pitch><step>E</step><octave>4</octave></pitch>
+        <duration>960</duration>
+        <voice>1</voice><type>quarter</type>
+        <notations><fermata>normal</fermata></notations>
+      </note>
+      <note>
+        <rest/><duration>960</duration><voice>1</voice><type>quarter</type>
+      </note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithDecorations);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!accent!");
+    expect(abc).toContain("!tenuto!");
+    expect(abc).toContain("!fermata!");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const notes = Array.from(outDoc.querySelectorAll("part > measure > note"));
+    expect(notes[0]?.querySelector(":scope > notations > articulations > accent")).not.toBeNull();
+    expect(notes[1]?.querySelector(":scope > notations > articulations > tenuto")).not.toBeNull();
+    expect(notes[2]?.querySelector(":scope > notations > fermata")).not.toBeNull();
+  });
+
+  it("MusicXML->ABC exports accent decoration and roundtrips it", () => {
+    const xmlWithAccent = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>1920</duration>
+        <voice>1</voice><type>half</type>
+        <notations><articulations><accent/></articulations></notations>
+      </note>
+      <note><rest/><duration>1920</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithAccent);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!accent!");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector("note > notations > articulations > accent")).not.toBeNull();
+  });
+
+  it("MusicXML->ABC exports tenuto decoration and roundtrips it", () => {
+    const xmlWithTenuto = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>1920</duration>
+        <voice>1</voice><type>half</type>
+        <notations><articulations><tenuto/></articulations></notations>
+      </note>
+      <note><rest/><duration>1920</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithTenuto);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!tenuto!");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector("note > notations > articulations > tenuto")).not.toBeNull();
+  });
+
+  it("MusicXML->ABC exports fermata decoration and roundtrips it", () => {
+    const xmlWithFermata = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>1920</duration>
+        <voice>1</voice><type>half</type>
+        <notations><fermata>normal</fermata></notations>
+      </note>
+      <note><rest/><duration>1920</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithFermata);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!fermata!");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector("note > notations > fermata")).not.toBeNull();
+  });
+
+  it("MusicXML->ABC exports stress and unstress decorations and roundtrips them", () => {
+    const xmlWithStress = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>960</duration>
+        <voice>1</voice><type>quarter</type>
+        <notations><articulations><stress/></articulations></notations>
+      </note>
+      <note>
+        <pitch><step>D</step><octave>4</octave></pitch>
+        <duration>960</duration>
+        <voice>1</voice><type>quarter</type>
+        <notations><articulations><unstress/></articulations></notations>
+      </note>
+      <note><rest/><duration>1920</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithStress);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!stress!");
+    expect(abc).toContain("!unstress!");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const notes = Array.from(outDoc.querySelectorAll("part > measure > note"));
+    expect(notes[0]?.querySelector(":scope > notations > articulations > stress")).not.toBeNull();
+    expect(notes[1]?.querySelector(":scope > notations > articulations > unstress")).not.toBeNull();
+  });
+
+  it("MusicXML->ABC exports stress decoration and roundtrips it", () => {
+    const xmlWithStress = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>1920</duration>
+        <voice>1</voice><type>half</type>
+        <notations><articulations><stress/></articulations></notations>
+      </note>
+      <note><rest/><duration>1920</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithStress);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!stress!");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector("note > notations > articulations > stress")).not.toBeNull();
+  });
+
+  it("MusicXML->ABC exports unstress decoration and roundtrips it", () => {
+    const xmlWithUnstress = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>1920</duration>
+        <voice>1</voice><type>half</type>
+        <notations><articulations><unstress/></articulations></notations>
+      </note>
+      <note><rest/><duration>1920</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithUnstress);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!unstress!");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector("note > notations > articulations > unstress")).not.toBeNull();
+  });
+
+  it("MusicXML->ABC exports inverted fermata and roundtrips it", () => {
+    const xmlWithInvertedFermata = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>1920</duration>
+        <voice>1</voice><type>half</type>
+        <notations><fermata type="inverted">inverted</fermata></notations>
+      </note>
+      <note>
+        <rest/><duration>1920</duration><voice>1</voice><type>half</type>
+      </note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithInvertedFermata);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!invertedfermata!");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector("note > notations > fermata")?.textContent?.trim()).toBe("inverted");
+  });
+
+  it("ABC inverted fermata alias !inverted fermata! roundtrips back to canonical !invertedfermata!", () => {
+    const abc = `X:1
+T:Inverted fermata alias
+M:4/4
+L:1/4
+K:C
+!inverted fermata!C z |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const srcDoc = parseMusicXmlDocument(xml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+    expect(srcDoc.querySelector("note > notations > fermata")?.textContent?.trim()).toBe("inverted");
+
+    const exportedAbc = exportMusicXmlDomToAbc(srcDoc);
+    expect(exportedAbc).toContain("!invertedfermata!");
+    expect(exportedAbc).not.toContain("!inverted fermata!");
+  });
+
+  it("MusicXML->ABC exports marcato, breath, and caesura decorations and roundtrips them", () => {
+    const xmlWithDecorations = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>960</duration>
+        <voice>1</voice><type>quarter</type>
+        <notations><articulations><strong-accent/></articulations></notations>
+      </note>
+      <note>
+        <pitch><step>D</step><octave>4</octave></pitch>
+        <duration>960</duration>
+        <voice>1</voice><type>quarter</type>
+        <notations><articulations><breath-mark/></articulations></notations>
+      </note>
+      <note>
+        <pitch><step>E</step><octave>4</octave></pitch>
+        <duration>960</duration>
+        <voice>1</voice><type>quarter</type>
+        <notations><articulations><caesura/></articulations></notations>
+      </note>
+      <note>
+        <rest/><duration>960</duration><voice>1</voice><type>quarter</type>
+      </note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithDecorations);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!marcato!");
+    expect(abc).toContain("!breath!");
+    expect(abc).toContain("!caesura!");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const notes = Array.from(outDoc.querySelectorAll("part > measure > note"));
+    expect(notes[0]?.querySelector(":scope > notations > articulations > strong-accent")).not.toBeNull();
+    expect(notes[1]?.querySelector(":scope > notations > articulations > breath-mark")).not.toBeNull();
+    expect(notes[2]?.querySelector(":scope > notations > articulations > caesura")).not.toBeNull();
+  });
+
+  it("MusicXML->ABC exports marcato decoration and roundtrips it", () => {
+    const xmlWithMarcato = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>1920</duration>
+        <voice>1</voice><type>half</type>
+        <notations><articulations><strong-accent/></articulations></notations>
+      </note>
+      <note><rest/><duration>1920</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithMarcato);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!marcato!");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector("note > notations > articulations > strong-accent")).not.toBeNull();
+  });
+
+  it("ABC marcato alias !strong accent! roundtrips back to canonical !marcato!", () => {
+    const abc = `X:1
+T:Marcato alias
+M:4/4
+L:1/4
+K:C
+!strong accent!C z |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const srcDoc = parseMusicXmlDocument(xml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+    expect(srcDoc.querySelector("note > notations > articulations > strong-accent")).not.toBeNull();
+
+    const exportedAbc = exportMusicXmlDomToAbc(srcDoc);
+    expect(exportedAbc).toContain("!marcato!");
+    expect(exportedAbc).not.toContain("!strong accent!");
+  });
+
+  it("ABC marcato alias !strongaccent! roundtrips back to canonical !marcato!", () => {
+    const abc = `X:1
+T:Marcato compact alias
+M:4/4
+L:1/4
+K:C
+!strongaccent!C z |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const srcDoc = parseMusicXmlDocument(xml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+    expect(srcDoc.querySelector("note > notations > articulations > strong-accent")).not.toBeNull();
+
+    const exportedAbc = exportMusicXmlDomToAbc(srcDoc);
+    expect(exportedAbc).toContain("!marcato!");
+    expect(exportedAbc).not.toContain("!strongaccent!");
+  });
+
+  it("MusicXML->ABC exports breath decoration and roundtrips it", () => {
+    const xmlWithBreath = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>1920</duration>
+        <voice>1</voice><type>half</type>
+        <notations><articulations><breath-mark/></articulations></notations>
+      </note>
+      <note><rest/><duration>1920</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithBreath);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!breath!");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector("note > notations > articulations > breath-mark")).not.toBeNull();
+  });
+
+  it("ABC breath-mark alias !breathmark! roundtrips back to canonical !breath!", () => {
+    const abc = `X:1
+T:Breath alias
+M:4/4
+L:1/4
+K:C
+!breathmark!C z |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const srcDoc = parseMusicXmlDocument(xml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+    expect(srcDoc.querySelector("note > notations > articulations > breath-mark")).not.toBeNull();
+
+    const exportedAbc = exportMusicXmlDomToAbc(srcDoc);
+    expect(exportedAbc).toContain("!breath!");
+    expect(exportedAbc).not.toContain("!breathmark!");
+  });
+
+  it("MusicXML->ABC exports caesura decoration and roundtrips it", () => {
+    const xmlWithCaesura = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>1920</duration>
+        <voice>1</voice><type>half</type>
+        <notations><articulations><caesura/></articulations></notations>
+      </note>
+      <note><rest/><duration>1920</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithCaesura);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!caesura!");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector("note > notations > articulations > caesura")).not.toBeNull();
+  });
+
+  it("MusicXML->ABC exports staccatissimo as !wedge! and roundtrips it", () => {
+    const xmlWithStaccatissimo = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>1920</duration>
+        <voice>1</voice><type>half</type>
+        <notations><articulations><staccatissimo/></articulations></notations>
+      </note>
+      <note>
+        <rest/><duration>1920</duration><voice>1</voice><type>half</type>
+      </note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithStaccatissimo);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!wedge!");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector("note > notations > articulations > staccatissimo")).not.toBeNull();
+    expect(outDoc.querySelector("note > notations > articulations > staccato")).toBeNull();
+  });
+
+  it("MusicXML->ABC exports wedge directions as ABC wedge decorations and roundtrips them", () => {
+    const xml = `<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>480</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <direction><direction-type><wedge type="crescendo"/></direction-type></direction>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>480</duration><voice>1</voice><type>quarter</type></note>
+      <direction><direction-type><wedge type="stop"/></direction-type></direction>
+      <note><pitch><step>D</step><octave>4</octave></pitch><duration>480</duration><voice>1</voice><type>quarter</type></note>
+      <direction><direction-type><wedge type="diminuendo"/></direction-type></direction>
+      <note><pitch><step>E</step><octave>4</octave></pitch><duration>480</duration><voice>1</voice><type>quarter</type></note>
+      <direction><direction-type><wedge type="stop"/></direction-type></direction>
+      <note><pitch><step>F</step><octave>4</octave></pitch><duration>480</duration><voice>1</voice><type>quarter</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+
+    const srcDoc = parseMusicXmlDocument(xml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!crescendo(!C");
+    expect(abc).toContain("!crescendo)!D");
+    expect(abc).toContain("!diminuendo(!E");
+    expect(abc).toContain("!diminuendo)!F");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const wedgeTypes = Array.from(outDoc.querySelectorAll("part > measure > direction > direction-type > wedge"))
+      .map((node) => node.getAttribute("type"));
+    expect(wedgeTypes).toEqual(["crescendo", "stop", "diminuendo", "stop"]);
+  });
+
+  it("MusicXML->ABC exports crescendo wedge start and roundtrips it", () => {
+    const xml = `<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>480</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <direction><direction-type><wedge type="crescendo"/></direction-type></direction>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>1920</duration><voice>1</voice><type>whole</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!crescendo(!C");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector("part > measure > direction > direction-type > wedge")?.getAttribute("type")).toBe("crescendo");
+  });
+
+  it("MusicXML->ABC exports wedge stop and roundtrips it", () => {
+    const xml = `<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>480</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <direction><direction-type><wedge type="stop"/></direction-type></direction>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>1920</duration><voice>1</voice><type>whole</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain(")!C");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector("part > measure > direction > direction-type > wedge")?.getAttribute("type")).toBe("stop");
+  });
+
+  it("MusicXML->ABC exports diminuendo wedge start and roundtrips it", () => {
+    const xml = `<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>480</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <direction><direction-type><wedge type="diminuendo"/></direction-type></direction>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>1920</duration><voice>1</voice><type>whole</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!diminuendo(!C");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector("part > measure > direction > direction-type > wedge")?.getAttribute("type")).toBe("diminuendo");
+  });
+
+  it("MusicXML->ABC exports up-bow/down-bow and roundtrips them", () => {
+    const xmlWithBowing = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>960</duration>
+        <voice>1</voice><type>quarter</type>
+        <notations><technical><up-bow/></technical></notations>
+      </note>
+      <note>
+        <pitch><step>D</step><octave>4</octave></pitch>
+        <duration>960</duration>
+        <voice>1</voice><type>quarter</type>
+        <notations><technical><down-bow/></technical></notations>
+      </note>
+      <note><rest/><duration>1920</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithBowing);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!upbow!");
+    expect(abc).toContain("!downbow!");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const notes = Array.from(outDoc.querySelectorAll("part > measure > note"));
+    expect(notes[0]?.querySelector(":scope > notations > technical > up-bow")).not.toBeNull();
+    expect(notes[1]?.querySelector(":scope > notations > technical > down-bow")).not.toBeNull();
+  });
+
+  it("MusicXML->ABC exports up-bow and roundtrips it", () => {
+    const xmlWithUpBow = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>1920</duration>
+        <voice>1</voice><type>half</type>
+        <notations><technical><up-bow/></technical></notations>
+      </note>
+      <note><rest/><duration>1920</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithUpBow);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!upbow!");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector("note > notations > technical > up-bow")).not.toBeNull();
+  });
+
+  it("ABC bowing alias !up bow! roundtrips back to canonical !upbow!", () => {
+    const abc = `X:1
+T:Bowing alias
+M:4/4
+L:1/4
+K:C
+!up bow!C z |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const srcDoc = parseMusicXmlDocument(xml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+    expect(srcDoc.querySelector("note > notations > technical > up-bow")).not.toBeNull();
+
+    const exportedAbc = exportMusicXmlDomToAbc(srcDoc);
+    expect(exportedAbc).toContain("!upbow!");
+    expect(exportedAbc).not.toContain("!up bow!");
+  });
+
+  it("MusicXML->ABC exports down-bow and roundtrips it", () => {
+    const xmlWithDownBow = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>1920</duration>
+        <voice>1</voice><type>half</type>
+        <notations><technical><down-bow/></technical></notations>
+      </note>
+      <note><rest/><duration>1920</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithDownBow);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!downbow!");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector("note > notations > technical > down-bow")).not.toBeNull();
+  });
+
+  it("MusicXML->ABC exports double-tongue, triple-tongue, heel, and toe and roundtrips them", () => {
+    const xmlWithTechnicalMarks = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>960</duration><voice>1</voice><type>quarter</type>
+        <notations><technical><double-tongue/></technical></notations>
+      </note>
+      <note>
+        <pitch><step>D</step><octave>4</octave></pitch>
+        <duration>960</duration><voice>1</voice><type>quarter</type>
+        <notations><technical><triple-tongue/></technical></notations>
+      </note>
+      <note>
+        <pitch><step>E</step><octave>4</octave></pitch>
+        <duration>960</duration><voice>1</voice><type>quarter</type>
+        <notations><technical><heel/></technical></notations>
+      </note>
+      <note>
+        <pitch><step>F</step><octave>4</octave></pitch>
+        <duration>960</duration><voice>1</voice><type>quarter</type>
+        <notations><technical><toe/></technical></notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithTechnicalMarks);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!doubletongue!");
+    expect(abc).toContain("!tripletongue!");
+    expect(abc).toContain("!heel!");
+    expect(abc).toContain("!toe!");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const notes = Array.from(outDoc.querySelectorAll("part > measure > note"));
+    expect(notes[0]?.querySelector(":scope > notations > technical > double-tongue")).not.toBeNull();
+    expect(notes[1]?.querySelector(":scope > notations > technical > triple-tongue")).not.toBeNull();
+    expect(notes[2]?.querySelector(":scope > notations > technical > heel")).not.toBeNull();
+    expect(notes[3]?.querySelector(":scope > notations > technical > toe")).not.toBeNull();
+  });
+
+  it("MusicXML->ABC exports double-tongue and roundtrips it", () => {
+    const xmlWithDoubleTongue = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>1920</duration>
+        <voice>1</voice><type>half</type>
+        <notations><technical><double-tongue/></technical></notations>
+      </note>
+      <note><rest/><duration>1920</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithDoubleTongue);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!doubletongue!");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector("note > notations > technical > double-tongue")).not.toBeNull();
+  });
+
+  it("ABC tongue alias !double tongue! roundtrips back to canonical !doubletongue!", () => {
+    const abc = `X:1
+T:Tongue alias
+M:4/4
+L:1/4
+K:C
+!double tongue!C z |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const srcDoc = parseMusicXmlDocument(xml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+    expect(srcDoc.querySelector("note > notations > technical > double-tongue")).not.toBeNull();
+
+    const exportedAbc = exportMusicXmlDomToAbc(srcDoc);
+    expect(exportedAbc).toContain("!doubletongue!");
+    expect(exportedAbc).not.toContain("!double tongue!");
+  });
+
+  it("MusicXML->ABC exports triple-tongue and roundtrips it", () => {
+    const xmlWithTripleTongue = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>1920</duration>
+        <voice>1</voice><type>half</type>
+        <notations><technical><triple-tongue/></technical></notations>
+      </note>
+      <note><rest/><duration>1920</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithTripleTongue);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!tripletongue!");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector("note > notations > technical > triple-tongue")).not.toBeNull();
+  });
+
+  it("MusicXML->ABC exports heel and roundtrips it", () => {
+    const xmlWithHeel = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>1920</duration>
+        <voice>1</voice><type>half</type>
+        <notations><technical><heel/></technical></notations>
+      </note>
+      <note><rest/><duration>1920</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithHeel);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!heel!");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector("note > notations > technical > heel")).not.toBeNull();
+  });
+
+  it("MusicXML->ABC exports toe and roundtrips it", () => {
+    const xmlWithToe = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>1920</duration>
+        <voice>1</voice><type>half</type>
+        <notations><technical><toe/></technical></notations>
+      </note>
+      <note><rest/><duration>1920</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithToe);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!toe!");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector("note > notations > technical > toe")).not.toBeNull();
+  });
+
+  it("MusicXML->ABC exports fingering and string as mikuscore decorations and roundtrips them", () => {
+    const xmlWithFingeringsAndStrings = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>1920</duration><voice>1</voice><type>half</type>
+        <notations><technical><fingering>1</fingering><fingering substitution="yes">4</fingering></technical></notations>
+      </note>
+      <note>
+        <pitch><step>D</step><octave>4</octave></pitch>
+        <duration>960</duration><voice>1</voice><type>quarter</type>
+        <notations><technical><string>1</string></technical></notations>
+      </note>
+      <note>
+        <pitch><step>E</step><octave>4</octave></pitch>
+        <duration>960</duration><voice>1</voice><type>quarter</type>
+        <notations><technical><string>4</string></technical></notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithFingeringsAndStrings);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!fingering:1!");
+    expect(abc).toContain("!fingering:4!");
+    expect(abc).toContain("!string:1!");
+    expect(abc).toContain("!string:4!");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const notes = Array.from(outDoc.querySelectorAll("part > measure > note"));
+    const fingerings = Array.from(notes[0]?.querySelectorAll(":scope > notations > technical > fingering") ?? []).map((n) => n.textContent?.trim());
+    expect(fingerings).toEqual(["1", "4"]);
+    expect(notes[1]?.querySelector(":scope > notations > technical > string")?.textContent?.trim()).toBe("1");
+    expect(notes[2]?.querySelector(":scope > notations > technical > string")?.textContent?.trim()).toBe("4");
+  });
+
+  it("MusicXML->ABC exports fingering decorations and roundtrips them", () => {
+    const xmlWithFingerings = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>1920</duration><voice>1</voice><type>half</type>
+        <notations><technical><fingering>1</fingering><fingering substitution="yes">4</fingering></technical></notations>
+      </note>
+      <note><rest/><duration>1920</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithFingerings);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!fingering:1!");
+    expect(abc).toContain("!fingering:4!");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const fingerings = Array.from(outDoc.querySelectorAll("note > notations > technical > fingering")).map((n) => n.textContent?.trim());
+    expect(fingerings).toEqual(["1", "4"]);
+  });
+
+  it("MusicXML->ABC exports a single fingering decoration and roundtrips it", () => {
+    const xmlWithSingleFingering = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>1920</duration><voice>1</voice><type>half</type>
+        <notations><technical><fingering>1</fingering></technical></notations>
+      </note>
+      <note><rest/><duration>1920</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithSingleFingering);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!fingering:1!");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const fingerings = Array.from(outDoc.querySelectorAll("note > notations > technical > fingering")).map((n) => n.textContent?.trim());
+    expect(fingerings).toEqual(["1"]);
+  });
+
+  it("MusicXML->ABC exports string decorations and roundtrips them", () => {
+    const xmlWithString = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>1920</duration><voice>1</voice><type>half</type>
+        <notations><technical><string>3</string></technical></notations>
+      </note>
+      <note><rest/><duration>1920</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithString);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!string:3!");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector("note > notations > technical > string")?.textContent?.trim()).toBe("3");
+  });
+
+  it("MusicXML->ABC exports a single string decoration and roundtrips it", () => {
+    const xmlWithSingleString = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>1920</duration><voice>1</voice><type>half</type>
+        <notations><technical><string>2</string></technical></notations>
+      </note>
+      <note><rest/><duration>1920</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithSingleString);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!string:2!");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector("note > notations > technical > string")?.textContent?.trim()).toBe("2");
+  });
+
+  it("MusicXML->ABC exports pluck as mikuscore decorations and roundtrips it", () => {
+    const xmlWithPluck = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>3840</duration><voice>1</voice><type>whole</type>
+        <notations><technical><pluck>p</pluck><pluck>i</pluck><pluck>m</pluck><pluck>a</pluck></technical></notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithPluck);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!pluck:p!");
+    expect(abc).toContain("!pluck:i!");
+    expect(abc).toContain("!pluck:m!");
+    expect(abc).toContain("!pluck:a!");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const plucks = Array.from(outDoc.querySelectorAll("part > measure > note > notations > technical > pluck")).map((n) => n.textContent?.trim());
+    expect(plucks).toEqual(["p", "i", "m", "a"]);
+  });
+
+  it("MusicXML->ABC exports a single pluck decoration and roundtrips it", () => {
+    const xmlWithSinglePluck = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>1920</duration><voice>1</voice><type>half</type>
+        <notations><technical><pluck>p</pluck></technical></notations>
+      </note>
+      <note><rest/><duration>1920</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithSinglePluck);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!pluck:p!");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const plucks = Array.from(outDoc.querySelectorAll("note > notations > technical > pluck")).map((n) => n.textContent?.trim());
+    expect(plucks).toEqual(["p"]);
+  });
+
+  it("MusicXML->ABC exports open-string and roundtrips it", () => {
+    const xmlWithOpenString = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>1920</duration>
+        <voice>1</voice><type>half</type>
+        <notations><technical><open-string/></technical></notations>
+      </note>
+      <note>
+        <rest/><duration>1920</duration><voice>1</voice><type>half</type>
+      </note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithOpenString);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!open!");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector("note > notations > technical > open-string")).not.toBeNull();
+  });
+
+  it("ABC open-string alias !openstring! roundtrips back to canonical !open!", () => {
+    const abc = `X:1
+T:Open string alias
+M:4/4
+L:1/4
+K:C
+!openstring!C z |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const srcDoc = parseMusicXmlDocument(xml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+    expect(srcDoc.querySelector("note > notations > technical > open-string")).not.toBeNull();
+
+    const exportedAbc = exportMusicXmlDomToAbc(srcDoc);
+    expect(exportedAbc).toContain("!open!");
+    expect(exportedAbc).not.toContain("!openstring!");
+  });
+
+  it("ABC open-string alias !open-string! roundtrips back to canonical !open!", () => {
+    const abc = `X:1
+T:Open-string alias
+M:4/4
+L:1/4
+K:C
+!open-string!C z |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const srcDoc = parseMusicXmlDocument(xml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+    expect(srcDoc.querySelector("note > notations > technical > open-string")).not.toBeNull();
+
+    const exportedAbc = exportMusicXmlDomToAbc(srcDoc);
+    expect(exportedAbc).toContain("!open!");
+    expect(exportedAbc).not.toContain("!open-string!");
+  });
+
+  it("MusicXML->ABC exports snap-pizzicato and roundtrips it", () => {
+    const xmlWithSnapPizzicato = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>1920</duration>
+        <voice>1</voice><type>half</type>
+        <notations><technical><snap-pizzicato/></technical></notations>
+      </note>
+      <note>
+        <rest/><duration>1920</duration><voice>1</voice><type>half</type>
+      </note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithSnapPizzicato);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!snap!");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector("note > notations > technical > snap-pizzicato")).not.toBeNull();
+  });
+
+  it("ABC snap-pizzicato alias !snappizzicato! roundtrips back to canonical !snap!", () => {
+    const abc = `X:1
+T:Snap alias
+M:4/4
+L:1/4
+K:C
+!snappizzicato!C z |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const srcDoc = parseMusicXmlDocument(xml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+    expect(srcDoc.querySelector("note > notations > technical > snap-pizzicato")).not.toBeNull();
+
+    const exportedAbc = exportMusicXmlDomToAbc(srcDoc);
+    expect(exportedAbc).toContain("!snap!");
+    expect(exportedAbc).not.toContain("!snappizzicato!");
+  });
+
+  it("ABC snap-pizzicato alias !snap-pizzicato! roundtrips back to canonical !snap!", () => {
+    const abc = `X:1
+T:Snap-pizzicato alias
+M:4/4
+L:1/4
+K:C
+!snap-pizzicato!C z |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const srcDoc = parseMusicXmlDocument(xml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+    expect(srcDoc.querySelector("note > notations > technical > snap-pizzicato")).not.toBeNull();
+
+    const exportedAbc = exportMusicXmlDomToAbc(srcDoc);
+    expect(exportedAbc).toContain("!snap!");
+    expect(exportedAbc).not.toContain("!snap-pizzicato!");
+  });
+
+  it("MusicXML->ABC exports harmonic and roundtrips it", () => {
+    const xmlWithHarmonic = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>1920</duration>
+        <voice>1</voice><type>half</type>
+        <notations><technical><harmonic/></technical></notations>
+      </note>
+      <note>
+        <rest/><duration>1920</duration><voice>1</voice><type>half</type>
+      </note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithHarmonic);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!harmonic!");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector("note > notations > technical > harmonic")).not.toBeNull();
+  });
+
+  it("MusicXML->ABC exports thumb-position and roundtrips it", () => {
+    const xmlWithThumbPosition = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>1920</duration>
+        <voice>1</voice><type>half</type>
+        <notations><technical><thumb-position/></technical></notations>
+      </note>
+      <note>
+        <rest/><duration>1920</duration><voice>1</voice><type>half</type>
+      </note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithThumbPosition);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!thumb!");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector("note > notations > technical > thumb-position")).not.toBeNull();
+  });
+
+  it("ABC thumb-position alias !thumbpos! roundtrips back to canonical !thumb!", () => {
+    const abc = `X:1
+T:Thumb alias
+M:4/4
+L:1/4
+K:C
+!thumbpos!C z |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const srcDoc = parseMusicXmlDocument(xml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+    expect(srcDoc.querySelector("note > notations > technical > thumb-position")).not.toBeNull();
+
+    const exportedAbc = exportMusicXmlDomToAbc(srcDoc);
+    expect(exportedAbc).toContain("!thumb!");
+    expect(exportedAbc).not.toContain("!thumbpos!");
+  });
+
+  it("ABC thumb-position alias !thumbposition! roundtrips back to canonical !thumb!", () => {
+    const abc = `X:1
+T:Thumb position alias
+M:4/4
+L:1/4
+K:C
+!thumbposition!C z |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const srcDoc = parseMusicXmlDocument(xml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+    expect(srcDoc.querySelector("note > notations > technical > thumb-position")).not.toBeNull();
+
+    const exportedAbc = exportMusicXmlDomToAbc(srcDoc);
+    expect(exportedAbc).toContain("!thumb!");
+    expect(exportedAbc).not.toContain("!thumbposition!");
+  });
+
+  it("MusicXML->ABC exports mordent/inverted-mordent and roundtrips them", () => {
+    const xmlWithMordents = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>960</duration>
+        <voice>1</voice><type>quarter</type>
+        <notations><ornaments><mordent/></ornaments></notations>
+      </note>
+      <note>
+        <pitch><step>D</step><octave>4</octave></pitch>
+        <duration>960</duration>
+        <voice>1</voice><type>quarter</type>
+        <notations><ornaments><inverted-mordent/></ornaments></notations>
+      </note>
+      <note><rest/><duration>1920</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithMordents);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!mordent!");
+    expect(abc).toContain("!pralltriller!");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const notes = Array.from(outDoc.querySelectorAll("part > measure > note"));
+    expect(notes[0]?.querySelector(":scope > notations > ornaments > mordent")).not.toBeNull();
+    expect(notes[1]?.querySelector(":scope > notations > ornaments > inverted-mordent")).not.toBeNull();
+  });
+
+  it("MusicXML->ABC exports mordent and roundtrips it", () => {
+    const xmlWithMordent = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>1920</duration>
+        <voice>1</voice><type>half</type>
+        <notations><ornaments><mordent/></ornaments></notations>
+      </note>
+      <note><rest/><duration>1920</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithMordent);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!mordent!");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector("note > notations > ornaments > mordent")).not.toBeNull();
+  });
+
+  it("MusicXML->ABC exports inverted-mordent and roundtrips it", () => {
+    const xmlWithInvertedMordent = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>1920</duration>
+        <voice>1</voice><type>half</type>
+        <notations><ornaments><inverted-mordent/></ornaments></notations>
+      </note>
+      <note><rest/><duration>1920</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithInvertedMordent);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!pralltriller!");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector("note > notations > ornaments > inverted-mordent")).not.toBeNull();
+  });
+
+  it("MusicXML->ABC exports arpeggiate as !roll! and roundtrips it", () => {
+    const xmlWithArpeggiate = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>1920</duration>
+        <voice>1</voice><type>half</type>
+        <notations><arpeggiate/></notations>
+      </note>
+      <note>
+        <chord/>
+        <pitch><step>E</step><octave>4</octave></pitch>
+        <duration>1920</duration>
+        <voice>1</voice><type>half</type>
+      </note>
+      <note>
+        <rest/><duration>1920</duration><voice>1</voice><type>half</type>
+      </note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithArpeggiate);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!roll![");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector("note > notations > arpeggiate")).not.toBeNull();
+  });
+
+  it("MusicXML->ABC exports schleifer/shake and roundtrips them", () => {
+    const xmlWithSchleiferAndShake = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>960</duration>
+        <voice>1</voice><type>quarter</type>
+        <notations><ornaments><schleifer/></ornaments></notations>
+      </note>
+      <note>
+        <pitch><step>D</step><octave>4</octave></pitch>
+        <duration>960</duration>
+        <voice>1</voice><type>quarter</type>
+        <notations><ornaments><shake/></ornaments></notations>
+      </note>
+      <note><rest/><duration>1920</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithSchleiferAndShake);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!schleifer!");
+    expect(abc).toContain("!shake!");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const notes = Array.from(outDoc.querySelectorAll("part > measure > note"));
+    expect(notes[0]?.querySelector(":scope > notations > ornaments > schleifer")).not.toBeNull();
+    expect(notes[1]?.querySelector(":scope > notations > ornaments > shake")).not.toBeNull();
+  });
+
+  it("MusicXML->ABC exports schleifer and roundtrips it", () => {
+    const xmlWithSchleifer = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>1920</duration>
+        <voice>1</voice><type>half</type>
+        <notations><ornaments><schleifer/></ornaments></notations>
+      </note>
+      <note><rest/><duration>1920</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithSchleifer);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!schleifer!");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector("note > notations > ornaments > schleifer")).not.toBeNull();
+  });
+
+  it("MusicXML->ABC exports shake and roundtrips it", () => {
+    const xmlWithShake = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>1920</duration>
+        <voice>1</voice><type>half</type>
+        <notations><ornaments><shake/></ornaments></notations>
+      </note>
+      <note><rest/><duration>1920</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithShake);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!shake!");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector("note > notations > ornaments > shake")).not.toBeNull();
+  });
+
+  it("MusicXML->ABC exports segno/coda directions and roundtrips them", () => {
+    const xmlWithDirections = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <direction><direction-type><segno/></direction-type></direction>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>960</duration><voice>1</voice><type>quarter</type></note>
+      <direction><direction-type><coda/></direction-type></direction>
+      <note><pitch><step>D</step><octave>4</octave></pitch><duration>960</duration><voice>1</voice><type>quarter</type></note>
+      <note><rest/><duration>1920</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithDirections);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!segno!C");
+    expect(abc).toContain("!coda!D");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const directions = Array.from(outDoc.querySelectorAll("part > measure > direction > direction-type"));
+    expect(directions[0]?.querySelector(":scope > segno")).not.toBeNull();
+    expect(directions[1]?.querySelector(":scope > coda")).not.toBeNull();
+  });
+
+  it("MusicXML->ABC exports segno direction and roundtrips it", () => {
+    const xmlWithSegno = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <direction><direction-type><segno/></direction-type></direction>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>960</duration><voice>1</voice><type>quarter</type></note>
+      <note><rest/><duration>2880</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithSegno);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!segno!C");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector("part > measure > direction > direction-type > segno")).not.toBeNull();
+  });
+
+  it("MusicXML->ABC exports coda direction and roundtrips it", () => {
+    const xmlWithCoda = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <direction><direction-type><coda/></direction-type></direction>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>960</duration><voice>1</voice><type>quarter</type></note>
+      <note><rest/><duration>2880</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithCoda);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!coda!C");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector("part > measure > direction > direction-type > coda")).not.toBeNull();
+  });
+
+  it("MusicXML->ABC exports fine sound marker and roundtrips it", () => {
+    const xmlWithFine = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <direction><sound fine="yes"/></direction>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>960</duration><voice>1</voice><type>quarter</type></note>
+      <note><rest/><duration>2880</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithFine);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!fine!C");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector('part > measure > direction > sound[fine="yes"]')).not.toBeNull();
+  });
+
+  it("MusicXML->ABC exports dacapo sound marker and roundtrips it", () => {
+    const xmlWithDaCapo = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <direction><sound dacapo="yes"/></direction>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>960</duration><voice>1</voice><type>quarter</type></note>
+      <note><rest/><duration>2880</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithDaCapo);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!dacapo!C");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector('part > measure > direction > sound[dacapo="yes"]')).not.toBeNull();
+  });
+
+  it("ABC dacapo alias !da capo! roundtrips back to canonical !dacapo!", () => {
+    const abc = `X:1
+T:Da capo alias
+M:4/4
+L:1/4
+K:C
+!da capo!C z |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const srcDoc = parseMusicXmlDocument(xml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+    expect(srcDoc.querySelector('part > measure > direction > sound[dacapo="yes"]')).not.toBeNull();
+
+    const exportedAbc = exportMusicXmlDomToAbc(srcDoc);
+    expect(exportedAbc).toContain("!dacapo!");
+    expect(exportedAbc).not.toContain("!da capo!");
+  });
+
+  it("ABC dacapo alias !da-capo! roundtrips back to canonical !dacapo!", () => {
+    const abc = `X:1
+T:Da-capo alias
+M:4/4
+L:1/4
+K:C
+!da-capo!C z |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const srcDoc = parseMusicXmlDocument(xml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+    expect(srcDoc.querySelector('part > measure > direction > sound[dacapo="yes"]')).not.toBeNull();
+
+    const exportedAbc = exportMusicXmlDomToAbc(srcDoc);
+    expect(exportedAbc).toContain("!dacapo!");
+    expect(exportedAbc).not.toContain("!da-capo!");
+  });
+
+  it("MusicXML->ABC exports dalsegno sound marker and roundtrips it", () => {
+    const xmlWithDalSegno = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <direction><sound dalsegno="segno"/></direction>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>960</duration><voice>1</voice><type>quarter</type></note>
+      <note><rest/><duration>2880</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithDalSegno);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!dalsegno!C");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector('part > measure > direction > sound[dalsegno="segno"]')).not.toBeNull();
+  });
+
+  it("ABC dalsegno alias !dal segno! roundtrips back to canonical !dalsegno!", () => {
+    const abc = `X:1
+T:Dal segno alias
+M:4/4
+L:1/4
+K:C
+!dal segno!C z |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const srcDoc = parseMusicXmlDocument(xml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+    expect(srcDoc.querySelector('part > measure > direction > sound[dalsegno="segno"]')).not.toBeNull();
+
+    const exportedAbc = exportMusicXmlDomToAbc(srcDoc);
+    expect(exportedAbc).toContain("!dalsegno!");
+    expect(exportedAbc).not.toContain("!dal segno!");
+  });
+
+  it("ABC dalsegno alias !dal-segno! roundtrips back to canonical !dalsegno!", () => {
+    const abc = `X:1
+T:Dal-segno alias
+M:4/4
+L:1/4
+K:C
+!dal-segno!C z |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const srcDoc = parseMusicXmlDocument(xml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+    expect(srcDoc.querySelector('part > measure > direction > sound[dalsegno="segno"]')).not.toBeNull();
+
+    const exportedAbc = exportMusicXmlDomToAbc(srcDoc);
+    expect(exportedAbc).toContain("!dalsegno!");
+    expect(exportedAbc).not.toContain("!dal-segno!");
+  });
+
+  it("MusicXML->ABC exports tocoda sound marker and roundtrips it", () => {
+    const xmlWithToCoda = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <direction><sound tocoda="coda"/></direction>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>960</duration><voice>1</voice><type>quarter</type></note>
+      <note><rest/><duration>2880</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithToCoda);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!tocoda!C");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector('part > measure > direction > sound[tocoda="coda"]')).not.toBeNull();
+  });
+
+  it("ABC tocoda alias !to coda! roundtrips back to canonical !tocoda!", () => {
+    const abc = `X:1
+T:To coda alias
+M:4/4
+L:1/4
+K:C
+!to coda!C z |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const srcDoc = parseMusicXmlDocument(xml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+    expect(srcDoc.querySelector('part > measure > direction > sound[tocoda="coda"]')).not.toBeNull();
+
+    const exportedAbc = exportMusicXmlDomToAbc(srcDoc);
+    expect(exportedAbc).toContain("!tocoda!");
+    expect(exportedAbc).not.toContain("!to coda!");
+  });
+
+  it("ABC tocoda alias !to-coda! roundtrips back to canonical !tocoda!", () => {
+    const abc = `X:1
+T:To-coda alias
+M:4/4
+L:1/4
+K:C
+!to-coda!C z |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const srcDoc = parseMusicXmlDocument(xml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+    expect(srcDoc.querySelector('part > measure > direction > sound[tocoda="coda"]')).not.toBeNull();
+
+    const exportedAbc = exportMusicXmlDomToAbc(srcDoc);
+    expect(exportedAbc).toContain("!tocoda!");
+    expect(exportedAbc).not.toContain("!to-coda!");
+  });
+
+  it("MusicXML->ABC exports sfz dynamics and roundtrips it", () => {
+    const xmlWithDynamics = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <direction><direction-type><dynamics><sfz/></dynamics></direction-type></direction>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>960</duration><voice>1</voice><type>quarter</type></note>
+      <note><rest/><duration>2880</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithDynamics);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!sfz!C");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector("part > measure > direction > direction-type > dynamics > sfz")).not.toBeNull();
+  });
+
+  it("MusicXML->ABC exports common dynamics and roundtrips them", () => {
+    const xmlWithDynamics = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <direction><direction-type><dynamics><ppp/></dynamics></direction-type></direction>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>960</duration><voice>1</voice><type>quarter</type></note>
+      <direction><direction-type><dynamics><mf/></dynamics></direction-type></direction>
+      <note><pitch><step>D</step><octave>4</octave></pitch><duration>960</duration><voice>1</voice><type>quarter</type></note>
+      <direction><direction-type><dynamics><rfz/></dynamics></direction-type></direction>
+      <note><pitch><step>E</step><octave>4</octave></pitch><duration>960</duration><voice>1</voice><type>quarter</type></note>
+      <note><rest/><duration>960</duration><voice>1</voice><type>quarter</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithDynamics);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!ppp!C");
+    expect(abc).toContain("!mf!D");
+    expect(abc).toContain("!rfz!E");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    const dynamics = Array.from(outDoc.querySelectorAll("part > measure > direction > direction-type > dynamics"))
+      .map((node) => node.firstElementChild?.tagName?.toLowerCase());
+    expect(dynamics).toEqual(["ppp", "mf", "rfz"]);
+  });
+
+  it("MusicXML->ABC exports p dynamics and roundtrips it", () => {
+    const xmlWithDynamics = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <direction><direction-type><dynamics><p/></dynamics></direction-type></direction>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>960</duration><voice>1</voice><type>quarter</type></note>
+      <note><rest/><duration>2880</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithDynamics);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!p!C");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector("part > measure > direction > direction-type > dynamics > p")).not.toBeNull();
+  });
+
+  it("MusicXML->ABC exports pp dynamics and roundtrips it", () => {
+    const xmlWithDynamics = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <direction><direction-type><dynamics><pp/></dynamics></direction-type></direction>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>960</duration><voice>1</voice><type>quarter</type></note>
+      <note><rest/><duration>2880</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithDynamics);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!pp!C");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector("part > measure > direction > direction-type > dynamics > pp")).not.toBeNull();
+  });
+
+  it("MusicXML->ABC exports ff dynamics and roundtrips it", () => {
+    const xmlWithDynamics = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <direction><direction-type><dynamics><ff/></dynamics></direction-type></direction>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>960</duration><voice>1</voice><type>quarter</type></note>
+      <note><rest/><duration>2880</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithDynamics);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!ff!C");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector("part > measure > direction > direction-type > dynamics > ff")).not.toBeNull();
+  });
+
+  it("MusicXML->ABC exports f dynamics and roundtrips it", () => {
+    const xmlWithDynamics = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <direction><direction-type><dynamics><f/></dynamics></direction-type></direction>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>960</duration><voice>1</voice><type>quarter</type></note>
+      <note><rest/><duration>2880</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithDynamics);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!f!C");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector("part > measure > direction > direction-type > dynamics > f")).not.toBeNull();
+  });
+
+  it("MusicXML->ABC exports mf dynamics and roundtrips it", () => {
+    const xmlWithDynamics = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <direction><direction-type><dynamics><mf/></dynamics></direction-type></direction>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>960</duration><voice>1</voice><type>quarter</type></note>
+      <note><rest/><duration>2880</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithDynamics);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!mf!C");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector("part > measure > direction > direction-type > dynamics > mf")).not.toBeNull();
+  });
+
+  it("MusicXML->ABC exports mp dynamics and roundtrips it", () => {
+    const xmlWithDynamics = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <direction><direction-type><dynamics><mp/></dynamics></direction-type></direction>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>960</duration><voice>1</voice><type>quarter</type></note>
+      <note><rest/><duration>2880</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithDynamics);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!mp!C");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector("part > measure > direction > direction-type > dynamics > mp")).not.toBeNull();
+  });
+
+  it("MusicXML->ABC exports ppp dynamics and roundtrips it", () => {
+    const xmlWithDynamics = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <direction><direction-type><dynamics><ppp/></dynamics></direction-type></direction>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>960</duration><voice>1</voice><type>quarter</type></note>
+      <note><rest/><duration>2880</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithDynamics);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!ppp!C");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector("part > measure > direction > direction-type > dynamics > ppp")).not.toBeNull();
+  });
+
+  it("MusicXML->ABC exports fff dynamics and roundtrips it", () => {
+    const xmlWithDynamics = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <direction><direction-type><dynamics><fff/></dynamics></direction-type></direction>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>960</duration><voice>1</voice><type>quarter</type></note>
+      <note><rest/><duration>2880</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithDynamics);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!fff!C");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector("part > measure > direction > direction-type > dynamics > fff")).not.toBeNull();
+  });
+
+  it("MusicXML->ABC exports fp dynamics and roundtrips it", () => {
+    const xmlWithDynamics = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <direction><direction-type><dynamics><fp/></dynamics></direction-type></direction>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>960</duration><voice>1</voice><type>quarter</type></note>
+      <note><rest/><duration>2880</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithDynamics);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!fp!C");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector("part > measure > direction > direction-type > dynamics > fp")).not.toBeNull();
+  });
+
+  it("MusicXML->ABC exports rfz dynamics and roundtrips it", () => {
+    const xmlWithDynamics = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <direction><direction-type><dynamics><rfz/></dynamics></direction-type></direction>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>960</duration><voice>1</voice><type>quarter</type></note>
+      <note><rest/><duration>2880</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithDynamics);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!rfz!C");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector("part > measure > direction > direction-type > dynamics > rfz")).not.toBeNull();
+  });
+
+  it("MusicXML->ABC exports sfp dynamics and roundtrips it", () => {
+    const xmlWithDynamics = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <direction><direction-type><dynamics><sfp/></dynamics></direction-type></direction>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>960</duration><voice>1</voice><type>quarter</type></note>
+      <note><rest/><duration>2880</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithDynamics);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!sfp!C");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector("part > measure > direction > direction-type > dynamics > sfp")).not.toBeNull();
+  });
+
+  it("MusicXML->ABC exports sf dynamics and roundtrips it", () => {
+    const xmlWithDynamics = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <direction><direction-type><dynamics><sf/></dynamics></direction-type></direction>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>960</duration><voice>1</voice><type>quarter</type></note>
+      <note><rest/><duration>2880</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithDynamics);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!sf!C");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector("part > measure > direction > direction-type > dynamics > sf")).not.toBeNull();
+  });
+
+  it("MusicXML->ABC exports fz dynamics and roundtrips it", () => {
+    const xmlWithDynamics = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <direction><direction-type><dynamics><fz/></dynamics></direction-type></direction>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>960</duration><voice>1</voice><type>quarter</type></note>
+      <note><rest/><duration>2880</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithDynamics);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!fz!C");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector("part > measure > direction > direction-type > dynamics > fz")).not.toBeNull();
+  });
+
+  it("MusicXML->ABC exports stopped and roundtrips it", () => {
+    const xmlWithStopped = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>1920</duration>
+        <voice>1</voice><type>half</type>
+        <notations><technical><stopped/></technical></notations>
+      </note>
+      <note>
+        <rest/><duration>1920</duration><voice>1</voice><type>half</type>
+      </note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithStopped);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!stopped!");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector("note > notations > technical > stopped")).not.toBeNull();
+  });
+
+  it("ABC stopped alias !plus! roundtrips back to canonical !stopped!", () => {
+    const abc = `X:1
+T:Stopped alias
+M:4/4
+L:1/4
+K:C
+!plus!C z |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const srcDoc = parseMusicXmlDocument(xml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+    expect(srcDoc.querySelector("note > notations > technical > stopped")).not.toBeNull();
+
+    const exportedAbc = exportMusicXmlDomToAbc(srcDoc);
+    expect(exportedAbc).toContain("!stopped!");
+    expect(exportedAbc).not.toContain("!plus!");
+  });
+
+  it("ABC stopped alias !stopped horn! roundtrips back to canonical !stopped!", () => {
+    const abc = `X:1
+T:Stopped horn alias
+M:4/4
+L:1/4
+K:C
+!stopped horn!C z |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const srcDoc = parseMusicXmlDocument(xml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+    expect(srcDoc.querySelector("note > notations > technical > stopped")).not.toBeNull();
+
+    const exportedAbc = exportMusicXmlDomToAbc(srcDoc);
+    expect(exportedAbc).toContain("!stopped!");
+    expect(exportedAbc).not.toContain("!stopped horn!");
   });
 
   it("MusicXML->ABC exports slur notation and roundtrips it", () => {
@@ -747,6 +6777,68 @@ V:1
     expect(outDoc.querySelector('note > tie[type="stop"]')).not.toBeNull();
     expect(outDoc.querySelector('note > notations > tied[type="start"]')).not.toBeNull();
     expect(outDoc.querySelector('note > notations > tied[type="stop"]')).not.toBeNull();
+  });
+
+  it("MusicXML->ABC roundtrips chord ties across all notes in the chord", () => {
+    const xmlWithChordTie = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>1920</duration>
+        <voice>1</voice><type>half</type>
+        <tie type="start"/><notations><tied type="start"/></notations>
+      </note>
+      <note>
+        <chord/>
+        <pitch><step>E</step><octave>4</octave></pitch>
+        <duration>1920</duration>
+        <voice>1</voice><type>half</type>
+        <tie type="start"/><notations><tied type="start"/></notations>
+      </note>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>1920</duration>
+        <voice>1</voice><type>half</type>
+        <tie type="stop"/><notations><tied type="stop"/></notations>
+      </note>
+      <note>
+        <chord/>
+        <pitch><step>E</step><octave>4</octave></pitch>
+        <duration>1920</duration>
+        <voice>1</voice><type>half</type>
+        <tie type="stop"/><notations><tied type="stop"/></notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithChordTie);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("[CE]4- [CE]4");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const notes = Array.from(outDoc.querySelectorAll("part > measure > note"));
+    const firstChord = notes.slice(0, 2);
+    const secondChord = notes.slice(2, 4);
+    expect(firstChord.every((note) => note.querySelector(':scope > tie[type="start"]') !== null)).toBe(true);
+    expect(secondChord.every((note) => note.querySelector(':scope > tie[type="stop"]') !== null)).toBe(true);
   });
 
   it("MusicXML->ABC keeps explicit accidental when lane key is unknown", () => {
@@ -858,7 +6950,7 @@ V:1
     expect(outDoc.querySelector("note > notations > ornaments > accidental-mark")?.textContent?.trim()).toBe("sharp");
   });
 
-  it("MusicXML->ABC->MusicXML preserves per-part key signatures via mks key hints", () => {
+  it("MusicXML->ABC->MusicXML preserves per-part key signatures via standard K fields", () => {
     const xmlWithMixedPartKeys = `<?xml version="1.0" encoding="UTF-8"?>
 <score-partwise version="3.1">
   <part-list>
@@ -901,10 +6993,12 @@ V:1
     if (!srcDoc) return;
 
     const abc = exportMusicXmlDomToAbc(srcDoc);
-    expect(abc).toContain("%@mks key voice=P1 measure=1 fifths=3");
-    expect(abc).toContain("%@mks key voice=P2 measure=1 fifths=0");
-    expect(abc).toContain("%@mks key voice=P1 measure=2 fifths=0");
-    expect(abc).toContain("%@mks key voice=P2 measure=2 fifths=3");
+    expect(abc).not.toContain("%@mks key");
+    expect(abc).toContain("K:A");
+    expect(abc).toContain("V:P1");
+    expect(abc).toContain("V:P2");
+    expect(abc).toContain("[K:C]");
+    expect(abc).toContain("[K:A]");
 
     const roundtripXml = convertAbcToMusicXml(abc);
     const outDoc = parseMusicXmlDocument(roundtripXml);
@@ -948,7 +7042,7 @@ z6 |
     expect(parts[1].querySelector('measure[number="1"] > attributes > key > fifths')?.textContent?.trim()).toBe("3");
   });
 
-  it("MusicXML->ABC emits initial %@mks key hints for each lane with explicit measure key", () => {
+  it("MusicXML->ABC uses shared header K when all lanes start with the same key", () => {
     const xmlWithSharedKey = `<?xml version="1.0" encoding="UTF-8"?>
 <score-partwise version="3.1">
   <part-list>
@@ -983,10 +7077,9 @@ z6 |
     if (!srcDoc) return;
 
     const abc = exportMusicXmlDomToAbc(srcDoc);
-    expect(abc).toContain("%@mks key voice=P1 measure=1 fifths=1");
-    expect(abc).toContain("%@mks key voice=P2 measure=1 fifths=1");
-    expect(abc).not.toContain("%@mks key voice=P1 measure=2 fifths=0");
-    expect(abc).not.toContain("%@mks key voice=P2 measure=2 fifths=0");
+    expect(abc).toContain("K:G");
+    expect(abc).not.toContain("%@mks key");
+    expect(abc).not.toContain("[K:G]");
   });
 
   it("MusicXML->ABC emits natural against lane key signature (A major G->=G)", () => {
@@ -1109,14 +7202,18 @@ z6 |
 
     const abc = exportMusicXmlDomToAbc(srcDoc);
     expect(abc).toContain("%@mks transpose voice=P1 chromatic=-3 diatonic=-2");
-    expect(abc).toContain("%@mks measure voice=P1 measure=1 number=0 implicit=1 repeat=forward");
-    expect(abc).toContain("%@mks measure voice=P1 measure=2 number=1 implicit=0 repeat=backward times=2");
+    expect(abc).toContain("%@mks measure voice=P1 measure=1 number=0 implicit=1");
+    expect(abc).not.toContain("repeat=forward");
+    expect(abc).not.toContain("repeat=backward");
+    expect(abc).not.toContain("times=2");
+    expect(abc).toContain("|:");
+    expect(abc).toContain(":|");
     expect(abc).toContain("(3:2:3");
     expect(abc).toContain("(3:2:3d");
     expect(abc).not.toContain("(3:2:3d2/3");
   });
 
-  it("ABC->MusicXML restores measure/repeat/transpose metadata and tuplet tags", () => {
+  it("ABC->MusicXML restores standard repeat barlines plus measure/transpose metadata and tuplet tags", () => {
     const abcWithMeta = `X:1
 T:Meta restore
 M:3/4
@@ -1124,10 +7221,9 @@ L:1/8
 K:C
 V:P1 name="Clarinet in A" clef=treble
 V:P1
-c2 z4 | (3:2:3 d/2 e/2 f/2 z4 |
+|: c2 z4 | (3:2:3 d/2 e/2 f/2 z4 :|
 %@mks transpose voice=P1 chromatic=-3 diatonic=-2
-%@mks measure voice=P1 measure=1 number=0 implicit=1 repeat=forward
-%@mks measure voice=P1 measure=2 number=1 implicit=0 repeat=backward times=2
+%@mks measure voice=P1 measure=1 number=0 implicit=1
 `;
     const xml = convertAbcToMusicXml(abcWithMeta);
     const outDoc = parseMusicXmlDocument(xml);
@@ -1136,13 +7232,46 @@ c2 z4 | (3:2:3 d/2 e/2 f/2 z4 |
 
     expect(outDoc.querySelector('part > measure[number="0"]')?.getAttribute("implicit")).toBe("yes");
     expect(outDoc.querySelector('part > measure[number="0"] > barline[location="left"] > repeat')?.getAttribute("direction")).toBe("forward");
-    expect(outDoc.querySelector('part > measure[number="1"] > barline[location="right"] > repeat')?.getAttribute("direction")).toBe("backward");
-    expect(outDoc.querySelector('part > measure[number="1"] > barline[location="right"] > repeat')?.getAttribute("times")).toBe("2");
+    expect(outDoc.querySelector('part > measure[number="2"] > barline[location="right"] > repeat')?.getAttribute("direction")).toBe("backward");
+    expect(outDoc.querySelector('part > measure[number="2"] > barline[location="right"] > repeat')?.getAttribute("times")).toBeNull();
     expect(outDoc.querySelector("part > measure > attributes > transpose > chromatic")?.textContent?.trim()).toBe("-3");
     expect(outDoc.querySelector("part > measure > attributes > transpose > diatonic")?.textContent?.trim()).toBe("-2");
-    expect(outDoc.querySelector('part > measure[number="1"] note > time-modification > actual-notes')?.textContent?.trim()).toBe("3");
-    expect(outDoc.querySelector('part > measure[number="1"] note > notations > tuplet[type="start"]')).not.toBeNull();
-    expect(outDoc.querySelector('part > measure[number="1"] note > notations > tuplet[type="stop"]')).not.toBeNull();
+    expect(outDoc.querySelector('part > measure[number="2"] note > time-modification > actual-notes')?.textContent?.trim()).toBe("3");
+    expect(outDoc.querySelector('part > measure[number="2"] note > notations > tuplet[type="start"]')).not.toBeNull();
+    expect(outDoc.querySelector('part > measure[number="2"] note > notations > tuplet[type="stop"]')).not.toBeNull();
+  });
+
+  it("MusicXML->ABC keeps %@mks repeat times only when standard ABC cannot express them", () => {
+    const xmlWithThreeTimesRepeat = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <barline location="left"><repeat direction="forward"/></barline>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>3840</duration><voice>1</voice><type>whole</type></note>
+    </measure>
+    <measure number="2">
+      <note><pitch><step>D</step><octave>4</octave></pitch><duration>3840</duration><voice>1</voice><type>whole</type></note>
+      <barline location="right"><repeat direction="backward" times="3"/></barline>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithThreeTimesRepeat);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("|:");
+    expect(abc).toContain(":|");
+    expect(abc).toContain("%@mks measure voice=P1 measure=2 number=2 implicit=0 times=3");
   });
 
   it("MusicXML->ABC does not split a separate lane for grace notes missing voice", () => {


### PR DESCRIPTION
## 概要

ABC まわりの互換性改善をまとめた変更です。
`src/ts/abc-io.ts` を中心に、標準 ABC と実地互換で使われる記法の対応範囲を広げ、あわせて `tests/unit/abc-io.spec.ts`、`docs/spec/ABC_IO.md`、`docs/spec/abc-compat-parser-ebnf.md`、`TODO.md` を更新しています。 生成物として `src/js/main.js` と `mikuscore.html` も更新されています。

## 変更内容

- ABC import/export の対応範囲を拡張
  - repeat / ending の標準記法対応の改善
  - `//` 長さ省略記法の対応
  - inline field の対応強化
  - `w:` lyrics の対応
  - quoted chord symbol / annotation の対応強化
  - `&` overlay import の改善
  - standard shorthand decoration symbol の import 対応
  - standard decoration / alias / mikuscore extension decoration の対応拡張
- ABC roundtrip / regression test を大幅に追加
- ABC 関連の仕様文書と TODO を更新
  - 現在の対応範囲
  - 残課題
  - 再開ポイント

## テスト

- `tests/unit/abc-io.spec.ts` を拡充
- コミット時点で会話内で確認できている範囲:
  - `npx vitest run tests/unit/abc-io.spec.ts`
  - `npm run typecheck`
  - `npm run test:unit`