### PR TITLE
ABC 2.2 対応方針の文書化と ABC 互換パーサ/装飾記号対応の強化

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ It is delivered as a **single-file web app** (`mikuscore.html`) and runs offline
 - MuseScore (`.mscx` / `.mscz`)
 - MIDI (`.mid` / `.midi`)
 - VSQX (`.vsqx`) (via vendored `utaformatix3-ts-plus`)
-- ABC (`.abc`) (experimental)
+- ABC (`.abc`) (ABC standard 2.2 baseline; some standard features remain partially implemented or unimplemented)
 - MEI (`.mei`) (experimental)
 - LilyPond (`.ly`) (experimental)
 
@@ -102,7 +102,7 @@ mikuscore は、MusicXML を中核に据えた **譜面フォーマット変換�
 - MuseScore（`.mscx` / `.mscz`）
 - MIDI（`.mid` / `.midi`）
 - VSQX（`.vsqx`）（同梱 `utaformatix3-ts-plus` 経由）
-- ABC（`.abc`）（実験的対応）
+- ABC（`.abc`）（ABC standard 2.2 ベース。一部の標準機能は未実装または部分対応）
 - MEI（`.mei`）（実験的対応）
 - LilyPond（`.ly`）（実験的対応）
 

--- a/TODO.md
+++ b/TODO.md
@@ -124,7 +124,109 @@
 - [ ] ABC spec/implementation audit follow-up (2026-04-05):
   - Current audit result:
     - high-confidence gaps where the spec reads as supported but the implementation is still incomplete: `0`
-    - known standard-ABC features that are still unsupported / only partially implemented: `3`
+    - known standard-ABC features that are still unsupported / only partially implemented: decoration coverage remains broader than the currently implemented subset; see categorized backlog below
+  - Coverage baseline:
+    - chapter-level ABC standard coverage tracking now lives in `docs/spec/ABC_STANDARD_COVERAGE.md`
+    - latest formal standard is `2.2`, but current completion baseline is managed as `2.1 + explicit 2.2 delta`
+    - use that file as the source of truth for completion judgment; use this TODO only for actionable deltas
+    - broader actionable backlog is enumerated there as `ABC-COV-*`; local TODO items should reference those backlog ids when possible
+  - Ordered coverage-derived backlog (`ABC-COV-*`):
+    - [ ] `ABC-COV-009` (`P1`, `mixed`, initial stance: `support now`)
+      - Resolve pending decoration policy items:
+        - `!arpeggio!` / `!roll!`
+        - `!+!` / `!plus!`
+        - mordent-family export naming
+        - `!slide!` stop-side policy
+      - Progress:
+        - policy decision is now written in `docs/spec/ABC_STANDARD_COVERAGE.md` and `docs/spec/ABC_IO.md`
+        - `!arpeggio!` export has been aligned to canonical `!arpeggio!` with regression coverage
+        - `!+!` / `!plus!`, mordent-family canonical export, and `!slide!` stop-side extension policy are already consistent with the written policy
+      - Done when:
+        - each pending item is resolved in spec text, with implementation/tests if needed
+    - [ ] `ABC-COV-016` (`P1`, `mixed`, initial stance: `support bounded subset`)
+      - Enumerate which standard voice properties are supported, unsupported, or extension-only
+      - Done when:
+        - supported/unsupported voice-property list is explicit and testable
+    - [ ] `ABC-COV-005` (`P1`, `mixed`, initial stance: `support bounded subset`)
+      - Decide how far ABC whitespace-as-beam-separation must be preserved on export
+      - Done when:
+        - whitespace-beam preservation target is decided and tested to that level
+    - [ ] `ABC-COV-006` (`P1`, `mixed`, initial stance: `support bounded subset`)
+      - Audit remaining repeat/ending edge variants and mark what is still unsupported
+      - Done when:
+        - remaining repeat/ending edge forms are either supported with tests or explicitly marked unsupported
+    - [ ] `ABC-COV-012` (`P1`, `mixed`, initial stance: `support bounded subset`)
+      - Expand or explicitly bound the supported chord-symbol inventory
+      - Done when:
+        - supported chord-symbol inventory is enumerated enough to test and maintain
+    - [ ] `ABC-COV-007` (`P1`, `mixed`, initial stance: `support bounded subset`)
+      - Close the slur-span reconstruction policy or keep it explicitly partial with defined limits
+      - Done when:
+        - slur-span limits are written down and tested, or stronger preservation is implemented
+    - [ ] `ABC-COV-017` (`P1`, `policy`, initial stance: `defer intentionally`)
+      - Decide whether faithful same-part overlay preservation is required
+      - Done when:
+        - overlay preservation target is explicitly accepted or rejected
+    - [ ] `ABC-COV-018` (`P2`, `policy`, initial stance: `defer intentionally`)
+      - Decide whether `!editorial!` and `!courtesy!` are in the supported roadmap or intentionally deferred
+      - Done when:
+        - 2.2 delta items are either put on roadmap or marked intentionally deferred
+    - [ ] `ABC-COV-008` (`P2`, `mixed`, initial stance: `support bounded subset`)
+      - Audit remaining tuplet ratio/edge semantics and mark what is still unsupported
+      - Done when:
+        - remaining tuplet edge semantics are either tested or explicitly excluded
+    - [ ] `ABC-COV-011` (`P2`, `policy`, initial stance: `support bounded subset`)
+      - Decide whether `U:` remains import-only or needs broader parity/export support
+      - Done when:
+        - `U:` support boundary is explicitly written down
+    - [ ] `ABC-COV-015` (`P2`, `mixed`, initial stance: `support bounded subset`)
+      - Audit lyrics alignment, multi-verse behavior, and numbering scope
+      - Done when:
+        - lyric scope is bounded and tested for the chosen supported subset
+    - [ ] `ABC-COV-001` (`P2`, `policy`, initial stance: `support bounded subset`)
+      - Decide and document which non-core standard information fields are intentionally unsupported versus planned
+      - Done when:
+        - non-core field policy is written in spec and reflected in linked docs
+    - [ ] `ABC-COV-002` (`P2`, `policy`, initial stance: `support bounded subset`)
+      - Decide whether the supported inline-field subset stops at `[K/M/L/Q/V]` or should expand
+      - Done when:
+        - supported inline subset is explicitly bounded in spec text
+    - [ ] `ABC-COV-013` (`P2`, `policy`, initial stance: `support bounded subset`)
+      - Define the supported annotation behavior and explicit exclusions
+      - Done when:
+        - supported annotation subset and exclusions are written down
+    - [ ] `ABC-COV-003` (`P3`, `policy`, initial stance: `defer intentionally`)
+      - Either implement field continuation support or explicitly freeze it as unsupported in the practical scope
+      - Done when:
+        - continuation is explicitly frozen as unsupported or promoted to planned work
+    - [ ] `ABC-COV-010` (`P3`, `policy`, initial stance: `out of practical scope`)
+      - Decide whether `s:` symbol lines are in scope or intentionally out of scope
+      - Done when:
+        - `s:` is explicitly marked in-scope or frozen out-of-scope
+    - [ ] `ABC-COV-014` (`P3`, `policy`, initial stance: `support bounded subset`)
+      - Decide whether broad practical acceptance is enough or whether stricter conformance is required
+      - Done when:
+        - acceptance philosophy and explicit exclusions are written down
+  - Resume note for next ABC session:
+    - Stop point:
+      - `ABC-COV-009` policy has been written down in `docs/spec/ABC_STANDARD_COVERAGE.md` and `docs/spec/ABC_IO.md`
+      - canonical `!arpeggio!` export is now aligned in code/tests
+      - `!+!` / `!plus!`, mordent-family canonical export, and `!slide!` stop-side extension policy are already aligned with the written policy
+    - First task to resume:
+      - decide whether `ABC-COV-009` can be closed outright, or whether one more focused regression pass is needed before checking it off
+    - If `ABC-COV-009` is closed, continue in this order:
+      - 1. `ABC-COV-016` voice-property enumeration
+      - 2. `ABC-COV-005` beam-separation preservation target
+      - 3. `ABC-COV-006` repeat / ending edge audit
+    - Files to open first:
+      - `docs/spec/ABC_STANDARD_COVERAGE.md`
+      - `docs/spec/ABC_IO.md`
+      - `TODO.md`
+  - Compatibility follow-up:
+    - [x] accept shorthand `V:` tails such as `V:2 bass` as voice metadata instead of body text
+    - [x] treat recognized bare clef names in `V:` tails (`bass`, `treble`, `alto`, `tenor`, etc.) as `clef=...`
+    - [x] add regression tests so `V:2 bass` no longer falls through to note/rest parsing and fails on trailing `ss`
+    - [x] warn on unsupported bare `V:` tail words instead of letting them fail later as note/rest parsing errors
   - Resume note (2026-04-06):
     - Stop point for this series: quoted chord symbols and standard shorthand decoration symbols are already covered.
     - Next restart target: continue the remaining standard-decoration expansion, not the chord-symbol work.
@@ -137,6 +239,31 @@
     - Current practical interpretation:
       - quoted chord symbols are now good enough for common forms; broader coverage can wait
       - the main remaining ABC-series work is standard decoration coverage
+  - Decoration backlog from ABC decoration-list cross-check:
+    - Standard 2.1 candidates still missing or only partially supported:
+      - Partial with semantics/export-policy still open:
+        - implementation follow-up so canonical export fully matches the now-settled policy for:
+          - `!arpeggio!` versus `!roll!`
+          - `!+!` / `!plus!`
+          - mordent-family export naming: `!lowermordent!` / `!uppermordent!` / `!mordent!` / `!pralltriller!`
+          - `!slide!` stop-side standard policy versus current `!slide-stop!` extension
+    - Completed in current series:
+      - phrase marks `!shortphrase!` / `!mediumphrase!` / `!longphrase!` now import/export and roundtrip via MusicXML `other-articulation`
+      - `!trill(!` / `!trill)!` now import/export and roundtrip as long-trill start/stop markers
+      - standard `!slide!` now imports/exports as the canonical slide-start form; explicit stop remains `!slide-stop!`
+      - standard dynamics `!pppp!` / `!ffff!` now import/export and roundtrip
+      - symbolic wedge aliases `!<(!` / `!<)!` / `!>(!` / `!>)!` now import through the canonical wedge path
+      - standard fingering decorations `!0!` / `!1!` / `!2!` / `!3!` / `!4!` / `!5!` now import/export and roundtrip
+      - `!D.S.!` / `!D.C.!` aliases and `!dacoda!` now import/export and roundtrip through existing repeat-jump sound markers
+      - `!>!` / `!emphasis!` now import as accent aliases and roundtrip back to canonical `!accent!`
+      - `!turnx!` / `!invertedturnx!` now import/export and roundtrip as slashed turn variants
+    - Standard 2.2 / ext candidates still missing or only partially supported:
+      - `!editorial!`
+      - `!courtesy!`
+    - Recommended execution order for the next decoration pass:
+      - 1. align implementation/export behavior with the now-settled decoration policy items
+      - 2. add regression tests where canonical export spelling changes
+      - 3. only after that, consider 2.2 / ext additions such as `!editorial!` / `!courtesy!`
   - A. Spec says or strongly implies "supported", but implementation is still weak:
     - Completed in current series:
       - Chord-tie handling now ties whole chords in paths such as `[CE]-[CE]`.

--- a/docs/FORMAT_COVERAGE.md
+++ b/docs/FORMAT_COVERAGE.md
@@ -4,7 +4,7 @@
 
 - Priority order: MusicXML fidelity > conversion breadth.
 - "Supported" means available in product flows, not full notation parity.
-- Experimental formats may change behavior as compatibility work progresses.
+- Supported formats may still change behavior as compatibility and parity work progress.
 
 ## Current Coverage
 
@@ -14,7 +14,7 @@
 | MuseScore (`.mscz`) | import/export | Supported | Focus on reliable conversion and parity tests |
 | MIDI (`.mid`) | import/export | Supported | Quantization/notation reconstruction has expected limits |
 | VSQX | import/export | Supported via vendored integration | Uses `utaformatix3-ts-plus` |
-| ABC | import/export | Experimental | Coverage and edge-case handling are evolving; implementation is compatibility-oriented and may emit/accept `mikuscore` extension metadata comments such as `%@mks ...` for roundtrip support |
+| ABC | import/export | Supported | ABC standard 2.2 baseline with practical import/export coverage; some standard features remain partial or unsupported, and `mikuscore` may emit/accept extension metadata comments such as `%@mks ...` for roundtrip support |
 | MEI | import/export | Experimental | Compatibility work tracked with reference samples |
 | LilyPond (`.ly`) | import/export | Experimental | Conversion coverage is limited |
 
@@ -30,5 +30,6 @@
 
 - `docs/spec/MIDI_IO.md`
 - `docs/spec/ABC_IO.md`
+- `docs/spec/ABC_STANDARD_COVERAGE.md`
 - `docs/spec/DIAGNOSTICS.md`
 - `docs/spec/MISCELLANEOUS_FIELDS.md`

--- a/docs/spec/ABC_IO.md
+++ b/docs/spec/ABC_IO.md
@@ -30,6 +30,34 @@ This distinction is important:
 - `mikuscore` extension metadata is not part of the standard ABC musical surface
 - `%@mks ...` lines are `mikuscore`-specific comment hints for restoration and roundtrip support
 
+`mikuscore` treats ABC as a supported score interchange format.
+Compatibility behavior and extension metadata are support mechanisms for practical import/export and roundtrip stability, not an indication that ABC support is merely experimental.
+
+### Practical ecosystem note
+
+In practice, ABC support cannot be defined only by a narrow reading of the base grammar.
+Real-world ABC interchange is also shaped by de facto ecosystem behavior, especially inputs and conventions commonly accepted by tools such as `abcjs` and `abcm2ps`.
+
+For `mikuscore`, these ecosystems are not treated as normative specifications by themselves.
+However, they are treated as important evidence for what counts as common, practical ABC interchange behavior in the wild.
+
+This means:
+
+- the formal ABC surface remains the baseline reference
+- behavior widely accepted by `abcjs` / `abcm2ps` may be adopted as compatibility behavior even when it is better described as de facto practice than narrow core grammar
+- such compatibility acceptance must still be documented explicitly in spec text and tests
+- de facto compatibility is not the same thing as accepting arbitrary malformed input
+
+Because of that, `mikuscore` uses the following stance:
+
+- preserve a clear distinction between standard ABC surface syntax and compatibility-only behavior
+- accept widely used real-world variants when their musical intent is clear enough
+- avoid silently treating non-body directive leftovers as body note text
+- reject or warn on inputs that remain structurally ambiguous or musically unclear
+
+The goal is not "accept everything".
+The goal is to accept broadly used ABC variants without unnecessary failure, while still failing clearly on genuinely broken or uninterpretable input.
+
 ---
 
 ## Public API
@@ -78,6 +106,8 @@ The parser accepts three categories of input:
 
 - optional `%%score` voice ordering directive
 - partial/legacy patterns accepted for practical compatibility
