### PR TITLE
ABC coverage baseline を整理し、ABC I/O と回帰テストを強化

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -131,7 +131,7 @@
     - use that file as the source of truth for completion judgment; use this TODO only for actionable deltas
     - broader actionable backlog is enumerated there as `ABC-COV-*`; local TODO items should reference those backlog ids when possible
   - Ordered coverage-derived backlog (`ABC-COV-*`):
-    - [ ] `ABC-COV-009` (`P1`, `mixed`, initial stance: `support now`)
+    - [x] `ABC-COV-009` (`P1`, `mixed`, initial stance: `support now`)
       - Resolve pending decoration policy items:
         - `!arpeggio!` / `!roll!`
         - `!+!` / `!plus!`
@@ -143,81 +143,193 @@
         - `!+!` / `!plus!`, mordent-family canonical export, and `!slide!` stop-side extension policy are already consistent with the written policy
       - Done when:
         - each pending item is resolved in spec text, with implementation/tests if needed
-    - [ ] `ABC-COV-016` (`P1`, `mixed`, initial stance: `support bounded subset`)
+    - [x] `ABC-COV-016` (`P1`, `mixed`, initial stance: `support bounded subset`)
       - Enumerate which standard voice properties are supported, unsupported, or extension-only
+      - Progress:
+        - `docs/spec/ABC_STANDARD_COVERAGE.md` now decomposes `7.1 Voice properties` into:
+          - supported: `V:id`, `name=...`, common `clef=...`
+          - partial: `transpose=...`
+          - ext-only: transpose-preserving roundtrip through `%@mks transpose ...`
+          - unsupported: broader standard properties such as `staves`, `brace`, `bracket`, `merge`, `middle`, `gchords`
+        - `docs/spec/ABC_IO.md` now states the current supported `V:` property subset explicitly
+        - unsupported standard `V:` properties are now specified to warn rather than silently widening the supported subset
       - Done when:
         - supported/unsupported voice-property list is explicit and testable
-    - [ ] `ABC-COV-005` (`P1`, `mixed`, initial stance: `support bounded subset`)
+    - [x] `ABC-COV-005` (`P1`, `mixed`, initial stance: `support bounded subset`)
       - Decide how far ABC whitespace-as-beam-separation must be preserved on export
+      - Progress:
+        - `docs/spec/ABC_STANDARD_COVERAGE.md` now fixes the bounded policy:
+          - import: whitespace is a beam-break hint within the current voice/measure
+          - export: canonical ABC does not currently preserve beam-specific spacing text; it emits ordinary token spacing
+          - exact source whitespace preservation is currently out of scope for standard roundtrip claims
+        - `docs/spec/ABC_IO.md` now mirrors this beam / whitespace policy
+        - regression coverage now exists for both import-side beam-break hints and current export-side non-preservation of exact beam spacing
       - Done when:
         - whitespace-beam preservation target is decided and tested to that level
-    - [ ] `ABC-COV-006` (`P1`, `mixed`, initial stance: `support bounded subset`)
+    - [x] `ABC-COV-006` (`P1`, `mixed`, initial stance: `support bounded subset`)
       - Audit remaining repeat/ending edge variants and mark what is still unsupported
+      - Progress:
+        - `docs/spec/ABC_STANDARD_COVERAGE.md` now fixes the bounded subset:
+          - standard surface: `|:`, `:|`, `[1`, `[2`, `|1`, `:|2`
+          - extension-assisted edge cases: `%@mks measure ... times=...`, `%@mks measure ... ending-stop=... ending-type=discontinue`
+        - `docs/spec/ABC_IO.md` now mirrors the current repeat / ending policy
+        - regression coverage now exists for:
+          - standard repeat barlines
+          - standard alternate endings
+          - repeat counts beyond the ordinary case via `%@mks measure ... times=...`
+          - ending stop type `discontinue` via `%@mks measure ... ending-stop=... ending-type=discontinue`
       - Done when:
         - remaining repeat/ending edge forms are either supported with tests or explicitly marked unsupported
-    - [ ] `ABC-COV-012` (`P1`, `mixed`, initial stance: `support bounded subset`)
+    - [x] `ABC-COV-012` (`P1`, `mixed`, initial stance: `support bounded subset`)
       - Expand or explicitly bound the supported chord-symbol inventory
+      - Progress:
+        - `docs/spec/ABC_STANDARD_COVERAGE.md` now enumerates the current bounded quoted-chord inventory
+        - `docs/spec/ABC_IO.md` now mirrors the supported suffix/root/bass subset
+        - unsupported quoted chord-like text is now specified to fall back to annotation/words instead of being forced into `harmony`
+        - regression coverage now exists for both the supported quoted-chord subset and unsupported quoted-chord fallback to annotation
       - Done when:
         - supported chord-symbol inventory is enumerated enough to test and maintain
-    - [ ] `ABC-COV-007` (`P1`, `mixed`, initial stance: `support bounded subset`)
+    - [x] `ABC-COV-007` (`P1`, `mixed`, initial stance: `support bounded subset`)
       - Close the slur-span reconstruction policy or keep it explicitly partial with defined limits
+      - Progress:
+        - `docs/spec/ABC_STANDARD_COVERAGE.md` now fixes the bounded slur policy:
+          - supported: common unnumbered start/stop slur presence
+          - unsupported/not yet claimed: numbered/nested slur identity preservation
+          - explicit limit: slur stop without a preceding non-rest note is unsupported and warning-based
+        - `docs/spec/ABC_IO.md` now mirrors the current slur policy
+        - regression coverage now exists for both common slur start/stop roundtrip and the warning-based unsupported edge case
       - Done when:
         - slur-span limits are written down and tested, or stronger preservation is implemented
-    - [ ] `ABC-COV-017` (`P1`, `policy`, initial stance: `defer intentionally`)
+    - [x] `ABC-COV-017` (`P1`, `policy`, initial stance: `defer intentionally`)
       - Decide whether faithful same-part overlay preservation is required
+      - Progress:
+        - `docs/spec/ABC_STANDARD_COVERAGE.md` now fixes the overlay policy:
+          - supported: `&` import acceptance via synthetic overlay voices / parts
+          - intentionally not claimed: faithful same-part multi-voice preservation and exact `&` roundtrip preservation
+        - `docs/spec/ABC_IO.md` now mirrors the same bounded overlay policy
       - Done when:
         - overlay preservation target is explicitly accepted or rejected
-    - [ ] `ABC-COV-018` (`P2`, `policy`, initial stance: `defer intentionally`)
+    - [x] `ABC-COV-018` (`P2`, `mixed`, initial stance: `support bounded subset`)
       - Decide whether `!editorial!` and `!courtesy!` are in the supported roadmap or intentionally deferred
+      - Progress:
+        - `docs/spec/ABC_STANDARD_COVERAGE.md` now moves both `!editorial!` and `!courtesy!` into the bounded supported 2.2 subset
+        - `docs/spec/ABC_IO.md` now mirrors the same accidental-level support stance
+        - implementation and regression tests now cover import/export/roundtrip through MusicXML accidental `editorial="yes"` / `cautionary="yes"`
       - Done when:
-        - 2.2 delta items are either put on roadmap or marked intentionally deferred
-    - [ ] `ABC-COV-008` (`P2`, `mixed`, initial stance: `support bounded subset`)
+        - the 2.2 delta stance is explicit in spec and the bounded accidental-level support has code/test parity
+    - [x] `ABC-COV-008` (`P2`, `mixed`, initial stance: `support bounded subset`)
       - Audit remaining tuplet ratio/edge semantics and mark what is still unsupported
+      - Progress:
+        - `docs/spec/ABC_STANDARD_COVERAGE.md` now fixes the tuplet scope as a bounded subset
+        - `docs/spec/ABC_IO.md` now mirrors the same tuplet stance
+        - supported: common `(n[:q][:r])` syntax and current MusicXML roundtrip through `time-modification` plus note-level `tuplet`
+        - not currently claimed: broader ratio/edge semantics or more complex span behavior
       - Done when:
         - remaining tuplet edge semantics are either tested or explicitly excluded
-    - [ ] `ABC-COV-011` (`P2`, `policy`, initial stance: `support bounded subset`)
+    - [x] `ABC-COV-011` (`P2`, `policy`, initial stance: `support bounded subset`)
       - Decide whether `U:` remains import-only or needs broader parity/export support
+      - Progress:
+        - `docs/spec/ABC_STANDARD_COVERAGE.md` now fixes `U:` as bounded import-first functionality
+        - `docs/spec/ABC_IO.md` now mirrors the same `U:` stance
+        - current supported subset is explicit:
+          - single-character alias import
+          - `!decor!` / `+decor+` right-hand side forms
+          - malformed `U:` ignored
+        - export parity for `U:` is intentionally not claimed
       - Done when:
         - `U:` support boundary is explicitly written down
-    - [ ] `ABC-COV-015` (`P2`, `mixed`, initial stance: `support bounded subset`)
+    - [x] `ABC-COV-015` (`P2`, `mixed`, initial stance: `support bounded subset`)
       - Audit lyrics alignment, multi-verse behavior, and numbering scope
+      - Progress:
+        - `docs/spec/ABC_STANDARD_COVERAGE.md` now fixes the lyrics scope as a bounded subset
+        - `docs/spec/ABC_IO.md` now mirrors the same lyric stance
+        - supported: common `w:` underlay import/export and ordinary hyphenated lyric handling
+        - not currently claimed: full alignment nuance, full multi-verse parity, or verse numbering semantics
       - Done when:
         - lyric scope is bounded and tested for the chosen supported subset
-    - [ ] `ABC-COV-001` (`P2`, `policy`, initial stance: `support bounded subset`)
+    - [x] `ABC-COV-001` (`P2`, `policy`, initial stance: `support bounded subset`)
       - Decide and document which non-core standard information fields are intentionally unsupported versus planned
+      - Progress:
+        - `docs/spec/ABC_STANDARD_COVERAGE.md` now fixes the supported core field subset to `X/T/C/M/L/K/Q` plus separately-scoped `V:`
+        - non-core information fields are now explicitly marked unsupported at the semantic level even if they are lexically tolerated by header scanning
+        - `docs/spec/ABC_IO.md` now mirrors the same information-field stance
       - Done when:
         - non-core field policy is written in spec and reflected in linked docs
-    - [ ] `ABC-COV-002` (`P2`, `policy`, initial stance: `support bounded subset`)
+    - [x] `ABC-COV-002` (`P2`, `policy`, initial stance: `support bounded subset`)
       - Decide whether the supported inline-field subset stops at `[K/M/L/Q/V]` or should expand
+      - Progress:
+        - `docs/spec/ABC_STANDARD_COVERAGE.md` now fixes the supported inline-field subset at `[K/M/L/Q/V]`
+        - unsupported inline fields are now explicitly documented as warning-based skips
+        - `docs/spec/ABC_IO.md` now mirrors the same inline-field stance
       - Done when:
         - supported inline subset is explicitly bounded in spec text
-    - [ ] `ABC-COV-013` (`P2`, `policy`, initial stance: `support bounded subset`)
+    - [x] `ABC-COV-013` (`P2`, `policy`, initial stance: `support bounded subset`)
       - Define the supported annotation behavior and explicit exclusions
+      - Progress:
+        - `docs/spec/ABC_STANDARD_COVERAGE.md` now fixes the bounded annotation subset
+        - `docs/spec/ABC_IO.md` now mirrors the same annotation stance
+        - supported: common quoted non-harmonic text as direction words / annotations
+        - supported fallback: unsupported quoted chord-like text becomes annotation/words rather than forced `harmony`
+        - broader annotation placement semantics are intentionally not claimed
       - Done when:
         - supported annotation subset and exclusions are written down
-    - [ ] `ABC-COV-003` (`P3`, `policy`, initial stance: `defer intentionally`)
+    - [x] `ABC-COV-003` (`P3`, `policy`, initial stance: `defer intentionally`)
       - Either implement field continuation support or explicitly freeze it as unsupported in the practical scope
+      - Progress:
+        - `docs/spec/ABC_STANDARD_COVERAGE.md` now freezes field continuation as intentionally deferred / unsupported in the current bounded target
+        - `docs/spec/ABC_IO.md` now mirrors the same field-continuation stance
+        - lexical tolerance is explicitly distinguished from actual continuation support
       - Done when:
         - continuation is explicitly frozen as unsupported or promoted to planned work
-    - [ ] `ABC-COV-010` (`P3`, `policy`, initial stance: `out of practical scope`)
+    - [x] `ABC-COV-010` (`P3`, `policy`, initial stance: `out of practical scope`)
       - Decide whether `s:` symbol lines are in scope or intentionally out of scope
+      - Progress:
+        - `docs/spec/ABC_STANDARD_COVERAGE.md` now fixes `s:` symbol lines as out of practical scope
+        - `docs/spec/ABC_IO.md` now mirrors the same symbol-line stance
+        - there is explicitly no current import/export or roundtrip support claim
       - Done when:
         - `s:` is explicitly marked in-scope or frozen out-of-scope
-    - [ ] `ABC-COV-014` (`P3`, `policy`, initial stance: `support bounded subset`)
+    - [x] `ABC-COV-014` (`P3`, `policy`, initial stance: `support bounded subset`)
       - Decide whether broad practical acceptance is enough or whether stricter conformance is required
+      - Progress:
+        - `docs/spec/ABC_STANDARD_COVERAGE.md` now fixes the order-of-constructs stance as bounded practical acceptance
+        - `docs/spec/ABC_IO.md` now mirrors the same acceptance philosophy
+        - supported stance: common construct orderings already handled by the parser
+        - explicit limit: full formal order-of-constructs conformance is not currently claimed
+        - explicit boundary: unusual ordering is only rejected when it becomes structurally ambiguous or breaks directive/body interpretation
       - Done when:
         - acceptance philosophy and explicit exclusions are written down
   - Resume note for next ABC session:
     - Stop point:
-      - `ABC-COV-009` policy has been written down in `docs/spec/ABC_STANDARD_COVERAGE.md` and `docs/spec/ABC_IO.md`
-      - canonical `!arpeggio!` export is now aligned in code/tests
-      - `!+!` / `!plus!`, mordent-family canonical export, and `!slide!` stop-side extension policy are already aligned with the written policy
-    - First task to resume:
-      - decide whether `ABC-COV-009` can be closed outright, or whether one more focused regression pass is needed before checking it off
-    - If `ABC-COV-009` is closed, continue in this order:
-      - 1. `ABC-COV-016` voice-property enumeration
-      - 2. `ABC-COV-005` beam-separation preservation target
-      - 3. `ABC-COV-006` repeat / ending edge audit
+      - the current `ABC-COV-*` coverage pass is closed in md
+      - `docs/spec/ABC_STANDARD_COVERAGE.md` is now the completion baseline, not an active discovery scratchpad
+    - Continue in this order:
+      - 1. implementation/test follow-up where a closed policy still needs stronger code parity
+      - 2. add or strengthen regression tests for bounded subsets that are already policy-closed
+      - 3. only after that, derive new ABC backlog items if real input data exposes uncovered gaps
+    - Closed in latest md pass:
+      - `ABC-COV-004` clef breadth policy
+      - `ABC-COV-008` tuplet edge policy
+      - `ABC-COV-015` lyrics scope
+    - Recent code/test follow-up already completed after the md pass:
+      - added `MusicXML -> ABC -> MusicXML` regression for `alto` / `tenor` C-clef headers
+      - fixed hyphenated `w:` lyric tokenization so exported `hal- le- lu` roundtrips back to `begin/middle/end`
+      - added bounded-subset roundtrip regression for hyphenated lyrics
+      - added bounded-subset regression for common tuplet shorthand `(3`
+      - added roundtrip regression proving unsupported chord-like quoted text stays in annotation/words instead of becoming `harmony`
+      - added canonicalization regressions for decoration aliases (`!roll!`, `!arpeggiate!`, mordent-family aliases, wedge aliases)
+      - fixed literal `!+!` stopped alias import so it roundtrips back to canonical `!stopped!`
+      - added stop-side wedge alias regressions so `!<)!` / `!>)!` canonicalize to `!crescendo)!` / `!diminuendo)!`
+      - added stopped-family hyphen alias regression so `!stopped-horn!` canonicalizes to `!stopped!`
+      - added spaced-alias regressions so `!breath mark!`, `!open string!`, and `!snap pizzicato!` canonicalize to `!breath!`, `!open!`, and `!snap!`
+      - added more canonicalization regressions for `!strong-accent!`, `!down-bow!`, and `!triple tongue!`
+      - added technical-family regressions so `!toe mark!`, `!thumb pos!`, and `!thumb position!` canonicalize to `!toe!` / `!thumb!`
+      - added more technical-family regressions so `!down bow!`, `!double-tongue!`, and `!heel mark!` canonicalize to `!downbow!` / `!doubletongue!` / `!heel!`
+      - added short-form alias regressions so `!stacc!`, `!stac!`, and `!up-bow!` canonicalize to `!staccato!` / `!upbow!`
+      - added hyphen-alias regressions so `!breath-mark!`, `!triple-tongue!`, and `!thumb-position!` canonicalize to `!breath!` / `!tripletongue!` / `!thumb!`
+      - added turn-family regression so `!lowerturn!` canonicalizes to `!invertedturn!`
+      - aligned plain trill behavior so `!tr!` / `!triller!` canonicalize to `!trill!` without being promoted to long-trill start; added `!spiccato! -> !wedge!` regression
+      - moved `!editorial!` / `!courtesy!` from deferred 2.2 delta items into the bounded supported subset with import/export/roundtrip coverage
     - Files to open first:
       - `docs/spec/ABC_STANDARD_COVERAGE.md`
       - `docs/spec/ABC_IO.md`
@@ -229,24 +341,20 @@
     - [x] warn on unsupported bare `V:` tail words instead of letting them fail later as note/rest parsing errors
   - Resume note (2026-04-06):
     - Stop point for this series: quoted chord symbols and standard shorthand decoration symbols are already covered.
-    - Next restart target: continue the remaining standard-decoration expansion, not the chord-symbol work.
+    - Next restart target: continue only small decoration-audit follow-up, not a broad expansion pass.
     - Recommended restart order:
-      - 1. audit standard ABC 2.1 decoration names against the currently hardcoded subset
-      - 2. pick one small missing standard decoration cluster at a time
-      - 3. add import support
-      - 4. add `MusicXML -> ABC -> MusicXML` regression tests
-      - 5. update `docs/spec/ABC_IO.md` and this TODO entry
+      - 1. audit whether any standard ABC 2.1 decoration aliases are still import-only without canonical roundtrip coverage
+      - 2. add a small regression only if a real missing alias or canonicalization gap is found
+      - 3. update `docs/spec/ABC_IO.md` and this TODO entry only if the bounded supported subset changes
     - Current practical interpretation:
       - quoted chord symbols are now good enough for common forms; broader coverage can wait
-      - the main remaining ABC-series work is standard decoration coverage
+      - the main remaining ABC-series work is small decoration alias audit, not broad standard-surface expansion
   - Decoration backlog from ABC decoration-list cross-check:
     - Standard 2.1 candidates still missing or only partially supported:
-      - Partial with semantics/export-policy still open:
-        - implementation follow-up so canonical export fully matches the now-settled policy for:
-          - `!arpeggio!` versus `!roll!`
-          - `!+!` / `!plus!`
-          - mordent-family export naming: `!lowermordent!` / `!uppermordent!` / `!mordent!` / `!pralltriller!`
-          - `!slide!` stop-side standard policy versus current `!slide-stop!` extension
+      - No current standard 2.1 blocker is known inside the bounded supported subset.
+      - Remaining follow-up is audit-oriented:
+        - check whether any standard alias is still accepted only on import without canonical roundtrip regression
+        - keep `!slide-stop!` as extension-only unless the bounded slide policy is intentionally widened later
     - Completed in current series:
       - phrase marks `!shortphrase!` / `!mediumphrase!` / `!longphrase!` now import/export and roundtrip via MusicXML `other-articulation`
       - `!trill(!` / `!trill)!` now import/export and roundtrip as long-trill start/stop markers
@@ -258,12 +366,11 @@
       - `!>!` / `!emphasis!` now import as accent aliases and roundtrip back to canonical `!accent!`
       - `!turnx!` / `!invertedturnx!` now import/export and roundtrip as slashed turn variants
     - Standard 2.2 / ext candidates still missing or only partially supported:
-      - `!editorial!`
-      - `!courtesy!`
+      - none currently prioritized inside the bounded accidental-decoration subset
     - Recommended execution order for the next decoration pass:
-      - 1. align implementation/export behavior with the now-settled decoration policy items
-      - 2. add regression tests where canonical export spelling changes
-      - 3. only after that, consider 2.2 / ext additions such as `!editorial!` / `!courtesy!`
+      - 1. do a final alias audit against the current hardcoded decoration table
+      - 2. add regression tests only for any real canonicalization gap found there
+      - 3. only after that, consider any further 2.2 / ext additions beyond `!editorial!` / `!courtesy!`
   - A. Spec says or strongly implies "supported", but implementation is still weak:
     - Completed in current series:
       - Chord-tie handling now ties whole chords in paths such as `[CE]-[CE]`.

--- a/docs/spec/ABC_IO.md
+++ b/docs/spec/ABC_IO.md
@@ -102,6 +102,55 @@ The parser accepts three categories of input:
 - voice directives (`V:` with optional `name`, `clef`, `transpose`)
 - body note/rest/chord tokens
 
+### Current information-field stance
+
+`mikuscore` currently treats the following as the supported core ABC field subset:
+
+- `X:`
+- `T:`
+- `C:`
+- `M:`
+- `L:`
+- `K:`
+- `Q:`
+- `V:` (with the bounded voice-property subset documented separately)
+
+Fields outside that core subset are not currently part of the supported ABC interchange target.
+They may be lexically tolerated by the header scan, but they are not claimed as semantically supported import/export behavior.
+
+### Current inline-field stance
+
+`mikuscore` currently treats the following as the supported inline-field subset:
+
+- `[K:...]`
+- `[M:...]`
+- `[L:...]`
+- `[Q:...]`
+- `[V:...]`
+
+Inline fields outside that subset are not currently part of the supported ABC interchange target.
+They are skipped with warnings rather than treated as semantically supported behavior.
+
+### Current field-continuation stance
+
+`mikuscore` does not currently treat continued information-field lines as part of the supported ABC interchange subset.
+
+This means:
+
+- field continuation is currently unsupported
+- lexical tolerance of adjacent header text does not count as continuation support
+- continuation support is intentionally deferred unless practical input evidence makes it necessary
+
+### Current symbol-line stance
+
+`mikuscore` does not currently treat standard `s:` symbol lines as part of the supported ABC interchange subset.
+
+This means:
+
+- `s:` symbol lines are out of practical scope for the present bounded target
+- there is no current import/export or roundtrip support claim for them
+- this area stays out of scope unless practical input demand changes priority
+
 #### 2. Compatibility behavior
 
 - optional `%%score` voice ordering directive
@@ -134,6 +183,90 @@ Parser is intentionally lenient for real-world ABC:
 - should not pass unknown directive-tail fragments through as ordinary body note text
 - should warn on unsupported bare `V:` tail words instead of letting them fail later as body note/rest parsing errors
 
+### Current overlay policy
+
+`mikuscore` currently treats ABC overlay syntax `&` as bounded import-side compatibility behavior:
+
+- accepted on import
+- preserved by expanding overlay material into synthetic overlay voices / parts
+- not currently claimed as faithful one-part multi-voice preservation
+- not currently claimed as exact standard ABC `&` roundtrip preservation
+
+This is an intentional scope boundary, not an accidental gap.
+
+### Current beam / whitespace policy
+
+`mikuscore` currently uses a bounded beam policy:
+
+- on import, inter-note whitespace between beamable notes is treated as an explicit beam-break hint
+- this affects the current voice/measure parse stream and is used when forming MusicXML beam state
+- beat boundaries still split implicit beam runs even when there is no whitespace
+- on export, ABC is not currently generated with beam-specific spacing preservation; note tokens are emitted in ordinary measure text and original spacing is not replayed verbatim
+
+This means:
+
+- beam-break intent is preserved on ABC import into MusicXML
+- exact source whitespace used for beam layout is not currently treated as canonical roundtrip data
+
+### Current supported `V:` property subset
+
+In the standard ABC path, `mikuscore` currently treats the following `V:` properties as the supported working subset:
+
+- `name=...`
+  - supported on import and export
+- `clef=...`
+  - supported on import and export for the common working subset: `treble`, `bass`, `alto`, `tenor`, `c3`, `c4`
+- `transpose=...`
+  - accepted on import as a bounded chromatic transpose value
+  - not currently emitted back as standard `V:` metadata on export
+  - roundtrip export currently relies on `%@mks transpose ...` extension metadata instead
+
+In other words:
+
+- standard `V:` transpose support is currently `import-partial`
+- transpose-preserving roundtrip is currently `extension-assisted` through `%@mks transpose ...`
+
+The following standard voice-property family is currently outside the supported standard subset and should be treated as unsupported unless documented otherwise:
+
+- `staves`
+- `brace`
+- `bracket`
+- `merge`
+- `middle`
+- `gchords`
+
+Current handling for unsupported standard `V:` properties:
+
+- unsupported `key=value` voice-property tokens are skipped in the standard path
+- they should produce warnings rather than silently expanding the supported subset
+- they should not be reinterpreted as body note text
+
+Compatibility note:
+
+- recognized bare clef shorthand such as `V:2 bass` is accepted as compatibility behavior, not as a separate standard property form
+
+### Current clef / transposition stance
+
+`mikuscore` currently uses a bounded clef / transposition policy:
+
+- supported standard clef subset in `V:` metadata:
+  - `treble`
+  - `bass`
+  - `alto`
+  - `tenor`
+  - `c3`
+  - `c4`
+- supported compatibility behavior:
+  - recognized bare clef shorthand such as `V:2 bass`
+- partial / extension-assisted:
+  - standard `V:` transpose is currently import-partial
+  - transpose-preserving roundtrip currently relies on `%@mks transpose ...`
+
+Current limits:
+
+- broader standard clef forms beyond the current recognized subset are not currently claimed
+- full standard `V:` transpose export parity is not currently claimed
+
 ### Supported musical tokens
 
 #### Standard musical content