+- de facto ecosystem conventions commonly accepted by `abcjs` / `abcm2ps` may be supported when the intended musical meaning is clear and implementation behavior can be specified
+- `V:` directive tails may accept recognized bare clef names / aliases such as `bass`, `treble`, `alto`, `tenor`, `c3`, `c4` as compatibility shorthand for `clef=...`
 - unsupported inline text / decoration forms may be skipped with warnings
 - overlay marker `&` is imported by splitting one ABC body stream into synthetic overlay voices
 - current overlay limitation: these synthetic overlay voices become separate MusicXML parts rather than one part with multiple synchronized voices
@@ -100,6 +130,9 @@ Parser is intentionally lenient for real-world ABC:
 - ignores standalone octave marks in unsupported positions
 - skips unsupported decorations/inline strings with warnings
 - accepts partial/legacy patterns where possible
+- may accept de facto ecosystem forms seen in `abcjs` / `abcm2ps`-style inputs when they are structurally recognizable and musically interpretable
+- should not pass unknown directive-tail fragments through as ordinary body note text
+- should warn on unsupported bare `V:` tail words instead of letting them fail later as body note/rest parsing errors
 
 ### Supported musical tokens
 
@@ -116,10 +149,25 @@ Parser is intentionally lenient for real-world ABC:
 
 #### Supported decorations and grace forms
 
-- decorations: `!trill!` (also accepts `!tr!` / `!triller!` on import), `!turn!` (also accepts `!lowerturn!` as inverted-turn on import), `!invertedturn!`, `!mordent!`/`!pralltriller!` (including `!prall!`, `!pralltrill!`, `!uppermordent!`, `!lowermordent!`, `!invertedmordent!`, `!inverted-mordent!` aliases), `!schleifer!`, `!shake!`, `!roll!` (also accepts `!arpeggio!` / `!arpeggiate!` on import), `!staccato!` (also accepts `!stacc!` / `!stac!` on import), `!wedge!`/`!staccatissimo!` (also accepts `!spiccato!` on import), `!accent!`, `!tenuto!`, `!stress!`, `!unstress!`, `!fermata!` / `!invertedfermata!` (also accepts `!inverted fermata!` on import), `!marcato!` (also accepts `!strong accent!` / `!strongaccent!` / `!strong-accent!` on import), `!breath!` (also accepts `!breathmark!` / `!breath mark!` / `!breath-mark!` on import), `!caesura!`, `!segno!`, `!coda!`, `!fine!`, `!dacapo!` (also accepts `!da capo!` / `!da-capo!` on import), `!dalsegno!` (also accepts `!dal segno!` / `!dal-segno!` on import), `!tocoda!` (also accepts `!to coda!` / `!to-coda!` on import), wedge decorations `!crescendo(!`, `!crescendo)!`, `!diminuendo(!`, `!diminuendo)!` (also accepts aliases `!cresc(!`, `!cresc)!`, `!dim(!`, `!dim)!`, `!decresc(!`, `!decresc)!`, `!decrescendo(!`, `!decrescendo)!` on import), dynamics `!ppp!`, `!pp!`, `!p!`, `!mp!`, `!mf!`, `!f!`, `!ff!`, `!fff!`, `!fp!`, `!fz!`, `!rfz!`, `!sf!`, `!sfp!`, `!sfz!`, `!upbow!` / `!downbow!` (also accepts `!up bow!` / `!down bow!` / `!up-bow!` / `!down-bow!` on import), `!doubletongue!` / `!tripletongue!` (also accepts `!double tongue!` / `!triple tongue!` / `!double-tongue!` / `!triple-tongue!` on import), `!heel!` / `!toe!` (also accepts `!heel mark!` / `!toe mark!` on import), `!open!` (also accepts `!openstring!` / `!open string!` / `!open-string!` on import), `!snap!` (also accepts `!snappizzicato!` / `!snap pizzicato!` / `!snap-pizzicato!` on import), `!harmonic!`, `!stopped!` (including `!plus!`, `!stopped horn!`, `!stopped-horn!` aliases), `!thumb!` (also accepts `!thumbposition!` / `!thumb-position!` / `!thumbpos!` / `!thumb pos!` / `!thumb position!` on import)
+- decorations: `!trill!` (also accepts `!tr!` / `!triller!` on import), long-trill delimiters `!trill(!` / `!trill)!`, `!turn!` (also accepts `!lowerturn!` as inverted-turn on import), `!turnx!`, `!invertedturn!`, `!invertedturnx!`, `!mordent!`/`!pralltriller!` (including `!prall!`, `!pralltrill!`, `!uppermordent!`, `!lowermordent!`, `!invertedmordent!`, `!inverted-mordent!` aliases), `!schleifer!`, `!shake!`, `!roll!` (also accepts `!arpeggio!` / `!arpeggiate!` on import), `!slide!` (canonical import/export for MusicXML slide start; explicit stop still uses `mikuscore` extension `!slide-stop!`), phrase marks `!shortphrase!`, `!mediumphrase!`, `!longphrase!` (roundtrip via MusicXML `other-articulation`), `!staccato!` (also accepts `!stacc!` / `!stac!` on import), `!wedge!`/`!staccatissimo!` (also accepts `!spiccato!` on import), `!accent!` (also accepts `!>!` / `!emphasis!` on import), `!tenuto!`, `!stress!`, `!unstress!`, `!fermata!` / `!invertedfermata!` (also accepts `!inverted fermata!` on import), `!marcato!` (also accepts `!strong accent!` / `!strongaccent!` / `!strong-accent!` on import), `!breath!` (also accepts `!breathmark!` / `!breath mark!` / `!breath-mark!` on import), `!caesura!`, `!segno!`, `!coda!`, `!fine!`, `!dacapo!` (also accepts `!da capo!` / `!da-capo!` / `!D.C.!` on import), `!dalsegno!` (also accepts `!dal segno!` / `!dal-segno!` / `!D.S.!` on import), `!tocoda!` (also accepts `!to coda!` / `!to-coda!` on import), `!dacoda!`, fingering decorations `!0!`, `!1!`, `!2!`, `!3!`, `!4!`, `!5!` (single-digit technical fingering export prefers these standard forms over `!fingering:TEXT!`), wedge decorations `!crescendo(!`, `!crescendo)!`, `!diminuendo(!`, `!diminuendo)!` (also accepts aliases `!cresc(!`, `!cresc)!`, `!dim(!`, `!dim)!`, `!decresc(!`, `!decresc)!`, `!decrescendo(!`, `!decrescendo)!`, `!<(!`, `!<)!`, `!>(!`, `!>)!` on import), dynamics `!pppp!`, `!ppp!`, `!pp!`, `!p!`, `!mp!`, `!mf!`, `!f!`, `!ff!`, `!fff!`, `!ffff!`, `!fp!`, `!fz!`, `!rfz!`, `!sf!`, `!sfp!`, `!sfz!`, `!upbow!` / `!downbow!` (also accepts `!up bow!` / `!down bow!` / `!up-bow!` / `!down-bow!` on import), `!doubletongue!` / `!tripletongue!` (also accepts `!double tongue!` / `!triple tongue!` / `!double-tongue!` / `!triple-tongue!` on import), `!heel!` / `!toe!` (also accepts `!heel mark!` / `!toe mark!` on import), `!open!` (also accepts `!openstring!` / `!open string!` / `!open-string!` on import), `!snap!` (also accepts `!snappizzicato!` / `!snap pizzicato!` / `!snap-pizzicato!` on import), `!harmonic!`, `!stopped!` (including `!plus!`, `!stopped horn!`, `!stopped-horn!` aliases), `!thumb!` (also accepts `!thumbposition!` / `!thumb-position!` / `!thumbpos!` / `!thumb pos!` / `!thumb position!` on import)
 - standard shorthand decoration symbols on import: `~` (roll), `H` (fermata), `L` (accent), `M` (lowermordent), `O` (coda), `P` (uppermordent), `S` (segno), `T` (trill), `u` (up-bow), `v` (down-bow)
-- mikuscore extension decorations: `!delayedturn!`, `!delayedinvertedturn!`, `!tremolo-single-N!`, `!tremolo-start-N!`, `!tremolo-stop-N!`, `!gliss-start!`, `!gliss-stop!`, `!slide-start!`, `!slide-stop!`, `!rehearsal:TEXT!`, `!fingering:TEXT!`, `!string:TEXT!`, `!pluck:TEXT!`
+- mikuscore extension decorations: `!delayedturn!`, `!delayedinvertedturn!`, `!tremolo-single-N!`, `!tremolo-start-N!`, `!tremolo-stop-N!`, `!gliss-start!`, `!gliss-stop!`, `!slide-start!` (legacy import alias for standard `!slide!`), `!slide-stop!`, `!rehearsal:TEXT!`, `!fingering:TEXT!`, `!string:TEXT!`, `!pluck:TEXT!`
 - grace groups `{...}` including slash grace variant (`{/g}`)
+
+#### Pending standard-decoration policy notes
+
+- `!arpeggio!` and `!roll!`
+  - import compatibility remains broad
+  - canonical export should prefer `!arpeggio!` for the current MusicXML `<arpeggiate/>` carrier
+  - `!roll!` remains an accepted compatibility alias on import unless a distinct roundtrip carrier is added
+- `!+!` / `!plus!`
+  - current support is a narrow technical/stopped-style interpretation
+  - canonical export remains `!stopped!`, not `!+!` / `!plus!`
+- mordent-family aliases
+  - import aliases stay broad
+  - canonical export remains `!mordent!` for lower mordent and `!pralltriller!` for upper/inverted mordent
+- `!slide!`
+  - current standard support is start-side only; explicit stop currently remains a `mikuscore` extension via `!slide-stop!`
 
 ### Parse result characteristics
 
@@ -169,6 +217,7 @@ Exports:
 - supports tuplet roundtrip export (`(n:q:r` style) from MusicXML time-modification/tuplet notations
 - supports ornament export/import mapping:
   - `trill-mark` / `wavy-line(start)` <-> `!trill!`
+  - extended trill line start/stop via `trill-mark` + `wavy-line(type="start")` / `wavy-line(type="stop")` <-> `!trill(!` / `!trill)!`
   - `turn` <-> `!turn!`
   - `inverted-turn` <-> `!invertedturn!`
 - supports grace slash mapping:
@@ -252,7 +301,7 @@ Supported mappings:
 
 ## Scope notes
 
-- This module is compatibility-oriented and intentionally pragmatic.
+- This module is intentionally compatibility-oriented and pragmatic.
 - It does not aim to be a complete strict ABC standard implementation.
-- Behavior prioritizes stable import/export for mikuscore workflows.
+- ABC is a supported format in `mikuscore`; behavior prioritizes stable import/export and roundtrip reliability for practical workflows.
 - `%@mks ...` comments are `mikuscore` extension metadata for roundtrip support, not standard ABC musical notation.