@@ -146,6 +279,60 @@ Parser is intentionally lenient for real-world ABC:
 - tuplets (`(n[:q][:r]`)
 - broken rhythm (`>` / `<`)
 - barlines
+
+#### Current quoted chord-symbol subset
+
+Quoted text attached to notes is split between:
+
+- harmonic chord-symbol parsing into MusicXML `harmony`
+- ordinary quoted annotation text into MusicXML direction words
+
+Current supported harmonic quoted-chord subset:
+
+- root / bass spelling
+  - `A`-`G`
+  - optional `#` / `b`
+  - optional slash bass with the same spelling subset
+- supported suffixes
+  - ``
+  - `m`, `min`
+  - `6`, `m6`, `min6`
+  - `7`, `9`, `11`, `13`
+  - `maj7`, `maj9`
+  - `m7`, `min7`, `m9`, `min9`
+  - `7sus4`, `sus4`, `sus2`
+  - `dim`, `dim7`, `aug`, `+`, `m7b5`, `min7b5`, `ø`
+
+Current fallback rule:
+
+- quoted text outside that inventory is treated as annotation/words, not forced into MusicXML `harmony`
+
+### Current annotation stance
+
+`mikuscore` currently uses a bounded annotation policy for quoted non-harmonic text:
+
+- common quoted non-harmonic text attached to notes is supported as MusicXML direction words / annotations
+- quoted text that does not fit the supported harmony inventory falls back to annotation/words rather than being forced into `harmony`
+- this bounded subset is supported as practical interchange behavior
+
+Current limits:
+
+- broader annotation placement semantics are not currently claimed as preserved
+- the current support target is ordinary quoted annotation text, not full ABC annotation behavior parity
+
+### Current order-of-constructs stance
+
+`mikuscore` currently uses a bounded practical-acceptance stance for ABC construct ordering:
+
+- common construct orderings already handled by the parser are supported
+- practical acceptance of structurally recognizable real-world ABC is preferred over strict rejection based only on narrower construct-order readings
+- unsupported order cases should fail only when they become structurally ambiguous or break directive/body interpretation
+
+Current limits:
+
+- full formal conformance to every standard order-of-constructs nuance is not currently claimed
+- exact acceptance parity with every ABC implementation is not currently claimed
+- lexical tolerance of unusual ordering does not by itself widen the supported subset unless the behavior is documented
 
 #### Supported decorations and grace forms
 
@@ -258,6 +445,99 @@ Generation policy:
 - preserves tie semantics using both `<tie>` and `<notations><tied>`
 - restores tuplet semantics using both `<time-modification>` and `<notations><tuplet>`
 - restores standard repeat/ending barlines and key changes from ABC surface syntax, and restores non-standard measure metadata (`number`, `implicit`, extra repeat hints when needed) from `%@mks measure`
+
+### Current repeat / ending policy
+
+`mikuscore` currently uses this bounded repeat / ending policy:
+
+- standard ABC surface is preferred for common cases:
+  - `|:`
+  - `:|`
+  - `[1`, `[2`
+  - `|1`, `:|2`
+- `%@mks measure ...` is used only for edge semantics not directly represented in the current standard export path, including:
+  - backward repeat counts beyond the ordinary case via `times=...`
+  - ending stop type `discontinue` via `ending-stop=... ending-type=discontinue`
+
+This means:
+
+- common repeat / ending forms are standard-path behavior
+- some edge semantics are currently extension-assisted rather than pure standard-surface roundtrip behavior
+
+### Current slur policy
+
+`mikuscore` currently uses a bounded slur policy:
+
+- ABC `(` / `)` slur markers are supported in common note-to-note cases
+- MusicXML note-level slur start/stop presence is exported/imported in simple cases
+- slur handling is currently presence-based rather than identity-based
+
+Current limits:
+
+- slur numbering / nested-slur identity is not currently claimed as preserved
+- a slur stop without a preceding non-rest note is treated as unsupported and yields a warning in the ABC import path
+- ties are tracked separately and have stronger preservation guarantees than generic slur span identity
+
+### Current tuplet stance
+
+`mikuscore` currently uses a bounded tuplet policy:
+
+- common ABC tuplet syntax `(n[:q][:r])` is supported in ordinary note sequences
+- MusicXML roundtrip through `<time-modification>` and note-level `<tuplet>` start/stop is supported in the current path
+- common explicit tuplet export such as `(3:2:3` is supported
+
+Current limits:
+
+- broader ratio/edge semantics beyond the current tested subset are not currently claimed
+- broader cross-measure or more complex tuplet-span semantics are not currently claimed
+
+### Current lyric stance
+
+`mikuscore` currently uses a bounded lyric policy for ABC `w:` underlay:
+
+- common `w:` lyric import/export is supported
+- common single-verse lyric alignment in ordinary note sequences is supported
+- ordinary hyphenated lyric tokens are supported in the current `w:` path
+
+Current limits:
+
+- full lyric alignment nuance across rests, spacers, grace, and more complex spacing is not currently claimed
+- full multi-verse behavior is not currently claimed
+- verse numbering semantics are not currently claimed
+
+### Current ABC 2.2 delta stance
+
+The following ABC 2.2 decorations are currently supported in a bounded accidental-level subset:
+
+- `!editorial!`
+- `!courtesy!`
+
+Current bounded interpretation:
+
+- `!editorial!`
+  - applies to the following explicit accidental in the ABC import path
+  - maps to MusicXML `accidental editorial="yes"`
+- `!courtesy!`
+  - applies to the following explicit accidental in the ABC import path
+  - maps to MusicXML `accidental cautionary="yes"`
+
+Current limits:
+
+- support is intentionally bounded to accidental-level editorial/cautionary flags
+- broader engraving/layout semantics beyond those accidental attributes are not currently claimed
+
+### Current `U:` stance
+
+`mikuscore` currently treats `U:` as bounded import-first functionality:
+
+- supported
+  - single-character user-defined decoration aliases on import
+  - right-hand side decoration text written as either `!decor!` or `+decor+`
+- not currently claimed
+  - export of `U:` declarations as part of standard ABC roundtrip output
+  - broader parity for redefinable-symbol semantics beyond the current alias-import subset
+
+Malformed `U:` declarations are ignored rather than treated as fatal parse errors.
 - restores transpose (`chromatic`, `diatonic`) from `%@mks transpose`
 - inserts a fallback whole-rest note for empty measures
 

--- a/docs/spec/ABC_STANDARD_COVERAGE.md
+++ b/docs/spec/ABC_STANDARD_COVERAGE.md
@@ -150,20 +150,80 @@ Start here when converting coverage findings into concrete TODO items.
 | Core identification / title / attribution: `X:`, `T:`, `C:` | supported | Supported in ordinary import/export flows. |
 | Core musical defaults: `M:`, `L:`, `K:`, `Q:` | supported | Supported in ordinary import/export flows, including inline-core variants where implemented. |
 | Voice field: `V:` | partial | Common voice metadata is supported, but full property breadth is not yet covered. |
-| Other standard fields outside the current core subset | unsupported | No complete support claim yet. |
+| Other standard fields outside the current core subset | unsupported | They may be lexically accepted as inert header text, but no supported semantic import/export claim is made for them. |
+
+### 3.1 Information-Field Policy Notes
+
+Current bounded subset for `mikuscore` header-field support:
+
+- supported core subset
+  - `X:`, `T:`, `C:`
+  - `M:`, `L:`, `K:`, `Q:`
+  - `V:` remains covered separately under the voice-property policy
+- unsupported non-core field family
+  - standard information fields outside the current core subset are not part of the supported ABC interchange target
+  - they may be lexically tolerated in the header scan, but `mikuscore` does not currently claim semantic import/export support for them
+- export policy
+  - standard ABC export emits only the current core subset and `V:` sections needed by the current bounded target
+
+Practical result mode for `ABC-COV-001`:
+
+- `support bounded subset`
+- keep the supported header-field family explicit
+- do not treat lexically accepted but semantically inert fields as supported ABC coverage
 
 #### 3.2 Use of fields within the tune body
 
 | Inline field group | Status | Current interpretation for `mikuscore` |
 |---|---|---|
 | Core inline fields: `[K:...]`, `[M:...]`, `[L:...]`, `[Q:...]`, `[V:...]` | supported | These are supported in the current standard path. |
-| Broader inline-field family beyond the current core subset | unsupported | No complete support claim yet. |
+| Broader inline-field family beyond the current core subset | unsupported | Unsupported inline fields are skipped with warnings rather than treated as semantically supported. |
+
+### 3.2 / 7.3 Inline-Field Policy Notes
+
+Current bounded subset for `mikuscore` inline-field support:
+
+- supported
+  - `[K:...]`
+  - `[M:...]`
+  - `[L:...]`
+  - `[Q:...]`
+  - `[V:...]`
+- unsupported
+  - broader inline-field family beyond that core subset
+- handling rule
+  - unsupported inline fields are skipped with warnings
+  - lexical recognition of an inline field does not count as semantic support
+
+Practical result mode for `ABC-COV-002`:
+
+- `support bounded subset`
+- keep the inline-field subset explicit at `[K/M/L/Q/V]`
+- require deliberate policy work before expanding beyond that subset
 
 #### 3.3 Field continuation
 
 | Area | Status | Current interpretation for `mikuscore` |
 |---|---|---|
 | Continued information-field lines | unsupported | No current support claim or dedicated reconstruction policy. |
+
+### 3.3 Field-Continuation Policy Notes
+
+Current policy for `mikuscore`:
+
+- unsupported in the present bounded ABC target
+  - continued information-field lines are not part of the supported interchange subset
+  - lexical tolerance of adjacent header text does not count as continuation support
+- intentionally deferred
+  - field continuation will not be treated as planned work unless practical input evidence makes it necessary
+- rationale
+  - current core field subset works without continuation support
+  - continuation support looks low-value relative to other practical ABC interoperability gaps
+
+Practical result mode for `ABC-COV-003`:
+
+- `defer intentionally`
+- keep field continuation explicitly outside the current supported subset unless real-world demand changes that priority
 
 ### 4.6 Clefs and Transposition
 
@@ -173,12 +233,58 @@ Start here when converting coverage findings into concrete TODO items.
 | Broader standard clef forms and exact parity | partial | Full standard breadth and export parity are not yet closed. |
 | Voice-level transpose handling | partial | Some `V:`-level transpose behavior exists, but full standard coverage is not yet claimed. |
 
+### 4.6 Clef / Transposition Policy Notes
+
+Current policy for `mikuscore`:
+
+- supported in the bounded subset
+  - common standard `V:` clef values: `treble`, `bass`, `alto`, `tenor`, `c3`, `c4`
+  - compatibility shorthand import such as bare `V:2 bass`
+  - current clef export for the common recognized subset
+- partial / extension-assisted
+  - standard `V:` transpose is import-partial in the current path
+  - transpose-preserving roundtrip currently relies on `%@mks transpose ...`
+- intentionally not claimed
+  - broader standard clef breadth or exact parity beyond the current recognized subset
+  - full standard `V:` transpose parity on export
+- rationale
+  - the common working clef subset already covers practical interchange cases seen in current inputs
+  - explicit boundary-setting is clearer than implying broader clef/transpose parity than the implementation actually provides
+
+Practical result mode for `ABC-COV-004`:
+
+- `support bounded subset`
+- keep the current common clef subset and extension-assisted transpose story explicit
+- do not claim broader clef/transpose parity beyond the current recognized subset
+
 ### 4.7 Beams
 
 | Sub-area | Status | Current interpretation for `mikuscore` |
 |---|---|---|
 | Duration-based beam reconstruction | supported | Normal export reconstructs beams from note values. |
-| Whitespace as explicit beam-separation intent | partial | Import recognizes it, but export does not yet preserve ABC spacing intent faithfully. |
+| Whitespace as explicit beam-separation intent | partial | Import recognizes it as a beam-break hint within a voice/measure beam run, but export does not preserve original ABC spacing textually. |
+| Exact source whitespace preservation for beam grouping | unsupported | Original ABC inter-note spacing is not currently treated as canonical roundtrip data. |
+
+### 4.7 Beam Policy Notes
+
+Current bounded subset for `mikuscore`:
+
+- import side
+  - whitespace between beamable notes is treated as an explicit beam-break hint
+  - this hint applies within the current voice and measure
+  - beat boundaries still split implicit beam runs even without whitespace
+- export side
+  - canonical export does not currently encode beam grouping through preserved ABC spacing patterns
+  - exported ABC uses ordinary token spacing and leaves beam reconstruction largely to downstream ABC consumers
+- roundtrip claim
+  - `mikuscore` currently preserves beam-break intent on ABC import into MusicXML
+  - `mikuscore` does not currently claim export-side preservation of original ABC whitespace used only as beam layout intent
+
+Practical result mode for `ABC-COV-005`:
+
+- `support bounded subset`
+- preserve import-side beam-break interpretation in the current MusicXML/ABC interchange level
+- do not treat exact original inter-note spacing as canonical interchange data unless a future extension carrier is introduced
 
 ### 4.8-4.10 Repeat Structure
 
@@ -187,6 +293,7 @@ Start here when converting coverage findings into concrete TODO items.
 | Sub-area | Status | Current interpretation for `mikuscore` |
 |---|---|---|
 | Common repeat barlines | supported | Standard repeat/barline handling works in common cases. |
+| Repeat counts beyond ordinary `:|` behavior | partial | Backward repeat is supported in the standard surface; explicit repeat counts beyond the ordinary case currently rely on `%@mks measure ... times=...` extension metadata. |
 | Broader repeat/barline variants and edge reconstruction | partial | Full closure is not yet claimed. |
 
 #### 4.9 First and second repeats
@@ -201,15 +308,56 @@ Start here when converting coverage findings into concrete TODO items.
 | Sub-area | Status | Current interpretation for `mikuscore` |
 |---|---|---|
 | Common variant-ending surface syntax | supported | Common standard syntax works in the current path. |
+| Ending stop type `discontinue` | partial | Ordinary start/stop endings are supported in the standard surface; `discontinue` currently relies on `%@mks measure ... ending-stop=... ending-type=discontinue` extension metadata. |
 | Broader variant-ending semantics | partial | Full semantics and edge-case coverage remain to be audited. |
+
+### 4.8-4.10 Repeat / Ending Policy Notes
+
+Current bounded subset for `mikuscore`:
+
+- standard ABC surface support
+  - common repeat barlines: `|:` and `:|`
+  - common alternate-ending starts/stops: `[1`, `[2`, `|1`, `:|2`
+- extension-assisted repeat / ending preservation
+  - backward repeat counts beyond the ordinary case use `%@mks measure ... times=...`
+  - ending stop type `discontinue` uses `%@mks measure ... ending-stop=... ending-type=discontinue`
+- unsupported or not yet claimed
+  - broader repeat/barline variants beyond the current common subset
+  - broader variant-ending semantics beyond ordinary start/stop behavior
+
+Practical result mode for `ABC-COV-006`:
+
+- `support bounded subset`
+- prefer standard ABC surface syntax for common repeat / ending cases
+- use `%@mks measure` only for edge semantics that the current standard export path does not encode directly
 
 ### 4.11 Ties and Slurs
 
 | Sub-area | Status | Current interpretation for `mikuscore` |
 |---|---|---|
 | Tie syntax and common reconstruction | supported | Common tie handling is solid, including whole-chord tie paths. |
-| Slur syntax acceptance | supported | Common slur syntax is accepted. |
-| Exact slur span reconstruction and edge semantics | partial | Cross-format span behavior still needs care. |
+| Slur syntax acceptance | supported | Common unnumbered slur start/stop syntax is accepted. |
+| Exact slur span reconstruction and edge semantics | partial | Cross-format span behavior still needs care; numbered/nested slur identity and broader edge semantics are not fully preserved. |
+
+### 4.11 Slur Policy Notes
+
+Current bounded subset for `mikuscore` slur handling:
+
+- supported
+  - ordinary ABC `(` / `)` slur markers in common note-to-note cases
+  - MusicXML note-level slur start/stop presence in simple cases
+- current interpretation limits
+  - slur handling is currently presence-based, not identity-based
+  - `mikuscore` does not currently claim faithful preservation of slur numbering, nested slur identity, or other exact span-matching semantics
+  - ABC slur stop without a preceding non-rest note is treated as unsupported and currently yields a warning
+- tie distinction
+  - ties remain stronger than slurs and are tracked separately; chord ties are preserved more faithfully than generic slur span identity
+
+Practical result mode for `ABC-COV-007`:
+
+- `support bounded subset`
+- preserve common start/stop slur presence
+- do not claim numbered/nested slur identity preservation until a stronger span model is implemented
 
 ### 4.13 Tuplets
 
@@ -217,6 +365,27 @@ Start here when converting coverage findings into concrete TODO items.
 |---|---|---|
 | Core tuplet syntax and common roundtrip | supported | Core parse/export works in the current path. |
 | Full standard ratio nuance and edge semantics | partial | Full audit closure is not yet complete. |
+
+### 4.13 Tuplet Policy Notes
+
+Current policy for `mikuscore`:
+
+- supported in the bounded subset
+  - common ABC tuplet syntax `(n[:q][:r])` in ordinary note sequences
+  - common MusicXML roundtrip through `<time-modification>` and note-level `<tuplet>` start/stop
+  - common explicit tuplet export such as `(3:2:3` in the current MusicXML -> ABC path
+- intentionally not claimed
+  - full standard nuance for broader ratio/edge semantics beyond the currently tested subset
+  - broader cross-measure or more complex tuplet-span semantics
+- rationale
+  - core tuplet interchange is already useful and covered by focused regression tests
+  - the remaining work is edge clarification, not basic support
+
+Practical result mode for `ABC-COV-008`:
+
+- `support bounded subset`
+- keep common tuplet syntax and current MusicXML roundtrip behavior supported and tested
+- do not claim broader ratio/span semantics beyond the current bounded subset
 
 ### 4.14 Decorations (ABC 2.1)
 
@@ -286,27 +455,108 @@ These notes are the current canonical policy for standard-decoration handling.
 |---|---|---|
 | `s:` symbol lines | unsupported | No current support claim. |
 
+### 4.15 Symbol-Line Policy Notes
+
+Current policy for `mikuscore`:
+
+- out of practical scope for the present bounded ABC target
+  - standard `s:` symbol lines are not part of the supported interchange subset
+  - there is no current import/export or roundtrip support claim for them
+- intentionally frozen out of scope unless real input demand changes priority
+- rationale
+  - symbol lines currently look low-value compared with other musical-structure interoperability work
+  - leaving them unsupported is clearer than implying partial support without a defined preservation model
+
+Practical result mode for `ABC-COV-010`:
+
+- `out of practical scope`
+- keep `s:` explicitly outside the current bounded support target unless practical demand changes
+
 ### 4.16 Redefinable Symbols
 
 | Sub-area | Status | Current interpretation for `mikuscore` |
 |---|---|---|
 | `U:` single-character import aliases | supported | Current import path supports user-defined decoration aliases. |
-| Broader `U:` parity, export, and exact standard semantics | partial | Full support claim is not yet made. |
+| Broader `U:` parity, export, and exact standard semantics | partial | Current support is import-first; export parity and broader semantics are not claimed. |
+
+### 4.16 `U:` Policy Notes
+
+Current bounded subset for `mikuscore`:
+
+- supported
+  - import of `U:` single-character decoration aliases
+  - both `!decor!` and `+decor+` style right-hand side wrappers in the current import path
+- intentionally not claimed
+  - export of `U:` declarations as a standard ABC roundtrip feature
+  - exact parity for broader redefinable-symbol semantics beyond the current single-character decoration-alias import behavior
+- malformed input handling
+  - malformed `U:` declarations are ignored rather than treated as fatal parse errors
+
+Practical result mode for `ABC-COV-011`:
+
+- `support bounded subset`
+- keep `U:` as import-first functionality
+- do not currently require `U:` export parity for ABC completion claims
 
 ### 4.18 Chord Symbols
 
 | Sub-area | Status | Current interpretation for `mikuscore` |
 |---|---|---|
-| Common harmonic quoted symbols | partial | Many common forms now roundtrip through MusicXML `harmony`. |
-| Broader quality inventory and edge spelling | partial | Coverage remains incomplete. |
+| Common harmonic quoted symbols | supported | The current bounded inventory roundtrips through MusicXML `harmony`. |
+| Broader quality inventory and edge spelling | partial | Coverage remains incomplete; unsupported chord-like quoted text falls back to annotation/words instead of being forced into `harmony`. |
 | Full standard chord-symbol breadth | unsupported | No full support claim yet. |
+
+### 4.18 Chord-Symbol Policy Notes
+
+Current bounded subset for `mikuscore` quoted chord-symbol support:
+
+- supported root spelling
+  - `A`-`G`
+  - optional `#` / `b`
+  - optional slash bass with the same root spelling subset
+- supported suffix inventory
+  - major: empty suffix
+  - minor: `m`, `min`
+  - sixths: `6`, `m6`, `min6`
+  - sevenths / extensions: `7`, `9`, `11`, `13`, `maj7`, `maj9`, `m7`, `min7`, `m9`, `min9`
+  - suspended / altered common subset: `7sus4`, `sus4`, `sus2`
+  - diminished / augmented subset: `dim`, `dim7`, `aug`, `+`, `m7b5`, `min7b5`, `ø`
+- export policy
+  - recognized MusicXML harmony kinds are exported back to canonical ABC quoted chord symbols in the current subset
+  - unsupported harmony kinds are not claimed as standard quoted-chord coverage
+- fallback policy
+  - quoted text outside the supported chord-symbol inventory is treated as annotation/words rather than forced into MusicXML `harmony`
+
+Practical result mode for `ABC-COV-012`:
+
+- `support bounded subset`
+- keep the recognized quoted-chord inventory explicit and testable
+- treat unsupported chord-like quoted text as annotation fallback unless and until the supported inventory is deliberately expanded
 
 ### 4.19 Annotations
 
 | Sub-area | Status | Current interpretation for `mikuscore` |
 |---|---|---|
-| Common quoted non-harmonic text | partial | Common forms are partially mapped as direction words / annotations. |
+| Common quoted non-harmonic text | supported | Common quoted non-harmonic text is mapped as direction words / annotations in the current bounded subset. |
 | Broader annotation placement and behavior | unsupported | No full standard support claim yet. |
+
+### 4.19 Annotation Policy Notes
+
+Current bounded subset for `mikuscore` annotation handling:
+
+- supported
+  - quoted non-harmonic text attached to notes is imported as MusicXML direction words
+  - MusicXML direction words are exported as quoted ABC annotations in common cases
+  - quoted text that does not fit the supported chord-symbol inventory falls back to annotation/words
+- intentionally not claimed
+  - broader annotation placement semantics beyond the current note-attached quoted-text / direction-words path
+  - full parity for all standard annotation positioning/behavior nuances
+
+Practical result mode for `ABC-COV-013`:
+
+- `support bounded subset`
+- keep quoted non-harmonic text support explicit through the current direction-words path
+- do not claim broader annotation semantics beyond that bounded subset
 
 ### 4.20 Order of abc constructs
 
@@ -314,6 +564,27 @@ These notes are the current canonical policy for standard-decoration handling.
 |---|---|---|
 | Common construct orderings seen in practical ABC | partial | Many common orders work, but there is no complete conformance claim. |
 | Full order-of-constructs conformance | unsupported | Not yet audited to closure. |
+
+### 4.20 Order-of-Constructs Policy Notes
+
+Current policy for `mikuscore`:
+
+- supported in the bounded practical sense
+  - accept the common construct orderings already handled by the current parser
+  - prefer practical acceptance of structurally recognizable real-world ABC over strict rejection based only on a narrower reading of construct-order rules
+  - keep the failure boundary at cases that remain structurally ambiguous or that break note/directive interpretation
+- intentionally not claimed
+  - full formal conformance to every standard order-of-constructs nuance
+  - exact acceptance parity with every ABC implementation for unusual but technically legal construct orderings
+- rationale
+  - the current ABC target is practical interchange, not a fully validated reference implementation of the standard grammar
+  - the important boundary is to avoid misparsing or silently reclassifying structurally unclear input as supported music content
+
+Practical result mode for `ABC-COV-014`:
+
+- `support bounded subset`
+- keep broad practical acceptance where the current parser behavior is stable and musically interpretable
+- do not claim complete formal order-of-constructs conformance beyond that bounded subset
 
 ### 5. Lyrics
 