--- a/docs/spec/ABC_STANDARD_COVERAGE.md
+++ b/docs/spec/ABC_STANDARD_COVERAGE.md
@@ -1,0 +1,494 @@
+# ABC Standard Coverage
+
+## Purpose
+
+This document tracks `mikuscore` coverage against the ABC standard at a chapter-by-chapter level.
+
+Unlike `TODO.md`, this file is intended to be the coverage baseline and completion reference.
+Implementation TODO items should be derived from this file, not the other way around.
+
+## Version Policy
+
+- Latest formal ABC standard at the time of writing: `2.2`
+- Current `mikuscore` audit baseline: `2.1`
+- Reason:
+  - most currently implemented/imported behavior and earlier audit work were organized against the widely used `2.1` chapter structure
+  - `2.2` additions should be tracked explicitly as deltas, not mixed invisibly into the `2.1` baseline table
+
+Practical rule:
+
+- use the `2.1` table below as the main completion baseline
+- track `2.2` additions separately in a small delta section
+- do not mark a chapter fully `supported` if support depends only on `mikuscore` extensions or de facto compatibility behavior outside the standard surface
+
+## Status Labels
+
+- `supported`
+  - implemented in normal import/export flows with no currently known major gap for the scoped item
+- `partial`
+  - some meaningful support exists, but coverage, semantics, roundtrip, or edge-case behavior is still incomplete
+- `unsupported`
+  - not currently supported in the normal ABC import/export path
+- `ext-only`
+  - behavior exists only through `mikuscore` extension metadata or `mikuscore`-specific decorations, not through standard ABC surface syntax
+
+## Work-Type Labels
+
+- `impl`
+  - mainly an implementation / test / roundtrip task
+- `policy`
+  - mainly a scope or semantics decision that should be written down before implementation
+- `mixed`
+  - requires both a policy decision and follow-up implementation
+
+## Completion Rule by Work Type
+
+- `impl`
+  - complete when implementation, regression tests, and coverage-table status update are all done
+- `policy`
+  - complete when a written decision is recorded here and linked specs / TODO wording are updated accordingly
+- `mixed`
+  - complete when both the policy decision and the implementation/test follow-up are done
+
+## Reading Rule
+
+- This is a conservative baseline.
+- When there is doubt, the status should be `partial`, not `supported`.
+- Coverage is judged from practical `mikuscore` import/export behavior, not from parser token acceptance alone.
+- For decoration aliases and compatibility forms, see `docs/spec/ABC_IO.md`.
+
+## Scope
+
+- Baseline reference: ABC 2.1 standard
+- Delta reference: ABC 2.2 additions relevant to score interchange
+- Focus: chapters that materially affect score interchange in `mikuscore`
+- Out of scope for now:
+  - stylesheet directives and formatting-only details that `mikuscore` does not aim to preserve
+  - prose-only appendices and tutorial material
+
+## Operating Procedure
+
+Use this document in the following order:
+
+1. find the affected ABC chapter or delta item
+2. check whether a decomposed sub-area table already exists
+3. if not, decompose the chapter before creating implementation TODOs
+4. choose the intended result mode:
+   - `support now`
+   - `support bounded subset`
+   - `defer intentionally`
+   - `out of practical scope`
+5. if the work is backlog-sized, assign or reuse an `ABC-COV-*` item
+6. only then create or update `TODO.md`
+7. after implementation or policy closure, update this document first, then `TODO.md`, then narrower specs such as `docs/spec/ABC_IO.md`
+
+## Exit Condition For This Document
+
+`ABC_STANDARD_COVERAGE.md` should be considered "sufficiently prepared" when:
+
+- every major `partial` / `unsupported` ABC area that matters to score interchange has either:
+  - a decomposed sub-area table, or
+  - an explicit statement that it is intentionally out of practical scope
+- every remaining major unresolved area has an `ABC-COV-*` backlog item
+- each `ABC-COV-*` item has:
+  - work type
+  - priority
+  - done condition
+  - initial stance
+- `TODO.md` has a corresponding execution list derived from those `ABC-COV-*` items
+
+At that point, further progress should usually happen in `TODO.md`, `docs/spec/ABC_IO.md`, and implementation/tests rather than by endlessly refining this file.
+
+## Coverage Table
+
+| ABC 2.1 area | Status | Current interpretation for `mikuscore` |
+|---|---|---|
+| 3.1 Information fields | partial | Core fields such as `X:`, `T:`, `C:`, `M:`, `L:`, `K:`, `Q:`, and `V:` are handled, but not the full field family or all field semantics. |
+| 3.2 Use of fields within the tune body | partial | Inline body fields `[K:...]`, `[M:...]`, `[L:...]`, `[Q:...]`, `[V:...]` are supported, but full field-level parity is not yet claimed. |
+| 3.3 Field continuation | unsupported | No complete coverage claim yet. |
+| 4.1 Pitch | supported | Ordinary pitch spelling and octave notation are core supported behavior. |
+| 4.2 Accidentals | supported | Standard accidental forms are supported, with measure/key-context export rules implemented. |
+| 4.3 Note lengths | supported | Standard ABC length tokens are part of the normal path. |
+| 4.4 Broken rhythm | supported | `>` / `<` handling is implemented. |
+| 4.5 Rests | supported | Standard rests are supported. |
+| 4.6 Clefs and transposition | partial | Common clefs and some `V:`-level transpose handling exist, but full standard coverage and exact parity are not yet claimed. |
+| 4.7 Beams | partial | Import recognizes whitespace as beam-break intent, but export/render behavior still reconstructs beams mainly from durations. |
+| 4.8 Repeat/bar symbols | partial | Standard repeat/barline handling is substantially improved, but full coverage is not yet declared. |
+| 4.9 First and second repeats | partial | Common alternate-ending forms are supported, but broader variant-ending coverage still needs a stricter audit. |
+| 4.10 Variant endings | partial | Standard surface forms now work for common cases, but full closure is not yet claimed. |
+| 4.11 Ties and slurs | partial | Ties are solid in common paths; slur reconstruction and exact span semantics still need care. |
+| 4.12 Grace notes | supported | Standard grace groups and slash grace are supported. |
+| 4.13 Tuplets | partial | Core tuplet parsing/export works, but full standard nuance still needs audit closure. |
+| 4.14 Decorations | partial | Large portions of the standard set are now covered, but the full decoration inventory is not yet complete. |
+| 4.15 Symbol lines | unsupported | No current standard `s:` symbol-line support claim. |
+| 4.16 Redefinable symbols | partial | `U:` single-character decoration aliases import through normal decoration parsing, but full support is not yet claimed. |
+| 4.17 Chords and unisons | supported | Standard chord-note group syntax is supported in ordinary paths. |
+| 4.18 Chord symbols | partial | Common quoted chord symbols are mapped, but broader harmony quality coverage is still incomplete. |
+| 4.19 Annotations | partial | Quoted non-harmonic text is partially mapped, but broader annotation behavior is not yet closed. |
+| 4.20 Order of abc constructs | partial | Many common orders are accepted, but there is no complete conformance claim yet. |
+| 5.1 Alignment | partial | Lyrics alignment support exists, but not all standard alignment nuance is yet audited. |
+| 5.2 Verses | partial | `w:` underlay works in common cases, but full multi-verse coverage is not yet claimed. |
+| 5.3 Numbering | unsupported | No complete support claim yet. |
+| 6.1 Typesetting | unsupported | Formatting/typesetting directives are not a current parity target. |
+| 6.2 Playback | unsupported | ABC playback semantics are not a standard-coverage target for `mikuscore`. |
+| 7.1 Voice properties | partial | `V:` handling exists for common voice metadata, but standard voice-property breadth is not fully covered. |
+| 7.2 Breaking lines | unsupported | Line-breaking semantics are not a current preserved interchange feature. |
+| 7.3 Inline fields | partial | Core inline field support exists, but broader field coverage remains partial. |
+| 7.4 Voice overlay | partial | `&` imports into synthetic overlay voices, but this is not yet faithful one-part multi-voice preservation. |
+
+## Decomposed Coverage
+
+This section breaks selected `partial` chapters into implementation-sized coverage units.
+Start here when converting coverage findings into concrete TODO items.
+
+### 3. Information Fields
+
+#### 3.1 Information fields
+
+| Field group | Status | Current interpretation for `mikuscore` |
+|---|---|---|
+| Core identification / title / attribution: `X:`, `T:`, `C:` | supported | Supported in ordinary import/export flows. |
+| Core musical defaults: `M:`, `L:`, `K:`, `Q:` | supported | Supported in ordinary import/export flows, including inline-core variants where implemented. |
+| Voice field: `V:` | partial | Common voice metadata is supported, but full property breadth is not yet covered. |
+| Other standard fields outside the current core subset | unsupported | No complete support claim yet. |
+
+#### 3.2 Use of fields within the tune body
+
+| Inline field group | Status | Current interpretation for `mikuscore` |
+|---|---|---|
+| Core inline fields: `[K:...]`, `[M:...]`, `[L:...]`, `[Q:...]`, `[V:...]` | supported | These are supported in the current standard path. |
+| Broader inline-field family beyond the current core subset | unsupported | No complete support claim yet. |
+
+#### 3.3 Field continuation
+
+| Area | Status | Current interpretation for `mikuscore` |
+|---|---|---|
+| Continued information-field lines | unsupported | No current support claim or dedicated reconstruction policy. |
+
+### 4.6 Clefs and Transposition
+
+| Sub-area | Status | Current interpretation for `mikuscore` |
+|---|---|---|
+| Common clefs in `V:` metadata (`treble`, `bass`, `alto`, `tenor`, `c3`, `c4`) | supported | Common working set is supported, including compatibility shorthand on import. |
+| Broader standard clef forms and exact parity | partial | Full standard breadth and export parity are not yet closed. |
+| Voice-level transpose handling | partial | Some `V:`-level transpose behavior exists, but full standard coverage is not yet claimed. |
+
+### 4.7 Beams
+
+| Sub-area | Status | Current interpretation for `mikuscore` |
+|---|---|---|
+| Duration-based beam reconstruction | supported | Normal export reconstructs beams from note values. |
+| Whitespace as explicit beam-separation intent | partial | Import recognizes it, but export does not yet preserve ABC spacing intent faithfully. |
+
+### 4.8-4.10 Repeat Structure
+
+#### 4.8 Repeat / bar symbols
+
+| Sub-area | Status | Current interpretation for `mikuscore` |
+|---|---|---|
+| Common repeat barlines | supported | Standard repeat/barline handling works in common cases. |
+| Broader repeat/barline variants and edge reconstruction | partial | Full closure is not yet claimed. |
+
+#### 4.9 First and second repeats
+
+| Sub-area | Status | Current interpretation for `mikuscore` |
+|---|---|---|
+| Common first/second ending syntax (`[1`, `[2`, `|1`, `:|2`) | supported | Common surface forms are supported. |
+| Broader alternate-ending coverage and edge forms | partial | Full closure is not yet claimed. |
+
+#### 4.10 Variant endings
+
+| Sub-area | Status | Current interpretation for `mikuscore` |
+|---|---|---|
+| Common variant-ending surface syntax | supported | Common standard syntax works in the current path. |
+| Broader variant-ending semantics | partial | Full semantics and edge-case coverage remain to be audited. |
+
+### 4.11 Ties and Slurs
+
+| Sub-area | Status | Current interpretation for `mikuscore` |
+|---|---|---|
+| Tie syntax and common reconstruction | supported | Common tie handling is solid, including whole-chord tie paths. |
+| Slur syntax acceptance | supported | Common slur syntax is accepted. |
+| Exact slur span reconstruction and edge semantics | partial | Cross-format span behavior still needs care. |
+
+### 4.13 Tuplets
+
+| Sub-area | Status | Current interpretation for `mikuscore` |
+|---|---|---|
+| Core tuplet syntax and common roundtrip | supported | Core parse/export works in the current path. |
+| Full standard ratio nuance and edge semantics | partial | Full audit closure is not yet complete. |
+
+### 4.14 Decorations (ABC 2.1)
+
+| Decoration group | Status | Current interpretation for `mikuscore` |
+|---|---|---|
+| Trill family: `!trill!`, `!trill(!`, `!trill)!` | supported | Standard trill and extended trill start/stop now import/export and roundtrip. |
+| Turn family: `!turn!`, `!turnx!`, `!invertedturn!`, `!invertedturnx!` | supported | Standard turn and slashed-turn variants now import/export and roundtrip. |
+| Mordent family: `!lowermordent!`, `!uppermordent!`, `!mordent!`, `!pralltriller!` | partial | Import aliases are accepted, but export naming policy and exact semantic distinction still need audit closure. |
+| `!roll!` / `!arpeggio!` | supported | Standard import acceptance exists, canonical export now prefers `!arpeggio!` for MusicXML `arpeggiate`, and `!roll!` remains a compatibility alias unless a distinct roundtrip carrier is introduced. |
+| Accent family: `!>!`, `!accent!`, `!emphasis!` | supported | Import aliases are accepted and canonical export is stable. |
+| Fermata family: `!fermata!`, `!invertedfermata!` | supported | Standard forms are supported in common roundtrip paths. |
+| `!tenuto!` | supported | Supported in common import/export paths. |
+| Fingering shorthand: `!0!`-`!5!` | supported | Standard fingering shorthand now imports/exports and roundtrips. |
+| `!+!` / `!plus!` | partial | Import aliases are accepted, but current standard-path policy is the narrow `stopped` technical interpretation with canonical export `!stopped!`. |
+| `!snap!` | supported | Supported in common import/export paths. |
+| `!slide!` | partial | Standard slide-start form is supported; explicit stop remains outside the standard surface in current policy and uses `mikuscore` extension `!slide-stop!`. |
+| `!wedge!` | supported | Supported through the staccatissimo path. |
+| `!upbow!` / `!downbow!` | supported | Standard forms and common aliases are supported. |
+| `!open!` | supported | Supported in common import/export paths. |
+| `!thumb!` | supported | Supported in common import/export paths. |
+| `!breath!` | supported | Supported in common import/export paths. |
+| Dynamics: `!pppp!`..`!ffff!`, `!sfz!`, etc. | supported | Standard dynamic marks in the currently enumerated subset import/export and roundtrip. |
+| Wedges: `!crescendo(!`, `!crescendo)!`, `!diminuendo(!`, `!diminuendo)!`, symbolic aliases | supported | Standard wedge start/stop and symbolic aliases are supported. |
+| Repeat-jump marks: `!segno!`, `!coda!`, `!D.S.!`, `!D.C.!`, `!dacoda!`, `!dacapo!`, `!fine!` | supported | Standard/de facto jump tokens in the current subset import/export and roundtrip. |
+| Phrase marks: `!shortphrase!`, `!mediumphrase!`, `!longphrase!` | supported | Standard phrase-mark tokens now import/export and roundtrip via MusicXML `other-articulation` preservation. |
+
+### 4.14 Standard Shorthand Decoration Symbols
+
+| Symbol | Status | Current interpretation for `mikuscore` |
+|---|---|---|
+| `~` | supported | Imports as `roll`. |
+| `H` | supported | Imports as `fermata`. |
+| `L` | supported | Imports as `accent`. |
+| `M` | supported | Imports as lowermordent / `mordent` path. |
+| `O` | supported | Imports as `coda`. |
+| `P` | supported | Imports as uppermordent / `pralltriller` path. |
+| `S` | supported | Imports as `segno`. |
+| `T` | supported | Imports as `trill`. |
+| `u` | supported | Imports as `up-bow`. |
+| `v` | supported | Imports as `down-bow`. |
+
+### 4.14 Canonical Policy Notes
+
+These notes are the current canonical policy for standard-decoration handling.
+
+- `!arpeggio!` versus `!roll!`
+  - keep broad import compatibility for both names
+  - do not claim they are semantically identical
+  - canonical export for the current MusicXML `<arpeggiate/>` carrier should prefer `!arpeggio!`
+  - `!roll!` remains accepted on import as compatibility behavior unless a distinct roundtrip carrier is added
+- `!+!` / `!plus!`
+  - accept them on import as aliases into the current `stopped` technical path
+  - canonical export remains `!stopped!`
+  - do not currently claim generalized cross-instrument semantics beyond that narrow interpretation
+- Mordent-family export naming
+  - keep broad import alias acceptance
+  - canonical export for lower mordent remains `!mordent!`
+  - canonical export for upper/inverted mordent remains `!pralltriller!`
+- `!slide!`
+  - standard support is start-side only in the current policy
+  - canonical start-side export remains `!slide!`
+  - explicit stop remains a `mikuscore` extension via `!slide-stop!`
+
+### 4.15 Symbol Lines
+
+| Sub-area | Status | Current interpretation for `mikuscore` |
+|---|---|---|
+| `s:` symbol lines | unsupported | No current support claim. |
+
+### 4.16 Redefinable Symbols
+
+| Sub-area | Status | Current interpretation for `mikuscore` |
+|---|---|---|
+| `U:` single-character import aliases | supported | Current import path supports user-defined decoration aliases. |
+| Broader `U:` parity, export, and exact standard semantics | partial | Full support claim is not yet made. |
+
+### 4.18 Chord Symbols
+
+| Sub-area | Status | Current interpretation for `mikuscore` |
+|---|---|---|
+| Common harmonic quoted symbols | partial | Many common forms now roundtrip through MusicXML `harmony`. |
+| Broader quality inventory and edge spelling | partial | Coverage remains incomplete. |
+| Full standard chord-symbol breadth | unsupported | No full support claim yet. |
+
+### 4.19 Annotations
+
+| Sub-area | Status | Current interpretation for `mikuscore` |
+|---|---|---|
+| Common quoted non-harmonic text | partial | Common forms are partially mapped as direction words / annotations. |
+| Broader annotation placement and behavior | unsupported | No full standard support claim yet. |
+
+### 4.20 Order of abc constructs
+
+| Sub-area | Status | Current interpretation for `mikuscore` |
+|---|---|---|
+| Common construct orderings seen in practical ABC | partial | Many common orders work, but there is no complete conformance claim. |
+| Full order-of-constructs conformance | unsupported | Not yet audited to closure. |
+
+### 5. Lyrics
+
+#### 5.1 Alignment
+
+| Sub-area | Status | Current interpretation for `mikuscore` |
+|---|---|---|
+| Common lyric alignment for `w:` underlay | partial | Works in common cases. |
+| Full alignment nuance across rests, spacers, grace, and complex spacing | unsupported | Not yet audited to closure. |
+
+#### 5.2 Verses
+
+| Sub-area | Status | Current interpretation for `mikuscore` |
+|---|---|---|
+| Single-verse underlay | supported | Common `w:` import path exists. |
+| Multi-verse behavior and edge semantics | partial | Not yet fully audited. |
+
+#### 5.3 Numbering
+
+| Sub-area | Status | Current interpretation for `mikuscore` |
+|---|---|---|
+| Verse numbering semantics | unsupported | No current support claim. |
+
+### 7. Multiple Voices
+
+#### 7.1 Voice properties
+
+| Sub-area | Status | Current interpretation for `mikuscore` |
+|---|---|---|
+| Common voice identity and metadata (`V:`, name, clef, common transpose) | partial | Common working subset is supported. |
+| Full standard voice-property breadth | unsupported | No complete support claim yet. |
+
+#### 7.2 Breaking lines
+
+| Sub-area | Status | Current interpretation for `mikuscore` |
+|---|---|---|
+| Line-breaking semantics | unsupported | Not a current preserved interchange target. |
+
+#### 7.3 Inline fields
+
+| Sub-area | Status | Current interpretation for `mikuscore` |
+|---|---|---|
+| Core inline-field subset | supported | The current core subset is supported. |
+| Broader inline-field breadth | unsupported | No complete support claim yet. |
+
+#### 7.4 Voice overlay
+
+| Sub-area | Status | Current interpretation for `mikuscore` |
+|---|---|---|
+| Import acceptance of `&` overlay syntax | supported | Overlay syntax is accepted on import. |
+| Faithful preservation as one part with synchronized voices | unsupported | Current import expands overlays into synthetic parts instead. |
+
+## ABC 2.2 Delta
+
+This section tracks standard items that are better treated as post-2.1 additions rather than silently folded into the baseline table.
+
+| ABC 2.2 delta item | Status | Current interpretation for `mikuscore` |
+|---|---|---|
+| `!editorial!` decoration | unsupported | Not yet supported in the standard ABC path. |
+| `!courtesy!` decoration | unsupported | Not yet supported in the standard ABC path. |
+
+## Derived Actionable Backlog
+
+This section is the direct bridge from coverage to implementation TODOs.
+If an item here is completed, update the detailed coverage tables first, then update `TODO.md`.
+
+| Item | Source area | Work type | Priority | Default direction | Done when | Target outcome |
+|---|---|---|---|---|---|---|
+| `ABC-COV-001` | `3.1 Information fields` | `policy` | `P2` | bound scope first | non-core field policy is written here and reflected in linked specs | Decide and document which non-core standard fields are intentionally unsupported versus planned. |
+| `ABC-COV-002` | `3.2 / 7.3 Inline fields` | `policy` | `P2` | bound scope first | supported inline subset is explicitly bounded in spec text | Decide whether the supported inline-field subset stops at `[K/M/L/Q/V]` or should expand. |
+| `ABC-COV-003` | `3.3 Field continuation` | `policy` | `P3` | likely defer or freeze | continuation is either explicitly frozen as unsupported or promoted to planned work | Either implement continuation support or explicitly freeze it as unsupported in the practical scope. |
+| `ABC-COV-004` | `4.6 Clefs and transposition` | `mixed` | `P1` | expand common working subset conservatively | supported standard clef/transpose set is enumerated and covered by tests | Close the remaining standard clef/transpose policy beyond the current common subset. |
+| `ABC-COV-005` | `4.7 Beams` | `mixed` | `P1` | decide preservation target before code | whitespace-beam preservation target is decided and tested to that level | Decide how far ABC whitespace-as-beam-separation must be preserved on export. |
+| `ABC-COV-006` | `4.8-4.10 Repeat structure` | `mixed` | `P1` | finish edge-case audit | remaining repeat/ending edge forms are either supported with tests or explicitly marked unsupported | Audit remaining repeat/ending edge variants and mark what is still unsupported. |
+| `ABC-COV-007` | `4.11 Ties and slurs` | `mixed` | `P1` | keep ties strong, define slur limits | slur-span limits are written down and tested, or stronger preservation is implemented | Close the slur-span reconstruction policy or keep it explicitly partial with defined limits. |
+| `ABC-COV-008` | `4.13 Tuplets` | `mixed` | `P2` | close edge semantics incrementally | remaining tuplet edge semantics are either tested or explicitly excluded | Audit remaining ratio/edge semantics and mark what is still unsupported. |
+| `ABC-COV-009` | `4.14 Decorations` | `mixed` | `P1` | finish pending policy notes | each pending decoration-policy item is resolved in spec text, with implementation/tests if needed | Resolve pending policy items: `!arpeggio!` / `!roll!`, `!+!` / `!plus!`, mordent export naming, `!slide!` stop policy. |
+| `ABC-COV-010` | `4.15 Symbol lines` | `policy` | `P3` | likely out of scope unless demanded by real data | `s:` is explicitly marked in-scope or frozen out-of-scope | Decide whether `s:` symbol lines are in scope or intentionally out of scope. |
+| `ABC-COV-011` | `4.16 Redefinable symbols` | `policy` | `P2` | likely keep import-first | `U:` support boundary is explicitly written down | Decide whether `U:` remains import-only or needs broader parity/export support. |
+| `ABC-COV-012` | `4.18 Chord symbols` | `mixed` | `P1` | expand common inventory, bound the rest | supported chord-symbol inventory is enumerated enough to test and maintain | Expand or explicitly bound the supported chord-symbol inventory. |
+| `ABC-COV-013` | `4.19 Annotations` | `policy` | `P2` | define supported subset explicitly | supported annotation subset and exclusions are written down | Define the supported annotation behavior and explicit exclusions. |
+| `ABC-COV-014` | `4.20 Order of constructs` | `policy` | `P3` | prefer practical acceptance over formal completeness | acceptance philosophy and any explicit exclusions are written down | Decide whether broad practical acceptance is enough or whether stricter conformance is required. |
+| `ABC-COV-015` | `5.1-5.3 Lyrics` | `mixed` | `P2` | strengthen single/multi-verse clarity | lyric scope is bounded and tested for the chosen supported subset | Audit lyrics alignment, multi-verse behavior, and numbering scope. |
+| `ABC-COV-016` | `7.1 Voice properties` | `mixed` | `P1` | enumerate supported standard properties explicitly | supported/unsupported voice-property list is explicit and testable | Enumerate which standard voice properties are supported, unsupported, or extension-only. |
+| `ABC-COV-017` | `7.4 Voice overlay` | `policy` | `P1` | decide whether current synthetic-part import is acceptable | overlay preservation target is explicitly accepted or rejected | Decide whether faithful same-part overlay preservation is required. |
+| `ABC-COV-018` | `ABC 2.2 delta` | `policy` | `P2` | decide roadmap versus explicit defer | 2.2 delta items are either put on roadmap or marked intentionally deferred | Decide whether `!editorial!` and `!courtesy!` are in the supported roadmap or intentionally deferred. |
+
+## Result Modes
+
+When closing a backlog item above, prefer one of these explicit outcomes:
+
+- `support now`
+  - implement and test it
+- `support bounded subset`
+  - document the exact supported subset and explicit exclusions
+- `defer intentionally`
+  - record that it is not in the current supported roadmap
+- `out of practical scope`
+  - record that `mikuscore` does not currently target this standard area
+
+## Initial Stance by Backlog Item
+
+This is a non-binding starting recommendation for turning the backlog into TODOs.
+
+| Item | Recommended result mode | Rationale |
+|---|---|---|
+| `ABC-COV-001` | `support bounded subset` | Core fields already work; the main need is to bound the rest. |
+| `ABC-COV-002` | `support bounded subset` | The current inline subset is already practical; expansion should be deliberate. |
+| `ABC-COV-003` | `defer intentionally` | Field continuation looks low-value unless real input data demands it. |
+| `ABC-COV-004` | `support bounded subset` | Common clefs/transpose already exist; the next step is explicit boundary-setting. |
+| `ABC-COV-005` | `support bounded subset` | Beam intent preservation likely needs a bounded target rather than full formal parity. |
+| `ABC-COV-006` | `support bounded subset` | Common repeat/ending forms are already strong; finish the edge boundary. |
+| `ABC-COV-007` | `support bounded subset` | Ties are strong, but slurs likely need explicit limits before deeper work. |
+| `ABC-COV-008` | `support bounded subset` | Tuplets are usable; the remaining work is edge clarification. |
+| `ABC-COV-009` | `support now` | These decoration-policy items are close enough to close in the current series. |
+| `ABC-COV-010` | `out of practical scope` | `s:` symbol lines currently look like a low-priority notation surface. |
+| `ABC-COV-011` | `support bounded subset` | `U:` already has an import path; scope should be bounded before any export ambitions. |
+| `ABC-COV-012` | `support bounded subset` | Chord symbols are important, but inventory-bounding is more realistic than full parity. |
+| `ABC-COV-013` | `support bounded subset` | Annotation support should be explicit, not accidental. |
+| `ABC-COV-014` | `support bounded subset` | Practical acceptance is likely sufficient, but that should be stated plainly. |
+| `ABC-COV-015` | `support bounded subset` | Lyrics already work in useful cases; scope clarification is the next step. |
+| `ABC-COV-016` | `support bounded subset` | Voice-property breadth should be enumerated explicitly around the current working subset. |
+| `ABC-COV-017` | `defer intentionally` | Faithful overlay preservation may be expensive relative to current value unless demanded. |
+| `ABC-COV-018` | `defer intentionally` | ABC 2.2 delta items should be roadmap decisions, not silent obligations. |
+
+## Ready-to-Transfer TODO Order
+
+If the goal is to turn this document into executable TODO items with minimal extra analysis, use this order:
+
+1. `ABC-COV-009` decorations pending policy
+2. `ABC-COV-016` voice-property enumeration
+3. `ABC-COV-005` beam-separation preservation target
+4. `ABC-COV-006` repeat / ending edge audit
+5. `ABC-COV-012` chord-symbol inventory bounds
+6. `ABC-COV-007` slur-span policy
+7. `ABC-COV-017` overlay preservation decision
+8. `ABC-COV-018` ABC 2.2 delta decision
+9. `ABC-COV-008`, `ABC-COV-011`, `ABC-COV-015`
+10. `ABC-COV-001`, `ABC-COV-002`, `ABC-COV-003`, `ABC-COV-010`, `ABC-COV-013`, `ABC-COV-014`
+
+## Likely Practical-Scope Freezes
+
+These are not final decisions, but they currently look like the strongest candidates for "explicitly unsupported unless real-world demand appears":
+
+- `3.3` field continuation
+- `4.15` symbol lines
+- `6.1` formatting/typesetting details
+- `6.2` playback semantics from ABC notation itself
+- `7.2` line-breaking semantics
+
+## Current High-Priority Gaps
+
+- `4.14 Decorations`
+  - ABC 2.2 delta decorations `!editorial!` / `!courtesy!` are still open
+  - implementation follow-up remains open only where code still differs from the settled policy
+- `4.7 Beams`
+  - whitespace-as-beam-separation is only partially preserved
+- `4.18 Chord symbols`
+  - common forms work, but broader standard harmony spelling coverage remains incomplete
+- `7.4 Voice overlay`
+  - imported overlays still become separate MusicXML parts instead of preserved synchronized voices inside one part
+
+## TODO Derivation Rule
+
+When creating or updating ABC-related TODO items:
+
+1. identify the affected `ABC 2.1` chapter or `ABC 2.2 delta` item in this file
+2. update the status and note here first if the understanding changed
+3. create implementation TODO items only for the delta between current and desired status
+4. when possible, reference the `ABC-COV-*` backlog item that the TODO comes from
+5. treat this file as the source for completion judgment
+
+## Related Documents
+
+- `docs/spec/ABC_IO.md`
+- `docs/spec/abc-compat-parser-ebnf.md`
+- `docs/FORMAT_COVERAGE.md`
+- `TODO.md`