@@ -337,13 +608,40 @@ These notes are the current canonical policy for standard-decoration handling.
 |---|---|---|
 | Verse numbering semantics | unsupported | No current support claim. |
 
+### 5.1-5.3 Lyrics Policy Notes
+
+Current policy for `mikuscore`:
+
+- supported in the bounded subset
+  - common `w:` underlay import/export
+  - common single-verse lyric alignment in ordinary note sequences
+  - ordinary hyphenated lyric token handling in the current `w:` path
+- intentionally not claimed
+  - full lyric alignment nuance across rests, spacers, grace, and more complex spacing rules
+  - full multi-verse behavior parity
+  - verse numbering semantics
+- rationale
+  - current lyric support is useful for common interchange cases and is already exercised by focused tests
+  - broader lyric semantics should not be implied until alignment and multi-verse behavior are audited more deeply
+
+Practical result mode for `ABC-COV-015`:
+
+- `support bounded subset`
+- keep common `w:` lyric behavior supported and tested
+- do not claim broader lyric alignment, multi-verse, or numbering semantics beyond that subset
+
 ### 7. Multiple Voices
 
 #### 7.1 Voice properties
 
 | Sub-area | Status | Current interpretation for `mikuscore` |
 |---|---|---|
-| Common voice identity and metadata (`V:`, name, clef, common transpose) | partial | Common working subset is supported. |
+| Voice identity / lane selection (`V:id`) | supported | Standard voice selection and per-voice body routing are supported in normal import/export flow. |
+| Voice name (`name=...`) | supported | Import/export of `name=...` is supported in the current standard path. |
+| Common clef metadata (`clef=treble`, `clef=bass`, `clef=alto`, `clef=tenor`, `clef=c3`, `clef=c4`) | supported | Common working clef subset is supported on import/export; bare clef shorthand is accepted as compatibility behavior. |
+| Voice transpose property (`transpose=...`) | partial | Import path accepts a bounded chromatic transpose value, but standard `V:` transpose is not yet emitted on export; export currently relies on `%@mks transpose ...` extension metadata for roundtrip restoration. |
+| Extension-assisted voice transpose roundtrip (`%@mks transpose ...`) | ext-only | Voice transpose can be preserved on export/import roundtrip through `mikuscore` extension metadata even where the standard `V:` property is not emitted. |
+| Broader standard voice properties (`staves`, `brace`, `bracket`, `merge`, `middle`, `gchords`, etc.) | unsupported | No current support claim in the standard ABC path; unsupported properties should be skipped with warnings rather than silently treated as supported metadata. |
 | Full standard voice-property breadth | unsupported | No complete support claim yet. |
 
 #### 7.2 Breaking lines
@@ -366,14 +664,58 @@ These notes are the current canonical policy for standard-decoration handling.
 | Import acceptance of `&` overlay syntax | supported | Overlay syntax is accepted on import. |
 | Faithful preservation as one part with synchronized voices | unsupported | Current import expands overlays into synthetic parts instead. |
 
+### 7.4 Overlay Policy Notes
+
+Current policy for `mikuscore`:
+
+- supported
+  - accept ABC overlay syntax `&` on import
+  - preserve the overlaid musical material by expanding it into synthetic overlay voices / parts
+- intentionally not claimed
+  - faithful preservation as one MusicXML part with synchronized internal voices
+  - exact overlay identity roundtrip back to standard ABC `&` surface syntax
+- rationale
+  - current synthetic-part expansion preserves musical content well enough for practical import
+  - faithful same-part overlay preservation would require a stronger internal/roundtrip model than the current bounded ABC support target
+
+Practical result mode for `ABC-COV-017`:
+
+- `defer intentionally`
+- keep `&` import acceptance as supported compatibility behavior
+- do not currently require faithful same-part overlay preservation for ABC completion claims
+
 ## ABC 2.2 Delta
 
 This section tracks standard items that are better treated as post-2.1 additions rather than silently folded into the baseline table.
 
 | ABC 2.2 delta item | Status | Current interpretation for `mikuscore` |
 |---|---|---|
-| `!editorial!` decoration | unsupported | Not yet supported in the standard ABC path. |
-| `!courtesy!` decoration | unsupported | Not yet supported in the standard ABC path. |
+| `!editorial!` decoration | supported | Supported as a bounded accidental-decoration modifier on the following explicit accidental, mapped to MusicXML `accidental@editorial="yes"`. |
+| `!courtesy!` decoration | supported | Supported as a bounded accidental-decoration modifier on the following explicit accidental, mapped to MusicXML `accidental@cautionary="yes"`. |
+
+### ABC 2.2 Delta Policy Notes
+
+Current policy for `mikuscore`:
+
+- `!editorial!`
+  - now included in the bounded supported roadmap
+  - interpreted as a modifier for the following explicit accidental
+- `!courtesy!`
+  - now included in the bounded supported roadmap
+  - interpreted as a modifier for the following explicit accidental
+
+Rationale:
+
+- current ABC completion work is organized around the `2.1` baseline plus explicit delta triage
+- both decorations fit naturally into the existing accidental import/export path
+- both are standard 2.2 decorations with practical musical value, and are narrower than broader deferred engraving/layout areas
+- the bounded support target is accidental-level editorial/cautionary flags, not wider engraving semantics
+
+Practical result mode for `ABC-COV-018`:
+
+- `support bounded subset`
+- keep broader 2.2 delta expansion explicit, but treat these two accidental decorations as in-scope
+- do not include them in current ABC completion claims
 
 ## Derived Actionable Backlog
 
@@ -420,24 +762,24 @@ This is a non-binding starting recommendation for turning the backlog into TODOs
 
 | Item | Recommended result mode | Rationale |
 |---|---|---|
-| `ABC-COV-001` | `support bounded subset` | Core fields already work; the main need is to bound the rest. |
-| `ABC-COV-002` | `support bounded subset` | The current inline subset is already practical; expansion should be deliberate. |
+| `ABC-COV-001` | `support bounded subset` | Closed for the current bounded subset: the supported core field family is explicit, and non-core information fields are now explicitly treated as semantically unsupported even if lexically tolerated. |
+| `ABC-COV-002` | `support bounded subset` | Closed for the current bounded subset: supported inline fields are explicitly limited to `[K/M/L/Q/V]`, and broader inline fields are now explicitly treated as warning-based skips rather than supported semantics. |
 | `ABC-COV-003` | `defer intentionally` | Field continuation looks low-value unless real input data demands it. |
-| `ABC-COV-004` | `support bounded subset` | Common clefs/transpose already exist; the next step is explicit boundary-setting. |
-| `ABC-COV-005` | `support bounded subset` | Beam intent preservation likely needs a bounded target rather than full formal parity. |
-| `ABC-COV-006` | `support bounded subset` | Common repeat/ending forms are already strong; finish the edge boundary. |
-| `ABC-COV-007` | `support bounded subset` | Ties are strong, but slurs likely need explicit limits before deeper work. |
+| `ABC-COV-004` | `support bounded subset` | Closed for the current bounded subset: the supported clef set is explicit, compatibility shorthand is documented, and transpose remains explicitly partial/extension-assisted. |
+| `ABC-COV-005` | `support bounded subset` | Closed for the current bounded policy: import-side beam-break hints are supported, while exact export-side ABC spacing preservation remains out of scope and is now explicitly documented/tested. |
+| `ABC-COV-006` | `support bounded subset` | Closed for the current bounded subset: common repeat / ending forms use standard ABC surface, while edge cases such as repeat counts beyond the ordinary case and `ending type=discontinue` are explicitly extension-assisted and now covered by tests/spec text. |
+| `ABC-COV-007` | `support bounded subset` | Closed for the current bounded subset: common unnumbered slur start/stop presence is supported, while numbered/nested slur identity and broader span semantics remain explicitly out of claim and are now documented/tested. |
 | `ABC-COV-008` | `support bounded subset` | Tuplets are usable; the remaining work is edge clarification. |
-| `ABC-COV-009` | `support now` | These decoration-policy items are close enough to close in the current series. |
+| `ABC-COV-009` | `support now` | Closed in the current series; canonical policy and implementation/tests are aligned for the tracked items. |
 | `ABC-COV-010` | `out of practical scope` | `s:` symbol lines currently look like a low-priority notation surface. |
-| `ABC-COV-011` | `support bounded subset` | `U:` already has an import path; scope should be bounded before any export ambitions. |
-| `ABC-COV-012` | `support bounded subset` | Chord symbols are important, but inventory-bounding is more realistic than full parity. |
+| `ABC-COV-011` | `support bounded subset` | Closed for the current bounded subset: `U:` remains import-first, single-character decoration-alias support is explicit, malformed declarations are ignored, and export parity is intentionally not claimed. |
+| `ABC-COV-012` | `support bounded subset` | Closed for the current bounded inventory: supported quoted chord-symbol roots/suffixes are now enumerated in spec text and backed by tests, while unsupported quoted chord-like text explicitly falls back to annotation rather than forced harmony parsing. |
 | `ABC-COV-013` | `support bounded subset` | Annotation support should be explicit, not accidental. |
 | `ABC-COV-014` | `support bounded subset` | Practical acceptance is likely sufficient, but that should be stated plainly. |
-| `ABC-COV-015` | `support bounded subset` | Lyrics already work in useful cases; scope clarification is the next step. |
-| `ABC-COV-016` | `support bounded subset` | Voice-property breadth should be enumerated explicitly around the current working subset. |
-| `ABC-COV-017` | `defer intentionally` | Faithful overlay preservation may be expensive relative to current value unless demanded. |
-| `ABC-COV-018` | `defer intentionally` | ABC 2.2 delta items should be roadmap decisions, not silent obligations. |
+| `ABC-COV-015` | `support bounded subset` | Closed for the current bounded subset: common `w:` underlay and ordinary hyphenation are supported, while broader alignment, multi-verse, and numbering semantics remain explicitly out of claim. |
+| `ABC-COV-016` | `support bounded subset` | Closed for the current working subset; supported, partial, ext-only, and unsupported `V:` properties are now enumerated explicitly and backed by tests. |
+| `ABC-COV-017` | `defer intentionally` | Closed by policy: `&` import acceptance remains supported via synthetic overlay voices / parts, while faithful same-part overlay preservation and exact `&` roundtrip are intentionally not current completion targets. |
+| `ABC-COV-018` | `support bounded subset` | Closed for the current bounded 2.2 subset: `!editorial!` and `!courtesy!` are now supported as accidental-level modifiers with import/export/roundtrip coverage. |
 
 ## Ready-to-Transfer TODO Order
 
@@ -454,6 +796,11 @@ If the goal is to turn this document into executable TODO items with minimal ext
 9. `ABC-COV-008`, `ABC-COV-011`, `ABC-COV-015`
 10. `ABC-COV-001`, `ABC-COV-002`, `ABC-COV-003`, `ABC-COV-010`, `ABC-COV-013`, `ABC-COV-014`
 
+Current phase note:
+
+- this transfer order has been fully consumed for the current bounded-coverage pass
+- treat it as historical execution order, not as the current active queue
+
 ## Likely Practical-Scope Freezes
 
 These are not final decisions, but they currently look like the strongest candidates for "explicitly unsupported unless real-world demand appears":
@@ -464,17 +811,159 @@ These are not final decisions, but they currently look like the strongest candid
 - `6.2` playback semantics from ABC notation itself
 - `7.2` line-breaking semantics
 
-## Current High-Priority Gaps
+## Current High-Priority Follow-Ups
 
 - `4.14 Decorations`
-  - ABC 2.2 delta decorations `!editorial!` / `!courtesy!` are still open
-  - implementation follow-up remains open only where code still differs from the settled policy
+  - canonical decoration policy is closed, but implementation/test follow-up may still be needed where broader parity is intentionally bounded
 - `4.7 Beams`
-  - whitespace-as-beam-separation is only partially preserved
+  - bounded policy is closed, but exact export-side spacing preservation remains intentionally out of scope
 - `4.18 Chord symbols`
-  - common forms work, but broader standard harmony spelling coverage remains incomplete
+  - bounded inventory is closed, but broader harmony spelling coverage remains intentionally outside the current subset
 - `7.4 Voice overlay`
-  - imported overlays still become separate MusicXML parts instead of preserved synchronized voices inside one part
+  - policy is closed, but current import still expands overlays into synthetic parts rather than synchronized voices inside one part
+
+## Recently Closed Backlog Items
+
+- `ABC-COV-009`
+  - closed as `support now`
+  - policy text is settled in this document and `docs/spec/ABC_IO.md`
+  - current implementation/tests align on:
+    - canonical `!arpeggio!` export for the current MusicXML `arpeggiate` carrier
+    - canonical `!stopped!` export for `!+!` / `!plus!` import aliases
+    - canonical `!mordent!` / `!pralltriller!` export for mordent-family import aliases
+    - standard `!slide!` as start-side support, with explicit stop kept as `mikuscore` extension `!slide-stop!`
+- `ABC-COV-016`
+  - closed as `support bounded subset`
+  - `7.1 Voice properties` is now decomposed into:
+    - supported: `V:id`, `name=...`, common `clef=...`
+    - partial: standard `transpose=...` import
+    - ext-only: transpose-preserving roundtrip through `%@mks transpose ...`
+    - unsupported: broader standard properties such as `staves`, `brace`, `bracket`, `merge`, `middle`, `gchords`
+  - regression coverage now exists for:
+    - supported `transpose=...` import
+    - warnings on unsupported standard `V:` properties
+- `ABC-COV-005`
+  - closed as `support bounded subset`
+  - bounded policy is now explicit:
+    - import: whitespace is a beam-break hint within the current voice/measure
+    - export: exact beam-specific ABC spacing is not preserved
+    - practical interchange target is beam-break interpretation on import, not verbatim source spacing roundtrip
+  - regression coverage now exists for:
+    - import-side whitespace beam-break hints
+    - current export-side non-preservation of exact beam spacing text
+- `ABC-COV-006`
+  - closed as `support bounded subset`
+  - bounded policy is now explicit:
+    - standard surface support covers common repeat / ending forms: `|:`, `:|`, `[1`, `[2`, `|1`, `:|2`
+    - edge semantics beyond that subset currently rely on `%@mks measure` metadata
+    - repeat counts beyond the ordinary case use `times=...`
+    - ending stop type `discontinue` uses `ending-stop=... ending-type=discontinue`
+  - regression coverage now exists for:
+    - standard repeat barlines
+    - standard alternate endings
+    - extension-assisted repeat counts
+    - extension-assisted `discontinue` ending stop
+- `ABC-COV-012`
+  - closed as `support bounded subset`
+  - bounded quoted-chord inventory is now explicit:
+    - roots/bass: `A`-`G` with optional `#` / `b`
+    - supported suffix subset:
+      - ``
+      - `m`, `min`
+      - `6`, `m6`, `min6`
+      - `7`, `9`, `11`, `13`
+      - `maj7`, `maj9`
+      - `m7`, `min7`, `m9`, `min9`
+      - `7sus4`, `sus4`, `sus2`
+      - `dim`, `dim7`, `aug`, `+`, `m7b5`, `min7b5`, `ø`
+    - unsupported quoted chord-like text falls back to annotation/words
+  - regression coverage now exists for:
+    - supported quoted-chord harmony parsing/export
+    - unsupported quoted chord-like fallback to annotation
+- `ABC-COV-007`
+  - closed as `support bounded subset`
+  - bounded slur policy is now explicit:
+    - supported: common unnumbered start/stop slur presence
+    - unsupported/not yet claimed: numbered/nested slur identity preservation and broader exact span semantics
+    - warning-based edge handling: slur stop without a preceding non-rest note
+  - regression coverage now exists for:
+    - common slur start/stop roundtrip
+    - warning-based unsupported edge behavior
+- `ABC-COV-017`
+  - closed as `defer intentionally`
+  - overlay policy is now explicit:
+    - supported: import acceptance of `&` via synthetic overlay voices / parts
+    - intentionally not claimed: faithful same-part multi-voice preservation
+    - intentionally not claimed: exact standard ABC `&` roundtrip preservation
+- `ABC-COV-018`
+  - closed as `support bounded subset`
+  - 2.2 delta policy is now explicit:
+    - `!editorial!` is supported as a bounded accidental-level modifier
+    - `!courtesy!` is supported as a bounded accidental-level modifier
+    - broader 2.2 delta work still remains outside the current bounded target
+- `ABC-COV-011`
+  - closed as `support bounded subset`
+  - `U:` policy is now explicit:
+    - supported: single-character decoration-alias import
+    - supported: `!decor!` / `+decor+` right-hand side forms in the current import path
+    - malformed `U:` declarations are ignored
+    - export parity for `U:` is intentionally not claimed
+- `ABC-COV-001`
+  - closed as `support bounded subset`
+  - information-field policy is now explicit:
+    - supported core subset: `X:`, `T:`, `C:`, `M:`, `L:`, `K:`, `Q:`
+    - `V:` remains supported only through its separately bounded voice-property subset
+    - non-core information fields are not semantically supported
+    - lexical tolerance of an unsupported field does not count as ABC coverage
+- `ABC-COV-002`
+  - closed as `support bounded subset`
+  - inline-field policy is now explicit:
+    - supported subset: `[K:...]`, `[M:...]`, `[L:...]`, `[Q:...]`, `[V:...]`
+    - broader inline fields are not semantically supported
+    - unsupported inline fields are skipped with warnings
+- `ABC-COV-013`
+  - closed as `support bounded subset`
+  - annotation policy is now explicit:
+    - supported: common quoted non-harmonic text as direction words / annotations
+    - supported: unsupported quoted chord-like text falls back to annotation/words instead of being forced into `harmony`
+    - not currently claimed: broader annotation placement and behavior semantics
+- `ABC-COV-014`
+  - closed as `support bounded subset`
+  - order-of-constructs policy is now explicit:
+    - supported in the practical sense: common construct orderings already handled by the parser
+    - preferred stance: broad practical acceptance for structurally recognizable real-world ABC
+    - not currently claimed: full formal conformance to every order-of-constructs nuance
+- `ABC-COV-003`
+  - closed as `defer intentionally`
+  - field-continuation policy is now explicit:
+    - continued information-field lines are outside the current supported subset
+    - lexical tolerance does not count as continuation support
+    - this area is intentionally deferred unless practical input evidence makes it worth revisiting
+- `ABC-COV-010`
+  - closed as `out of practical scope`
+  - symbol-line policy is now explicit:
+    - standard `s:` symbol lines are outside the current bounded support target
+    - there is no current import/export or roundtrip support claim
+    - this area stays out of scope unless practical input demand changes priority
+- `ABC-COV-015`
+  - closed as `support bounded subset`
+  - lyrics policy is now explicit:
+    - supported: common `w:` underlay import/export and ordinary hyphenated lyric handling
+    - not currently claimed: full alignment nuance, full multi-verse behavior, or verse numbering semantics
+    - current support target is useful common lyric interchange, not full lyric-parity coverage
+- `ABC-COV-008`
+  - closed as `support bounded subset`
+  - tuplet policy is now explicit:
+    - supported: common `(n[:q][:r])` syntax and common MusicXML roundtrip through `time-modification` plus note-level `tuplet` markers
+    - supported: current explicit tuplet export such as `(3:2:3` in the common path
+    - not currently claimed: broader ratio/edge semantics or more complex span behavior beyond the current tested subset
+- `ABC-COV-004`
+  - closed as `support bounded subset`
+  - clef / transposition policy is now explicit:
+    - supported: common `V:` clef subset `treble`, `bass`, `alto`, `tenor`, `c3`, `c4`
+    - supported: bare clef shorthand as compatibility behavior on import
+    - partial/ext-only: standard `V:` transpose import plus `%@mks transpose ...` for roundtrip preservation
+    - not currently claimed: broader standard clef breadth or full standard `V:` transpose export parity
 
 ## TODO Derivation Rule
 