--- a/docs/spec/abc-compat-parser-ebnf.md
+++ b/docs/spec/abc-compat-parser-ebnf.md
@@ -1,7 +1,7 @@
-# ABC Compat Parser EBNF (draft)
+# ABC Compat Parser EBNF
 
 ## English
-This document defines the grammar baseline for the project ABC parser.
+This document defines the current grammar baseline for the project ABC parser.
 
 It is based on ABC 2.1 and includes currently supported compatibility behavior observed in real-world `abcjs` / `abcm2ps` style inputs.
 
@@ -10,6 +10,35 @@ The parser should be understood in three layers:
 - standard ABC surface
 - compatibility behavior for real-world ABC variance
 - `mikuscore` extension metadata comments (`%@mks ...`) used for roundtrip support
+
+ABC is a supported format in `mikuscore`.
+This grammar therefore documents the implemented compatibility baseline for supported import behavior, rather than an experimental parser sketch.
+
+## Practical Interpretation
+
+ABC interoperability is influenced not only by the narrow core grammar, but also by de facto conventions widely seen in tools such as `abcjs` and `abcm2ps`.
+
+For that reason, this document should be read as:
+
+- a grammar baseline for the standard ABC surface actually implemented by `mikuscore`
+- a record of compatibility behavior accepted for common real-world inputs
+- not a promise that every informal ABC variant in the wild is accepted
+
+For `mikuscore`, `abcjs` / `abcm2ps` behavior is not itself the normative grammar.
+Instead, it is evidence for de facto interoperability expectations that may justify explicit compatibility rules in this document.
+
+De facto compatibility should therefore be understood as:
+
+- acceptable to adopt when a pattern is common enough in practice
+- acceptable to adopt when the intended musical meaning is sufficiently clear
+- required to be documented in spec text and regression tests once adopted
+- not a blanket reason to accept arbitrary malformed or ambiguous ABC
+
+When extending compatibility, the preferred policy is:
+
+- add support by recognizable pattern classes, not by one-off token hacks
+- keep directive/context parsing separate from body note parsing
+- fail clearly on input that is still structurally or musically uninterpretable after compatibility handling
 
 ## Scope
 - Header: `X,T,C,M,L,K,U,V` and `%%score`
@@ -92,6 +121,10 @@ digit            = "0".."9" ;
 - Support `U:` single-character user-defined decoration aliases on import by expanding them into regular decoration markers before parsing.
 - Ignore `:` in barline variants (`:|`, `|:`, `||`) without parse failure.
 - Ignore standalone `,` / `'` for compatibility.
+- Allow recognized bare `V:` clef shorthands such as `V:2 bass`, `V:1 treble C D |`, `V:1 c3`, and `V:2 c4`.
+- Prefer class-based compatibility rules derived from common `abcjs` / `abcm2ps` practice over one-off special cases.
+- Do not let unknown directive-tail fragments silently fall through into body note parsing.
+- Prefer warning on unsupported bare `V:` tail words over later note/rest parse failure caused by directive leftovers.
 
 ## `mikuscore` Extension Notes
 - Accept `%@mks` metadata comments (`key`, `measure`, `transpose`) and feed roundtrip metadata when present.

--- a/mikuscore.html
+++ b/mikuscore.html
@@ -30009,6 +30009,12 @@ function parseForMusicXml(source, settings) {
                 if (parsedVoice.transpose) {
                     voiceTransposeById[currentVoiceId] = parsedVoice.transpose;
                 }
+                if (parsedVoice.skippedText) {
+                    warnings.push("line " +
+                        lineNo +
+                        ": Skipped unsupported V: directive tail token: " +
+                        parsedVoice.skippedText);
+                }
                 if (parsedVoice.bodyText) {
                     const expandedBodyText = expandUserDefinedDecorationSymbols(parsedVoice.bodyText, userDefinedDecorationBySymbol);
                     const inlineVoiceSegments = splitBodyTextByInlineVoice(expandedBodyText, currentVoiceId);
@@ -31536,12 +31542,17 @@ function parseScoreVoiceOrder(raw, declaredVoiceIds) {
 }
 function parseVoiceDirectiveTail(raw) {
     if (!raw) {
-        return { name: "", clef: "", transpose: null, bodyText: "" };
+        return { name: "", clef: "", transpose: null, bodyText: "", skippedText: "" };
     }
     let bodyText = String(raw);
     let name = "";
     let clef = "";
     let transpose = null;
+    const bareClefMatch = bodyText.match(/^\s*(bass|treble|alto|tenor)(?=\s|$)/i);
+    if (bareClefMatch) {
+        clef = String(bareClefMatch[1] || "").trim().toLowerCase();
+        bodyText = bodyText.slice(bareClefMatch[0].length);
+    }
     const attrRegex = /([A-Za-z][A-Za-z0-9_-]*)\s*=\s*("([^"]*)"|(\S+))/g;
     bodyText = bodyText.replace(attrRegex, (_full, key, _quotedValue, quotedInner, bareValue) => {
         const lowerKey = String(key).toLowerCase();
@@ -31559,11 +31570,20 @@ function parseVoiceDirectiveTail(raw) {
         }
         return " ";
     });
+    bodyText = bodyText.trim();
+    let skippedText = "";
+    const firstTokenMatch = bodyText.match(/^(\S+)/);
+    const firstToken = firstTokenMatch ? firstTokenMatch[1] : "";
+    if (firstToken && /^[A-Za-z][A-Za-z0-9_-]*$/.test(firstToken) && /[^A-Ga-gzZxX]/.test(firstToken)) {
+        skippedText = firstToken;
+        bodyText = bodyText.slice(firstToken.length).trim();
+    }
     return {
         name: name.trim(),
         clef: clef.trim(),
         transpose,
-        bodyText: bodyText.trim()
+        bodyText,
+        skippedText
     };
 }
 function inferTransposeFromPartName(partName) {

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -21937,6 +21937,12 @@ function parseForMusicXml(source, settings) {
                 if (parsedVoice.transpose) {
                     voiceTransposeById[currentVoiceId] = parsedVoice.transpose;
                 }
+                if (parsedVoice.skippedText) {
+                    warnings.push("line " +
+                        lineNo +
+                        ": Skipped unsupported V: directive tail token: " +
+                        parsedVoice.skippedText);
+                }
                 if (parsedVoice.bodyText) {
                     const expandedBodyText = expandUserDefinedDecorationSymbols(parsedVoice.bodyText, userDefinedDecorationBySymbol);
                     const inlineVoiceSegments = splitBodyTextByInlineVoice(expandedBodyText, currentVoiceId);
@@ -23464,12 +23470,17 @@ function parseScoreVoiceOrder(raw, declaredVoiceIds) {
 }
 function parseVoiceDirectiveTail(raw) {
     if (!raw) {
-        return { name: "", clef: "", transpose: null, bodyText: "" };
+        return { name: "", clef: "", transpose: null, bodyText: "", skippedText: "" };
     }
     let bodyText = String(raw);
     let name = "";
     let clef = "";
     let transpose = null;
+    const bareClefMatch = bodyText.match(/^\s*(bass|treble|alto|tenor)(?=\s|$)/i);
+    if (bareClefMatch) {
+        clef = String(bareClefMatch[1] || "").trim().toLowerCase();
+        bodyText = bodyText.slice(bareClefMatch[0].length);
+    }
     const attrRegex = /([A-Za-z][A-Za-z0-9_-]*)\s*=\s*("([^"]*)"|(\S+))/g;
     bodyText = bodyText.replace(attrRegex, (_full, key, _quotedValue, quotedInner, bareValue) => {
         const lowerKey = String(key).toLowerCase();
@@ -23487,11 +23498,20 @@ function parseVoiceDirectiveTail(raw) {
         }
         return " ";
     });
+    bodyText = bodyText.trim();
+    let skippedText = "";
+    const firstTokenMatch = bodyText.match(/^(\S+)/);
+    const firstToken = firstTokenMatch ? firstTokenMatch[1] : "";
+    if (firstToken && /^[A-Za-z][A-Za-z0-9_-]*$/.test(firstToken) && /[^A-Ga-gzZxX]/.test(firstToken)) {
+        skippedText = firstToken;
+        bodyText = bodyText.slice(firstToken.length).trim();
+    }
     return {
         name: name.trim(),
         clef: clef.trim(),
         transpose,
-        bodyText: bodyText.trim()
+        bodyText,
+        skippedText
     };
 }
 function inferTransposeFromPartName(partName) {

--- a/src/ts/abc-io.ts
+++ b/src/ts/abc-io.ts
@@ -631,6 +631,14 @@ const abcCommon = AbcCommon;
           if (parsedVoice.transpose) {
             voiceTransposeById[currentVoiceId] = parsedVoice.transpose;
           }
+          if (parsedVoice.skippedText) {
+            warnings.push(
+              "line " +
+                lineNo +
+                ": Skipped unsupported V: directive tail token: " +
+                parsedVoice.skippedText
+            );
+          }
           if (parsedVoice.bodyText) {
             const expandedBodyText = expandUserDefinedDecorationSymbols(parsedVoice.bodyText, userDefinedDecorationBySymbol);
             const inlineVoiceSegments = splitBodyTextByInlineVoice(expandedBodyText, currentVoiceId);
@@ -766,7 +774,10 @@ const abcCommon = AbcCommon;
       let lastEventNotes = [];
       let pendingTieToNext = false;
       let pendingTrill = false;
+      let pendingTrillLineStart = false;
+      let pendingTrillLineStop = false;
       let pendingTurn: "" | "turn" | "inverted-turn" = "";
+      let pendingTurnSlash = false;
       let pendingDelayedTurn = false;
       let pendingMordent: "" | "mordent" | "inverted-mordent" = "";
       let pendingTremolo: { type: "single" | "start" | "stop"; marks: number } | null = null;
@@ -787,6 +798,7 @@ const abcCommon = AbcCommon;
       let pendingStrongAccent = false;
       let pendingBreathMark = false;
       let pendingCaesura = false;
+      let pendingPhraseMark: "" | "shortphrase" | "mediumphrase" | "longphrase" = "";
       let pendingSegno = false;
       let pendingCoda = false;
       let pendingFine = false;
@@ -1056,6 +1068,11 @@ const abcCommon = AbcCommon;
           const decoration = rawDecoration.toLowerCase();
           if (decoration === "trill" || decoration === "tr" || decoration === "triller") {
             pendingTrill = true;
+          } else if (decoration === "trill(") {
+            pendingTrill = true;
+            pendingTrillLineStart = true;
+          } else if (decoration === "trill)") {
+            pendingTrillLineStop = true;
           } else if (decoration.startsWith("rehearsal:")) {
             const rehearsalText = rawDecoration.slice("rehearsal:".length).trim();
             if (rehearsalText) {
@@ -1069,8 +1086,16 @@ const abcCommon = AbcCommon;
             pendingDelayedTurn = true;
           } else if (decoration === "turn") {
             pendingTurn = "turn";
+            pendingTurnSlash = false;
+          } else if (decoration === "turnx") {
+            pendingTurn = "turn";
+            pendingTurnSlash = true;
           } else if (decoration === "invertedturn" || decoration === "inverted-turn" || decoration === "lowerturn") {
             pendingTurn = "inverted-turn";
+            pendingTurnSlash = false;
+          } else if (decoration === "invertedturnx" || decoration === "inverted-turnx") {
+            pendingTurn = "inverted-turn";
+            pendingTurnSlash = true;
           } else if (decoration === "mordent" || decoration === "lowermordent") {
             pendingMordent = "mordent";
           } else if (
@@ -1094,7 +1119,7 @@ const abcCommon = AbcCommon;
             pendingGlissandoStart = true;
           } else if (decoration === "gliss-stop" || decoration === "glissando-stop") {
             pendingGlissandoStop = true;
-          } else if (decoration === "slide-start") {
+          } else if (decoration === "slide" || decoration === "slide-start") {
             pendingSlideStart = true;
           } else if (decoration === "slide-stop") {
             pendingSlideStop = true;
@@ -1112,7 +1137,7 @@ const abcCommon = AbcCommon;
             pendingStaccato = true;
           } else if (decoration === "staccatissimo" || decoration === "wedge" || decoration === "spiccato") {
             pendingStaccatissimo = true;
-          } else if (decoration === "accent") {
+          } else if (decoration === "accent" || decoration === ">" || decoration === "emphasis") {
             pendingAccent = true;
           } else if (decoration === "tenuto") {
             pendingTenuto = true;
@@ -1144,37 +1169,45 @@ const abcCommon = AbcCommon;
             pendingBreathMark = true;
           } else if (decoration === "caesura") {
             pendingCaesura = true;
+          } else if (decoration === "shortphrase" || decoration === "mediumphrase" || decoration === "longphrase") {
+            pendingPhraseMark = decoration as "shortphrase" | "mediumphrase" | "longphrase";
           } else if (decoration === "segno") {
             pendingSegno = true;
           } else if (decoration === "coda") {
             pendingCoda = true;
           } else if (decoration === "fine") {
             pendingFine = true;
-          } else if (decoration === "dacapo" || decoration === "da-capo" || decoration === "da capo") {
+          } else if (decoration === "dacoda") {
             pendingDaCapo = true;
-          } else if (decoration === "dalsegno" || decoration === "dal-segno" || decoration === "dal segno") {
+            pendingToCoda = true;
+          } else if (decoration === "dacapo" || decoration === "da-capo" || decoration === "da capo" || decoration === "d.c.") {
+            pendingDaCapo = true;
+          } else if (decoration === "dalsegno" || decoration === "dal-segno" || decoration === "dal segno" || decoration === "d.s.") {
             pendingDalSegno = true;
           } else if (decoration === "tocoda" || decoration === "to-coda" || decoration === "to coda") {
             pendingToCoda = true;
-          } else if (decoration === "crescendo(" || decoration === "cresc(") {
+          } else if (decoration === "crescendo(" || decoration === "cresc(" || decoration === "<(") {
             pendingCrescendoStart = true;
-          } else if (decoration === "crescendo)" || decoration === "cresc)") {
+          } else if (decoration === "crescendo)" || decoration === "cresc)" || decoration === "<)") {
             pendingCrescendoStop = true;
           } else if (
             decoration === "diminuendo(" ||
             decoration === "decrescendo(" ||
             decoration === "dim(" ||
-            decoration === "decresc("
+            decoration === "decresc(" ||
+            decoration === ">("
           ) {
             pendingDiminuendoStart = true;
           } else if (
             decoration === "diminuendo)" ||
             decoration === "decrescendo)" ||
             decoration === "dim)" ||
-            decoration === "decresc)"
+            decoration === "decresc)" ||
+            decoration === ">)"
           ) {
             pendingDiminuendoStop = true;
           } else if (
+            decoration === "pppp" ||
             decoration === "ppp" ||
             decoration === "p" ||
             decoration === "pp" ||
@@ -1183,6 +1216,7 @@ const abcCommon = AbcCommon;
             decoration === "f" ||
             decoration === "ff" ||
             decoration === "fff" ||
+            decoration === "ffff" ||
             decoration === "fp" ||
             decoration === "fz" ||
             decoration === "rfz" ||
@@ -1212,6 +1246,8 @@ const abcCommon = AbcCommon;
             pendingHeel = true;
           } else if (decoration === "toe" || decoration === "toe mark") {
             pendingToe = true;
+          } else if (/^[0-5]$/.test(decoration)) {
+            pendingFingerings.push(decoration);
           } else if (decoration.startsWith("fingering:")) {
             const fingeringText = rawDecoration.slice("fingering:".length).trim();
             if (fingeringText) pendingFingerings.push(fingeringText);
@@ -1405,17 +1441,29 @@ const abcCommon = AbcCommon;
             }
             if (chordIndex === 0 && pendingTrill && !note.isRest) {
               note.trill = true;
+              note.trillLineStart = pendingTrillLineStart;
               pendingTrill = false;
+              pendingTrillLineStart = false;
+            }
+            if (chordIndex === 0 && pendingTrillLineStop && !note.isRest) {
+              note.trillLineStop = true;
+              pendingTrillLineStop = false;
             }
             if (chordIndex === 0 && pendingTurn && !note.isRest) {
               note.turnType = pendingTurn;
+              note.turnSlash = pendingTurnSlash;
               note.delayedTurn = pendingDelayedTurn;
               pendingTurn = "";
+              pendingTurnSlash = false;
               pendingDelayedTurn = false;
             }
             if (chordIndex === 0 && pendingMordent && !note.isRest) {
               note.mordentType = pendingMordent;
               pendingMordent = "";
+            }
+            if (chordIndex === 0 && pendingPhraseMark && !note.isRest) {
+              note.phraseMark = pendingPhraseMark;
+              pendingPhraseMark = "";
             }
             if (chordIndex === 0 && pendingTremolo && !note.isRest) {
               note.tremoloType = pendingTremolo.type;
@@ -1761,17 +1809,29 @@ const abcCommon = AbcCommon;
         applyBeamModeForEvent(note, dur);
         if (pendingTrill && !note.isRest) {
           note.trill = true;
+          note.trillLineStart = pendingTrillLineStart;
           pendingTrill = false;
+          pendingTrillLineStart = false;
+        }
+        if (pendingTrillLineStop && !note.isRest) {
+          note.trillLineStop = true;
+          pendingTrillLineStop = false;
         }
         if (pendingTurn && !note.isRest) {
           note.turnType = pendingTurn;
+          note.turnSlash = pendingTurnSlash;
           note.delayedTurn = pendingDelayedTurn;
           pendingTurn = "";
+          pendingTurnSlash = false;
           pendingDelayedTurn = false;
         }
         if (pendingMordent && !note.isRest) {
           note.mordentType = pendingMordent;
           pendingMordent = "";
+        }
+        if (pendingPhraseMark && !note.isRest) {
+          note.phraseMark = pendingPhraseMark;
+          pendingPhraseMark = "";
         }
         if (pendingTremolo && !note.isRest) {
           note.tremoloType = pendingTremolo.type;
@@ -2208,12 +2268,17 @@ const abcCommon = AbcCommon;
 
   function parseVoiceDirectiveTail(raw) {
     if (!raw) {
-      return { name: "", clef: "", transpose: null, bodyText: "" };
+      return { name: "", clef: "", transpose: null, bodyText: "", skippedText: "" };
     }
     let bodyText = String(raw);
     let name = "";
     let clef = "";
     let transpose = null;
+    const bareClefMatch = bodyText.match(/^\s*(bass|treble|alto|tenor|c3|c4)(?=\s|$)/i);
+    if (bareClefMatch) {
+      clef = String(bareClefMatch[1] || "").trim().toLowerCase();
+      bodyText = bodyText.slice(bareClefMatch[0].length);
+    }
     const attrRegex = /([A-Za-z][A-Za-z0-9_-]*)\s*=\s*("([^"]*)"|(\S+))/g;
     bodyText = bodyText.replace(attrRegex, (_full, key, _quotedValue, quotedInner, bareValue) => {
       const lowerKey = String(key).toLowerCase();
@@ -2229,11 +2294,20 @@ const abcCommon = AbcCommon;
       }
       return " ";
     });
+    bodyText = bodyText.trim();
+    let skippedText = "";
+    const firstTokenMatch = bodyText.match(/^(\S+)/);
+    const firstToken = firstTokenMatch ? firstTokenMatch[1] : "";
+    if (firstToken && /^[A-Za-z][A-Za-z0-9_-]*$/.test(firstToken) && /[^A-Ga-gzZxX]/.test(firstToken)) {
+      skippedText = firstToken;
+      bodyText = bodyText.slice(firstToken.length).trim();
+    }
     return {
       name: name.trim(),
       clef: clef.trim(),
       transpose,
-      bodyText: bodyText.trim()
+      bodyText,
+      skippedText
     };
   }
 
@@ -2979,13 +3053,17 @@ export const exportMusicXmlDomToAbc = (doc: Document): string => {
             if (child.querySelector(':scope > sound[fine="yes"]')) {
               pendingDirectionDecorations.push("!fine!");
             }
-            if (child.querySelector(':scope > sound[dacapo="yes"]')) {
+            const hasDaCapo = Boolean(child.querySelector(':scope > sound[dacapo="yes"]'));
+            const hasToCoda = Boolean(child.querySelector(":scope > sound[tocoda]"));
+            if (hasDaCapo && hasToCoda) {
+              pendingDirectionDecorations.push("!dacoda!");
+            } else if (hasDaCapo) {
               pendingDirectionDecorations.push("!dacapo!");
             }
             if (child.querySelector(":scope > sound[dalsegno]")) {
               pendingDirectionDecorations.push("!dalsegno!");
             }
-            if (child.querySelector(":scope > sound[tocoda]")) {
+            if (hasToCoda && !hasDaCapo) {
               pendingDirectionDecorations.push("!tocoda!");
             }
             for (const wedgeNode of Array.from(child.querySelectorAll(":scope > direction-type > wedge"))) {
@@ -3001,7 +3079,7 @@ export const exportMusicXmlDomToAbc = (doc: Document): string => {
                 activeWedgeType = "";
               }
             }
-            for (const dynamicName of ["ppp", "pp", "p", "mp", "mf", "f", "ff", "fff", "fp", "fz", "rfz", "sf", "sfp", "sfz"]) {
+            for (const dynamicName of ["pppp", "ppp", "pp", "p", "mp", "mf", "f", "ff", "fff", "ffff", "fp", "fz", "rfz", "sf", "sfp", "sfz"]) {
               if (child.querySelector(`:scope > direction-type > dynamics > ${dynamicName}`)) {
                 pendingDirectionDecorations.push(`!${dynamicName}!`);
               }
@@ -3030,6 +3108,8 @@ export const exportMusicXmlDomToAbc = (doc: Document): string => {
           const hasTrillMark = Boolean(child.querySelector(":scope > notations > ornaments > trill-mark"));
           const hasTurn = Boolean(child.querySelector(":scope > notations > ornaments > turn"));
           const hasInvertedTurn = Boolean(child.querySelector(":scope > notations > ornaments > inverted-turn"));
+          const hasTurnSlash = Array.from(child.querySelectorAll(":scope > notations > ornaments > turn, :scope > notations > ornaments > inverted-turn"))
+            .some((node) => (node.getAttribute("slash") || "").trim().toLowerCase() === "yes");
           const hasDelayedTurn = Boolean(child.querySelector(":scope > notations > ornaments > delayed-turn"));
           const hasMordent = Boolean(child.querySelector(":scope > notations > ornaments > mordent"));
           const hasInvertedMordent = Boolean(child.querySelector(":scope > notations > ornaments > inverted-mordent"));
@@ -3046,6 +3126,12 @@ export const exportMusicXmlDomToAbc = (doc: Document): string => {
           ).some((node) => {
             const type = (node.getAttribute("type") ?? "").trim().toLowerCase();
             return type === "" || type === "start";
+          });
+          const hasWavyLineStop = Array.from(
+            child.querySelectorAll(":scope > notations > ornaments > wavy-line")
+          ).some((node) => {
+            const type = (node.getAttribute("type") ?? "").trim().toLowerCase();
+            return type === "stop";
           });
           const hasTrill = hasTrillMark || hasWavyLineStart;
           const turnType: "" | "turn" | "inverted-turn" = hasInvertedTurn ? "inverted-turn" : (hasTurn ? "turn" : "");
@@ -3066,6 +3152,9 @@ export const exportMusicXmlDomToAbc = (doc: Document): string => {
           const hasStrongAccent = Boolean(child.querySelector(":scope > notations > articulations > strong-accent"));
           const hasBreathMark = Boolean(child.querySelector(":scope > notations > articulations > breath-mark"));
           const hasCaesura = Boolean(child.querySelector(":scope > notations > articulations > caesura"));
+          const phraseMarkText = Array.from(child.querySelectorAll(":scope > notations > articulations > other-articulation"))
+            .map((node) => (node.textContent || "").trim().toLowerCase())
+            .find((text) => text === "shortphrase" || text === "mediumphrase" || text === "longphrase") || "";
           const hasUpBow = Boolean(child.querySelector(":scope > notations > technical > up-bow"));
           const hasDownBow = Boolean(child.querySelector(":scope > notations > technical > down-bow"));
           const hasDoubleTongue = Boolean(child.querySelector(":scope > notations > technical > double-tongue"));
@@ -3175,18 +3264,20 @@ export const exportMusicXmlDomToAbc = (doc: Document): string => {
                   ? `(${activeTuplet.actual}:${activeTuplet.normal}:${activeTuplet.actual}`
                   : "")
               : "";
-          const trillPrefix = hasTrill ? "!trill!" : "";
+          const trillPrefix = hasWavyLineStop
+            ? "!trill)!"
+            : (hasWavyLineStart && !hasTrillMark ? "!trill!" : (hasWavyLineStart ? "!trill(!" : (hasTrill ? "!trill!" : "")));
           const turnPrefix =
             turnType === "inverted-turn"
-              ? (hasDelayedTurn ? "!delayedinvertedturn!" : "!invertedturn!")
-              : (turnType === "turn" ? (hasDelayedTurn ? "!delayedturn!" : "!turn!") : "");
+              ? (hasDelayedTurn ? "!delayedinvertedturn!" : (hasTurnSlash ? "!invertedturnx!" : "!invertedturn!"))
+              : (turnType === "turn" ? (hasDelayedTurn ? "!delayedturn!" : (hasTurnSlash ? "!turnx!" : "!turn!")) : "");
           const mordentPrefix = mordentType === "inverted-mordent" ? "!pralltriller!" : (mordentType === "mordent" ? "!mordent!" : "");
           const tremoloPrefix = tremoloType ? `!tremolo-${tremoloType}-${tremoloMarks}!` : "";
           const glissandoPrefix = hasGlissandoStart ? "!gliss-start!" : (hasGlissandoStop ? "!gliss-stop!" : "");
-          const slidePrefix = hasSlideStart ? "!slide-start!" : (hasSlideStop ? "!slide-stop!" : "");
+          const slidePrefix = hasSlideStart ? "!slide!" : (hasSlideStop ? "!slide-stop!" : "");
           const schleiferPrefix = hasSchleifer ? "!schleifer!" : "";
           const shakePrefix = hasShake ? "!shake!" : "";
-          const arpeggiatePrefix = hasArpeggiate ? "!roll!" : "";
+          const arpeggiatePrefix = hasArpeggiate ? "!arpeggio!" : "";
           const staccatoPrefix = hasStaccatissimo ? "!wedge!" : (hasStaccato ? "!staccato!" : "");
           const accentPrefix = hasAccent ? "!accent!" : "";
           const tenutoPrefix = hasTenuto ? "!tenuto!" : "";
@@ -3195,13 +3286,19 @@ export const exportMusicXmlDomToAbc = (doc: Document): string => {
           const strongAccentPrefix = hasStrongAccent ? "!marcato!" : "";
           const breathMarkPrefix = hasBreathMark ? "!breath!" : "";
           const caesuraPrefix = hasCaesura ? "!caesura!" : "";
+          const phraseMarkPrefix =
+            phraseMarkText === "shortphrase" || phraseMarkText === "mediumphrase" || phraseMarkText === "longphrase"
+              ? `!${phraseMarkText}!`
+              : "";
           const upBowPrefix = hasUpBow ? "!upbow!" : "";
           const downBowPrefix = hasDownBow ? "!downbow!" : "";
           const doubleTonguePrefix = hasDoubleTongue ? "!doubletongue!" : "";
           const tripleTonguePrefix = hasTripleTongue ? "!tripletongue!" : "";
           const heelPrefix = hasHeel ? "!heel!" : "";
           const toePrefix = hasToe ? "!toe!" : "";
-          const fingeringPrefix = fingeringTexts.map((value) => `!fingering:${value}!`).join("");
+          const fingeringPrefix = fingeringTexts
+            .map((value) => (/^[0-5]$/.test(value) ? `!${value}!` : `!fingering:${value}!`))
+            .join("");
           const stringPrefix = stringTexts.map((value) => `!string:${value}!`).join("");
           const pluckPrefix = pluckTexts.map((value) => `!pluck:${value}!`).join("");
           const openStringPrefix = hasOpenString ? "!open!" : "";
@@ -3221,7 +3318,7 @@ export const exportMusicXmlDomToAbc = (doc: Document): string => {
               : "";
           const directionDecorationPrefix =
             !isChord && pendingDirectionDecorations.length > 0 ? pendingDirectionDecorations.join("") : "";
-          const eventPrefix = `${harmonyPrefix}${wordsPrefix}${directionDecorationPrefix}${tupletPrefix}${slurStartPrefix}${gracePrefix}${trillPrefix}${turnPrefix}${mordentPrefix}${tremoloPrefix}${glissandoPrefix}${slidePrefix}${schleiferPrefix}${shakePrefix}${arpeggiatePrefix}${staccatoPrefix}${accentPrefix}${tenutoPrefix}${stressPrefix}${unstressPrefix}${strongAccentPrefix}${breathMarkPrefix}${caesuraPrefix}${upBowPrefix}${downBowPrefix}${doubleTonguePrefix}${tripleTonguePrefix}${heelPrefix}${toePrefix}${fingeringPrefix}${stringPrefix}${pluckPrefix}${openStringPrefix}${snapPizzicatoPrefix}${harmonicPrefix}${stoppedPrefix}${thumbPrefix}${fermataPrefix}`;
+          const eventPrefix = `${harmonyPrefix}${wordsPrefix}${directionDecorationPrefix}${tupletPrefix}${slurStartPrefix}${gracePrefix}${trillPrefix}${turnPrefix}${mordentPrefix}${tremoloPrefix}${glissandoPrefix}${slidePrefix}${schleiferPrefix}${shakePrefix}${arpeggiatePrefix}${staccatoPrefix}${accentPrefix}${tenutoPrefix}${stressPrefix}${unstressPrefix}${strongAccentPrefix}${breathMarkPrefix}${caesuraPrefix}${phraseMarkPrefix}${upBowPrefix}${downBowPrefix}${doubleTonguePrefix}${tripleTonguePrefix}${heelPrefix}${toePrefix}${fingeringPrefix}${stringPrefix}${pluckPrefix}${openStringPrefix}${snapPizzicatoPrefix}${harmonicPrefix}${stoppedPrefix}${thumbPrefix}${fermataPrefix}`;
           if (!isChord && pendingHarmonySymbols.length > 0) {
             pendingHarmonySymbols.length = 0;
           }
@@ -3549,10 +3646,14 @@ type AbcParsedNote = {
   grace?: boolean;
   graceSlash?: boolean;
   trill?: boolean;
+  trillLineStart?: boolean;
+  trillLineStop?: boolean;
   trillAccidentalText?: string;
   turnType?: "turn" | "inverted-turn";
+  turnSlash?: boolean;
   delayedTurn?: boolean;
   mordentType?: "mordent" | "inverted-mordent";
+  phraseMark?: "shortphrase" | "mediumphrase" | "longphrase";
   tremoloType?: "single" | "start" | "stop";
   tremoloMarks?: number;
   glissandoStart?: boolean;
@@ -4063,6 +4164,7 @@ const buildMusicXmlFromAbcParsed = (
                     note.slurStart ||
                     note.slurStop ||
                     note.trill ||
+                    note.trillLineStop ||
                     note.turnType ||
                     note.delayedTurn ||
                     note.mordentType ||
@@ -4084,6 +4186,7 @@ const buildMusicXmlFromAbcParsed = (
                     note.strongAccent ||
                     note.breathMark ||
                     note.caesura ||
+                    note.phraseMark ||
                     note.upBow ||
                     note.downBow ||
                     note.doubleTongue ||
@@ -4108,10 +4211,16 @@ const buildMusicXmlFromAbcParsed = (
                     if (note.slurStop) chunks.push('<slur type="stop"/>');
                     if (note.tupletStart) chunks.push('<tuplet type="start"/>');
                     if (note.tupletStop) chunks.push('<tuplet type="stop"/>');
-                    if (note.trill) {
+                    if (note.trill || note.trillLineStop) {
                       const trillParts: string[] = [];
-                      trillParts.push("<trill-mark/>");
-                      trillParts.push('<wavy-line type="start"/>');
+                      if (note.trill) {
+                        trillParts.push("<trill-mark/>");
+                      }
+                      if (note.trillLineStop) {
+                        trillParts.push('<wavy-line type="stop"/>');
+                      } else if (note.trillLineStart || note.trill) {
+                        trillParts.push('<wavy-line type="start"/>');
+                      }
                       if (note.trillAccidentalText) {
                         trillParts.push(`<accidental-mark>${xmlEscape(String(note.trillAccidentalText))}</accidental-mark>`);
                       }
@@ -4119,7 +4228,8 @@ const buildMusicXmlFromAbcParsed = (
                     }
                     if (note.turnType) {
                       const tag = note.turnType === "inverted-turn" ? "inverted-turn" : "turn";
-                      chunks.push(`<ornaments><${tag}/>${note.delayedTurn ? "<delayed-turn/>" : ""}</ornaments>`);
+                      const slashAttr = note.turnSlash ? ' slash="yes"' : "";
+                      chunks.push(`<ornaments><${tag}${slashAttr}/>${note.delayedTurn ? "<delayed-turn/>" : ""}</ornaments>`);
                     }
                     if (note.mordentType) {
                       const tag = note.mordentType === "inverted-mordent" ? "inverted-mordent" : "mordent";
@@ -4160,6 +4270,7 @@ const buildMusicXmlFromAbcParsed = (
                     if (note.strongAccent) articulationParts.push("<strong-accent/>");
                     if (note.breathMark) articulationParts.push("<breath-mark/>");
                     if (note.caesura) articulationParts.push("<caesura/>");
+                    if (note.phraseMark) articulationParts.push(`<other-articulation>${xmlEscape(String(note.phraseMark))}</other-articulation>`);
                     if (articulationParts.length > 0) {
                       chunks.push(`<articulations>${articulationParts.join("")}</articulations>`);
                     }

--- a/tests/unit/abc-io.spec.ts
+++ b/tests/unit/abc-io.spec.ts
@@ -254,6 +254,95 @@ C,, D,, E,, F,, |`;
     expect(line).toBe("4");
   });
 
+  it("ABC import accepts bare clef names in V: directives", () => {
+    const abc = `X:1
+T:Voice clef shorthand
+M:4/4
+L:1/4
+K:C
+V:1 treble
+C D E F |
+V:2 bass
+C,, D,, E,, F,, |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const parts = Array.from(outDoc.querySelectorAll("part"));
+    expect(parts.length).toBe(2);
+    expect(parts[0]?.querySelector("measure > attributes > clef > sign")?.textContent?.trim()).toBe("G");
+    expect(parts[0]?.querySelector("measure > attributes > clef > line")?.textContent?.trim()).toBe("2");
+    expect(parts[1]?.querySelector("measure > attributes > clef > sign")?.textContent?.trim()).toBe("F");
+    expect(parts[1]?.querySelector("measure > attributes > clef > line")?.textContent?.trim()).toBe("4");
+    expect(outDoc.querySelector('miscellaneous-field[name="mks:diag:count"]')).toBeNull();
+  });
+
+  it("ABC import keeps same-line body text after a bare V: clef shorthand", () => {
+    const abc = `X:1
+T:Voice clef shorthand inline body
+M:2/4
+L:1/4
+K:C
+V:1 bass C,, D,, |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    expect(outDoc.querySelector("part > measure > attributes > clef > sign")?.textContent?.trim()).toBe("F");
+    expect(outDoc.querySelectorAll("part > measure note").length).toBe(2);
+    expect(outDoc.querySelector('miscellaneous-field[name="mks:diag:count"]')).toBeNull();
+  });
+
+  it("ABC import accepts bare V: clef aliases c3 and c4", () => {
+    const abc = `X:1
+T:Voice clef alias shorthand
+M:2/4
+L:1/4
+K:C
+V:1 c3
+C D |
+V:2 c4
+E F |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const parts = Array.from(outDoc.querySelectorAll("part"));
+    expect(parts.length).toBe(2);
+    expect(parts[0]?.querySelector("measure > attributes > clef > sign")?.textContent?.trim()).toBe("C");
+    expect(parts[0]?.querySelector("measure > attributes > clef > line")?.textContent?.trim()).toBe("3");
+    expect(parts[1]?.querySelector("measure > attributes > clef > sign")?.textContent?.trim()).toBe("C");
+    expect(parts[1]?.querySelector("measure > attributes > clef > line")?.textContent?.trim()).toBe("4");
+    expect(outDoc.querySelector('miscellaneous-field[name="mks:diag:count"]')).toBeNull();
+  });
+
+  it("ABC import warns on unsupported bare V: tail words instead of parsing them as notes", () => {
+    const abc = `X:1
+T:Voice tail warning
+M:4/4
+L:1/4
+K:C
+V:1 bassoon
+C D E F |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    expect(outDoc.querySelectorAll("part > measure note").length).toBe(4);
+    expect(outDoc.querySelector('miscellaneous-field[name="mks:diag:count"]')?.textContent?.trim()).toBe("1");
+    expect(outDoc.querySelector('miscellaneous-field[name="mks:diag:0001"]')?.textContent).toContain(
+      "Skipped unsupported V: directive tail token: bassoon"
+    );
+  });
+
   it("ABC import reflows overfull measure content to avoid MEASURE_OVERFULL", () => {
     const overfullAbc = `X:1
 T:Overfull
@@ -1141,6 +1230,24 @@ K:C
     expect(firstNote?.querySelector(":scope > notations > ornaments > inverted-turn")).not.toBeNull();
   });
 
+  it("ABC->MusicXML parses turnx and invertedturnx as slashed turn variants", () => {
+    const abc = `X:1
+T:Turn slash variants
+M:4/4
+L:1/4
+K:C
+!turnx!C !invertedturnx!D |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const notes = Array.from(outDoc.querySelectorAll("part > measure > note"));
+    expect(notes[0]?.querySelector(':scope > notations > ornaments > turn[slash="yes"]')).not.toBeNull();
+    expect(notes[1]?.querySelector(':scope > notations > ornaments > inverted-turn[slash="yes"]')).not.toBeNull();
+  });
+
   it("ABC->MusicXML parses delayed turn variants", () => {
     const abc = `X:1
 T:Delayed turn
@@ -1159,6 +1266,25 @@ K:C
     expect(notes[0]?.querySelector(":scope > notations > ornaments > delayed-turn")).not.toBeNull();
     expect(notes[1]?.querySelector(":scope > notations > ornaments > inverted-turn")).not.toBeNull();
     expect(notes[1]?.querySelector(":scope > notations > ornaments > delayed-turn")).not.toBeNull();
+  });
+
+  it("ABC->MusicXML parses long trill start and stop decorations", () => {
+    const abc = `X:1
+T:Long trill
+M:4/4
+L:1/4
+K:C
+!trill(!C D !trill)!E F |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const notes = Array.from(outDoc.querySelectorAll("part > measure > note"));
+    expect(notes[0]?.querySelector(":scope > notations > ornaments > trill-mark")).not.toBeNull();
+    expect(notes[0]?.querySelector(':scope > notations > ornaments > wavy-line[type="start"]')).not.toBeNull();
+    expect(notes[2]?.querySelector(':scope > notations > ornaments > wavy-line[type="stop"]')).not.toBeNull();
   });
 
   it("ABC->MusicXML parses mikuscore tremolo decorations", () => {
@@ -1201,6 +1327,42 @@ K:C
     expect(notes[1]?.querySelector(':scope > notations > glissando[type="stop"]')).not.toBeNull();
     expect(notes[2]?.querySelector(':scope > notations > slide[type="start"]')).not.toBeNull();
     expect(notes[3]?.querySelector(':scope > notations > slide[type="stop"]')).not.toBeNull();
+  });
+
+  it("ABC->MusicXML accepts standard !slide! decoration as slide start", () => {
+    const abc = `X:1
+T:Standard slide
+M:4/4
+L:1/4
+K:C
+!slide!C D |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const firstNote = outDoc.querySelector("part > measure > note");
+    expect(firstNote?.querySelector(':scope > notations > slide[type="start"]')).not.toBeNull();
+  });
+
+  it("ABC->MusicXML parses standard phrase-mark decorations", () => {
+    const abc = `X:1
+T:Phrase marks
+M:4/4
+L:1/4
+K:C
+!shortphrase!C !mediumphrase!D !longphrase!E F |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const notes = Array.from(outDoc.querySelectorAll("part > measure > note"));
+    expect(notes[0]?.querySelector(':scope > notations > articulations > other-articulation')?.textContent?.trim()).toBe("shortphrase");
+    expect(notes[1]?.querySelector(':scope > notations > articulations > other-articulation')?.textContent?.trim()).toBe("mediumphrase");
+    expect(notes[2]?.querySelector(':scope > notations > articulations > other-articulation')?.textContent?.trim()).toBe("longphrase");
   });
 
   it("ABC->MusicXML parses staccato decoration", () => {
@@ -1256,6 +1418,24 @@ K:C
     expect(notes[0]?.querySelector(":scope > notations > articulations > accent")).not.toBeNull();
     expect(notes[1]?.querySelector(":scope > notations > articulations > tenuto")).not.toBeNull();
     expect(notes[2]?.querySelector(":scope > notations > fermata")).not.toBeNull();
+  });
+
+  it("ABC->MusicXML accepts !>! and !emphasis! as accent aliases", () => {
+    const abc = `X:1
+T:Accent aliases
+M:4/4
+L:1/4
+K:C
+!>!C !emphasis!D |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const notes = Array.from(outDoc.querySelectorAll("part > measure > note"));
+    expect(notes[0]?.querySelector(":scope > notations > articulations > accent")).not.toBeNull();
+    expect(notes[1]?.querySelector(":scope > notations > articulations > accent")).not.toBeNull();
   });
 
   it("ABC->MusicXML parses stress and unstress decorations", () => {
@@ -1613,6 +1793,24 @@ K:C
     expect(fingerings).toEqual(["1", "4"]);
     expect(notes[1]?.querySelector(":scope > notations > technical > string")?.textContent?.trim()).toBe("1");
     expect(notes[2]?.querySelector(":scope > notations > technical > string")?.textContent?.trim()).toBe("4");
+  });
+
+  it("ABC->MusicXML parses standard fingering decorations !0! to !5!", () => {
+    const abc = `X:1
+T:Standard fingering decorations
+M:4/4
+L:1/4
+K:C
+!0!C !1!D !2!E !3!F !4!G !5!A |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const fingerings = Array.from(outDoc.querySelectorAll("part > measure note > notations > technical > fingering"))
+      .map((n) => n.textContent?.trim());
+    expect(fingerings).toEqual(["0", "1", "2", "3", "4", "5"]);
   });
 
   it("ABC->MusicXML parses mikuscore pluck decorations", () => {
@@ -2040,6 +2238,22 @@ K:C
     expect(outDoc.querySelector('part > measure > direction > sound[dacapo="yes"]')).not.toBeNull();
   });
 
+  it("ABC->MusicXML accepts !D.C.! as dacapo alias", () => {
+    const abc = `X:1
+T:D.C. alias
+M:4/4
+L:1/4
+K:C
+!D.C.!C D |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    expect(outDoc.querySelector('part > measure > direction > sound[dacapo="yes"]')).not.toBeNull();
+  });
+
   it("ABC->MusicXML parses dalsegno decoration as sound direction", () => {
     const abc = `X:1
 T:Dal Segno
@@ -2079,6 +2293,22 @@ M:4/4
 L:1/4
 K:C
 !dal-segno!C D |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    expect(outDoc.querySelector('part > measure > direction > sound[dalsegno="segno"]')).not.toBeNull();
+  });
+
+  it("ABC->MusicXML accepts !D.S.! as dalsegno alias", () => {
+    const abc = `X:1
+T:D.S. alias
+M:4/4
+L:1/4
+K:C
+!D.S.!C D |`;
 
     const xml = convertAbcToMusicXml(abc);
     const outDoc = parseMusicXmlDocument(xml);
@@ -2136,6 +2366,23 @@ K:C
     expect(outDoc.querySelector('part > measure > direction > sound[tocoda="coda"]')).not.toBeNull();
   });
 
+  it("ABC->MusicXML parses dacoda decoration as dacapo plus tocoda", () => {
+    const abc = `X:1
+T:Da Coda
+M:4/4
+L:1/4
+K:C
+!dacoda!C D |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    expect(outDoc.querySelector('part > measure > direction > sound[dacapo="yes"]')).not.toBeNull();
+    expect(outDoc.querySelector('part > measure > direction > sound[tocoda="coda"]')).not.toBeNull();
+  });
+
   it("ABC->MusicXML parses crescendo and diminuendo wedge decorations as directions", () => {
     const abc = `X:1
 T:Wedges
@@ -2161,6 +2408,24 @@ M:4/4
 L:1/4
 K:C
 !cresc(!C !cresc)!D !dim(!E !decresc)!F |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const wedgeTypes = Array.from(outDoc.querySelectorAll("part > measure > direction > direction-type > wedge"))
+      .map((node) => node.getAttribute("type"));
+    expect(wedgeTypes).toEqual(["crescendo", "stop", "diminuendo", "stop"]);
+  });
+
+  it("ABC->MusicXML accepts symbolic wedge decoration aliases <( <) >( >)", () => {
+    const abc = `X:1
+T:Symbolic wedge aliases
+M:4/4
+L:1/4
+K:C
+!<(!C !<)!D !>(!E !>)!F |`;
 
     const xml = convertAbcToMusicXml(abc);
     const outDoc = parseMusicXmlDocument(xml);
@@ -2478,6 +2743,24 @@ K:C
     const dynamics = Array.from(outDoc.querySelectorAll("part > measure > direction > direction-type > dynamics"))
       .map((node) => node.firstElementChild?.tagName?.toLowerCase());
     expect(dynamics).toEqual(["ppp", "mp", "mf", "ff", "fp", "fz", "rfz", "sfp"]);
+  });
+
+  it("ABC->MusicXML parses pppp and ffff decorations as dynamics directions", () => {
+    const abc = `X:1
+T:Extreme dynamics
+M:4/4
+L:1/4
+K:C
+!pppp!C !ffff!D |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const dynamics = Array.from(outDoc.querySelectorAll("part > measure > direction > direction-type > dynamics"))
+      .map((node) => node.firstElementChild?.tagName?.toLowerCase());
+    expect(dynamics).toEqual(["pppp", "ffff"]);
   });
 
   it("ABC->MusicXML accepts mordent aliases used in real-world ABC", () => {
@@ -3162,6 +3445,51 @@ K:C
     expect(outDoc.querySelector("note > notations > ornaments > inverted-turn")).not.toBeNull();
   });
 
+  it("MusicXML->ABC exports turnx and invertedturnx variants and roundtrips them", () => {
+    const xmlWithTurnSlashVariants = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>960</duration><voice>1</voice><type>quarter</type>
+        <notations><ornaments><turn slash="yes"/></ornaments></notations>
+      </note>
+      <note>
+        <pitch><step>D</step><octave>4</octave></pitch>
+        <duration>960</duration><voice>1</voice><type>quarter</type>
+        <notations><ornaments><inverted-turn slash="yes"/></ornaments></notations>
+      </note>
+      <note><rest/><duration>1920</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithTurnSlashVariants);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!turnx!");
+    expect(abc).toContain("!invertedturnx!");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    const notes = Array.from(outDoc.querySelectorAll("part > measure > note"));
+    expect(notes[0]?.querySelector(':scope > notations > ornaments > turn[slash="yes"]')).not.toBeNull();
+    expect(notes[1]?.querySelector(':scope > notations > ornaments > inverted-turn[slash="yes"]')).not.toBeNull();
+  });
+
   it("MusicXML->ABC exports delayed turn variants and roundtrips them", () => {
     const xmlWithDelayedTurns = `<?xml version="1.0" encoding="UTF-8"?>
 <score-partwise version="3.1">
@@ -3503,7 +3831,7 @@ K:C
     const abc = exportMusicXmlDomToAbc(srcDoc);
     expect(abc).toContain("!gliss-start!");
     expect(abc).toContain("!gliss-stop!");
-    expect(abc).toContain("!slide-start!");
+    expect(abc).toContain("!slide!");
     expect(abc).toContain("!slide-stop!");
 
     const roundtripXml = convertAbcToMusicXml(abc);
@@ -3620,7 +3948,7 @@ K:C
     if (!srcDoc) return;
 
     const abc = exportMusicXmlDomToAbc(srcDoc);
-    expect(abc).toContain("!slide-start!");
+    expect(abc).toContain("!slide!");
 
     const roundtripXml = convertAbcToMusicXml(abc);
     const outDoc = parseMusicXmlDocument(roundtripXml);
@@ -3698,6 +4026,120 @@ K:C
 
     const abc = exportMusicXmlDomToAbc(srcDoc);
     expect(abc).toContain("!trill!");
+  });
+
+  it("MusicXML->ABC exports long trill start and stop decorations", () => {
+    const xmlWithLongTrill = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>960</duration>
+        <voice>1</voice><type>quarter</type>
+        <notations><ornaments><trill-mark/><wavy-line type="start"/></ornaments></notations>
+      </note>
+      <note>
+        <pitch><step>D</step><octave>4</octave></pitch>
+        <duration>960</duration>
+        <voice>1</voice><type>quarter</type>
+      </note>
+      <note>
+        <pitch><step>E</step><octave>4</octave></pitch>
+        <duration>960</duration>
+        <voice>1</voice><type>quarter</type>
+        <notations><ornaments><wavy-line type="stop"/></ornaments></notations>
+      </note>
+      <note>
+        <rest/><duration>960</duration><voice>1</voice><type>quarter</type>
+      </note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithLongTrill);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!trill(!");
+    expect(abc).toContain("!trill)!");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const notes = Array.from(outDoc.querySelectorAll("part > measure > note"));
+    expect(notes[0]?.querySelector(":scope > notations > ornaments > trill-mark")).not.toBeNull();
+    expect(notes[0]?.querySelector(':scope > notations > ornaments > wavy-line[type="start"]')).not.toBeNull();
+    expect(notes[2]?.querySelector(':scope > notations > ornaments > wavy-line[type="stop"]')).not.toBeNull();
+  });
+
+  it("MusicXML->ABC exports phrase-mark decorations and roundtrips them", () => {
+    const xmlWithPhraseMarks = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>960</duration>
+        <voice>1</voice><type>quarter</type>
+        <notations><articulations><other-articulation>shortphrase</other-articulation></articulations></notations>
+      </note>
+      <note>
+        <pitch><step>D</step><octave>4</octave></pitch>
+        <duration>960</duration>
+        <voice>1</voice><type>quarter</type>
+        <notations><articulations><other-articulation>mediumphrase</other-articulation></articulations></notations>
+      </note>
+      <note>
+        <pitch><step>E</step><octave>4</octave></pitch>
+        <duration>960</duration>
+        <voice>1</voice><type>quarter</type>
+        <notations><articulations><other-articulation>longphrase</other-articulation></articulations></notations>
+      </note>
+      <note>
+        <rest/><duration>960</duration><voice>1</voice><type>quarter</type>
+      </note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithPhraseMarks);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!shortphrase!");
+    expect(abc).toContain("!mediumphrase!");
+    expect(abc).toContain("!longphrase!");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const notes = Array.from(outDoc.querySelectorAll("part > measure > note"));
+    expect(notes[0]?.querySelector(':scope > notations > articulations > other-articulation')?.textContent?.trim()).toBe("shortphrase");
+    expect(notes[1]?.querySelector(':scope > notations > articulations > other-articulation')?.textContent?.trim()).toBe("mediumphrase");
+    expect(notes[2]?.querySelector(':scope > notations > articulations > other-articulation')?.textContent?.trim()).toBe("longphrase");
   });
 
   it("MusicXML->ABC exports staccato decoration and roundtrips it", () => {
@@ -3834,6 +4276,44 @@ K:C
     expect(outDoc).not.toBeNull();
     if (!outDoc) return;
     expect(outDoc.querySelector("note > notations > articulations > accent")).not.toBeNull();
+  });
+
+  it("ABC accent alias !>! roundtrips back to canonical !accent!", () => {
+    const abc = `X:1
+T:Accent alias symbol
+M:4/4
+L:1/4
+K:C
+!>!C z |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const srcDoc = parseMusicXmlDocument(xml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+    expect(srcDoc.querySelector("note > notations > articulations > accent")).not.toBeNull();
+
+    const exportedAbc = exportMusicXmlDomToAbc(srcDoc);
+    expect(exportedAbc).toContain("!accent!");
+    expect(exportedAbc).not.toContain("!>!");
+  });
+
+  it("ABC accent alias !emphasis! roundtrips back to canonical !accent!", () => {
+    const abc = `X:1
+T:Accent alias emphasis
+M:4/4
+L:1/4
+K:C
+!emphasis!C z |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const srcDoc = parseMusicXmlDocument(xml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+    expect(srcDoc.querySelector("note > notations > articulations > accent")).not.toBeNull();
+
+    const exportedAbc = exportMusicXmlDomToAbc(srcDoc);
+    expect(exportedAbc).toContain("!accent!");
+    expect(exportedAbc).not.toContain("!emphasis!");
   });
 
   it("MusicXML->ABC exports tenuto decoration and roundtrips it", () => {
@@ -4410,6 +4890,45 @@ K:C
     expect(wedgeTypes).toEqual(["crescendo", "stop", "diminuendo", "stop"]);
   });
 
+  it("MusicXML->ABC exports pppp and ffff dynamics and roundtrips them", () => {
+    const xml = `<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>480</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <direction><direction-type><dynamics><pppp/></dynamics></direction-type></direction>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>480</duration><voice>1</voice><type>quarter</type></note>
+      <direction><direction-type><dynamics><ffff/></dynamics></direction-type></direction>
+      <note><pitch><step>D</step><octave>4</octave></pitch><duration>480</duration><voice>1</voice><type>quarter</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+
+    const srcDoc = parseMusicXmlDocument(xml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!pppp!C");
+    expect(abc).toContain("!ffff!D");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const dynamics = Array.from(outDoc.querySelectorAll("part > measure > direction > direction-type > dynamics"))
+      .map((node) => node.firstElementChild?.tagName?.toLowerCase());
+    expect(dynamics).toEqual(["pppp", "ffff"]);
+  });
+
   it("MusicXML->ABC exports crescendo wedge start and roundtrips it", () => {
     const xml = `<score-partwise version="3.1">
   <part-list>
@@ -4916,8 +5435,8 @@ K:C
     if (!srcDoc) return;
 
     const abc = exportMusicXmlDomToAbc(srcDoc);
-    expect(abc).toContain("!fingering:1!");
-    expect(abc).toContain("!fingering:4!");
+    expect(abc).toContain("!1!");
+    expect(abc).toContain("!4!");
     expect(abc).toContain("!string:1!");
     expect(abc).toContain("!string:4!");
 
@@ -4961,8 +5480,8 @@ K:C
     if (!srcDoc) return;
 
     const abc = exportMusicXmlDomToAbc(srcDoc);
-    expect(abc).toContain("!fingering:1!");
-    expect(abc).toContain("!fingering:4!");
+    expect(abc).toContain("!1!");
+    expect(abc).toContain("!4!");
 
     const roundtripXml = convertAbcToMusicXml(abc);
     const outDoc = parseMusicXmlDocument(roundtripXml);
@@ -5001,7 +5520,7 @@ K:C
     if (!srcDoc) return;
 
     const abc = exportMusicXmlDomToAbc(srcDoc);
-    expect(abc).toContain("!fingering:1!");
+    expect(abc).toContain("!1!");
 
     const roundtripXml = convertAbcToMusicXml(abc);
     const outDoc = parseMusicXmlDocument(roundtripXml);
@@ -5010,6 +5529,53 @@ K:C
 
     const fingerings = Array.from(outDoc.querySelectorAll("note > notations > technical > fingering")).map((n) => n.textContent?.trim());
     expect(fingerings).toEqual(["1"]);
+  });
+
+  it("MusicXML->ABC exports single-digit fingering 0-5 using standard decorations and roundtrips them", () => {
+    const xmlWithDigitFingerings = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>960</duration><voice>1</voice><type>quarter</type>
+        <notations><technical><fingering>0</fingering></technical></notations>
+      </note>
+      <note>
+        <pitch><step>D</step><octave>4</octave></pitch>
+        <duration>960</duration><voice>1</voice><type>quarter</type>
+        <notations><technical><fingering>5</fingering></technical></notations>
+      </note>
+      <note><rest/><duration>1920</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithDigitFingerings);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!0!C");
+    expect(abc).toContain("!5!D");
+    expect(abc).not.toContain("!fingering:0!");
+    expect(abc).not.toContain("!fingering:5!");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const fingerings = Array.from(outDoc.querySelectorAll("note > notations > technical > fingering")).map((n) => n.textContent?.trim());
+    expect(fingerings).toEqual(["0", "5"]);
   });
 
   it("MusicXML->ABC exports string decorations and roundtrips them", () => {
@@ -5564,7 +6130,7 @@ K:C
     expect(outDoc.querySelector("note > notations > ornaments > inverted-mordent")).not.toBeNull();
   });
 
-  it("MusicXML->ABC exports arpeggiate as !roll! and roundtrips it", () => {
+  it("MusicXML->ABC exports arpeggiate as canonical !arpeggio! and roundtrips it", () => {
     const xmlWithArpeggiate = `<?xml version="1.0" encoding="UTF-8"?>
 <score-partwise version="3.1">
   <part-list>
@@ -5601,7 +6167,7 @@ K:C
     if (!srcDoc) return;
 
     const abc = exportMusicXmlDomToAbc(srcDoc);
-    expect(abc).toContain("!roll![");
+    expect(abc).toContain("!arpeggio![");
 
     const roundtripXml = convertAbcToMusicXml(abc);
     const outDoc = parseMusicXmlDocument(roundtripXml);
@@ -5948,6 +6514,25 @@ K:C
     expect(exportedAbc).not.toContain("!da-capo!");
   });
 
+  it("ABC dacapo alias !D.C.! roundtrips back to canonical !dacapo!", () => {
+    const abc = `X:1
+T:D.C. alias
+M:4/4
+L:1/4
+K:C
+!D.C.!C z |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const srcDoc = parseMusicXmlDocument(xml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+    expect(srcDoc.querySelector('part > measure > direction > sound[dacapo="yes"]')).not.toBeNull();
+
+    const exportedAbc = exportMusicXmlDomToAbc(srcDoc);
+    expect(exportedAbc).toContain("!dacapo!");
+    expect(exportedAbc).not.toContain("!D.C.!");
+  });
+
   it("MusicXML->ABC exports dalsegno sound marker and roundtrips it", () => {
     const xmlWithDalSegno = `<?xml version="1.0" encoding="UTF-8"?>
 <score-partwise version="3.1">
@@ -6020,6 +6605,25 @@ K:C
     expect(exportedAbc).not.toContain("!dal-segno!");
   });
 
+  it("ABC dalsegno alias !D.S.! roundtrips back to canonical !dalsegno!", () => {
+    const abc = `X:1
+T:D.S. alias
+M:4/4
+L:1/4
+K:C
+!D.S.!C z |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const srcDoc = parseMusicXmlDocument(xml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+    expect(srcDoc.querySelector('part > measure > direction > sound[dalsegno="segno"]')).not.toBeNull();
+
+    const exportedAbc = exportMusicXmlDomToAbc(srcDoc);
+    expect(exportedAbc).toContain("!dalsegno!");
+    expect(exportedAbc).not.toContain("!D.S.!");
+  });
+
   it("MusicXML->ABC exports tocoda sound marker and roundtrips it", () => {
     const xmlWithToCoda = `<?xml version="1.0" encoding="UTF-8"?>
 <score-partwise version="3.1">
@@ -6090,6 +6694,41 @@ K:C
     const exportedAbc = exportMusicXmlDomToAbc(srcDoc);
     expect(exportedAbc).toContain("!tocoda!");
     expect(exportedAbc).not.toContain("!to-coda!");
+  });
+
+  it("MusicXML->ABC exports combined dacapo+tocoda as !dacoda! and roundtrips it", () => {
+    const xmlWithDaCoda = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <direction><sound dacapo="yes" tocoda="coda"/></direction>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>960</duration><voice>1</voice><type>quarter</type></note>
+      <note><rest/><duration>2880</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithDaCoda);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!dacoda!C");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    expect(outDoc.querySelector('part > measure > direction > sound[dacapo="yes"]')).not.toBeNull();
+    expect(outDoc.querySelector('part > measure > direction > sound[tocoda="coda"]')).not.toBeNull();
   });
 
   it("MusicXML->ABC exports sfz dynamics and roundtrips it", () => {


### PR DESCRIPTION
### 概要

ABC を `mikuscore` の supported format として再整理し、ABC 2.2 ベースでの対応方針を文書化しました。あわせて、ABC 互換パーサと ABC I/O 実装を拡張し、`V:` 行の bare clef shorthand や標準装飾記号の対応を強化しています。

### 変更内容

#### ドキュメント整理
- `README.md`
  - ABC を `experimental` 表記から外し、`ABC standard 2.2 baseline; some standard features remain partially implemented or unimplemented` に更新
- `docs/FORMAT_COVERAGE.md`
  - ABC を `Supported` として整理し、`docs/spec/ABC_STANDARD_COVERAGE.md` への導線を追加
- `docs/spec/ABC_IO.md`
  - ABC は supported format であることを明記
  - `abcjs` / `abcm2ps` 由来の de facto 互換を compatibility behavior として扱う方針を追記
  - 標準装飾記号の対応状況と canonical policy を追記
- `docs/spec/abc-compat-parser-ebnf.md`
  - draft 表記を外し、supported import behavior の grammar baseline として位置づけを明確化
  - bare `V:` clef shorthand などの compatibility rule を追記
- `docs/spec/ABC_STANDARD_COVERAGE.md`
  - 新規追加
  - ABC 2.1 baseline / 2.2 delta の coverage 管理
  - `ABC-COV-*` backlog、priority、work type、done condition、initial stance、運用手順を整理
- `TODO.md`
  - `ABC_STANDARD_COVERAGE.md` を基準にした ABC backlog を追加
  - `ABC-COV-*` を順番付きで転記
  - 再開しやすい resume note を追加

#### 実装変更
- `src/ts/abc-io.ts`
  - `V:` directive tail で bare clef shorthand を受理
    - `bass`, `treble`, `alto`, `tenor`, `c3`, `c4`
  - unsupported bare `V:` tail word は body note parser に流さず warning 化
  - long trill `!trill(!` / `!trill)!` を import/export/roundtrip 対応
  - slashed turn `!turnx!` / `!invertedturnx!` を import/export/roundtrip 対応
  - standard `!slide!` を slide start の canonical form として扱うよう更新
  - phrase marks `!shortphrase!` / `!mediumphrase!` / `!longphrase!` を MusicXML `other-articulation` で roundtrip 対応
  - accent alias `!>!` / `!emphasis!` を対応
  - fingering shorthand `!0!`-`!5!` を import/export 対応
  - `!D.C.!`, `!D.S.!`, `!dacoda!` を対応
  - `!pppp!`, `!ffff!`、symbolic wedge alias `!<(!` / `!<)!` / `!>(!` / `!>)!` を対応
  - MusicXML `arpeggiate` の canonical export を `!roll!` ではなく `!arpeggio!` に変更

#### テスト
- `tests/unit/abc-io.spec.ts`
  - 上記の ABC import/export/roundtrip に対する unit test を追加・更新
  - `V:` bare clef shorthand
  - unsupported bare `V:` tail warning
  - long trill
  - slashed turn
  - `!slide!`
  - phrase marks
  - accent alias
  - fingering shorthand
  - `!D.C.!` / `!D.S.!` / `!dacoda!`
  - extreme dynamics
  - canonical export (`!arpeggio!`, `!accent!`, `!dacapo!`, `!dalsegno!` など)

#### 生成物更新
- `src/js/main.js`
- `mikuscore.html`

### 補足

- `ABC_STANDARD_COVERAGE.md` を完了判定の親表として追加しています。
- 未確認/要継続事項として、`ABC-COV-016`, `ABC-COV-005`, `ABC-COV-006` などの backlog は残っています。
- `ABC-COV-009` は policy 記述を先行で整理し、実装はその方針に沿って一部反映済みです。

### テスト

- `npm run test:unit -- tests/unit/abc-io.spec.ts`