--- a/mikuscore.html
+++ b/mikuscore.html
@@ -29620,6 +29620,7 @@ function tokenizeAbcLyricLine(text) {
         .map((token) => token.trim())
         .filter(Boolean);
     const tokens = [];
+    let pendingHyphenWord = false;
     for (const chunk of chunks) {
         if (chunk === "*") {
             tokens.push({ type: "skip" });
@@ -29630,9 +29631,23 @@ function tokenizeAbcLyricLine(text) {
             continue;
         }
         const normalized = chunk.replace(/~/g, " ");
+        if (normalized.endsWith("-") && normalized.length > 1) {
+            tokens.push({
+                type: "text",
+                text: normalized.slice(0, -1),
+                syllabic: pendingHyphenWord ? "middle" : "begin"
+            });
+            pendingHyphenWord = true;
+            continue;
+        }
         const parts = normalized.split("-").filter((part) => part.length > 0);
         if (parts.length <= 1) {
-            tokens.push({ type: "text", text: normalized, syllabic: "single" });
+            tokens.push({
+                type: "text",
+                text: normalized,
+                syllabic: pendingHyphenWord ? "end" : "single"
+            });
+            pendingHyphenWord = false;
             continue;
         }
         for (let i = 0; i < parts.length; i += 1) {
@@ -29641,6 +29656,7 @@ function tokenizeAbcLyricLine(text) {
                 : (i === parts.length - 1 ? "end" : "middle");
             tokens.push({ type: "text", text: parts[i], syllabic });
         }
+        pendingHyphenWord = false;
     }
     return tokens;
 }
@@ -30015,6 +30031,12 @@ function parseForMusicXml(source, settings) {
                         ": Skipped unsupported V: directive tail token: " +
                         parsedVoice.skippedText);
                 }
+                for (const unsupportedKey of parsedVoice.unsupportedKeys || []) {
+                    warnings.push("line " +
+                        lineNo +
+                        ": Skipped unsupported V: property: " +
+                        unsupportedKey);
+                }
                 if (parsedVoice.bodyText) {
                     const expandedBodyText = expandUserDefinedDecorationSymbols(parsedVoice.bodyText, userDefinedDecorationBySymbol);
                     const inlineVoiceSegments = splitBodyTextByInlineVoice(expandedBodyText, currentVoiceId);
@@ -30142,7 +30164,10 @@ function parseForMusicXml(source, settings) {
         let lastEventNotes = [];
         let pendingTieToNext = false;
         let pendingTrill = false;
+        let pendingTrillLineStart = false;
+        let pendingTrillLineStop = false;
         let pendingTurn = "";
+        let pendingTurnSlash = false;
         let pendingDelayedTurn = false;
         let pendingMordent = "";
         let pendingTremolo = null;
@@ -30163,6 +30188,7 @@ function parseForMusicXml(source, settings) {
         let pendingStrongAccent = false;
         let pendingBreathMark = false;
         let pendingCaesura = false;
+        let pendingPhraseMark = "";
         let pendingSegno = false;
         let pendingCoda = false;
         let pendingFine = false;
@@ -30183,6 +30209,8 @@ function parseForMusicXml(source, settings) {
         let pendingHarmonic = false;
         let pendingStopped = false;
         let pendingThumbPosition = false;
+        let pendingEditorialAccidental = false;
+        let pendingCourtesyAccidental = false;
         let pendingDoubleTongue = false;
         let pendingTripleTongue = false;
         let pendingHeel = false;
@@ -30415,6 +30443,19 @@ function parseForMusicXml(source, settings) {
                 if (decoration === "trill" || decoration === "tr" || decoration === "triller") {
                     pendingTrill = true;
                 }
+                else if (decoration === "editorial") {
+                    pendingEditorialAccidental = true;
+                }
+                else if (decoration === "courtesy") {
+                    pendingCourtesyAccidental = true;
+                }
+                else if (decoration === "trill(") {
+                    pendingTrill = true;
+                    pendingTrillLineStart = true;
+                }
+                else if (decoration === "trill)") {
+                    pendingTrillLineStop = true;
+                }
                 else if (decoration.startsWith("rehearsal:")) {
                     const rehearsalText = rawDecoration.slice("rehearsal:".length).trim();
                     if (rehearsalText) {
@@ -30431,9 +30472,19 @@ function parseForMusicXml(source, settings) {
                 }
                 else if (decoration === "turn") {
                     pendingTurn = "turn";
+                    pendingTurnSlash = false;
+                }
+                else if (decoration === "turnx") {
+                    pendingTurn = "turn";
+                    pendingTurnSlash = true;
                 }
                 else if (decoration === "invertedturn" || decoration === "inverted-turn" || decoration === "lowerturn") {
                     pendingTurn = "inverted-turn";
+                    pendingTurnSlash = false;
+                }
+                else if (decoration === "invertedturnx" || decoration === "inverted-turnx") {
+                    pendingTurn = "inverted-turn";
+                    pendingTurnSlash = true;
                 }
                 else if (decoration === "mordent" || decoration === "lowermordent") {
                     pendingMordent = "mordent";
@@ -30461,7 +30512,7 @@ function parseForMusicXml(source, settings) {
                 else if (decoration === "gliss-stop" || decoration === "glissando-stop") {
                     pendingGlissandoStop = true;
                 }
-                else if (decoration === "slide-start") {
+                else if (decoration === "slide" || decoration === "slide-start") {
                     pendingSlideStart = true;
                 }
                 else if (decoration === "slide-stop") {
@@ -30484,7 +30535,7 @@ function parseForMusicXml(source, settings) {
                 else if (decoration === "staccatissimo" || decoration === "wedge" || decoration === "spiccato") {
                     pendingStaccatissimo = true;
                 }
-                else if (decoration === "accent") {
+                else if (decoration === "accent" || decoration === ">" || decoration === "emphasis") {
                     pendingAccent = true;
                 }
                 else if (decoration === "tenuto") {
@@ -30519,6 +30570,9 @@ function parseForMusicXml(source, settings) {
                 else if (decoration === "caesura") {
                     pendingCaesura = true;
                 }
+                else if (decoration === "shortphrase" || decoration === "mediumphrase" || decoration === "longphrase") {
+                    pendingPhraseMark = decoration;
+                }
                 else if (decoration === "segno") {
                     pendingSegno = true;
                 }
@@ -30528,34 +30582,41 @@ function parseForMusicXml(source, settings) {
                 else if (decoration === "fine") {
                     pendingFine = true;
                 }
-                else if (decoration === "dacapo" || decoration === "da-capo" || decoration === "da capo") {
+                else if (decoration === "dacoda") {
+                    pendingDaCapo = true;
+                    pendingToCoda = true;
+                }
+                else if (decoration === "dacapo" || decoration === "da-capo" || decoration === "da capo" || decoration === "d.c.") {
                     pendingDaCapo = true;
                 }
-                else if (decoration === "dalsegno" || decoration === "dal-segno" || decoration === "dal segno") {
+                else if (decoration === "dalsegno" || decoration === "dal-segno" || decoration === "dal segno" || decoration === "d.s.") {
                     pendingDalSegno = true;
                 }
                 else if (decoration === "tocoda" || decoration === "to-coda" || decoration === "to coda") {
                     pendingToCoda = true;
                 }
-                else if (decoration === "crescendo(" || decoration === "cresc(") {
+                else if (decoration === "crescendo(" || decoration === "cresc(" || decoration === "<(") {
                     pendingCrescendoStart = true;
                 }
-                else if (decoration === "crescendo)" || decoration === "cresc)") {
+                else if (decoration === "crescendo)" || decoration === "cresc)" || decoration === "<)") {
                     pendingCrescendoStop = true;
                 }
                 else if (decoration === "diminuendo(" ||
                     decoration === "decrescendo(" ||
                     decoration === "dim(" ||
-                    decoration === "decresc(") {
+                    decoration === "decresc(" ||
+                    decoration === ">(") {
                     pendingDiminuendoStart = true;
                 }
                 else if (decoration === "diminuendo)" ||
                     decoration === "decrescendo)" ||
                     decoration === "dim)" ||
-                    decoration === "decresc)") {
+                    decoration === "decresc)" ||
+                    decoration === ">)") {
                     pendingDiminuendoStop = true;
                 }
-                else if (decoration === "ppp" ||
+                else if (decoration === "pppp" ||
+                    decoration === "ppp" ||
                     decoration === "p" ||
                     decoration === "pp" ||
                     decoration === "mp" ||
@@ -30563,6 +30624,7 @@ function parseForMusicXml(source, settings) {
                     decoration === "f" ||
                     decoration === "ff" ||
                     decoration === "fff" ||
+                    decoration === "ffff" ||
                     decoration === "fp" ||
                     decoration === "fz" ||
                     decoration === "rfz" ||
@@ -30595,6 +30657,9 @@ function parseForMusicXml(source, settings) {
                 else if (decoration === "toe" || decoration === "toe mark") {
                     pendingToe = true;
                 }
+                else if (/^[0-5]$/.test(decoration)) {
+                    pendingFingerings.push(decoration);
+                }
                 else if (decoration.startsWith("fingering:")) {
                     const fingeringText = rawDecoration.slice("fingering:".length).trim();
                     if (fingeringText)
@@ -30626,6 +30691,7 @@ function parseForMusicXml(source, settings) {
                     pendingHarmonic = true;
                 }
                 else if (decoration === "stopped" ||
+                    decoration === "+" ||
                     decoration === "plus" ||
                     decoration === "stopped horn" ||
                     decoration === "stopped-horn") {
@@ -30773,17 +30839,37 @@ function parseForMusicXml(source, settings) {
                     }
                     if (chordIndex === 0 && pendingTrill && !note.isRest) {
                         note.trill = true;
+                        note.trillLineStart = pendingTrillLineStart;
                         pendingTrill = false;
+                        pendingTrillLineStart = false;
+                    }
+                    if (chordIndex === 0 && pendingTrillLineStop && !note.isRest) {
+                        note.trillLineStop = true;
+                        pendingTrillLineStop = false;
                     }
                     if (chordIndex === 0 && pendingTurn && !note.isRest) {
                         note.turnType = pendingTurn;
+                        note.turnSlash = pendingTurnSlash;
                         note.delayedTurn = pendingDelayedTurn;
                         pendingTurn = "";
+                        pendingTurnSlash = false;
                         pendingDelayedTurn = false;
+                    }
+                    if (chordIndex === 0 && !note.isRest && (pendingEditorialAccidental || pendingCourtesyAccidental)) {
+                        if (note.accidentalText) {
+                            note.accidentalEditorial = pendingEditorialAccidental || undefined;
+                            note.accidentalCautionary = pendingCourtesyAccidental || undefined;
+                        }
+                        pendingEditorialAccidental = false;
+                        pendingCourtesyAccidental = false;
                     }
                     if (chordIndex === 0 && pendingMordent && !note.isRest) {
                         note.mordentType = pendingMordent;
                         pendingMordent = "";
+                    }
+                    if (chordIndex === 0 && pendingPhraseMark && !note.isRest) {
+                        note.phraseMark = pendingPhraseMark;
+                        pendingPhraseMark = "";
                     }
                     if (chordIndex === 0 && pendingTremolo && !note.isRest) {
                         note.tremoloType = pendingTremolo.type;
@@ -31111,17 +31197,37 @@ function parseForMusicXml(source, settings) {
             applyBeamModeForEvent(note, dur);
             if (pendingTrill && !note.isRest) {
                 note.trill = true;
+                note.trillLineStart = pendingTrillLineStart;
                 pendingTrill = false;
+                pendingTrillLineStart = false;
+            }
+            if (pendingTrillLineStop && !note.isRest) {
+                note.trillLineStop = true;
+                pendingTrillLineStop = false;
             }
             if (pendingTurn && !note.isRest) {
                 note.turnType = pendingTurn;
+                note.turnSlash = pendingTurnSlash;
                 note.delayedTurn = pendingDelayedTurn;
                 pendingTurn = "";
+                pendingTurnSlash = false;
                 pendingDelayedTurn = false;
+            }
+            if (!note.isRest && (pendingEditorialAccidental || pendingCourtesyAccidental)) {
+                if (note.accidentalText) {
+                    note.accidentalEditorial = pendingEditorialAccidental || undefined;
+                    note.accidentalCautionary = pendingCourtesyAccidental || undefined;
+                }
+                pendingEditorialAccidental = false;
+                pendingCourtesyAccidental = false;
             }
             if (pendingMordent && !note.isRest) {
                 note.mordentType = pendingMordent;
                 pendingMordent = "";
+            }
+            if (pendingPhraseMark && !note.isRest) {
+                note.phraseMark = pendingPhraseMark;
+                pendingPhraseMark = "";
             }
             if (pendingTremolo && !note.isRest) {
                 note.tremoloType = pendingTremolo.type;
@@ -31456,7 +31562,7 @@ function parseForMusicXml(source, settings) {
                     repeatTimes: (_g = (_f = hintedMeta === null || hintedMeta === void 0 ? void 0 : hintedMeta.repeatTimes) !== null && _f !== void 0 ? _f : notationMeta === null || notationMeta === void 0 ? void 0 : notationMeta.repeatTimes) !== null && _g !== void 0 ? _g : null,
                     endingStart: String((notationMeta === null || notationMeta === void 0 ? void 0 : notationMeta.endingStart) || (hintedMeta === null || hintedMeta === void 0 ? void 0 : hintedMeta.endingStart) || ""),
                     endingStop: String((notationMeta === null || notationMeta === void 0 ? void 0 : notationMeta.endingStop) || (hintedMeta === null || hintedMeta === void 0 ? void 0 : hintedMeta.endingStop) || ""),
-                    endingStopType: (notationMeta === null || notationMeta === void 0 ? void 0 : notationMeta.endingStopType) || (hintedMeta === null || hintedMeta === void 0 ? void 0 : hintedMeta.endingStopType) || "",
+                    endingStopType: (hintedMeta === null || hintedMeta === void 0 ? void 0 : hintedMeta.endingStopType) || (notationMeta === null || notationMeta === void 0 ? void 0 : notationMeta.endingStopType) || "",
                 };
             }
             if (meterHint) {
@@ -31542,13 +31648,14 @@ function parseScoreVoiceOrder(raw, declaredVoiceIds) {
 }
 function parseVoiceDirectiveTail(raw) {
     if (!raw) {
-        return { name: "", clef: "", transpose: null, bodyText: "", skippedText: "" };
+        return { name: "", clef: "", transpose: null, bodyText: "", skippedText: "", unsupportedKeys: [] };
     }
     let bodyText = String(raw);
     let name = "";
     let clef = "";
     let transpose = null;
-    const bareClefMatch = bodyText.match(/^\s*(bass|treble|alto|tenor)(?=\s|$)/i);
+    const unsupportedKeys = [];
+    const bareClefMatch = bodyText.match(/^\s*(bass|treble|alto|tenor|c3|c4)(?=\s|$)/i);
     if (bareClefMatch) {
         clef = String(bareClefMatch[1] || "").trim().toLowerCase();
         bodyText = bodyText.slice(bareClefMatch[0].length);
@@ -31568,6 +31675,9 @@ function parseVoiceDirectiveTail(raw) {
                 transpose = { chromatic: parsed };
             }
         }
+        else {
+            unsupportedKeys.push(lowerKey);
+        }
         return " ";
     });
     bodyText = bodyText.trim();
@@ -31583,7 +31693,8 @@ function parseVoiceDirectiveTail(raw) {
         clef: clef.trim(),
         transpose,
         bodyText,
-        skippedText
+        skippedText,
+        unsupportedKeys
     };
 }
 function inferTransposeFromPartName(partName) {
@@ -32082,7 +32193,7 @@ const exportMusicXmlDomToAbc = (doc) => {
     };
     const parts = Array.from(doc.querySelectorAll("score-partwise > part"));
     parts.forEach((part, partIndex) => {
-        var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p, _q, _r, _s, _t, _u, _v, _w, _x, _y, _z, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26;
+        var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p, _q, _r, _s, _t, _u, _v, _w, _x, _y, _z, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25;
         const partId = part.getAttribute("id") || `P${partIndex + 1}`;
         const partName = partNameById.get(partId) || partId;
         const measures = Array.from(part.querySelectorAll(":scope > measure"));
@@ -32288,13 +32399,18 @@ const exportMusicXmlDomToAbc = (doc) => {
                         if (child.querySelector(':scope > sound[fine="yes"]')) {
                             pendingDirectionDecorations.push("!fine!");
                         }
-                        if (child.querySelector(':scope > sound[dacapo="yes"]')) {
+                        const hasDaCapo = Boolean(child.querySelector(':scope > sound[dacapo="yes"]'));
+                        const hasToCoda = Boolean(child.querySelector(":scope > sound[tocoda]"));
+                        if (hasDaCapo && hasToCoda) {
+                            pendingDirectionDecorations.push("!dacoda!");
+                        }
+                        else if (hasDaCapo) {
                             pendingDirectionDecorations.push("!dacapo!");
                         }
                         if (child.querySelector(":scope > sound[dalsegno]")) {
                             pendingDirectionDecorations.push("!dalsegno!");
                         }
-                        if (child.querySelector(":scope > sound[tocoda]")) {
+                        if (hasToCoda && !hasDaCapo) {
                             pendingDirectionDecorations.push("!tocoda!");
                         }
                         for (const wedgeNode of Array.from(child.querySelectorAll(":scope > direction-type > wedge"))) {
@@ -32312,7 +32428,7 @@ const exportMusicXmlDomToAbc = (doc) => {
                                 activeWedgeType = "";
                             }
                         }
-                        for (const dynamicName of ["ppp", "pp", "p", "mp", "mf", "f", "ff", "fff", "fp", "fz", "rfz", "sf", "sfp", "sfz"]) {
+                        for (const dynamicName of ["pppp", "ppp", "pp", "p", "mp", "mf", "f", "ff", "fff", "ffff", "fp", "fz", "rfz", "sf", "sfp", "sfz"]) {
                             if (child.querySelector(`:scope > direction-type > dynamics > ${dynamicName}`)) {
                                 pendingDirectionDecorations.push(`!${dynamicName}!`);
                             }
@@ -32344,6 +32460,8 @@ const exportMusicXmlDomToAbc = (doc) => {
                     const hasTrillMark = Boolean(child.querySelector(":scope > notations > ornaments > trill-mark"));
                     const hasTurn = Boolean(child.querySelector(":scope > notations > ornaments > turn"));
                     const hasInvertedTurn = Boolean(child.querySelector(":scope > notations > ornaments > inverted-turn"));
+                    const hasTurnSlash = Array.from(child.querySelectorAll(":scope > notations > ornaments > turn, :scope > notations > ornaments > inverted-turn"))
+                        .some((node) => (node.getAttribute("slash") || "").trim().toLowerCase() === "yes");
                     const hasDelayedTurn = Boolean(child.querySelector(":scope > notations > ornaments > delayed-turn"));
                     const hasMordent = Boolean(child.querySelector(":scope > notations > ornaments > mordent"));
                     const hasInvertedMordent = Boolean(child.querySelector(":scope > notations > ornaments > inverted-mordent"));
@@ -32359,6 +32477,11 @@ const exportMusicXmlDomToAbc = (doc) => {
                         var _a;
                         const type = ((_a = node.getAttribute("type")) !== null && _a !== void 0 ? _a : "").trim().toLowerCase();
                         return type === "" || type === "start";
+                    });
+                    const hasWavyLineStop = Array.from(child.querySelectorAll(":scope > notations > ornaments > wavy-line")).some((node) => {
+                        var _a;
+                        const type = ((_a = node.getAttribute("type")) !== null && _a !== void 0 ? _a : "").trim().toLowerCase();
+                        return type === "stop";
                     });
                     const hasTrill = hasTrillMark || hasWavyLineStart;
                     const turnType = hasInvertedTurn ? "inverted-turn" : (hasTurn ? "turn" : "");
@@ -32378,6 +32501,9 @@ const exportMusicXmlDomToAbc = (doc) => {
                     const hasStrongAccent = Boolean(child.querySelector(":scope > notations > articulations > strong-accent"));
                     const hasBreathMark = Boolean(child.querySelector(":scope > notations > articulations > breath-mark"));
                     const hasCaesura = Boolean(child.querySelector(":scope > notations > articulations > caesura"));
+                    const phraseMarkText = Array.from(child.querySelectorAll(":scope > notations > articulations > other-articulation"))
+                        .map((node) => (node.textContent || "").trim().toLowerCase())
+                        .find((text) => text === "shortphrase" || text === "mediumphrase" || text === "longphrase") || "";
                     const hasUpBow = Boolean(child.querySelector(":scope > notations > technical > up-bow"));
                     const hasDownBow = Boolean(child.querySelector(":scope > notations > technical > down-bow"));
                     const hasDoubleTongue = Boolean(child.querySelector(":scope > notations > technical > double-tongue"));
@@ -32429,11 +32555,14 @@ const exportMusicXmlDomToAbc = (doc) => {
                         const stepOctaveKey = `${upperStep}${safeOctave}`;
                         const alterRaw = (_16 = (_15 = (_14 = child.querySelector(":scope > pitch > alter")) === null || _14 === void 0 ? void 0 : _14.textContent) === null || _15 === void 0 ? void 0 : _15.trim()) !== null && _16 !== void 0 ? _16 : "";
                         const explicitAlter = alterRaw !== "" && Number.isFinite(Number(alterRaw)) ? Math.round(Number(alterRaw)) : null;
-                        const accidentalText = (_19 = (_18 = (_17 = child.querySelector(":scope > accidental")) === null || _17 === void 0 ? void 0 : _17.textContent) === null || _18 === void 0 ? void 0 : _18.trim()) !== null && _19 !== void 0 ? _19 : "";
+                        const accidentalNode = child.querySelector(":scope > accidental");
+                        const accidentalText = (_18 = (_17 = accidentalNode === null || accidentalNode === void 0 ? void 0 : accidentalNode.textContent) === null || _17 === void 0 ? void 0 : _17.trim()) !== null && _18 !== void 0 ? _18 : "";
                         const accidentalAlter = accidentalTextToAlter(accidentalText);
-                        const keyAlter = (_20 = keyAlterMap[upperStep]) !== null && _20 !== void 0 ? _20 : 0;
+                        const accidentalEditorial = (((accidentalNode === null || accidentalNode === void 0 ? void 0 : accidentalNode.getAttribute("editorial")) || "").trim().toLowerCase() === "yes");
+                        const accidentalCautionary = (((accidentalNode === null || accidentalNode === void 0 ? void 0 : accidentalNode.getAttribute("cautionary")) || "").trim().toLowerCase() === "yes");
+                        const keyAlter = (_19 = keyAlterMap[upperStep]) !== null && _19 !== void 0 ? _19 : 0;
                         const currentAlter = measureAccidentalByStepOctave.has(stepOctaveKey)
-                            ? (_21 = measureAccidentalByStepOctave.get(stepOctaveKey)) !== null && _21 !== void 0 ? _21 : 0
+                            ? (_20 = measureAccidentalByStepOctave.get(stepOctaveKey)) !== null && _20 !== void 0 ? _20 : 0
                             : keyAlter;
                         // In MusicXML pitch, omitted <alter> means natural (0), not "follow key accidental".
                         // Key signature context is only used to decide whether an explicit accidental token is needed.
@@ -32449,6 +32578,12 @@ const exportMusicXmlDomToAbc = (doc) => {
                             : "";
                         measureAccidentalByStepOctave.set(stepOctaveKey, targetAlter);
                         pitchToken = `${accidental}${exports.AbcCommon.abcPitchFromStepOctave(step, Number.isFinite(octave) ? octave : 4)}`;
+                        if (accidentalEditorial && accidental) {
+                            pitchToken = `!editorial!${pitchToken}`;
+                        }
+                        if (accidentalCautionary && accidental) {
+                            pitchToken = `!courtesy!${pitchToken}`;
+                        }
                     }
                     if (isGrace) {
                         const graceSlashPrefix = hasGraceSlash ? "/" : "";
@@ -32456,7 +32591,7 @@ const exportMusicXmlDomToAbc = (doc) => {
                             pendingGraceTokens.push(`${graceSlashPrefix}${pitchToken}${len}${hasTieStart ? "-" : ""}`);
                         }
                         else {
-                            const last = (_22 = pendingGraceTokens.pop()) !== null && _22 !== void 0 ? _22 : "";
+                            const last = (_21 = pendingGraceTokens.pop()) !== null && _21 !== void 0 ? _21 : "";
                             const merged = last.startsWith("[")
                                 ? last.replace("]", `${graceSlashPrefix}${pitchToken}]`)
                                 : `[${last}${graceSlashPrefix}${pitchToken}]`;
@@ -32478,17 +32613,19 @@ const exportMusicXmlDomToAbc = (doc) => {
                             ? `(${activeTuplet.actual}:${activeTuplet.normal}:${activeTuplet.actual}`
                             : "")
                         : "";
-                    const trillPrefix = hasTrill ? "!trill!" : "";
+                    const trillPrefix = hasWavyLineStop
+                        ? "!trill)!"
+                        : (hasWavyLineStart && !hasTrillMark ? "!trill!" : (hasWavyLineStart ? "!trill(!" : (hasTrill ? "!trill!" : "")));
                     const turnPrefix = turnType === "inverted-turn"
-                        ? (hasDelayedTurn ? "!delayedinvertedturn!" : "!invertedturn!")
-                        : (turnType === "turn" ? (hasDelayedTurn ? "!delayedturn!" : "!turn!") : "");
+                        ? (hasDelayedTurn ? "!delayedinvertedturn!" : (hasTurnSlash ? "!invertedturnx!" : "!invertedturn!"))
+                        : (turnType === "turn" ? (hasDelayedTurn ? "!delayedturn!" : (hasTurnSlash ? "!turnx!" : "!turn!")) : "");
                     const mordentPrefix = mordentType === "inverted-mordent" ? "!pralltriller!" : (mordentType === "mordent" ? "!mordent!" : "");
                     const tremoloPrefix = tremoloType ? `!tremolo-${tremoloType}-${tremoloMarks}!` : "";
                     const glissandoPrefix = hasGlissandoStart ? "!gliss-start!" : (hasGlissandoStop ? "!gliss-stop!" : "");
-                    const slidePrefix = hasSlideStart ? "!slide-start!" : (hasSlideStop ? "!slide-stop!" : "");
+                    const slidePrefix = hasSlideStart ? "!slide!" : (hasSlideStop ? "!slide-stop!" : "");
                     const schleiferPrefix = hasSchleifer ? "!schleifer!" : "";
                     const shakePrefix = hasShake ? "!shake!" : "";
-                    const arpeggiatePrefix = hasArpeggiate ? "!roll!" : "";
+                    const arpeggiatePrefix = hasArpeggiate ? "!arpeggio!" : "";
                     const staccatoPrefix = hasStaccatissimo ? "!wedge!" : (hasStaccato ? "!staccato!" : "");
                     const accentPrefix = hasAccent ? "!accent!" : "";
                     const tenutoPrefix = hasTenuto ? "!tenuto!" : "";
@@ -32497,13 +32634,18 @@ const exportMusicXmlDomToAbc = (doc) => {
                     const strongAccentPrefix = hasStrongAccent ? "!marcato!" : "";
                     const breathMarkPrefix = hasBreathMark ? "!breath!" : "";
                     const caesuraPrefix = hasCaesura ? "!caesura!" : "";
+                    const phraseMarkPrefix = phraseMarkText === "shortphrase" || phraseMarkText === "mediumphrase" || phraseMarkText === "longphrase"
+                        ? `!${phraseMarkText}!`
+                        : "";
                     const upBowPrefix = hasUpBow ? "!upbow!" : "";
                     const downBowPrefix = hasDownBow ? "!downbow!" : "";
                     const doubleTonguePrefix = hasDoubleTongue ? "!doubletongue!" : "";
                     const tripleTonguePrefix = hasTripleTongue ? "!tripletongue!" : "";
                     const heelPrefix = hasHeel ? "!heel!" : "";
                     const toePrefix = hasToe ? "!toe!" : "";
-                    const fingeringPrefix = fingeringTexts.map((value) => `!fingering:${value}!`).join("");
+                    const fingeringPrefix = fingeringTexts
+                        .map((value) => (/^[0-5]$/.test(value) ? `!${value}!` : `!fingering:${value}!`))
+                        .join("");
                     const stringPrefix = stringTexts.map((value) => `!string:${value}!`).join("");
                     const pluckPrefix = pluckTexts.map((value) => `!pluck:${value}!`).join("");
                     const openStringPrefix = hasOpenString ? "!open!" : "";
@@ -32520,7 +32662,7 @@ const exportMusicXmlDomToAbc = (doc) => {
                         ? `${pendingHarmonySymbols.map((symbol) => `"${abcQuotedTextEscape(symbol)}"`).join("")}`
                         : "";
                     const directionDecorationPrefix = !isChord && pendingDirectionDecorations.length > 0 ? pendingDirectionDecorations.join("") : "";
-                    const eventPrefix = `${harmonyPrefix}${wordsPrefix}${directionDecorationPrefix}${tupletPrefix}${slurStartPrefix}${gracePrefix}${trillPrefix}${turnPrefix}${mordentPrefix}${tremoloPrefix}${glissandoPrefix}${slidePrefix}${schleiferPrefix}${shakePrefix}${arpeggiatePrefix}${staccatoPrefix}${accentPrefix}${tenutoPrefix}${stressPrefix}${unstressPrefix}${strongAccentPrefix}${breathMarkPrefix}${caesuraPrefix}${upBowPrefix}${downBowPrefix}${doubleTonguePrefix}${tripleTonguePrefix}${heelPrefix}${toePrefix}${fingeringPrefix}${stringPrefix}${pluckPrefix}${openStringPrefix}${snapPizzicatoPrefix}${harmonicPrefix}${stoppedPrefix}${thumbPrefix}${fermataPrefix}`;
+                    const eventPrefix = `${harmonyPrefix}${wordsPrefix}${directionDecorationPrefix}${tupletPrefix}${slurStartPrefix}${gracePrefix}${trillPrefix}${turnPrefix}${mordentPrefix}${tremoloPrefix}${glissandoPrefix}${slidePrefix}${schleiferPrefix}${shakePrefix}${arpeggiatePrefix}${staccatoPrefix}${accentPrefix}${tenutoPrefix}${stressPrefix}${unstressPrefix}${strongAccentPrefix}${breathMarkPrefix}${caesuraPrefix}${phraseMarkPrefix}${upBowPrefix}${downBowPrefix}${doubleTonguePrefix}${tripleTonguePrefix}${heelPrefix}${toePrefix}${fingeringPrefix}${stringPrefix}${pluckPrefix}${openStringPrefix}${snapPizzicatoPrefix}${harmonicPrefix}${stoppedPrefix}${thumbPrefix}${fermataPrefix}`;
                     if (!isChord && pendingHarmonySymbols.length > 0) {
                         pendingHarmonySymbols.length = 0;
                     }
@@ -32561,8 +32703,8 @@ const exportMusicXmlDomToAbc = (doc) => {
                     }
                     if (!isGrace && !isChord && !child.querySelector(":scope > rest")) {
                         const lyric = child.querySelector(":scope > lyric");
-                        const lyricText = ((_24 = (_23 = lyric === null || lyric === void 0 ? void 0 : lyric.querySelector(":scope > text")) === null || _23 === void 0 ? void 0 : _23.textContent) === null || _24 === void 0 ? void 0 : _24.trim()) || "";
-                        const lyricSyllabic = ((_26 = (_25 = lyric === null || lyric === void 0 ? void 0 : lyric.querySelector(":scope > syllabic")) === null || _25 === void 0 ? void 0 : _25.textContent) === null || _26 === void 0 ? void 0 : _26.trim()) || "single";
+                        const lyricText = ((_23 = (_22 = lyric === null || lyric === void 0 ? void 0 : lyric.querySelector(":scope > text")) === null || _22 === void 0 ? void 0 : _22.textContent) === null || _23 === void 0 ? void 0 : _23.trim()) || "";
+                        const lyricSyllabic = ((_25 = (_24 = lyric === null || lyric === void 0 ? void 0 : lyric.querySelector(":scope > syllabic")) === null || _24 === void 0 ? void 0 : _24.textContent) === null || _25 === void 0 ? void 0 : _25.trim()) || "single";
                         const lyricExtend = Boolean(lyric === null || lyric === void 0 ? void 0 : lyric.querySelector(":scope > extend"));
                         if (lyricText) {
                             lyricTokens.push(abcLyricTokenFromMusicXml(lyricText, lyricSyllabic));
@@ -33207,7 +33349,13 @@ const buildMusicXmlFromAbcParsed = (parsed, abcSource, options = {}) => {
                             chunks.push(`<time-modification><actual-notes>${Math.round(Number(note.timeModification.actual))}</actual-notes><normal-notes>${Math.round(Number(note.timeModification.normal))}</normal-notes></time-modification>`);
                         }
                         if (note.accidentalText) {
-                            chunks.push(`<accidental>${xmlEscape(String(note.accidentalText))}</accidental>`);
+                            const accidentalAttrs = [
+                                note.accidentalEditorial ? 'editorial="yes"' : "",
+                                note.accidentalCautionary ? 'cautionary="yes"' : "",
+                            ].filter(Boolean).join(" ");
+                            chunks.push(accidentalAttrs
+                                ? `<accidental ${accidentalAttrs}>${xmlEscape(String(note.accidentalText))}</accidental>`
+                                : `<accidental>${xmlEscape(String(note.accidentalText))}</accidental>`);
                         }
                         if (note.tieStart)
                             chunks.push('<tie type="start"/>');
@@ -33218,6 +33366,7 @@ const buildMusicXmlFromAbcParsed = (parsed, abcSource, options = {}) => {
                             note.slurStart ||
                             note.slurStop ||
                             note.trill ||
+                            note.trillLineStop ||
                             note.turnType ||
                             note.delayedTurn ||
                             note.mordentType ||
@@ -33239,6 +33388,7 @@ const buildMusicXmlFromAbcParsed = (parsed, abcSource, options = {}) => {
                             note.strongAccent ||
                             note.breathMark ||
                             note.caesura ||
+                            note.phraseMark ||
                             note.upBow ||
                             note.downBow ||
                             note.doubleTongue ||
@@ -33268,10 +33418,17 @@ const buildMusicXmlFromAbcParsed = (parsed, abcSource, options = {}) => {
                                 chunks.push('<tuplet type="start"/>');
                             if (note.tupletStop)
                                 chunks.push('<tuplet type="stop"/>');
-                            if (note.trill) {
+                            if (note.trill || note.trillLineStop) {
                                 const trillParts = [];
-                                trillParts.push("<trill-mark/>");
-                                trillParts.push('<wavy-line type="start"/>');
+                                if (note.trill) {
+                                    trillParts.push("<trill-mark/>");
+                                }
+                                if (note.trillLineStop) {
+                                    trillParts.push('<wavy-line type="stop"/>');
+                                }
+                                else if (note.trillLineStart) {
+                                    trillParts.push('<wavy-line type="start"/>');
+                                }
                                 if (note.trillAccidentalText) {
                                     trillParts.push(`<accidental-mark>${xmlEscape(String(note.trillAccidentalText))}</accidental-mark>`);
                                 }
@@ -33279,7 +33436,8 @@ const buildMusicXmlFromAbcParsed = (parsed, abcSource, options = {}) => {
                             }
                             if (note.turnType) {
                                 const tag = note.turnType === "inverted-turn" ? "inverted-turn" : "turn";
-                                chunks.push(`<ornaments><${tag}/>${note.delayedTurn ? "<delayed-turn/>" : ""}</ornaments>`);
+                                const slashAttr = note.turnSlash ? ' slash="yes"' : "";
+                                chunks.push(`<ornaments><${tag}${slashAttr}/>${note.delayedTurn ? "<delayed-turn/>" : ""}</ornaments>`);
                             }
                             if (note.mordentType) {
                                 const tag = note.mordentType === "inverted-mordent" ? "inverted-mordent" : "mordent";
@@ -33329,6 +33487,8 @@ const buildMusicXmlFromAbcParsed = (parsed, abcSource, options = {}) => {
                                 articulationParts.push("<breath-mark/>");
                             if (note.caesura)
                                 articulationParts.push("<caesura/>");
+                            if (note.phraseMark)
+                                articulationParts.push(`<other-articulation>${xmlEscape(String(note.phraseMark))}</other-articulation>`);
                             if (articulationParts.length > 0) {
                                 chunks.push(`<articulations>${articulationParts.join("")}</articulations>`);
                             }

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -21548,6 +21548,7 @@ function tokenizeAbcLyricLine(text) {
         .map((token) => token.trim())
         .filter(Boolean);
     const tokens = [];
+    let pendingHyphenWord = false;
     for (const chunk of chunks) {
         if (chunk === "*") {
             tokens.push({ type: "skip" });
@@ -21558,9 +21559,23 @@ function tokenizeAbcLyricLine(text) {
             continue;
         }
         const normalized = chunk.replace(/~/g, " ");
+        if (normalized.endsWith("-") && normalized.length > 1) {
+            tokens.push({
+                type: "text",
+                text: normalized.slice(0, -1),
+                syllabic: pendingHyphenWord ? "middle" : "begin"
+            });
+            pendingHyphenWord = true;
+            continue;
+        }
         const parts = normalized.split("-").filter((part) => part.length > 0);
         if (parts.length <= 1) {
-            tokens.push({ type: "text", text: normalized, syllabic: "single" });
+            tokens.push({
+                type: "text",
+                text: normalized,
+                syllabic: pendingHyphenWord ? "end" : "single"
+            });
+            pendingHyphenWord = false;
             continue;
         }
         for (let i = 0; i < parts.length; i += 1) {
@@ -21569,6 +21584,7 @@ function tokenizeAbcLyricLine(text) {
                 : (i === parts.length - 1 ? "end" : "middle");
             tokens.push({ type: "text", text: parts[i], syllabic });
         }
+        pendingHyphenWord = false;
     }
     return tokens;
 }
@@ -21943,6 +21959,12 @@ function parseForMusicXml(source, settings) {
                         ": Skipped unsupported V: directive tail token: " +
                         parsedVoice.skippedText);
                 }
+                for (const unsupportedKey of parsedVoice.unsupportedKeys || []) {
+                    warnings.push("line " +
+                        lineNo +
+                        ": Skipped unsupported V: property: " +
+                        unsupportedKey);
+                }
                 if (parsedVoice.bodyText) {
                     const expandedBodyText = expandUserDefinedDecorationSymbols(parsedVoice.bodyText, userDefinedDecorationBySymbol);
                     const inlineVoiceSegments = splitBodyTextByInlineVoice(expandedBodyText, currentVoiceId);
@@ -22070,7 +22092,10 @@ function parseForMusicXml(source, settings) {
         let lastEventNotes = [];
         let pendingTieToNext = false;
         let pendingTrill = false;
+        let pendingTrillLineStart = false;
+        let pendingTrillLineStop = false;
         let pendingTurn = "";
+        let pendingTurnSlash = false;
         let pendingDelayedTurn = false;
         let pendingMordent = "";
         let pendingTremolo = null;
@@ -22091,6 +22116,7 @@ function parseForMusicXml(source, settings) {
         let pendingStrongAccent = false;
         let pendingBreathMark = false;
         let pendingCaesura = false;
+        let pendingPhraseMark = "";
         let pendingSegno = false;
         let pendingCoda = false;
         let pendingFine = false;
@@ -22111,6 +22137,8 @@ function parseForMusicXml(source, settings) {
         let pendingHarmonic = false;
         let pendingStopped = false;
         let pendingThumbPosition = false;
+        let pendingEditorialAccidental = false;
+        let pendingCourtesyAccidental = false;
         let pendingDoubleTongue = false;
         let pendingTripleTongue = false;
         let pendingHeel = false;
@@ -22343,6 +22371,19 @@ function parseForMusicXml(source, settings) {
                 if (decoration === "trill" || decoration === "tr" || decoration === "triller") {
                     pendingTrill = true;
                 }
+                else if (decoration === "editorial") {
+                    pendingEditorialAccidental = true;
+                }
+                else if (decoration === "courtesy") {
+                    pendingCourtesyAccidental = true;
+                }
+                else if (decoration === "trill(") {
+                    pendingTrill = true;
+                    pendingTrillLineStart = true;
+                }
+                else if (decoration === "trill)") {
+                    pendingTrillLineStop = true;
+                }
                 else if (decoration.startsWith("rehearsal:")) {
                     const rehearsalText = rawDecoration.slice("rehearsal:".length).trim();
                     if (rehearsalText) {
@@ -22359,9 +22400,19 @@ function parseForMusicXml(source, settings) {
                 }
                 else if (decoration === "turn") {
                     pendingTurn = "turn";
+                    pendingTurnSlash = false;
+                }
+                else if (decoration === "turnx") {
+                    pendingTurn = "turn";
+                    pendingTurnSlash = true;
                 }
                 else if (decoration === "invertedturn" || decoration === "inverted-turn" || decoration === "lowerturn") {
                     pendingTurn = "inverted-turn";
+                    pendingTurnSlash = false;
+                }
+                else if (decoration === "invertedturnx" || decoration === "inverted-turnx") {
+                    pendingTurn = "inverted-turn";
+                    pendingTurnSlash = true;
                 }
                 else if (decoration === "mordent" || decoration === "lowermordent") {
                     pendingMordent = "mordent";
@@ -22389,7 +22440,7 @@ function parseForMusicXml(source, settings) {
                 else if (decoration === "gliss-stop" || decoration === "glissando-stop") {
                     pendingGlissandoStop = true;
                 }
-                else if (decoration === "slide-start") {
+                else if (decoration === "slide" || decoration === "slide-start") {
                     pendingSlideStart = true;
                 }
                 else if (decoration === "slide-stop") {
@@ -22412,7 +22463,7 @@ function parseForMusicXml(source, settings) {
                 else if (decoration === "staccatissimo" || decoration === "wedge" || decoration === "spiccato") {
                     pendingStaccatissimo = true;
                 }
-                else if (decoration === "accent") {
+                else if (decoration === "accent" || decoration === ">" || decoration === "emphasis") {
                     pendingAccent = true;
                 }
                 else if (decoration === "tenuto") {
@@ -22447,6 +22498,9 @@ function parseForMusicXml(source, settings) {
                 else if (decoration === "caesura") {
                     pendingCaesura = true;
                 }
+                else if (decoration === "shortphrase" || decoration === "mediumphrase" || decoration === "longphrase") {
+                    pendingPhraseMark = decoration;
+                }
                 else if (decoration === "segno") {
                     pendingSegno = true;
                 }
@@ -22456,34 +22510,41 @@ function parseForMusicXml(source, settings) {
                 else if (decoration === "fine") {
                     pendingFine = true;
                 }
-                else if (decoration === "dacapo" || decoration === "da-capo" || decoration === "da capo") {
+                else if (decoration === "dacoda") {
+                    pendingDaCapo = true;
+                    pendingToCoda = true;
+                }
+                else if (decoration === "dacapo" || decoration === "da-capo" || decoration === "da capo" || decoration === "d.c.") {
                     pendingDaCapo = true;
                 }
-                else if (decoration === "dalsegno" || decoration === "dal-segno" || decoration === "dal segno") {
+                else if (decoration === "dalsegno" || decoration === "dal-segno" || decoration === "dal segno" || decoration === "d.s.") {
                     pendingDalSegno = true;
                 }
                 else if (decoration === "tocoda" || decoration === "to-coda" || decoration === "to coda") {
                     pendingToCoda = true;
                 }
-                else if (decoration === "crescendo(" || decoration === "cresc(") {
+                else if (decoration === "crescendo(" || decoration === "cresc(" || decoration === "<(") {
                     pendingCrescendoStart = true;
                 }
-                else if (decoration === "crescendo)" || decoration === "cresc)") {
+                else if (decoration === "crescendo)" || decoration === "cresc)" || decoration === "<)") {
                     pendingCrescendoStop = true;
                 }
                 else if (decoration === "diminuendo(" ||
                     decoration === "decrescendo(" ||
                     decoration === "dim(" ||
-                    decoration === "decresc(") {
+                    decoration === "decresc(" ||
+                    decoration === ">(") {
                     pendingDiminuendoStart = true;
                 }
                 else if (decoration === "diminuendo)" ||
                     decoration === "decrescendo)" ||
                     decoration === "dim)" ||
-                    decoration === "decresc)") {
+                    decoration === "decresc)" ||
+                    decoration === ">)") {
                     pendingDiminuendoStop = true;
                 }
-                else if (decoration === "ppp" ||
+                else if (decoration === "pppp" ||
+                    decoration === "ppp" ||
                     decoration === "p" ||
                     decoration === "pp" ||
                     decoration === "mp" ||
@@ -22491,6 +22552,7 @@ function parseForMusicXml(source, settings) {
                     decoration === "f" ||
                     decoration === "ff" ||
                     decoration === "fff" ||
+                    decoration === "ffff" ||
                     decoration === "fp" ||
                     decoration === "fz" ||
                     decoration === "rfz" ||
@@ -22523,6 +22585,9 @@ function parseForMusicXml(source, settings) {
                 else if (decoration === "toe" || decoration === "toe mark") {
                     pendingToe = true;
                 }
+                else if (/^[0-5]$/.test(decoration)) {
+                    pendingFingerings.push(decoration);
+                }
                 else if (decoration.startsWith("fingering:")) {
                     const fingeringText = rawDecoration.slice("fingering:".length).trim();
                     if (fingeringText)
@@ -22554,6 +22619,7 @@ function parseForMusicXml(source, settings) {
                     pendingHarmonic = true;
                 }
                 else if (decoration === "stopped" ||
+                    decoration === "+" ||
                     decoration === "plus" ||
                     decoration === "stopped horn" ||
                     decoration === "stopped-horn") {
@@ -22701,17 +22767,37 @@ function parseForMusicXml(source, settings) {
                     }
                     if (chordIndex === 0 && pendingTrill && !note.isRest) {
                         note.trill = true;
+                        note.trillLineStart = pendingTrillLineStart;
                         pendingTrill = false;
+                        pendingTrillLineStart = false;
+                    }
+                    if (chordIndex === 0 && pendingTrillLineStop && !note.isRest) {
+                        note.trillLineStop = true;
+                        pendingTrillLineStop = false;
                     }
                     if (chordIndex === 0 && pendingTurn && !note.isRest) {
                         note.turnType = pendingTurn;
+                        note.turnSlash = pendingTurnSlash;
                         note.delayedTurn = pendingDelayedTurn;
                         pendingTurn = "";
+                        pendingTurnSlash = false;
                         pendingDelayedTurn = false;
+                    }
+                    if (chordIndex === 0 && !note.isRest && (pendingEditorialAccidental || pendingCourtesyAccidental)) {
+                        if (note.accidentalText) {
+                            note.accidentalEditorial = pendingEditorialAccidental || undefined;
+                            note.accidentalCautionary = pendingCourtesyAccidental || undefined;
+                        }
+                        pendingEditorialAccidental = false;
+                        pendingCourtesyAccidental = false;
                     }
                     if (chordIndex === 0 && pendingMordent && !note.isRest) {
                         note.mordentType = pendingMordent;
                         pendingMordent = "";
+                    }
+                    if (chordIndex === 0 && pendingPhraseMark && !note.isRest) {
+                        note.phraseMark = pendingPhraseMark;
+                        pendingPhraseMark = "";
                     }
                     if (chordIndex === 0 && pendingTremolo && !note.isRest) {
                         note.tremoloType = pendingTremolo.type;
@@ -23039,17 +23125,37 @@ function parseForMusicXml(source, settings) {
             applyBeamModeForEvent(note, dur);
             if (pendingTrill && !note.isRest) {
                 note.trill = true;
+                note.trillLineStart = pendingTrillLineStart;
                 pendingTrill = false;
+                pendingTrillLineStart = false;
+            }
+            if (pendingTrillLineStop && !note.isRest) {
+                note.trillLineStop = true;
+                pendingTrillLineStop = false;
             }
             if (pendingTurn && !note.isRest) {
                 note.turnType = pendingTurn;
+                note.turnSlash = pendingTurnSlash;
                 note.delayedTurn = pendingDelayedTurn;
                 pendingTurn = "";
+                pendingTurnSlash = false;
                 pendingDelayedTurn = false;
+            }
+            if (!note.isRest && (pendingEditorialAccidental || pendingCourtesyAccidental)) {
+                if (note.accidentalText) {
+                    note.accidentalEditorial = pendingEditorialAccidental || undefined;
+                    note.accidentalCautionary = pendingCourtesyAccidental || undefined;
+                }
+                pendingEditorialAccidental = false;
+                pendingCourtesyAccidental = false;
             }
             if (pendingMordent && !note.isRest) {
                 note.mordentType = pendingMordent;
                 pendingMordent = "";
+            }
+            if (pendingPhraseMark && !note.isRest) {
+                note.phraseMark = pendingPhraseMark;
+                pendingPhraseMark = "";
             }
             if (pendingTremolo && !note.isRest) {
                 note.tremoloType = pendingTremolo.type;
@@ -23384,7 +23490,7 @@ function parseForMusicXml(source, settings) {
                     repeatTimes: (_g = (_f = hintedMeta === null || hintedMeta === void 0 ? void 0 : hintedMeta.repeatTimes) !== null && _f !== void 0 ? _f : notationMeta === null || notationMeta === void 0 ? void 0 : notationMeta.repeatTimes) !== null && _g !== void 0 ? _g : null,
                     endingStart: String((notationMeta === null || notationMeta === void 0 ? void 0 : notationMeta.endingStart) || (hintedMeta === null || hintedMeta === void 0 ? void 0 : hintedMeta.endingStart) || ""),
                     endingStop: String((notationMeta === null || notationMeta === void 0 ? void 0 : notationMeta.endingStop) || (hintedMeta === null || hintedMeta === void 0 ? void 0 : hintedMeta.endingStop) || ""),
-                    endingStopType: (notationMeta === null || notationMeta === void 0 ? void 0 : notationMeta.endingStopType) || (hintedMeta === null || hintedMeta === void 0 ? void 0 : hintedMeta.endingStopType) || "",
+                    endingStopType: (hintedMeta === null || hintedMeta === void 0 ? void 0 : hintedMeta.endingStopType) || (notationMeta === null || notationMeta === void 0 ? void 0 : notationMeta.endingStopType) || "",
                 };
             }
             if (meterHint) {
@@ -23470,13 +23576,14 @@ function parseScoreVoiceOrder(raw, declaredVoiceIds) {
 }
 function parseVoiceDirectiveTail(raw) {
     if (!raw) {
-        return { name: "", clef: "", transpose: null, bodyText: "", skippedText: "" };
+        return { name: "", clef: "", transpose: null, bodyText: "", skippedText: "", unsupportedKeys: [] };
     }
     let bodyText = String(raw);
     let name = "";
     let clef = "";
     let transpose = null;
-    const bareClefMatch = bodyText.match(/^\s*(bass|treble|alto|tenor)(?=\s|$)/i);
+    const unsupportedKeys = [];
+    const bareClefMatch = bodyText.match(/^\s*(bass|treble|alto|tenor|c3|c4)(?=\s|$)/i);
     if (bareClefMatch) {
         clef = String(bareClefMatch[1] || "").trim().toLowerCase();
         bodyText = bodyText.slice(bareClefMatch[0].length);
@@ -23496,6 +23603,9 @@ function parseVoiceDirectiveTail(raw) {
                 transpose = { chromatic: parsed };
             }
         }
+        else {
+            unsupportedKeys.push(lowerKey);
+        }
         return " ";
     });
     bodyText = bodyText.trim();
@@ -23511,7 +23621,8 @@ function parseVoiceDirectiveTail(raw) {
         clef: clef.trim(),
         transpose,
         bodyText,
-        skippedText
+        skippedText,
+        unsupportedKeys
     };
 }
 function inferTransposeFromPartName(partName) {
@@ -24010,7 +24121,7 @@ const exportMusicXmlDomToAbc = (doc) => {
     };
     const parts = Array.from(doc.querySelectorAll("score-partwise > part"));
     parts.forEach((part, partIndex) => {
-        var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p, _q, _r, _s, _t, _u, _v, _w, _x, _y, _z, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26;
+        var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p, _q, _r, _s, _t, _u, _v, _w, _x, _y, _z, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25;
         const partId = part.getAttribute("id") || `P${partIndex + 1}`;
         const partName = partNameById.get(partId) || partId;
         const measures = Array.from(part.querySelectorAll(":scope > measure"));
@@ -24216,13 +24327,18 @@ const exportMusicXmlDomToAbc = (doc) => {
                         if (child.querySelector(':scope > sound[fine="yes"]')) {
                             pendingDirectionDecorations.push("!fine!");
                         }
-                        if (child.querySelector(':scope > sound[dacapo="yes"]')) {
+                        const hasDaCapo = Boolean(child.querySelector(':scope > sound[dacapo="yes"]'));
+                        const hasToCoda = Boolean(child.querySelector(":scope > sound[tocoda]"));
+                        if (hasDaCapo && hasToCoda) {
+                            pendingDirectionDecorations.push("!dacoda!");
+                        }
+                        else if (hasDaCapo) {
                             pendingDirectionDecorations.push("!dacapo!");
                         }
                         if (child.querySelector(":scope > sound[dalsegno]")) {
                             pendingDirectionDecorations.push("!dalsegno!");
                         }
-                        if (child.querySelector(":scope > sound[tocoda]")) {
+                        if (hasToCoda && !hasDaCapo) {
                             pendingDirectionDecorations.push("!tocoda!");
                         }
                         for (const wedgeNode of Array.from(child.querySelectorAll(":scope > direction-type > wedge"))) {
@@ -24240,7 +24356,7 @@ const exportMusicXmlDomToAbc = (doc) => {
                                 activeWedgeType = "";
                             }
                         }
-                        for (const dynamicName of ["ppp", "pp", "p", "mp", "mf", "f", "ff", "fff", "fp", "fz", "rfz", "sf", "sfp", "sfz"]) {
+                        for (const dynamicName of ["pppp", "ppp", "pp", "p", "mp", "mf", "f", "ff", "fff", "ffff", "fp", "fz", "rfz", "sf", "sfp", "sfz"]) {
                             if (child.querySelector(`:scope > direction-type > dynamics > ${dynamicName}`)) {
                                 pendingDirectionDecorations.push(`!${dynamicName}!`);
                             }
@@ -24272,6 +24388,8 @@ const exportMusicXmlDomToAbc = (doc) => {
                     const hasTrillMark = Boolean(child.querySelector(":scope > notations > ornaments > trill-mark"));
                     const hasTurn = Boolean(child.querySelector(":scope > notations > ornaments > turn"));
                     const hasInvertedTurn = Boolean(child.querySelector(":scope > notations > ornaments > inverted-turn"));
+                    const hasTurnSlash = Array.from(child.querySelectorAll(":scope > notations > ornaments > turn, :scope > notations > ornaments > inverted-turn"))
+                        .some((node) => (node.getAttribute("slash") || "").trim().toLowerCase() === "yes");
                     const hasDelayedTurn = Boolean(child.querySelector(":scope > notations > ornaments > delayed-turn"));
                     const hasMordent = Boolean(child.querySelector(":scope > notations > ornaments > mordent"));
                     const hasInvertedMordent = Boolean(child.querySelector(":scope > notations > ornaments > inverted-mordent"));
@@ -24287,6 +24405,11 @@ const exportMusicXmlDomToAbc = (doc) => {
                         var _a;
                         const type = ((_a = node.getAttribute("type")) !== null && _a !== void 0 ? _a : "").trim().toLowerCase();
                         return type === "" || type === "start";
+                    });
+                    const hasWavyLineStop = Array.from(child.querySelectorAll(":scope > notations > ornaments > wavy-line")).some((node) => {
+                        var _a;
+                        const type = ((_a = node.getAttribute("type")) !== null && _a !== void 0 ? _a : "").trim().toLowerCase();
+                        return type === "stop";
                     });
                     const hasTrill = hasTrillMark || hasWavyLineStart;
                     const turnType = hasInvertedTurn ? "inverted-turn" : (hasTurn ? "turn" : "");
@@ -24306,6 +24429,9 @@ const exportMusicXmlDomToAbc = (doc) => {
                     const hasStrongAccent = Boolean(child.querySelector(":scope > notations > articulations > strong-accent"));
                     const hasBreathMark = Boolean(child.querySelector(":scope > notations > articulations > breath-mark"));
                     const hasCaesura = Boolean(child.querySelector(":scope > notations > articulations > caesura"));
+                    const phraseMarkText = Array.from(child.querySelectorAll(":scope > notations > articulations > other-articulation"))
+                        .map((node) => (node.textContent || "").trim().toLowerCase())
+                        .find((text) => text === "shortphrase" || text === "mediumphrase" || text === "longphrase") || "";
                     const hasUpBow = Boolean(child.querySelector(":scope > notations > technical > up-bow"));
                     const hasDownBow = Boolean(child.querySelector(":scope > notations > technical > down-bow"));
                     const hasDoubleTongue = Boolean(child.querySelector(":scope > notations > technical > double-tongue"));
@@ -24357,11 +24483,14 @@ const exportMusicXmlDomToAbc = (doc) => {
                         const stepOctaveKey = `${upperStep}${safeOctave}`;
                         const alterRaw = (_16 = (_15 = (_14 = child.querySelector(":scope > pitch > alter")) === null || _14 === void 0 ? void 0 : _14.textContent) === null || _15 === void 0 ? void 0 : _15.trim()) !== null && _16 !== void 0 ? _16 : "";
                         const explicitAlter = alterRaw !== "" && Number.isFinite(Number(alterRaw)) ? Math.round(Number(alterRaw)) : null;
-                        const accidentalText = (_19 = (_18 = (_17 = child.querySelector(":scope > accidental")) === null || _17 === void 0 ? void 0 : _17.textContent) === null || _18 === void 0 ? void 0 : _18.trim()) !== null && _19 !== void 0 ? _19 : "";
+                        const accidentalNode = child.querySelector(":scope > accidental");
+                        const accidentalText = (_18 = (_17 = accidentalNode === null || accidentalNode === void 0 ? void 0 : accidentalNode.textContent) === null || _17 === void 0 ? void 0 : _17.trim()) !== null && _18 !== void 0 ? _18 : "";
                         const accidentalAlter = accidentalTextToAlter(accidentalText);
-                        const keyAlter = (_20 = keyAlterMap[upperStep]) !== null && _20 !== void 0 ? _20 : 0;
+                        const accidentalEditorial = (((accidentalNode === null || accidentalNode === void 0 ? void 0 : accidentalNode.getAttribute("editorial")) || "").trim().toLowerCase() === "yes");
+                        const accidentalCautionary = (((accidentalNode === null || accidentalNode === void 0 ? void 0 : accidentalNode.getAttribute("cautionary")) || "").trim().toLowerCase() === "yes");
+                        const keyAlter = (_19 = keyAlterMap[upperStep]) !== null && _19 !== void 0 ? _19 : 0;
                         const currentAlter = measureAccidentalByStepOctave.has(stepOctaveKey)
-                            ? (_21 = measureAccidentalByStepOctave.get(stepOctaveKey)) !== null && _21 !== void 0 ? _21 : 0
+                            ? (_20 = measureAccidentalByStepOctave.get(stepOctaveKey)) !== null && _20 !== void 0 ? _20 : 0
                             : keyAlter;
                         // In MusicXML pitch, omitted <alter> means natural (0), not "follow key accidental".
                         // Key signature context is only used to decide whether an explicit accidental token is needed.
@@ -24377,6 +24506,12 @@ const exportMusicXmlDomToAbc = (doc) => {
                             : "";
                         measureAccidentalByStepOctave.set(stepOctaveKey, targetAlter);
                         pitchToken = `${accidental}${exports.AbcCommon.abcPitchFromStepOctave(step, Number.isFinite(octave) ? octave : 4)}`;
+                        if (accidentalEditorial && accidental) {
+                            pitchToken = `!editorial!${pitchToken}`;
+                        }
+                        if (accidentalCautionary && accidental) {
+                            pitchToken = `!courtesy!${pitchToken}`;
+                        }
                     }
                     if (isGrace) {
                         const graceSlashPrefix = hasGraceSlash ? "/" : "";
@@ -24384,7 +24519,7 @@ const exportMusicXmlDomToAbc = (doc) => {
                             pendingGraceTokens.push(`${graceSlashPrefix}${pitchToken}${len}${hasTieStart ? "-" : ""}`);
                         }
                         else {
-                            const last = (_22 = pendingGraceTokens.pop()) !== null && _22 !== void 0 ? _22 : "";
+                            const last = (_21 = pendingGraceTokens.pop()) !== null && _21 !== void 0 ? _21 : "";
                             const merged = last.startsWith("[")
                                 ? last.replace("]", `${graceSlashPrefix}${pitchToken}]`)
                                 : `[${last}${graceSlashPrefix}${pitchToken}]`;
@@ -24406,17 +24541,19 @@ const exportMusicXmlDomToAbc = (doc) => {
                             ? `(${activeTuplet.actual}:${activeTuplet.normal}:${activeTuplet.actual}`
                             : "")
                         : "";
-                    const trillPrefix = hasTrill ? "!trill!" : "";
+                    const trillPrefix = hasWavyLineStop
+                        ? "!trill)!"
+                        : (hasWavyLineStart && !hasTrillMark ? "!trill!" : (hasWavyLineStart ? "!trill(!" : (hasTrill ? "!trill!" : "")));
                     const turnPrefix = turnType === "inverted-turn"
-                        ? (hasDelayedTurn ? "!delayedinvertedturn!" : "!invertedturn!")
-                        : (turnType === "turn" ? (hasDelayedTurn ? "!delayedturn!" : "!turn!") : "");
+                        ? (hasDelayedTurn ? "!delayedinvertedturn!" : (hasTurnSlash ? "!invertedturnx!" : "!invertedturn!"))
+                        : (turnType === "turn" ? (hasDelayedTurn ? "!delayedturn!" : (hasTurnSlash ? "!turnx!" : "!turn!")) : "");
                     const mordentPrefix = mordentType === "inverted-mordent" ? "!pralltriller!" : (mordentType === "mordent" ? "!mordent!" : "");
                     const tremoloPrefix = tremoloType ? `!tremolo-${tremoloType}-${tremoloMarks}!` : "";
                     const glissandoPrefix = hasGlissandoStart ? "!gliss-start!" : (hasGlissandoStop ? "!gliss-stop!" : "");
-                    const slidePrefix = hasSlideStart ? "!slide-start!" : (hasSlideStop ? "!slide-stop!" : "");
+                    const slidePrefix = hasSlideStart ? "!slide!" : (hasSlideStop ? "!slide-stop!" : "");
                     const schleiferPrefix = hasSchleifer ? "!schleifer!" : "";
                     const shakePrefix = hasShake ? "!shake!" : "";
-                    const arpeggiatePrefix = hasArpeggiate ? "!roll!" : "";
+                    const arpeggiatePrefix = hasArpeggiate ? "!arpeggio!" : "";
                     const staccatoPrefix = hasStaccatissimo ? "!wedge!" : (hasStaccato ? "!staccato!" : "");
                     const accentPrefix = hasAccent ? "!accent!" : "";
                     const tenutoPrefix = hasTenuto ? "!tenuto!" : "";
@@ -24425,13 +24562,18 @@ const exportMusicXmlDomToAbc = (doc) => {
                     const strongAccentPrefix = hasStrongAccent ? "!marcato!" : "";
                     const breathMarkPrefix = hasBreathMark ? "!breath!" : "";
                     const caesuraPrefix = hasCaesura ? "!caesura!" : "";
+                    const phraseMarkPrefix = phraseMarkText === "shortphrase" || phraseMarkText === "mediumphrase" || phraseMarkText === "longphrase"
+                        ? `!${phraseMarkText}!`
+                        : "";
                     const upBowPrefix = hasUpBow ? "!upbow!" : "";
                     const downBowPrefix = hasDownBow ? "!downbow!" : "";
                     const doubleTonguePrefix = hasDoubleTongue ? "!doubletongue!" : "";
                     const tripleTonguePrefix = hasTripleTongue ? "!tripletongue!" : "";
                     const heelPrefix = hasHeel ? "!heel!" : "";
                     const toePrefix = hasToe ? "!toe!" : "";
-                    const fingeringPrefix = fingeringTexts.map((value) => `!fingering:${value}!`).join("");
+                    const fingeringPrefix = fingeringTexts
+                        .map((value) => (/^[0-5]$/.test(value) ? `!${value}!` : `!fingering:${value}!`))
+                        .join("");
                     const stringPrefix = stringTexts.map((value) => `!string:${value}!`).join("");
                     const pluckPrefix = pluckTexts.map((value) => `!pluck:${value}!`).join("");
                     const openStringPrefix = hasOpenString ? "!open!" : "";
@@ -24448,7 +24590,7 @@ const exportMusicXmlDomToAbc = (doc) => {
                         ? `${pendingHarmonySymbols.map((symbol) => `"${abcQuotedTextEscape(symbol)}"`).join("")}`
                         : "";
                     const directionDecorationPrefix = !isChord && pendingDirectionDecorations.length > 0 ? pendingDirectionDecorations.join("") : "";
-                    const eventPrefix = `${harmonyPrefix}${wordsPrefix}${directionDecorationPrefix}${tupletPrefix}${slurStartPrefix}${gracePrefix}${trillPrefix}${turnPrefix}${mordentPrefix}${tremoloPrefix}${glissandoPrefix}${slidePrefix}${schleiferPrefix}${shakePrefix}${arpeggiatePrefix}${staccatoPrefix}${accentPrefix}${tenutoPrefix}${stressPrefix}${unstressPrefix}${strongAccentPrefix}${breathMarkPrefix}${caesuraPrefix}${upBowPrefix}${downBowPrefix}${doubleTonguePrefix}${tripleTonguePrefix}${heelPrefix}${toePrefix}${fingeringPrefix}${stringPrefix}${pluckPrefix}${openStringPrefix}${snapPizzicatoPrefix}${harmonicPrefix}${stoppedPrefix}${thumbPrefix}${fermataPrefix}`;
+                    const eventPrefix = `${harmonyPrefix}${wordsPrefix}${directionDecorationPrefix}${tupletPrefix}${slurStartPrefix}${gracePrefix}${trillPrefix}${turnPrefix}${mordentPrefix}${tremoloPrefix}${glissandoPrefix}${slidePrefix}${schleiferPrefix}${shakePrefix}${arpeggiatePrefix}${staccatoPrefix}${accentPrefix}${tenutoPrefix}${stressPrefix}${unstressPrefix}${strongAccentPrefix}${breathMarkPrefix}${caesuraPrefix}${phraseMarkPrefix}${upBowPrefix}${downBowPrefix}${doubleTonguePrefix}${tripleTonguePrefix}${heelPrefix}${toePrefix}${fingeringPrefix}${stringPrefix}${pluckPrefix}${openStringPrefix}${snapPizzicatoPrefix}${harmonicPrefix}${stoppedPrefix}${thumbPrefix}${fermataPrefix}`;
                     if (!isChord && pendingHarmonySymbols.length > 0) {
                         pendingHarmonySymbols.length = 0;
                     }
@@ -24489,8 +24631,8 @@ const exportMusicXmlDomToAbc = (doc) => {
                     }
                     if (!isGrace && !isChord && !child.querySelector(":scope > rest")) {
                         const lyric = child.querySelector(":scope > lyric");
-                        const lyricText = ((_24 = (_23 = lyric === null || lyric === void 0 ? void 0 : lyric.querySelector(":scope > text")) === null || _23 === void 0 ? void 0 : _23.textContent) === null || _24 === void 0 ? void 0 : _24.trim()) || "";
-                        const lyricSyllabic = ((_26 = (_25 = lyric === null || lyric === void 0 ? void 0 : lyric.querySelector(":scope > syllabic")) === null || _25 === void 0 ? void 0 : _25.textContent) === null || _26 === void 0 ? void 0 : _26.trim()) || "single";
+                        const lyricText = ((_23 = (_22 = lyric === null || lyric === void 0 ? void 0 : lyric.querySelector(":scope > text")) === null || _22 === void 0 ? void 0 : _22.textContent) === null || _23 === void 0 ? void 0 : _23.trim()) || "";
+                        const lyricSyllabic = ((_25 = (_24 = lyric === null || lyric === void 0 ? void 0 : lyric.querySelector(":scope > syllabic")) === null || _24 === void 0 ? void 0 : _24.textContent) === null || _25 === void 0 ? void 0 : _25.trim()) || "single";
                         const lyricExtend = Boolean(lyric === null || lyric === void 0 ? void 0 : lyric.querySelector(":scope > extend"));
                         if (lyricText) {
                             lyricTokens.push(abcLyricTokenFromMusicXml(lyricText, lyricSyllabic));
@@ -25135,7 +25277,13 @@ const buildMusicXmlFromAbcParsed = (parsed, abcSource, options = {}) => {
                             chunks.push(`<time-modification><actual-notes>${Math.round(Number(note.timeModification.actual))}</actual-notes><normal-notes>${Math.round(Number(note.timeModification.normal))}</normal-notes></time-modification>`);
                         }
                         if (note.accidentalText) {
-                            chunks.push(`<accidental>${xmlEscape(String(note.accidentalText))}</accidental>`);
+                            const accidentalAttrs = [
+                                note.accidentalEditorial ? 'editorial="yes"' : "",
+                                note.accidentalCautionary ? 'cautionary="yes"' : "",
+                            ].filter(Boolean).join(" ");
+                            chunks.push(accidentalAttrs
+                                ? `<accidental ${accidentalAttrs}>${xmlEscape(String(note.accidentalText))}</accidental>`
+                                : `<accidental>${xmlEscape(String(note.accidentalText))}</accidental>`);
                         }
                         if (note.tieStart)
                             chunks.push('<tie type="start"/>');
@@ -25146,6 +25294,7 @@ const buildMusicXmlFromAbcParsed = (parsed, abcSource, options = {}) => {
                             note.slurStart ||
                             note.slurStop ||
                             note.trill ||
+                            note.trillLineStop ||
                             note.turnType ||
                             note.delayedTurn ||
                             note.mordentType ||
@@ -25167,6 +25316,7 @@ const buildMusicXmlFromAbcParsed = (parsed, abcSource, options = {}) => {
                             note.strongAccent ||
                             note.breathMark ||
                             note.caesura ||
+                            note.phraseMark ||
                             note.upBow ||
                             note.downBow ||
                             note.doubleTongue ||
@@ -25196,10 +25346,17 @@ const buildMusicXmlFromAbcParsed = (parsed, abcSource, options = {}) => {
                                 chunks.push('<tuplet type="start"/>');
                             if (note.tupletStop)
                                 chunks.push('<tuplet type="stop"/>');
-                            if (note.trill) {
+                            if (note.trill || note.trillLineStop) {
                                 const trillParts = [];
-                                trillParts.push("<trill-mark/>");
-                                trillParts.push('<wavy-line type="start"/>');
+                                if (note.trill) {
+                                    trillParts.push("<trill-mark/>");
+                                }
+                                if (note.trillLineStop) {
+                                    trillParts.push('<wavy-line type="stop"/>');
+                                }
+                                else if (note.trillLineStart) {
+                                    trillParts.push('<wavy-line type="start"/>');
+                                }
                                 if (note.trillAccidentalText) {
                                     trillParts.push(`<accidental-mark>${xmlEscape(String(note.trillAccidentalText))}</accidental-mark>`);
                                 }
@@ -25207,7 +25364,8 @@ const buildMusicXmlFromAbcParsed = (parsed, abcSource, options = {}) => {
                             }
                             if (note.turnType) {
                                 const tag = note.turnType === "inverted-turn" ? "inverted-turn" : "turn";
-                                chunks.push(`<ornaments><${tag}/>${note.delayedTurn ? "<delayed-turn/>" : ""}</ornaments>`);
+                                const slashAttr = note.turnSlash ? ' slash="yes"' : "";
+                                chunks.push(`<ornaments><${tag}${slashAttr}/>${note.delayedTurn ? "<delayed-turn/>" : ""}</ornaments>`);
                             }
                             if (note.mordentType) {
                                 const tag = note.mordentType === "inverted-mordent" ? "inverted-mordent" : "mordent";
@@ -25257,6 +25415,8 @@ const buildMusicXmlFromAbcParsed = (parsed, abcSource, options = {}) => {
                                 articulationParts.push("<breath-mark/>");
                             if (note.caesura)
                                 articulationParts.push("<caesura/>");
+                            if (note.phraseMark)
+                                articulationParts.push(`<other-articulation>${xmlEscape(String(note.phraseMark))}</other-articulation>`);
                             if (articulationParts.length > 0) {
                                 chunks.push(`<articulations>${articulationParts.join("")}</articulations>`);
                             }

--- a/src/ts/abc-io.ts
+++ b/src/ts/abc-io.ts
@@ -223,6 +223,7 @@ const abcCommon = AbcCommon;
       .map((token) => token.trim())
       .filter(Boolean);
     const tokens = [];
+    let pendingHyphenWord = false;
     for (const chunk of chunks) {
       if (chunk === "*") {
         tokens.push({ type: "skip" });
@@ -233,9 +234,23 @@ const abcCommon = AbcCommon;
         continue;
       }
       const normalized = chunk.replace(/~/g, " ");
+      if (normalized.endsWith("-") && normalized.length > 1) {
+        tokens.push({
+          type: "text",
+          text: normalized.slice(0, -1),
+          syllabic: pendingHyphenWord ? "middle" : "begin"
+        });
+        pendingHyphenWord = true;
+        continue;
+      }
       const parts = normalized.split("-").filter((part) => part.length > 0);
       if (parts.length <= 1) {
-        tokens.push({ type: "text", text: normalized, syllabic: "single" });
+        tokens.push({
+          type: "text",
+          text: normalized,
+          syllabic: pendingHyphenWord ? "end" : "single"
+        });
+        pendingHyphenWord = false;
         continue;
       }
       for (let i = 0; i < parts.length; i += 1) {
@@ -245,6 +260,7 @@ const abcCommon = AbcCommon;
             : (i === parts.length - 1 ? "end" : "middle");
         tokens.push({ type: "text", text: parts[i], syllabic });
       }
+      pendingHyphenWord = false;
     }
     return tokens;
   }
@@ -639,6 +655,14 @@ const abcCommon = AbcCommon;
                 parsedVoice.skippedText
             );
           }
+          for (const unsupportedKey of parsedVoice.unsupportedKeys || []) {
+            warnings.push(
+              "line " +
+                lineNo +
+                ": Skipped unsupported V: property: " +
+                unsupportedKey
+            );
+          }
           if (parsedVoice.bodyText) {
             const expandedBodyText = expandUserDefinedDecorationSymbols(parsedVoice.bodyText, userDefinedDecorationBySymbol);
             const inlineVoiceSegments = splitBodyTextByInlineVoice(expandedBodyText, currentVoiceId);
@@ -819,6 +843,8 @@ const abcCommon = AbcCommon;
       let pendingHarmonic = false;
       let pendingStopped = false;
       let pendingThumbPosition = false;
+      let pendingEditorialAccidental = false;
+      let pendingCourtesyAccidental = false;
       let pendingDoubleTongue = false;
       let pendingTripleTongue = false;
       let pendingHeel = false;
@@ -1068,6 +1094,10 @@ const abcCommon = AbcCommon;
           const decoration = rawDecoration.toLowerCase();
           if (decoration === "trill" || decoration === "tr" || decoration === "triller") {
             pendingTrill = true;
+          } else if (decoration === "editorial") {
+            pendingEditorialAccidental = true;
+          } else if (decoration === "courtesy") {
+            pendingCourtesyAccidental = true;
           } else if (decoration === "trill(") {
             pendingTrill = true;
             pendingTrillLineStart = true;
@@ -1275,6 +1305,7 @@ const abcCommon = AbcCommon;
             pendingHarmonic = true;
           } else if (
             decoration === "stopped" ||
+            decoration === "+" ||
             decoration === "plus" ||
             decoration === "stopped horn" ||
             decoration === "stopped-horn"
@@ -1456,6 +1487,14 @@ const abcCommon = AbcCommon;
               pendingTurn = "";
               pendingTurnSlash = false;
               pendingDelayedTurn = false;
+            }
+            if (chordIndex === 0 && !note.isRest && (pendingEditorialAccidental || pendingCourtesyAccidental)) {
+              if (note.accidentalText) {
+                note.accidentalEditorial = pendingEditorialAccidental || undefined;
+                note.accidentalCautionary = pendingCourtesyAccidental || undefined;
+              }
+              pendingEditorialAccidental = false;
+              pendingCourtesyAccidental = false;
             }
             if (chordIndex === 0 && pendingMordent && !note.isRest) {
               note.mordentType = pendingMordent;
@@ -1825,6 +1864,14 @@ const abcCommon = AbcCommon;
           pendingTurnSlash = false;
           pendingDelayedTurn = false;
         }
+        if (!note.isRest && (pendingEditorialAccidental || pendingCourtesyAccidental)) {
+          if (note.accidentalText) {
+            note.accidentalEditorial = pendingEditorialAccidental || undefined;
+            note.accidentalCautionary = pendingCourtesyAccidental || undefined;
+          }
+          pendingEditorialAccidental = false;
+          pendingCourtesyAccidental = false;
+        }
         if (pendingMordent && !note.isRest) {
           note.mordentType = pendingMordent;
           pendingMordent = "";
@@ -2178,7 +2225,7 @@ const abcCommon = AbcCommon;
             repeatTimes: hintedMeta?.repeatTimes ?? notationMeta?.repeatTimes ?? null,
             endingStart: String(notationMeta?.endingStart || hintedMeta?.endingStart || ""),
             endingStop: String(notationMeta?.endingStop || hintedMeta?.endingStop || ""),
-            endingStopType: notationMeta?.endingStopType || hintedMeta?.endingStopType || "",
+            endingStopType: hintedMeta?.endingStopType || notationMeta?.endingStopType || "",
           };
         }
         if (meterHint) {
@@ -2268,12 +2315,13 @@ const abcCommon = AbcCommon;
 
   function parseVoiceDirectiveTail(raw) {
     if (!raw) {
-      return { name: "", clef: "", transpose: null, bodyText: "", skippedText: "" };
+      return { name: "", clef: "", transpose: null, bodyText: "", skippedText: "", unsupportedKeys: [] };
     }
     let bodyText = String(raw);
     let name = "";
     let clef = "";
     let transpose = null;
+    const unsupportedKeys = [];
     const bareClefMatch = bodyText.match(/^\s*(bass|treble|alto|tenor|c3|c4)(?=\s|$)/i);
     if (bareClefMatch) {
       clef = String(bareClefMatch[1] || "").trim().toLowerCase();
@@ -2291,6 +2339,8 @@ const abcCommon = AbcCommon;
         if (Number.isFinite(parsed) && parsed >= -24 && parsed <= 24) {
           transpose = { chromatic: parsed };
         }
+      } else {
+        unsupportedKeys.push(lowerKey);
       }
       return " ";
     });
@@ -2307,7 +2357,8 @@ const abcCommon = AbcCommon;
       clef: clef.trim(),
       transpose,
       bodyText,
-      skippedText
+      skippedText,
+      unsupportedKeys
     };
   }
 
@@ -3210,8 +3261,11 @@ export const exportMusicXmlDomToAbc = (doc: Document): string => {
             const alterRaw = child.querySelector(":scope > pitch > alter")?.textContent?.trim() ?? "";
             const explicitAlter =
               alterRaw !== "" && Number.isFinite(Number(alterRaw)) ? Math.round(Number(alterRaw)) : null;
-            const accidentalText = child.querySelector(":scope > accidental")?.textContent?.trim() ?? "";
+            const accidentalNode = child.querySelector(":scope > accidental");
+            const accidentalText = accidentalNode?.textContent?.trim() ?? "";
             const accidentalAlter = accidentalTextToAlter(accidentalText);
+            const accidentalEditorial = ((accidentalNode?.getAttribute("editorial") || "").trim().toLowerCase() === "yes");
+            const accidentalCautionary = ((accidentalNode?.getAttribute("cautionary") || "").trim().toLowerCase() === "yes");
 
             const keyAlter = keyAlterMap[upperStep] ?? 0;
             const currentAlter = measureAccidentalByStepOctave.has(stepOctaveKey)
@@ -3234,6 +3288,12 @@ export const exportMusicXmlDomToAbc = (doc: Document): string => {
               : "";
             measureAccidentalByStepOctave.set(stepOctaveKey, targetAlter);
             pitchToken = `${accidental}${AbcCommon.abcPitchFromStepOctave(step, Number.isFinite(octave) ? octave : 4)}`;
+            if (accidentalEditorial && accidental) {
+              pitchToken = `!editorial!${pitchToken}`;
+            }
+            if (accidentalCautionary && accidental) {
+              pitchToken = `!courtesy!${pitchToken}`;
+            }
           }
           if (isGrace) {
             const graceSlashPrefix = hasGraceSlash ? "/" : "";
@@ -3638,6 +3698,8 @@ type AbcParsedNote = {
   octave?: number;
   alter?: number | null;
   accidentalText?: string | null;
+  accidentalEditorial?: boolean;
+  accidentalCautionary?: boolean;
   tieStart?: boolean;
   tieStop?: boolean;
   slurStart?: boolean;
@@ -4154,7 +4216,15 @@ const buildMusicXmlFromAbcParsed = (
                     );
                   }
                   if (note.accidentalText) {
-                    chunks.push(`<accidental>${xmlEscape(String(note.accidentalText))}</accidental>`);
+                    const accidentalAttrs = [
+                      note.accidentalEditorial ? 'editorial="yes"' : "",
+                      note.accidentalCautionary ? 'cautionary="yes"' : "",
+                    ].filter(Boolean).join(" ");
+                    chunks.push(
+                      accidentalAttrs
+                        ? `<accidental ${accidentalAttrs}>${xmlEscape(String(note.accidentalText))}</accidental>`
+                        : `<accidental>${xmlEscape(String(note.accidentalText))}</accidental>`,
+                    );
                   }
                   if (note.tieStart) chunks.push('<tie type="start"/>');
                   if (note.tieStop) chunks.push('<tie type="stop"/>');
@@ -4213,14 +4283,14 @@ const buildMusicXmlFromAbcParsed = (
                     if (note.tupletStop) chunks.push('<tuplet type="stop"/>');
                     if (note.trill || note.trillLineStop) {
                       const trillParts: string[] = [];
-                      if (note.trill) {
-                        trillParts.push("<trill-mark/>");
-                      }
-                      if (note.trillLineStop) {
-                        trillParts.push('<wavy-line type="stop"/>');
-                      } else if (note.trillLineStart || note.trill) {
-                        trillParts.push('<wavy-line type="start"/>');
-                      }
+                    if (note.trill) {
+                      trillParts.push("<trill-mark/>");
+                    }
+                    if (note.trillLineStop) {
+                      trillParts.push('<wavy-line type="stop"/>');
+                    } else if (note.trillLineStart) {
+                      trillParts.push('<wavy-line type="start"/>');
+                    }
                       if (note.trillAccidentalText) {
                         trillParts.push(`<accidental-mark>${xmlEscape(String(note.trillAccidentalText))}</accidental-mark>`);
                       }

--- a/tests/unit/abc-io.spec.ts
+++ b/tests/unit/abc-io.spec.ts
@@ -343,6 +343,48 @@ C D E F |`;
     );
   });
 
+  it("ABC import applies supported V: transpose property as chromatic transpose", () => {
+    const abc = `X:1
+T:Voice transpose
+M:4/4
+L:1/4
+K:C
+V:1 name="Clarinet in A" clef=treble transpose=-3
+C D E F |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    expect(outDoc.querySelector("part > measure > attributes > transpose > chromatic")?.textContent?.trim()).toBe("-3");
+    expect(outDoc.querySelector('miscellaneous-field[name="mks:diag:count"]')).toBeNull();
+  });
+
+  it("ABC import warns on unsupported standard V: properties instead of treating them as supported metadata", () => {
+    const abc = `X:1
+T:Unsupported V property warning
+M:4/4
+L:1/4
+K:C
+V:1 name="Upper" staves=2 middle=c
+C D E F |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    expect(outDoc.querySelectorAll("part > measure note").length).toBe(4);
+    expect(outDoc.querySelector('miscellaneous-field[name="mks:diag:count"]')?.textContent?.trim()).toBe("2");
+    expect(outDoc.querySelector('miscellaneous-field[name="mks:diag:0001"]')?.textContent).toContain(
+      "Skipped unsupported V: property: staves"
+    );
+    expect(outDoc.querySelector('miscellaneous-field[name="mks:diag:0002"]')?.textContent).toContain(
+      "Skipped unsupported V: property: middle"
+    );
+  });
+
   it("ABC import reflows overfull measure content to avoid MEASURE_OVERFULL", () => {
     const overfullAbc = `X:1
 T:Overfull
@@ -587,6 +629,25 @@ K:C
     expect(harmonies[3]?.querySelector(":scope > bass > bass-alter")?.textContent?.trim()).toBe("1");
   });
 
+  it("ABC->MusicXML keeps unsupported quoted chord-like text as annotation instead of forcing harmony", () => {
+    const abc = `X:1
+T:Unsupported chord inventory
+M:4/4
+L:1/8
+K:C
+"Cadd9"C "Fmaj13"D |`;
+
+    const outDoc = parseMusicXmlDocument(convertAbcToMusicXml(abc));
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    expect(outDoc.querySelectorAll("part > measure > harmony").length).toBe(0);
+    const words = Array.from(outDoc.querySelectorAll("part > measure > direction > direction-type > words"))
+      .map((node) => node.textContent?.trim());
+    expect(words).toContain("Cadd9");
+    expect(words).toContain("Fmaj13");
+  });
+
   it("ABC->MusicXML parses mikuscore rehearsal decoration as rehearsal direction", () => {
     const abc = `X:1
 T:Rehearsal
@@ -659,6 +720,47 @@ K:C
 
     const abc = exportMusicXmlDomToAbc(doc);
     expect(abc).toContain('"rit."C');
+  });
+
+  it("MusicXML->ABC->MusicXML keeps unsupported chord-like quoted text as annotation", () => {
+    const xml = `<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>480</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <direction><direction-type><words>Cadd9</words></direction-type></direction>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>480</duration><voice>1</voice><type>eighth</type></note>
+      <direction><direction-type><words>Fmaj13</words></direction-type></direction>
+      <note><pitch><step>D</step><octave>4</octave></pitch><duration>480</duration><voice>1</voice><type>eighth</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+
+    const doc = parseMusicXmlDocument(xml);
+    expect(doc).not.toBeNull();
+    if (!doc) return;
+
+    const abc = exportMusicXmlDomToAbc(doc);
+    expect(abc).toContain('"Cadd9"C');
+    expect(abc).toContain('"Fmaj13"D');
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    expect(outDoc.querySelectorAll("part > measure > harmony").length).toBe(0);
+    const words = Array.from(outDoc.querySelectorAll("part > measure > direction > direction-type > words"))
+      .map((node) => node.textContent?.trim());
+    expect(words).toContain("Cadd9");
+    expect(words).toContain("Fmaj13");
   });
 
   it("MusicXML->ABC exports harmony as quoted chord symbols", () => {
@@ -881,6 +983,55 @@ w: hal-le-lu`;
     expect(syllabics).toEqual(["begin", "middle", "end"]);
   });
 
+  it("MusicXML->ABC->MusicXML roundtrips common hyphenated lyrics in the bounded subset", () => {
+    const xml = `<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Voice</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>480</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch><duration>480</duration><voice>1</voice><type>eighth</type>
+        <lyric><syllabic>begin</syllabic><text>hal</text></lyric>
+      </note>
+      <note>
+        <pitch><step>D</step><octave>4</octave></pitch><duration>480</duration><voice>1</voice><type>eighth</type>
+        <lyric><syllabic>middle</syllabic><text>le</text></lyric>
+      </note>
+      <note>
+        <pitch><step>E</step><octave>4</octave></pitch><duration>480</duration><voice>1</voice><type>eighth</type>
+        <lyric><syllabic>end</syllabic><text>lu</text></lyric>
+      </note>
+    </measure>
+  </part>
+</score-partwise>`;
+
+    const srcDoc = parseMusicXmlDocument(xml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("w: hal- le- lu");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const lyrics = Array.from(outDoc.querySelectorAll("part > measure > note > lyric > text"))
+      .map((node) => node.textContent?.trim());
+    expect(lyrics).toEqual(["hal", "le", "lu"]);
+    const syllabics = Array.from(outDoc.querySelectorAll("part > measure > note > lyric > syllabic"))
+      .map((node) => node.textContent?.trim());
+    expect(syllabics).toEqual(["begin", "middle", "end"]);
+  });
+
   it("ABC->MusicXML supports inline [V:...] voice switches in body text", () => {
     const abc = `X:1
 T:Inline voice switch
@@ -906,6 +1057,44 @@ V:2 name="Lower"
     expect(outDoc.querySelector('part-list > score-part[id="P1"] > part-name')?.textContent?.trim()).toBe("Upper");
     expect(outDoc.querySelector('part-list > score-part[id="P2"] > part-name')?.textContent?.trim()).toBe("Lower");
     expect(outDoc.querySelector('miscellaneous-field[name="mks:diag:count"]')).toBeNull();
+  });
+
+  it("ABC->MusicXML applies !editorial! to the next explicit accidental", () => {
+    const abc = `X:1
+T:Editorial accidental
+M:4/4
+L:1/4
+K:C
+!editorial!^C z |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const accidental = outDoc.querySelector("part > measure > note > accidental");
+    expect(accidental?.textContent?.trim()).toBe("sharp");
+    expect(accidental?.getAttribute("editorial")).toBe("yes");
+    expect(accidental?.getAttribute("cautionary")).toBeNull();
+  });
+
+  it("ABC->MusicXML applies !courtesy! to the next explicit accidental", () => {
+    const abc = `X:1
+T:Courtesy accidental
+M:4/4
+L:1/4
+K:G
+!courtesy!=F z |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const accidental = outDoc.querySelector("part > measure > note > accidental");
+    expect(accidental?.textContent?.trim()).toBe("natural");
+    expect(accidental?.getAttribute("cautionary")).toBe("yes");
+    expect(accidental?.getAttribute("editorial")).toBeNull();
   });
 
   it("ABC->MusicXML supports U: user-defined decoration symbols with punctuation", () => {
@@ -2976,6 +3165,54 @@ CD EF GA Bc |`;
     expect(beams).toEqual(["begin", "end", "begin", "end", "begin", "end", "begin", "end"]);
   });
 
+  it("MusicXML->ABC does not preserve beam grouping through exact ABC spacing", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>2</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>480</duration><voice>1</voice><type>eighth</type>
+        <beam number="1">begin</beam>
+      </note>
+      <note>
+        <pitch><step>D</step><octave>4</octave></pitch>
+        <duration>480</duration><voice>1</voice><type>eighth</type>
+        <beam number="1">end</beam>
+      </note>
+      <note>
+        <pitch><step>E</step><octave>4</octave></pitch>
+        <duration>480</duration><voice>1</voice><type>eighth</type>
+        <beam number="1">begin</beam>
+      </note>
+      <note>
+        <pitch><step>F</step><octave>4</octave></pitch>
+        <duration>480</duration><voice>1</voice><type>eighth</type>
+        <beam number="1">end</beam>
+      </note>
+    </measure>
+  </part>
+</score-partwise>`;
+
+    const srcDoc = parseMusicXmlDocument(xml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("V:P1");
+    expect(abc).toContain("C D E F |");
+    expect(abc).not.toContain("CD EF");
+  });
+
   it("ABC->MusicXML uses meter-sized empty-measure rests for missing voice measures", () => {
     const abc = `X:1
 T:Missing measure fallback
@@ -3073,6 +3310,26 @@ V:1
     expect(secondPitched?.querySelector(':scope > notations > slur[type="stop"]')).not.toBeNull();
   });
 
+  it("ABC->MusicXML warns when slur stop has no preceding non-rest note", () => {
+    const abc = `X:1
+T:Slur stop after rest
+M:4/4
+L:1/8
+K:C
+V:1
+(c2 z2) e2 f2 |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    expect(outDoc.querySelector('miscellaneous-field[name="mks:diag:count"]')?.textContent?.trim()).toBe("1");
+    expect(outDoc.querySelector('miscellaneous-field[name="mks:diag:0001"]')?.textContent).toContain(
+      "slur stop()) has no preceding note; skipped."
+    );
+  });
+
   it("ABC->MusicXML applies chord ties to all notes in the chord", () => {
     const abc = `X:1
 T:Chord tie test
@@ -3142,7 +3399,7 @@ K:C
     if (!outDoc) return;
     expect(outDoc.querySelector("note > grace")).not.toBeNull();
     expect(outDoc.querySelector("note > notations > ornaments > trill-mark")).not.toBeNull();
-    expect(outDoc.querySelector('note > notations > ornaments > wavy-line[type="start"]')).not.toBeNull();
+    expect(outDoc.querySelector('note > notations > ornaments > wavy-line[type="start"]')).toBeNull();
   });
 
   it("MusicXML->ABC preserves grace notes without ornaments", () => {
@@ -3231,7 +3488,45 @@ K:C
     if (!outDoc) return;
     expect(outDoc.querySelector("note > grace")).toBeNull();
     expect(outDoc.querySelector("note > notations > ornaments > trill-mark")).not.toBeNull();
-    expect(outDoc.querySelector('note > notations > ornaments > wavy-line[type="start"]')).not.toBeNull();
+    expect(outDoc.querySelector('note > notations > ornaments > wavy-line[type="start"]')).toBeNull();
+  });
+
+  it("ABC trill alias !tr! roundtrips back to canonical !trill!", () => {
+    const abc = `X:1
+T:Trill short alias
+M:4/4
+L:1/4
+K:C
+!tr!C z |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const srcDoc = parseMusicXmlDocument(xml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+    expect(srcDoc.querySelector("note > notations > ornaments > trill-mark")).not.toBeNull();
+
+    const exportedAbc = exportMusicXmlDomToAbc(srcDoc);
+    expect(exportedAbc).toContain("!trill!");
+    expect(exportedAbc).not.toContain("!tr!");
+  });
+
+  it("ABC trill alias !triller! roundtrips back to canonical !trill!", () => {
+    const abc = `X:1
+T:Trill alias
+M:4/4
+L:1/4
+K:C
+!triller!C z |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const srcDoc = parseMusicXmlDocument(xml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+    expect(srcDoc.querySelector("note > notations > ornaments > trill-mark")).not.toBeNull();
+
+    const exportedAbc = exportMusicXmlDomToAbc(srcDoc);
+    expect(exportedAbc).toContain("!trill!");
+    expect(exportedAbc).not.toContain("!triller!");
   });
 
   it("MusicXML->ABC exports turn and grace slash notes and roundtrips them", () => {
@@ -3443,6 +3738,25 @@ K:C
     expect(outDoc).not.toBeNull();
     if (!outDoc) return;
     expect(outDoc.querySelector("note > notations > ornaments > inverted-turn")).not.toBeNull();
+  });
+
+  it("ABC inverted-turn alias !lowerturn! roundtrips back to canonical !invertedturn!", () => {
+    const abc = `X:1
+T:Lower turn alias
+M:4/4
+L:1/4
+K:C
+!lowerturn!C z |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const srcDoc = parseMusicXmlDocument(xml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+    expect(srcDoc.querySelector("note > notations > ornaments > inverted-turn")).not.toBeNull();
+
+    const exportedAbc = exportMusicXmlDomToAbc(srcDoc);
+    expect(exportedAbc).toContain("!invertedturn!");
+    expect(exportedAbc).not.toContain("!lowerturn!");
   });
 
   it("MusicXML->ABC exports turnx and invertedturnx variants and roundtrips them", () => {
@@ -4316,6 +4630,44 @@ K:C
     expect(exportedAbc).not.toContain("!emphasis!");
   });
 
+  it("ABC staccato alias !stacc! roundtrips back to canonical !staccato!", () => {
+    const abc = `X:1
+T:Stacc alias
+M:4/4
+L:1/4
+K:C
+!stacc!C z |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const srcDoc = parseMusicXmlDocument(xml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+    expect(srcDoc.querySelector("note > notations > articulations > staccato")).not.toBeNull();
+
+    const exportedAbc = exportMusicXmlDomToAbc(srcDoc);
+    expect(exportedAbc).toContain("!staccato!");
+    expect(exportedAbc).not.toContain("!stacc!");
+  });
+
+  it("ABC staccato alias !stac! roundtrips back to canonical !staccato!", () => {
+    const abc = `X:1
+T:Stac alias
+M:4/4
+L:1/4
+K:C
+!stac!C z |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const srcDoc = parseMusicXmlDocument(xml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+    expect(srcDoc.querySelector("note > notations > articulations > staccato")).not.toBeNull();
+
+    const exportedAbc = exportMusicXmlDomToAbc(srcDoc);
+    expect(exportedAbc).toContain("!staccato!");
+    expect(exportedAbc).not.toContain("!stac!");
+  });
+
   it("MusicXML->ABC exports tenuto decoration and roundtrips it", () => {
     const xmlWithTenuto = `<?xml version="1.0" encoding="UTF-8"?>
 <score-partwise version="3.1">
@@ -4709,6 +5061,25 @@ K:C
     expect(exportedAbc).not.toContain("!strongaccent!");
   });
 
+  it("ABC marcato alias !strong-accent! roundtrips back to canonical !marcato!", () => {
+    const abc = `X:1
+T:Marcato hyphen alias
+M:4/4
+L:1/4
+K:C
+!strong-accent!C z |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const srcDoc = parseMusicXmlDocument(xml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+    expect(srcDoc.querySelector("note > notations > articulations > strong-accent")).not.toBeNull();
+
+    const exportedAbc = exportMusicXmlDomToAbc(srcDoc);
+    expect(exportedAbc).toContain("!marcato!");
+    expect(exportedAbc).not.toContain("!strong-accent!");
+  });
+
   it("MusicXML->ABC exports breath decoration and roundtrips it", () => {
     const xmlWithBreath = `<?xml version="1.0" encoding="UTF-8"?>
 <score-partwise version="3.1">
@@ -4764,6 +5135,44 @@ K:C
     const exportedAbc = exportMusicXmlDomToAbc(srcDoc);
     expect(exportedAbc).toContain("!breath!");
     expect(exportedAbc).not.toContain("!breathmark!");
+  });
+
+  it("ABC breath-mark alias !breath mark! roundtrips back to canonical !breath!", () => {
+    const abc = `X:1
+T:Breath spaced alias
+M:4/4
+L:1/4
+K:C
+!breath mark!C z |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const srcDoc = parseMusicXmlDocument(xml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+    expect(srcDoc.querySelector("note > notations > articulations > breath-mark")).not.toBeNull();
+
+    const exportedAbc = exportMusicXmlDomToAbc(srcDoc);
+    expect(exportedAbc).toContain("!breath!");
+    expect(exportedAbc).not.toContain("!breath mark!");
+  });
+
+  it("ABC breath-mark alias !breath-mark! roundtrips back to canonical !breath!", () => {
+    const abc = `X:1
+T:Breath hyphen alias
+M:4/4
+L:1/4
+K:C
+!breath-mark!C z |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const srcDoc = parseMusicXmlDocument(xml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+    expect(srcDoc.querySelector("note > notations > articulations > breath-mark")).not.toBeNull();
+
+    const exportedAbc = exportMusicXmlDomToAbc(srcDoc);
+    expect(exportedAbc).toContain("!breath!");
+    expect(exportedAbc).not.toContain("!breath-mark!");
   });
 
   it("MusicXML->ABC exports caesura decoration and roundtrips it", () => {
@@ -4843,6 +5252,25 @@ K:C
     if (!outDoc) return;
     expect(outDoc.querySelector("note > notations > articulations > staccatissimo")).not.toBeNull();
     expect(outDoc.querySelector("note > notations > articulations > staccato")).toBeNull();
+  });
+
+  it("ABC staccatissimo alias !spiccato! roundtrips back to canonical !wedge!", () => {
+    const abc = `X:1
+T:Spiccato alias
+M:4/4
+L:1/4
+K:C
+!spiccato!C z |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const srcDoc = parseMusicXmlDocument(xml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+    expect(srcDoc.querySelector("note > notations > articulations > staccatissimo")).not.toBeNull();
+
+    const exportedAbc = exportMusicXmlDomToAbc(srcDoc);
+    expect(exportedAbc).toContain("!wedge!");
+    expect(exportedAbc).not.toContain("!spiccato!");
   });
 
   it("MusicXML->ABC exports wedge directions as ABC wedge decorations and roundtrips them", () => {
@@ -4961,6 +5389,25 @@ K:C
     expect(outDoc.querySelector("part > measure > direction > direction-type > wedge")?.getAttribute("type")).toBe("crescendo");
   });
 
+  it("ABC wedge alias !<(! roundtrips back to canonical !crescendo(!", () => {
+    const abc = `X:1
+T:Symbolic crescendo alias
+M:4/4
+L:1/4
+K:C
+!<(!C z |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const srcDoc = parseMusicXmlDocument(xml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+    expect(srcDoc.querySelector("part > measure > direction > direction-type > wedge")?.getAttribute("type")).toBe("crescendo");
+
+    const exportedAbc = exportMusicXmlDomToAbc(srcDoc);
+    expect(exportedAbc).toContain("!crescendo(!C");
+    expect(exportedAbc).not.toContain("!<(!");
+  });
+
   it("MusicXML->ABC exports wedge stop and roundtrips it", () => {
     const xml = `<score-partwise version="3.1">
   <part-list>
@@ -5023,6 +5470,67 @@ K:C
     expect(outDoc).not.toBeNull();
     if (!outDoc) return;
     expect(outDoc.querySelector("part > measure > direction > direction-type > wedge")?.getAttribute("type")).toBe("diminuendo");
+  });
+
+  it("ABC wedge alias !>(! roundtrips back to canonical !diminuendo(!", () => {
+    const abc = `X:1
+T:Symbolic diminuendo alias
+M:4/4
+L:1/4
+K:C
+!>(!C z |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const srcDoc = parseMusicXmlDocument(xml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+    expect(srcDoc.querySelector("part > measure > direction > direction-type > wedge")?.getAttribute("type")).toBe("diminuendo");
+
+    const exportedAbc = exportMusicXmlDomToAbc(srcDoc);
+    expect(exportedAbc).toContain("!diminuendo(!C");
+    expect(exportedAbc).not.toContain("!>(!");
+  });
+
+  it("ABC wedge alias !<)! roundtrips back to canonical !crescendo)!", () => {
+    const abc = `X:1
+T:Symbolic crescendo stop alias
+M:4/4
+L:1/4
+K:C
+C !<)!D |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const srcDoc = parseMusicXmlDocument(xml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+    expect(srcDoc.querySelector("part > measure > direction > direction-type > wedge")?.getAttribute("type")).toBe("stop");
+
+    const exportedAbc = exportMusicXmlDomToAbc(srcDoc);
+    expect(exportedAbc).toContain("!crescendo)!D");
+    expect(exportedAbc).not.toContain("!<)!");
+  });
+
+  it("ABC wedge alias !>)! roundtrips back to canonical !diminuendo)!", () => {
+    const abc = `X:1
+T:Symbolic diminuendo stop alias
+M:4/4
+L:1/4
+K:C
+!>(!C !>)!D |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const srcDoc = parseMusicXmlDocument(xml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+    expect(
+      Array.from(srcDoc.querySelectorAll("part > measure > direction > direction-type > wedge")).some(
+        (node) => node.getAttribute("type") === "stop",
+      ),
+    ).toBe(true);
+
+    const exportedAbc = exportMusicXmlDomToAbc(srcDoc);
+    expect(exportedAbc).toContain("!diminuendo)!D");
+    expect(exportedAbc).not.toContain("!>)!");
   });
 
   it("MusicXML->ABC exports up-bow/down-bow and roundtrips them", () => {
@@ -5128,6 +5636,63 @@ K:C
     const exportedAbc = exportMusicXmlDomToAbc(srcDoc);
     expect(exportedAbc).toContain("!upbow!");
     expect(exportedAbc).not.toContain("!up bow!");
+  });
+
+  it("ABC bowing alias !up-bow! roundtrips back to canonical !upbow!", () => {
+    const abc = `X:1
+T:Up-bow hyphen alias
+M:4/4
+L:1/4
+K:C
+!up-bow!C z |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const srcDoc = parseMusicXmlDocument(xml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+    expect(srcDoc.querySelector("note > notations > technical > up-bow")).not.toBeNull();
+
+    const exportedAbc = exportMusicXmlDomToAbc(srcDoc);
+    expect(exportedAbc).toContain("!upbow!");
+    expect(exportedAbc).not.toContain("!up-bow!");
+  });
+
+  it("ABC bowing alias !down-bow! roundtrips back to canonical !downbow!", () => {
+    const abc = `X:1
+T:Down-bow hyphen alias
+M:4/4
+L:1/4
+K:C
+!down-bow!C z |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const srcDoc = parseMusicXmlDocument(xml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+    expect(srcDoc.querySelector("note > notations > technical > down-bow")).not.toBeNull();
+
+    const exportedAbc = exportMusicXmlDomToAbc(srcDoc);
+    expect(exportedAbc).toContain("!downbow!");
+    expect(exportedAbc).not.toContain("!down-bow!");
+  });
+
+  it("ABC bowing alias !down bow! roundtrips back to canonical !downbow!", () => {
+    const abc = `X:1
+T:Down bow spaced alias
+M:4/4
+L:1/4
+K:C
+!down bow!C z |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const srcDoc = parseMusicXmlDocument(xml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+    expect(srcDoc.querySelector("note > notations > technical > down-bow")).not.toBeNull();
+
+    const exportedAbc = exportMusicXmlDomToAbc(srcDoc);
+    expect(exportedAbc).toContain("!downbow!");
+    expect(exportedAbc).not.toContain("!down bow!");
   });
 
   it("MusicXML->ABC exports down-bow and roundtrips it", () => {
@@ -5284,6 +5849,63 @@ K:C
     expect(exportedAbc).not.toContain("!double tongue!");
   });
 
+  it("ABC tongue alias !double-tongue! roundtrips back to canonical !doubletongue!", () => {
+    const abc = `X:1
+T:Double tongue hyphen alias
+M:4/4
+L:1/4
+K:C
+!double-tongue!C z |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const srcDoc = parseMusicXmlDocument(xml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+    expect(srcDoc.querySelector("note > notations > technical > double-tongue")).not.toBeNull();
+
+    const exportedAbc = exportMusicXmlDomToAbc(srcDoc);
+    expect(exportedAbc).toContain("!doubletongue!");
+    expect(exportedAbc).not.toContain("!double-tongue!");
+  });
+
+  it("ABC tongue alias !triple tongue! roundtrips back to canonical !tripletongue!", () => {
+    const abc = `X:1
+T:Triple tongue alias
+M:4/4
+L:1/4
+K:C
+!triple tongue!C z |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const srcDoc = parseMusicXmlDocument(xml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+    expect(srcDoc.querySelector("note > notations > technical > triple-tongue")).not.toBeNull();
+
+    const exportedAbc = exportMusicXmlDomToAbc(srcDoc);
+    expect(exportedAbc).toContain("!tripletongue!");
+    expect(exportedAbc).not.toContain("!triple tongue!");
+  });
+
+  it("ABC tongue alias !triple-tongue! roundtrips back to canonical !tripletongue!", () => {
+    const abc = `X:1
+T:Triple tongue hyphen alias
+M:4/4
+L:1/4
+K:C
+!triple-tongue!C z |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const srcDoc = parseMusicXmlDocument(xml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+    expect(srcDoc.querySelector("note > notations > technical > triple-tongue")).not.toBeNull();
+
+    const exportedAbc = exportMusicXmlDomToAbc(srcDoc);
+    expect(exportedAbc).toContain("!tripletongue!");
+    expect(exportedAbc).not.toContain("!triple-tongue!");
+  });
+
   it("MusicXML->ABC exports triple-tongue and roundtrips it", () => {
     const xmlWithTripleTongue = `<?xml version="1.0" encoding="UTF-8"?>
 <score-partwise version="3.1">
@@ -5358,6 +5980,44 @@ K:C
     expect(outDoc).not.toBeNull();
     if (!outDoc) return;
     expect(outDoc.querySelector("note > notations > technical > heel")).not.toBeNull();
+  });
+
+  it("ABC toe alias !toe mark! roundtrips back to canonical !toe!", () => {
+    const abc = `X:1
+T:Toe mark alias
+M:4/4
+L:1/4
+K:C
+!toe mark!C z |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const srcDoc = parseMusicXmlDocument(xml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+    expect(srcDoc.querySelector("note > notations > technical > toe")).not.toBeNull();
+
+    const exportedAbc = exportMusicXmlDomToAbc(srcDoc);
+    expect(exportedAbc).toContain("!toe!");
+    expect(exportedAbc).not.toContain("!toe mark!");
+  });
+
+  it("ABC heel alias !heel mark! roundtrips back to canonical !heel!", () => {
+    const abc = `X:1
+T:Heel mark alias
+M:4/4
+L:1/4
+K:C
+!heel mark!C z |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const srcDoc = parseMusicXmlDocument(xml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+    expect(srcDoc.querySelector("note > notations > technical > heel")).not.toBeNull();
+
+    const exportedAbc = exportMusicXmlDomToAbc(srcDoc);
+    expect(exportedAbc).toContain("!heel!");
+    expect(exportedAbc).not.toContain("!heel mark!");
   });
 
   it("MusicXML->ABC exports toe and roundtrips it", () => {
@@ -5810,6 +6470,25 @@ K:C
     expect(exportedAbc).not.toContain("!open-string!");
   });
 
+  it("ABC open-string alias !open string! roundtrips back to canonical !open!", () => {
+    const abc = `X:1
+T:Open string spaced alias
+M:4/4
+L:1/4
+K:C
+!open string!C z |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const srcDoc = parseMusicXmlDocument(xml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+    expect(srcDoc.querySelector("note > notations > technical > open-string")).not.toBeNull();
+
+    const exportedAbc = exportMusicXmlDomToAbc(srcDoc);
+    expect(exportedAbc).toContain("!open!");
+    expect(exportedAbc).not.toContain("!open string!");
+  });
+
   it("MusicXML->ABC exports snap-pizzicato and roundtrips it", () => {
     const xmlWithSnapPizzicato = `<?xml version="1.0" encoding="UTF-8"?>
 <score-partwise version="3.1">
@@ -5886,6 +6565,25 @@ K:C
     const exportedAbc = exportMusicXmlDomToAbc(srcDoc);
     expect(exportedAbc).toContain("!snap!");
     expect(exportedAbc).not.toContain("!snap-pizzicato!");
+  });
+
+  it("ABC snap-pizzicato alias !snap pizzicato! roundtrips back to canonical !snap!", () => {
+    const abc = `X:1
+T:Snap pizzicato spaced alias
+M:4/4
+L:1/4
+K:C
+!snap pizzicato!C z |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const srcDoc = parseMusicXmlDocument(xml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+    expect(srcDoc.querySelector("note > notations > technical > snap-pizzicato")).not.toBeNull();
+
+    const exportedAbc = exportMusicXmlDomToAbc(srcDoc);
+    expect(exportedAbc).toContain("!snap!");
+    expect(exportedAbc).not.toContain("!snap pizzicato!");
   });
 
   it("MusicXML->ABC exports harmonic and roundtrips it", () => {
@@ -6004,6 +6702,63 @@ K:C
     const exportedAbc = exportMusicXmlDomToAbc(srcDoc);
     expect(exportedAbc).toContain("!thumb!");
     expect(exportedAbc).not.toContain("!thumbposition!");
+  });
+
+  it("ABC thumb-position alias !thumb pos! roundtrips back to canonical !thumb!", () => {
+    const abc = `X:1
+T:Thumb spaced alias
+M:4/4
+L:1/4
+K:C
+!thumb pos!C z |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const srcDoc = parseMusicXmlDocument(xml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+    expect(srcDoc.querySelector("note > notations > technical > thumb-position")).not.toBeNull();
+
+    const exportedAbc = exportMusicXmlDomToAbc(srcDoc);
+    expect(exportedAbc).toContain("!thumb!");
+    expect(exportedAbc).not.toContain("!thumb pos!");
+  });
+
+  it("ABC thumb-position alias !thumb position! roundtrips back to canonical !thumb!", () => {
+    const abc = `X:1
+T:Thumb position alias
+M:4/4
+L:1/4
+K:C
+!thumb position!C z |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const srcDoc = parseMusicXmlDocument(xml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+    expect(srcDoc.querySelector("note > notations > technical > thumb-position")).not.toBeNull();
+
+    const exportedAbc = exportMusicXmlDomToAbc(srcDoc);
+    expect(exportedAbc).toContain("!thumb!");
+    expect(exportedAbc).not.toContain("!thumb position!");
+  });
+
+  it("ABC thumb-position alias !thumb-position! roundtrips back to canonical !thumb!", () => {
+    const abc = `X:1
+T:Thumb hyphen alias
+M:4/4
+L:1/4
+K:C
+!thumb-position!C z |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const srcDoc = parseMusicXmlDocument(xml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+    expect(srcDoc.querySelector("note > notations > technical > thumb-position")).not.toBeNull();
+
+    const exportedAbc = exportMusicXmlDomToAbc(srcDoc);
+    expect(exportedAbc).toContain("!thumb!");
+    expect(exportedAbc).not.toContain("!thumb-position!");
   });
 
   it("MusicXML->ABC exports mordent/inverted-mordent and roundtrips them", () => {
@@ -6130,6 +6885,104 @@ K:C
     expect(outDoc.querySelector("note > notations > ornaments > inverted-mordent")).not.toBeNull();
   });
 
+  it("ABC mordent aliases roundtrip back to canonical mordent-family names", () => {
+    const abc = `X:1
+T:Mordent alias canonicalization
+M:4/4
+L:1/4
+K:C
+!lowermordent!C !uppermordent!D |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const srcDoc = parseMusicXmlDocument(xml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+    expect(srcDoc.querySelector("note > notations > ornaments > mordent")).not.toBeNull();
+    expect(srcDoc.querySelectorAll("note > notations > ornaments > inverted-mordent").length).toBeGreaterThanOrEqual(1);
+
+    const exportedAbc = exportMusicXmlDomToAbc(srcDoc);
+    expect(exportedAbc).toContain("!mordent!");
+    expect(exportedAbc).toContain("!pralltriller!");
+    expect(exportedAbc).not.toContain("!lowermordent!");
+    expect(exportedAbc).not.toContain("!uppermordent!");
+  });
+
+  it("ABC mordent alias !prall! roundtrips back to canonical !pralltriller!", () => {
+    const abc = `X:1
+T:Prall alias canonicalization
+M:4/4
+L:1/4
+K:C
+!prall!C z |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const srcDoc = parseMusicXmlDocument(xml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+    expect(srcDoc.querySelector("note > notations > ornaments > inverted-mordent")).not.toBeNull();
+
+    const exportedAbc = exportMusicXmlDomToAbc(srcDoc);
+    expect(exportedAbc).toContain("!pralltriller!");
+    expect(exportedAbc).not.toContain("!prall!");
+  });
+
+  it("ABC mordent alias !pralltrill! roundtrips back to canonical !pralltriller!", () => {
+    const abc = `X:1
+T:Pralltrill alias canonicalization
+M:4/4
+L:1/4
+K:C
+!pralltrill!C z |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const srcDoc = parseMusicXmlDocument(xml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+    expect(srcDoc.querySelector("note > notations > ornaments > inverted-mordent")).not.toBeNull();
+
+    const exportedAbc = exportMusicXmlDomToAbc(srcDoc);
+    expect(exportedAbc).toContain("!pralltriller!");
+    expect(exportedAbc).not.toContain("!pralltrill!");
+  });
+
+  it("ABC mordent alias !invertedmordent! roundtrips back to canonical !pralltriller!", () => {
+    const abc = `X:1
+T:Invertedmordent alias canonicalization
+M:4/4
+L:1/4
+K:C
+!invertedmordent!C z |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const srcDoc = parseMusicXmlDocument(xml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+    expect(srcDoc.querySelector("note > notations > ornaments > inverted-mordent")).not.toBeNull();
+
+    const exportedAbc = exportMusicXmlDomToAbc(srcDoc);
+    expect(exportedAbc).toContain("!pralltriller!");
+    expect(exportedAbc).not.toContain("!invertedmordent!");
+  });
+
+  it("ABC mordent alias !inverted-mordent! roundtrips back to canonical !pralltriller!", () => {
+    const abc = `X:1
+T:Inverted-mordent alias canonicalization
+M:4/4
+L:1/4
+K:C
+!inverted-mordent!C z |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const srcDoc = parseMusicXmlDocument(xml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+    expect(srcDoc.querySelector("note > notations > ornaments > inverted-mordent")).not.toBeNull();
+
+    const exportedAbc = exportMusicXmlDomToAbc(srcDoc);
+    expect(exportedAbc).toContain("!pralltriller!");
+    expect(exportedAbc).not.toContain("!inverted-mordent!");
+  });
+
   it("MusicXML->ABC exports arpeggiate as canonical !arpeggio! and roundtrips it", () => {
     const xmlWithArpeggiate = `<?xml version="1.0" encoding="UTF-8"?>
 <score-partwise version="3.1">
@@ -6174,6 +7027,44 @@ K:C
     expect(outDoc).not.toBeNull();
     if (!outDoc) return;
     expect(outDoc.querySelector("note > notations > arpeggiate")).not.toBeNull();
+  });
+
+  it("ABC arpeggiate alias !roll! roundtrips back to canonical !arpeggio!", () => {
+    const abc = `X:1
+T:Roll alias
+M:4/4
+L:1/4
+K:C
+!roll![CEG] z |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const srcDoc = parseMusicXmlDocument(xml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+    expect(srcDoc.querySelector("note > notations > arpeggiate")).not.toBeNull();
+
+    const exportedAbc = exportMusicXmlDomToAbc(srcDoc);
+    expect(exportedAbc).toContain("!arpeggio![");
+    expect(exportedAbc).not.toContain("!roll!");
+  });
+
+  it("ABC arpeggiate alias !arpeggiate! roundtrips back to canonical !arpeggio!", () => {
+    const abc = `X:1
+T:Arpeggiate alias canonicalization
+M:4/4
+L:1/4
+K:C
+!arpeggiate![CEG] z |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const srcDoc = parseMusicXmlDocument(xml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+    expect(srcDoc.querySelector("note > notations > arpeggiate")).not.toBeNull();
+
+    const exportedAbc = exportMusicXmlDomToAbc(srcDoc);
+    expect(exportedAbc).toContain("!arpeggio![");
+    expect(exportedAbc).not.toContain("!arpeggiate!");
   });
 
   it("MusicXML->ABC exports schleifer/shake and roundtrips them", () => {
@@ -7308,6 +8199,25 @@ K:C
     expect(exportedAbc).not.toContain("!plus!");
   });
 
+  it("ABC stopped alias !+! roundtrips back to canonical !stopped!", () => {
+    const abc = `X:1
+T:Stopped symbol alias
+M:4/4
+L:1/4
+K:C
+!+!C z |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const srcDoc = parseMusicXmlDocument(xml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+    expect(srcDoc.querySelector("note > notations > technical > stopped")).not.toBeNull();
+
+    const exportedAbc = exportMusicXmlDomToAbc(srcDoc);
+    expect(exportedAbc).toContain("!stopped!");
+    expect(exportedAbc).not.toContain("!+!");
+  });
+
   it("ABC stopped alias !stopped horn! roundtrips back to canonical !stopped!", () => {
     const abc = `X:1
 T:Stopped horn alias
@@ -7325,6 +8235,25 @@ K:C
     const exportedAbc = exportMusicXmlDomToAbc(srcDoc);
     expect(exportedAbc).toContain("!stopped!");
     expect(exportedAbc).not.toContain("!stopped horn!");
+  });
+
+  it("ABC stopped alias !stopped-horn! roundtrips back to canonical !stopped!", () => {
+    const abc = `X:1
+T:Stopped horn hyphen alias
+M:4/4
+L:1/4
+K:C
+!stopped-horn!C z |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const srcDoc = parseMusicXmlDocument(xml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+    expect(srcDoc.querySelector("note > notations > technical > stopped")).not.toBeNull();
+
+    const exportedAbc = exportMusicXmlDomToAbc(srcDoc);
+    expect(exportedAbc).toContain("!stopped!");
+    expect(exportedAbc).not.toContain("!stopped-horn!");
   });
 
   it("MusicXML->ABC exports slur notation and roundtrips it", () => {
@@ -7589,6 +8518,86 @@ K:C
     expect(outDoc.querySelector("note > notations > ornaments > accidental-mark")?.textContent?.trim()).toBe("sharp");
   });
 
+  it("MusicXML->ABC exports editorial accidentals and roundtrips them", () => {
+    const xmlWithEditorialAccidental = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note>
+        <pitch><step>C</step><alter>1</alter><octave>4</octave></pitch>
+        <duration>1920</duration>
+        <voice>1</voice><type>half</type>
+        <accidental editorial="yes">sharp</accidental>
+      </note>
+      <note><rest/><duration>1920</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithEditorialAccidental);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!editorial!^C");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    const accidental = outDoc.querySelector("note > accidental");
+    expect(accidental?.textContent?.trim()).toBe("sharp");
+    expect(accidental?.getAttribute("editorial")).toBe("yes");
+  });
+
+  it("MusicXML->ABC exports courtesy accidentals and roundtrips them", () => {
+    const xmlWithCourtesyAccidental = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>1</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note>
+        <pitch><step>F</step><alter>0</alter><octave>4</octave></pitch>
+        <duration>1920</duration>
+        <voice>1</voice><type>half</type>
+        <accidental cautionary="yes">natural</accidental>
+      </note>
+      <note><rest/><duration>1920</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithCourtesyAccidental);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("!courtesy!=F");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+    const accidental = outDoc.querySelector("note > accidental");
+    expect(accidental?.textContent?.trim()).toBe("natural");
+    expect(accidental?.getAttribute("cautionary")).toBe("yes");
+  });
+
   it("MusicXML->ABC->MusicXML preserves per-part key signatures via standard K fields", () => {
     const xmlWithMixedPartKeys = `<?xml version="1.0" encoding="UTF-8"?>
 <score-partwise version="3.1">
@@ -7793,6 +8802,57 @@ z6 |
     expect(p3Block).toContain("=G");
   });
 
+  it("MusicXML->ABC exports common C-clef headers and roundtrips them", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list>
+    <score-part id="P1"><part-name>Alto staff</part-name></score-part>
+    <score-part id="P2"><part-name>Tenor staff</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>C</sign><line>3</line></clef>
+      </attributes>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>960</duration><voice>1</voice><type>quarter</type></note>
+    </measure>
+  </part>
+  <part id="P2">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>C</sign><line>4</line></clef>
+      </attributes>
+      <note><pitch><step>D</step><octave>3</octave></pitch><duration>960</duration><voice>1</voice><type>quarter</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+
+    const srcDoc = parseMusicXmlDocument(xml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain('V:P1 name="Alto staff" clef=alto');
+    expect(abc).toContain('V:P2 name="Tenor staff" clef=tenor');
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const parts = Array.from(outDoc.querySelectorAll("part"));
+    expect(parts[0]?.querySelector("measure > attributes > clef > sign")?.textContent?.trim()).toBe("C");
+    expect(parts[0]?.querySelector("measure > attributes > clef > line")?.textContent?.trim()).toBe("3");
+    expect(parts[1]?.querySelector("measure > attributes > clef > sign")?.textContent?.trim()).toBe("C");
+    expect(parts[1]?.querySelector("measure > attributes > clef > line")?.textContent?.trim()).toBe("4");
+  });
+
   it("MusicXML->ABC emits mks metadata for measure/repeat/transpose and tuplet syntax", () => {
     const xmlWithMeasureMeta = `<?xml version="1.0" encoding="UTF-8"?>
 <score-partwise version="3.1">
@@ -7880,6 +8940,28 @@ V:P1
     expect(outDoc.querySelector('part > measure[number="2"] note > notations > tuplet[type="stop"]')).not.toBeNull();
   });
 
+  it("ABC->MusicXML supports common tuplet shorthand (3 in the bounded subset", () => {
+    const abc = `X:1
+T:Tuplet shorthand
+M:3/4
+L:1/8
+K:C
+V:1
+(3 DEF z2 |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const notes = Array.from(outDoc.querySelectorAll("part > measure note"));
+    expect(notes.length).toBeGreaterThanOrEqual(4);
+    expect(notes[0]?.querySelector("time-modification > actual-notes")?.textContent?.trim()).toBe("3");
+    expect(notes[0]?.querySelector("time-modification > normal-notes")?.textContent?.trim()).toBe("2");
+    expect(notes[0]?.querySelector('notations > tuplet[type="start"]')).not.toBeNull();
+    expect(notes[2]?.querySelector('notations > tuplet[type="stop"]')).not.toBeNull();
+  });
+
   it("MusicXML->ABC keeps %@mks repeat times only when standard ABC cannot express them", () => {
     const xmlWithThreeTimesRepeat = `<?xml version="1.0" encoding="UTF-8"?>
 <score-partwise version="3.1">
@@ -7911,6 +8993,78 @@ V:P1
     expect(abc).toContain("|:");
     expect(abc).toContain(":|");
     expect(abc).toContain("%@mks measure voice=P1 measure=2 number=2 implicit=0 times=3");
+  });
+
+  it("ABC->MusicXML restores repeat times from %@mks measure metadata when standard ABC surface is insufficient", () => {
+    const abc = `X:1
+T:Repeat times restore
+M:4/4
+L:1/4
+K:C
+V:P1
+|: C D E F | G A B c :|
+%@mks measure voice=P1 measure=1 number=1 implicit=0
+%@mks measure voice=P1 measure=2 number=2 implicit=0 times=3
+`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    expect(outDoc.querySelector('part > measure[number="2"] > barline[location="right"] > repeat')?.getAttribute("direction")).toBe("backward");
+    expect(outDoc.querySelector('part > measure[number="2"] > barline[location="right"] > repeat')?.getAttribute("times")).toBe("3");
+  });
+
+  it("MusicXML->ABC keeps discontinue ending metadata only when standard ABC surface is insufficient", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <barline location="left"><ending number="1" type="start"/></barline>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>3840</duration><voice>1</voice><type>whole</type></note>
+      <barline location="right"><ending number="1" type="discontinue"/></barline>
+    </measure>
+  </part>
+</score-partwise>`;
+
+    const srcDoc = parseMusicXmlDocument(xml);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("[1");
+    expect(abc).toContain("%@mks measure voice=P1 measure=1 number=1 implicit=0 ending-stop=1 ending-type=discontinue");
+  });
+
+  it("ABC->MusicXML restores discontinue ending type from %@mks measure metadata", () => {
+    const abc = `X:1
+T:Ending discontinue restore
+M:4/4
+L:1/4
+K:C
+V:P1
+[1 C D E F |
+%@mks measure voice=P1 measure=1 number=1 implicit=0 ending-stop=1 ending-type=discontinue
+`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    expect(outDoc.querySelector('part > measure[number="1"] > barline[location="left"] > ending')?.getAttribute("type")).toBe("start");
+    expect(outDoc.querySelector('part > measure[number="1"] > barline[location="right"] > ending')?.getAttribute("number")).toBe("1");
+    expect(outDoc.querySelector('part > measure[number="1"] > barline[location="right"] > ending')?.getAttribute("type")).toBe("discontinue");
   });
 
   it("MusicXML->ABC does not split a separate lane for grace notes missing voice", () => {


### PR DESCRIPTION
### 概要

ABC 対応について、仕様・coverage・TODO の基準を整理しつつ、`abc-io` 実装と unit test を拡張しました。 この変更では、ABC 標準に対する bounded support / partial / unsupported / ext-only の境界を文書化し、あわせて `V:`、装飾記号、quoted chord、slur、tuplet、lyrics などの実装・回帰テストを強化しています。

### 変更内容

#### ドキュメント整理
- `docs/spec/ABC_STANDARD_COVERAGE.md`
  - ABC 標準 coverage の基準を大きく拡充
  - `ABC-COV-*` ごとの result mode / rationale / close 状態を整理
  - core field / inline field / field continuation / clef / beam / repeat / slur / tuplet / voice property / 2.2 delta などの bounded policy を追記
- `docs/spec/ABC_IO.md`
  - 現在の supported core subset を明記
  - inline field、symbol line、overlay、beam/whitespace、`V:` property、quoted chord、annotation、repeat/ending、slur、tuplet などの current stance を追記
  - supported subset と warning-based skip / extension-assisted behavior の境界を明確化
- `TODO.md`
  - `ABC-COV-*` の進捗と close 状態を更新
  - decoration alias の code/test follow-up を反映
  - `!editorial!` / `!courtesy!` を deferred ではなく bounded support に更新

#### 実装変更
- `src/ts/abc-io.ts`
  - ABC decoration / alias / canonical export の扱いを拡張
  - plain trill と long-trill を区別する挙動を調整
  - `!editorial!` / `!courtesy!` を、次の明示 accidental に対する accidental-level modifier として扱う処理を追加
  - MusicXML accidental の `editorial="yes"` / `cautionary="yes"` と ABC decoration の相互変換を追加

#### テスト強化
- `tests/unit/abc-io.spec.ts`
  - ABC import/export/roundtrip の回帰テストを大量追加
  - decoration alias の canonicalization regressions を追加
  - `alto` / `tenor` C-clef header roundtrip を追加
  - hyphenated lyrics roundtrip を追加
  - common tuplet shorthand `(3` の regression を追加
  - unsupported chord-like quoted text が annotation/words に残ることの regression を追加
  - `!editorial!` / `!courtesy!` の import/export/roundtrip regression を追加

#### 生成物更新
- `src/js/main.js`
- `mikuscore.html`

### 補足

- この変更で、ABC coverage の既知論点は `docs/spec/ABC_STANDARD_COVERAGE.md` と `TODO.md` に展開済みの状態になっています。
- 一方で、defer / unsupported に置いた範囲がなくなったわけではなく、field continuation、symbol lines、exact beam whitespace preservation、faithful same-part overlay preservation などは引き続き bounded target の外です。
- `!editorial!` / `!courtesy!` は、今回の変更で 2.2 delta の deferred 項目ではなく、bounded accidental-level support として扱うように整理されています。