### PR TITLE
ABC parser を拡張し、ABC 取り込み処理を parser ベースへ整理

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -434,27 +434,34 @@
     - current failing/fragile note-length cases such as `3/` are covered by lexer/parser tests
     - note/chord/grace parsing no longer depends on ad hoc body regex matching inside `src/ts/abc-io.ts`
     - existing ABC unit tests stay green or regressions are explained and fixed in the same slice
-  - Progress (2026-04-06):
-    - added `src/ts/abc-lexer.ts`
-    - added `src/ts/abc-parser.ts`
-    - moved `note/chord/grace` parsing to the new parser path
-    - moved `tuplet` parsing to the new parser path
-    - `src/ts/abc-io.ts` now delegates these areas to parser helpers instead of owning the raw token scan directly
-    - added focused regressions for:
-      - numerator-slash shorthand such as `3/` in note/chord/grace paths
-      - explicit tuplet ratio parsing such as `(5:4:5`
+  - Progress:
+    - 2026-04-06:
+      - added `src/ts/abc-lexer.ts`
+      - added `src/ts/abc-parser.ts`
+      - moved `note/chord/grace` parsing to the new parser path
+      - moved `tuplet` parsing to the new parser path
+      - `src/ts/abc-io.ts` now delegates these areas to parser helpers instead of owning the raw token scan directly
+      - added focused regressions for:
+        - numerator-slash shorthand such as `3/` in note/chord/grace paths
+        - explicit tuplet ratio parsing such as `(5:4:5`
+    - 2026-04-07:
+      - moved body-side parser helpers such as `barline`, `repeat-ending`, `inline field`, `quoted string`, `decoration`, `broken rhythm`, `single-char shorthand`, `tie`, `slur-stop`, `bracket token`, `body token`, `playable event`, and `body entry` into `src/ts/abc-parser.ts`
+      - `src/ts/abc-io.ts` body import loop now runs primarily as parser-driven dispatch plus state application / MusicXML mapping
+      - added and expanded focused parser unit coverage in `tests/unit/abc-parser.spec.ts`
+      - parser / spec structure cleanup is substantially complete; remaining work is mainly test expansion, docs sync, and any future bounded helper extraction driven by real regressions
   - Resume note:
     - current stop point:
-      - `note/chord/grace/tuplet` are on the new parser path
-      - `barline / repeat-ending / decoration` are still parsed directly in `src/ts/abc-io.ts`
+      - the main staged lexer/parser migration is substantially landed
+      - `src/ts/abc-parser.ts` now owns most body-side parsing helpers and dispatch entrypoints
+      - `src/ts/abc-io.ts` is now mostly orchestration / state-application code for the body path
     - next restart target:
-      - move `barline / repeat-ending` parsing into `src/ts/abc-parser.ts`
+      - expand regression coverage only where real input or unsupported-boundary audits reveal gaps
     - recommended restart order:
-      - 1. extract parser helpers for barline tokens and alternate-ending markers
-      - 2. route `src/ts/abc-io.ts` through those helpers without changing higher-level measure orchestration
-      - 3. run focused repeat/ending regression tests
-      - 4. only then move decoration parsing/attachment
+      - 1. treat `tests/unit/abc-parser.spec.ts` and unsupported-input regression cases as the primary restart surface
+      - 2. update spec/docs only when the supported subset or parser behavior meaningfully changes
+      - 3. avoid reopening broad parser restructuring unless new failures show a concrete need
     - files to open first:
+      - `tests/unit/abc-parser.spec.ts`
       - `src/ts/abc-parser.ts`
       - `src/ts/abc-io.ts`
       - `tests/unit/abc-io.spec.ts`

--- a/docs/spec/abc-compat-parser-ebnf.md
+++ b/docs/spec/abc-compat-parser-ebnf.md
@@ -5,6 +5,12 @@ This document defines the current grammar baseline for the project ABC parser.
 
 It is based on ABC 2.1 and includes currently supported compatibility behavior observed in real-world `abcjs` / `abcm2ps` style inputs.
 
+Warning:
+
+- this document is a practical grammar baseline, not a fully synchronized dump of every parser helper and dispatch path in the current implementation
+- when this document and implementation detail appear to diverge, treat implementation, regression tests, and `docs/spec/ABC_IO.md` as the more authoritative source for the currently supported bounded behavior
+- update this document when the bounded grammar baseline changes materially, but do not assume every internal parser refactor requires line-by-line EBNF churn here
+
 The parser should be understood in three layers:
 
 - standard ABC surface

--- a/mikuscore.html
+++ b/mikuscore.html
@@ -29460,6 +29460,33 @@ const parseFractionText = (text, fallback = DEFAULT_UNIT) => {
     }
     return reduceFraction(num, den, fallback);
 };
+const isAbcjsWrapperLine = (text) => /^\[\s*\/?\s*abcjs(?:-[A-Za-z0-9_-]+)?(?:\s+[^\]]*)?\]$/i.test(String(text || "").trim());
+const estimateAbcMeasureContentDiv = (notes) => {
+    var _a, _b;
+    const byVoice = new Map();
+    const lastStartByVoice = new Map();
+    for (const note of Array.isArray(notes) ? notes : []) {
+        if (!note || note.grace)
+            continue;
+        const voice = String(note.voice || "1");
+        const durationDiv = Math.max(0, Math.round(Number(note.duration) || 0));
+        if (durationDiv <= 0)
+            continue;
+        const current = (_a = byVoice.get(voice)) !== null && _a !== void 0 ? _a : 0;
+        if (note.chord) {
+            const startDiv = (_b = lastStartByVoice.get(voice)) !== null && _b !== void 0 ? _b : current;
+            byVoice.set(voice, Math.max(current, startDiv + durationDiv));
+            continue;
+        }
+        lastStartByVoice.set(voice, current);
+        byVoice.set(voice, current + durationDiv);
+    }
+    let maxDiv = 0;
+    for (const value of byVoice.values()) {
+        maxDiv = Math.max(maxDiv, value);
+    }
+    return maxDiv;
+};
 const parseAbcLengthToken = (token, lineNo) => {
     if (!token) {
         return { num: 1, den: 1 };
@@ -29583,37 +29610,47 @@ if (typeof window !== "undefined") {
     window.AbcCommon = exports.AbcCommon;
 }
 const abcCommon = exports.AbcCommon;
-function parseRepeatEndingMarkerAt(text, idx) {
-    const match = String(text || "").slice(idx).match(/^\[(\d+(?:[,-]\d+)*)/);
-    if (!match) {
-        return null;
-    }
-    return {
-        marker: match[1],
-        nextIdx: idx + match[0].length,
-    };
-}
-function parseBareRepeatEndingMarkerAt(text, idx) {
-    const match = String(text || "").slice(idx).match(/^(\d+(?:[,-]\d+)*)/);
-    if (!match) {
-        return null;
-    }
-    return {
-        marker: match[1],
-        nextIdx: idx + match[0].length,
-    };
-}
-function parseInlineFieldAt(text, idx) {
-    const match = String(text || "").slice(idx).match(/^\[([A-Za-z]):([^\]]*)\]/);
-    if (!match) {
-        return null;
-    }
-    return {
-        fieldName: String(match[1] || "").toUpperCase(),
-        fieldValue: String(match[2] || "").trim(),
-        nextIdx: idx + match[0].length,
-    };
-}
+const TRILL_DECORATIONS = new Set(["trill", "tr", "triller"]);
+const TURN_DECORATIONS = new Set(["turn"]);
+const TURN_SLASH_DECORATIONS = new Set(["turnx"]);
+const INVERTED_TURN_DECORATIONS = new Set(["invertedturn", "inverted-turn", "lowerturn"]);
+const INVERTED_TURN_SLASH_DECORATIONS = new Set(["invertedturnx", "inverted-turnx"]);
+const LOWER_MORDENT_DECORATIONS = new Set(["mordent", "lowermordent"]);
+const UPPER_MORDENT_DECORATIONS = new Set([
+    "pralltriller",
+    "pralltrill",
+    "prall",
+    "uppermordent",
+    "invertedmordent",
+    "inverted-mordent",
+]);
+const GLISS_START_DECORATIONS = new Set(["gliss-start", "glissando-start"]);
+const GLISS_STOP_DECORATIONS = new Set(["gliss-stop", "glissando-stop"]);
+const SLIDE_START_DECORATIONS = new Set(["slide", "slide-start"]);
+const ARPEGGIATE_DECORATIONS = new Set(["roll", "arpeggio", "arpeggiate"]);
+const STACCATO_DECORATIONS = new Set(["staccato", "stacc", "stac"]);
+const STACCATISSIMO_DECORATIONS = new Set(["staccatissimo", "wedge", "spiccato"]);
+const ACCENT_DECORATIONS = new Set(["accent", ">", "emphasis"]);
+const INVERTED_FERMATA_DECORATIONS = new Set(["invertedfermata", "inverted-fermata", "inverted fermata"]);
+const STRONG_ACCENT_DECORATIONS = new Set(["marcato", "strongaccent", "strong-accent", "strong accent"]);
+const BREATH_DECORATIONS = new Set(["breath", "breath-mark", "breathmark", "breath mark"]);
+const PHRASE_DECORATIONS = new Set(["shortphrase", "mediumphrase", "longphrase"]);
+const DACAPO_DECORATIONS = new Set(["dacapo", "da-capo", "da capo", "d.c."]);
+const DALSEGNO_DECORATIONS = new Set(["dalsegno", "dal-segno", "dal segno", "d.s."]);
+const TOCODA_DECORATIONS = new Set(["tocoda", "to-coda", "to coda"]);
+const CRESC_START_DECORATIONS = new Set(["crescendo(", "cresc(", "<("]);
+const CRESC_STOP_DECORATIONS = new Set(["crescendo)", "cresc)", "<)"]);
+const DIM_START_DECORATIONS = new Set(["diminuendo(", "decrescendo(", "dim(", "decresc(", ">("]);
+const DIM_STOP_DECORATIONS = new Set(["diminuendo)", "decrescendo)", "dim)", "decresc)", ">)"]);
+const DYNAMIC_DECORATIONS = new Set(["pppp", "ppp", "p", "pp", "mp", "mf", "f", "ff", "fff", "ffff", "fp", "fz", "rfz", "sf", "sfp"]);
+const UPBOW_DECORATIONS = new Set(["upbow", "up-bow", "up bow"]);
+const DOWNBOW_DECORATIONS = new Set(["downbow", "down-bow", "down bow"]);
+const DOUBLE_TONGUE_DECORATIONS = new Set(["doubletongue", "double-tongue", "double tongue"]);
+const TRIPLE_TONGUE_DECORATIONS = new Set(["tripletongue", "triple-tongue", "triple tongue"]);
+const OPEN_STRING_DECORATIONS = new Set(["open", "open-string", "openstring", "open string"]);
+const SNAP_PIZZICATO_DECORATIONS = new Set(["snap", "snap-pizzicato", "snappizzicato", "snap pizzicato"]);
+const STOPPED_DECORATIONS = new Set(["stopped", "+", "plus", "stopped horn", "stopped-horn"]);
+const THUMB_POSITION_DECORATIONS = new Set(["thumb", "thumbposition", "thumb-position", "thumbpos", "thumb pos", "thumb position"]);
 function tokenizeAbcLyricLine(text) {
     const raw = String(text || "").trim();
     if (!raw)
@@ -29672,8 +29709,9 @@ function splitBodyTextByInlineVoice(text, initialVoiceId) {
     let idx = 0;
     while (idx < raw.length) {
         if (raw[idx] === "[") {
-            const inlineField = parseInlineFieldAt(raw, idx);
-            if (inlineField && inlineField.fieldName === "V") {
+            const bracketToken = (0, abc_parser_1.parseAbcBracketTokenAt)(raw, idx);
+            if (bracketToken.kind === "inline-field" && bracketToken.inlineField.fieldName === "V") {
+                const { inlineField } = bracketToken;
                 if (buffer.trim()) {
                     segments.push({ voiceId: activeVoiceId, text: buffer });
                 }
@@ -29712,28 +29750,28 @@ function splitBodyTextByOverlay(text, baseVoiceId) {
     while (idx < raw.length) {
         const ch = raw[idx];
         if (ch === '"') {
-            let endIdx = idx + 1;
-            while (endIdx < raw.length && raw[endIdx] !== '"') {
-                endIdx += 1;
+            const token = (0, abc_parser_1.parseAbcDelimitedSpanAt)(raw, idx, '"');
+            if (!token) {
+                idx += 1;
+                continue;
             }
-            const token = raw.slice(idx, Math.min(raw.length, endIdx + 1));
             ensureOverlayBuffer(activeOverlayIndex);
-            overlayBuffers[activeOverlayIndex] += token;
-            idx = Math.min(raw.length, endIdx + 1);
+            overlayBuffers[activeOverlayIndex] += token.text;
+            idx = token.nextIdx;
             continue;
         }
         if (ch === "!" || ch === "+") {
-            let endIdx = idx + 1;
-            while (endIdx < raw.length && raw[endIdx] !== ch) {
-                endIdx += 1;
+            const token = (0, abc_parser_1.parseAbcDelimitedSpanAt)(raw, idx, ch);
+            if (!token) {
+                idx += 1;
+                continue;
             }
-            const token = raw.slice(idx, Math.min(raw.length, endIdx + 1));
             ensureOverlayBuffer(activeOverlayIndex);
-            overlayBuffers[activeOverlayIndex] += token;
-            idx = Math.min(raw.length, endIdx + 1);
+            overlayBuffers[activeOverlayIndex] += token.text;
+            idx = token.nextIdx;
             continue;
         }
-        const barlineToken = parseBarlineTokenAt(raw, idx);
+        const barlineToken = (0, abc_parser_1.parseAbcBarlineTokenAt)(raw, idx);
         if (barlineToken) {
             const tokenText = raw.slice(idx, barlineToken.nextIdx);
             if (barlineToken.endsMeasure) {
@@ -29795,12 +29833,14 @@ function expandUserDefinedDecorationSymbols(text, userDefinedDecorationBySymbol)
     while (idx < raw.length) {
         const ch = raw[idx];
         if (ch === '"' || ch === "!" || ch === "+") {
-            let endIdx = idx + 1;
-            while (endIdx < raw.length && raw[endIdx] !== ch) {
-                endIdx += 1;
+            const token = (0, abc_parser_1.parseAbcDelimitedSpanAt)(raw, idx, ch);
+            if (!token) {
+                out += ch;
+                idx += 1;
+                continue;
             }
-            out += raw.slice(idx, Math.min(raw.length, endIdx + 1));
-            idx = Math.min(raw.length, endIdx + 1);
+            out += token.text;
+            idx = token.nextIdx;
             continue;
         }
         if (Object.prototype.hasOwnProperty.call(symbolMap, ch)) {
@@ -29812,33 +29852,6 @@ function expandUserDefinedDecorationSymbols(text, userDefinedDecorationBySymbol)
         idx += 1;
     }
     return out;
-}
-function parseBarlineTokenAt(text, idx) {
-    const slice = String(text || "").slice(idx);
-    const candidates = [
-        { token: ":|]", endsMeasure: true, repeatEnd: true, repeatStart: false, endingStop: true },
-        { token: ":|:", endsMeasure: true, repeatEnd: true, repeatStart: true, endingStop: false },
-        { token: "|:", endsMeasure: true, repeatEnd: false, repeatStart: true, endingStop: false },
-        { token: ":|", endsMeasure: true, repeatEnd: true, repeatStart: false, endingStop: false },
-        { token: "::", endsMeasure: true, repeatEnd: true, repeatStart: true, endingStop: false },
-        { token: "[|", endsMeasure: true, repeatEnd: false, repeatStart: false, endingStop: false },
-        { token: "|]", endsMeasure: true, repeatEnd: false, repeatStart: false, endingStop: false },
-        { token: "||", endsMeasure: true, repeatEnd: false, repeatStart: false, endingStop: false },
-        { token: "|", endsMeasure: true, repeatEnd: false, repeatStart: false, endingStop: false },
-        { token: ":", endsMeasure: false, repeatEnd: false, repeatStart: false, endingStop: false },
-    ];
-    for (const candidate of candidates) {
-        if (slice.startsWith(candidate.token)) {
-            return {
-                nextIdx: idx + candidate.token.length,
-                endsMeasure: candidate.endsMeasure,
-                repeatEnd: candidate.repeatEnd,
-                repeatStart: candidate.repeatStart,
-                endingStop: candidate.endingStop,
-            };
-        }
-    }
-    return null;
 }
 function parseTempoFromQ(rawQ, warnings) {
     const raw = String(rawQ || "").trim();
@@ -29927,6 +29940,11 @@ function parseForMusicXml(source, settings) {
         const raw = lines[i];
         const rawTrimmed = raw.trim();
         if (!rawTrimmed) {
+            pendingUnsupportedContinuedFieldName = "";
+            continue;
+        }
+        if (isAbcjsWrapperLine(rawTrimmed)) {
+            warnings.push("line " + lineNo + ": Skipped unsupported abcjs wrapper line: " + rawTrimmed);
             pendingUnsupportedContinuedFieldName = "";
             continue;
         }
@@ -30270,1037 +30288,301 @@ function parseForMusicXml(source, settings) {
         let activeEndingMarker = String(activeEndingByVoice[entry.voiceId] || "");
         let idx = 0;
         const text = entry.text;
-        const isBeamableAbcNote = (note) => Boolean(note &&
-            !note.isRest &&
-            !note.grace &&
-            ["eighth", "16th", "32nd", "64th"].includes(String(note.type || "").trim().toLowerCase()));
-        const applyBeamModeForEvent = (note, durationDiv) => {
-            const resolvedDurationDiv = Math.max(0, Math.round(Number(durationDiv) || 0));
-            const beatDiv = Math.max(1, Math.round((960 * 4) / Math.max(1, Math.round(Number(activeMeter === null || activeMeter === void 0 ? void 0 : activeMeter.beatType) || 4))));
-            const startsAtBeatBoundary = beamCursorDiv > 0 && beamCursorDiv % beatDiv === 0;
-            if (startsAtBeatBoundary) {
-                beamRunActive = false;
-            }
-            if (isBeamableAbcNote(note)) {
-                note.beamMode = !beamRunActive || sawInterEventWhitespace ? "begin" : "mid";
-                beamRunActive = true;
-            }
-            else {
-                beamRunActive = false;
-            }
-            sawInterEventWhitespace = false;
-            beamCursorDiv += resolvedDurationDiv;
+        const warnBody = (message) => {
+            warnings.push("line " + entry.lineNo + ": " + message);
         };
-        while (idx < text.length) {
-            const ch = text[idx];
-            if (ch === " " || ch === "\t") {
-                sawInterEventWhitespace = true;
-                idx += 1;
-                continue;
+        // Field and decoration application.
+        const applyBodyField = (fieldName, fieldValue) => {
+            if (fieldName === "K") {
+                const inlineKeyInfo = parseKey(fieldValue || "C", warnings);
+                activeKeyFifths = inlineKeyInfo.fifths;
+                activeKeySignatureAccidentals = keySignatureAlterByStep(activeKeyFifths);
+                currentKeyFifthsByVoice[entry.voiceId] = activeKeyFifths;
+                keyHintFifthsByKey.set(`${entry.voiceId}#${currentMeasureNo}`, activeKeyFifths);
+                measureAccidentals = {};
+                return true;
             }
-            if (ch === "\\") {
-                warnings.push("line " + entry.lineNo + ": Skipped stray body continuation marker: \\");
-                idx += 1;
-                continue;
+            if (fieldName === "L") {
+                activeUnitLength = parseFraction(fieldValue || "1/8", "L", warnings);
+                return true;
             }
-            if (ch === "," || ch === "'") {
-                // Lenient compatibility: some real-world sources include standalone octave marks.
-                // They are non-standard in strict ABC, but skipping them improves interoperability.
-                idx += 1;
-                continue;
+            if (fieldName === "M") {
+                activeMeter = parseMeter(fieldValue || "4/4", warnings);
+                ensureMeterByMeasure(entry.voiceId)[currentMeasureNo] = {
+                    beats: activeMeter.beats,
+                    beatType: activeMeter.beatType,
+                };
+                return true;
             }
-            if (ch === "|" || ch === ":") {
-                const barlineToken = parseBarlineTokenAt(text, idx);
-                if (!barlineToken) {
-                    idx += 1;
-                    continue;
+            if (fieldName === "Q") {
+                activeTempoBpm = parseTempoFromQ(fieldValue || "", warnings);
+                if (Number.isFinite(activeTempoBpm)) {
+                    ensureTempoByMeasure(entry.voiceId)[currentMeasureNo] = Math.max(20, Math.min(300, Math.round(Number(activeTempoBpm))));
                 }
-                const bareRepeatEndingMarker = barlineToken.endsMeasure ? parseBareRepeatEndingMarkerAt(text, barlineToken.nextIdx) : null;
-                if (barlineToken.repeatEnd) {
-                    ensureNotationMeasureMeta(entry.voiceId, currentMeasureNo).repeatEnd = true;
-                }
-                if ((barlineToken.endingStop || bareRepeatEndingMarker) && activeEndingMarker) {
-                    const measureMeta = ensureNotationMeasureMeta(entry.voiceId, currentMeasureNo);
-                    measureMeta.endingStop = activeEndingMarker;
-                    measureMeta.endingStopType = "stop";
-                    activeEndingMarker = "";
-                }
-                if (barlineToken.endsMeasure && (currentMeasure.length > 0 || measures.length === 0)) {
-                    currentMeasure = [];
-                    measures.push(currentMeasure);
-                    currentMeasureNo = Math.max(1, measures.length);
-                    currentEventNo = 0;
-                    beamCursorDiv = 0;
-                }
-                if (barlineToken.endsMeasure) {
-                    measureAccidentals = {};
-                    lastNote = null;
-                }
-                if (barlineToken.repeatStart) {
-                    ensureNotationMeasureMeta(entry.voiceId, currentMeasureNo).repeatStart = true;
-                }
-                if (bareRepeatEndingMarker) {
-                    const measureMeta = ensureNotationMeasureMeta(entry.voiceId, currentMeasureNo);
-                    measureMeta.endingStart = bareRepeatEndingMarker.marker;
-                    activeEndingMarker = bareRepeatEndingMarker.marker;
-                    idx = bareRepeatEndingMarker.nextIdx;
-                }
-                else {
-                    idx = barlineToken.nextIdx;
-                }
-                beamRunActive = false;
-                sawInterEventWhitespace = false;
-                continue;
+                return true;
             }
-            const standaloneBodyFieldMatch = text.slice(idx).match(/^([A-Za-z]):([^\s\]|]+)/);
-            if (standaloneBodyFieldMatch) {
-                const standaloneFieldName = String(standaloneBodyFieldMatch[1] || "").toUpperCase();
-                const standaloneFieldValue = String(standaloneBodyFieldMatch[2] || "").trim();
-                const standaloneFieldToken = standaloneBodyFieldMatch[0];
-                if (standaloneFieldName === "K") {
-                    const inlineKeyInfo = parseKey(standaloneFieldValue || "C", warnings);
-                    activeKeyFifths = inlineKeyInfo.fifths;
-                    activeKeySignatureAccidentals = keySignatureAlterByStep(activeKeyFifths);
-                    currentKeyFifthsByVoice[entry.voiceId] = activeKeyFifths;
-                    keyHintFifthsByKey.set(`${entry.voiceId}#${currentMeasureNo}`, activeKeyFifths);
-                    measureAccidentals = {};
+            return false;
+        };
+        const applyPrefixedDecoration = (rawDecoration, decoration) => {
+            if (decoration.startsWith("rehearsal:")) {
+                const rehearsalText = rawDecoration.slice("rehearsal:".length).trim();
+                if (rehearsalText) {
+                    pendingRehearsalMark = rehearsalText;
                 }
-                else if (standaloneFieldName === "L") {
-                    activeUnitLength = parseFraction(standaloneFieldValue || "1/8", "L", warnings);
+                return true;
+            }
+            if (decoration.startsWith("fingering:")) {
+                const fingeringText = rawDecoration.slice("fingering:".length).trim();
+                if (fingeringText) {
+                    pendingFingerings.push(fingeringText);
                 }
-                else if (standaloneFieldName === "M") {
-                    activeMeter = parseMeter(standaloneFieldValue || "4/4", warnings);
-                    ensureMeterByMeasure(entry.voiceId)[currentMeasureNo] = {
-                        beats: activeMeter.beats,
-                        beatType: activeMeter.beatType,
-                    };
+                return true;
+            }
+            if (decoration.startsWith("string:")) {
+                const stringText = rawDecoration.slice("string:".length).trim();
+                if (stringText) {
+                    pendingStrings.push(stringText);
                 }
-                else if (standaloneFieldName === "Q") {
-                    activeTempoBpm = parseTempoFromQ(standaloneFieldValue || "", warnings);
-                    if (Number.isFinite(activeTempoBpm)) {
-                        ensureTempoByMeasure(entry.voiceId)[currentMeasureNo] = Math.max(20, Math.min(300, Math.round(Number(activeTempoBpm))));
-                    }
+                return true;
+            }
+            if (decoration.startsWith("pluck:")) {
+                const pluckText = rawDecoration.slice("pluck:".length).trim();
+                if (pluckText) {
+                    pendingPlucks.push(pluckText);
                 }
-                else {
-                    warnings.push("line " + entry.lineNo + ": Skipped unsupported standalone body field token: " + standaloneFieldToken);
-                }
-                idx += standaloneFieldToken.length;
-                continue;
+                return true;
             }
-            const unsupportedBodyWordMatch = text
-                .slice(idx)
-                .match(/^([IJNQRWY][A-Za-z0-9_-]*|[h-jl-pr-twy][a-z][A-Za-z0-9_-]*)/);
-            if (unsupportedBodyWordMatch) {
-                warnings.push("line " + entry.lineNo + ": Skipped unsupported body token: " + unsupportedBodyWordMatch[1]);
-                idx += unsupportedBodyWordMatch[1].length;
-                continue;
+            return false;
+        };
+        const applyTurnDecoration = (decoration) => {
+            if (decoration === "delayedturn" || decoration === "delayed-turn") {
+                pendingTurn = pendingTurn || "turn";
+                pendingDelayedTurn = true;
+                return true;
             }
-            const unsupportedBodyNumberMatch = text.slice(idx).match(/^(\d+)/);
-            if (unsupportedBodyNumberMatch) {
-                warnings.push("line " + entry.lineNo + ": Skipped unsupported body number token: " + unsupportedBodyNumberMatch[1]);
-                idx += unsupportedBodyNumberMatch[1].length;
-                continue;
+            if (decoration === "delayedinvertedturn" || decoration === "delayed-inverted-turn") {
+                pendingTurn = "inverted-turn";
+                pendingDelayedTurn = true;
+                return true;
             }
-            if (ch === ">" || ch === "<") {
-                if (!lastEventNotes || lastEventNotes.length === 0 || lastEventNotes.some((n) => n.isRest)) {
-                    warnings.push("line " + entry.lineNo + ": broken rhythm(" + ch + ")  has no preceding note; skipped.");
-                    idx += 1;
-                    continue;
-                }
-                const lastScale = ch === ">" ? { num: 3, den: 2 } : { num: 1, den: 2 };
-                pendingRhythmScale = ch === ">" ? { num: 1, den: 2 } : { num: 3, den: 2 };
-                scaleNotesDuration(lastEventNotes, lastScale);
-                idx += 1;
-                continue;
+            const turnDecorationAppliers = [
+                [TURN_DECORATIONS, "turn", false],
+                [TURN_SLASH_DECORATIONS, "turn", true],
+                [INVERTED_TURN_DECORATIONS, "inverted-turn", false],
+                [INVERTED_TURN_SLASH_DECORATIONS, "inverted-turn", true],
+            ];
+            const matchedTurn = turnDecorationAppliers.find(([decorationSet]) => decorationSet.has(decoration));
+            if (!matchedTurn) {
+                return false;
             }
-            if (ch === "(") {
-                const tuplet = (0, abc_parser_1.parseAbcTupletAt)(text, idx);
-                if (tuplet) {
-                    if (tuplet.actual > 0 && tuplet.normal > 0 && tuplet.count > 0) {
-                        tupletScale = { num: tuplet.normal, den: tuplet.actual };
-                        tupletRemaining = tuplet.count;
-                        tupletSpec = { actual: tuplet.actual, normal: tuplet.normal, remaining: tuplet.count };
-                    }
-                    else {
-                        warnings.push("line " + entry.lineNo + ": Failed to parse tuplet notation: " + tuplet.raw);
-                    }
-                    idx = tuplet.nextIdx;
-                    continue;
-                }
-                pendingSlurStart += 1;
-                idx += 1;
-                continue;
+            pendingTurn = matchedTurn[1];
+            pendingTurnSlash = matchedTurn[2];
+            return true;
+        };
+        const applyTremoloDecoration = (decoration) => {
+            const matched = decoration.match(/^tremolo-(single|start|stop)-([1-9]\d*)$/);
+            if (!matched) {
+                return false;
             }
-            if (ch === "~") {
-                pendingArpeggiate = true;
-                idx += 1;
-                continue;
-            }
-            if (ch === "H") {
-                pendingFermata = "normal";
-                idx += 1;
-                continue;
-            }
-            if (ch === "L") {
-                pendingAccent = true;
-                idx += 1;
-                continue;
-            }
-            if (ch === "M") {
-                pendingMordent = "mordent";
-                idx += 1;
-                continue;
-            }
-            if (ch === "O") {
-                pendingCoda = true;
-                idx += 1;
-                continue;
-            }
-            if (ch === "P") {
-                pendingMordent = "inverted-mordent";
-                idx += 1;
-                continue;
-            }
-            if (ch === "S") {
-                pendingSegno = true;
-                idx += 1;
-                continue;
-            }
-            if (ch === "T") {
-                pendingTrill = true;
-                idx += 1;
-                continue;
-            }
-            if (ch === "u") {
-                pendingUpBow = true;
-                idx += 1;
-                continue;
-            }
-            if (ch === "v") {
-                pendingDownBow = true;
-                idx += 1;
-                continue;
-            }
-            if (ch === "-") {
-                if (lastEventNotes && lastEventNotes.length > 0 && lastEventNotes.some((n) => !n.isRest)) {
-                    for (const eventNote of lastEventNotes) {
-                        if (!eventNote.isRest) {
-                            eventNote.tieStart = true;
-                        }
-                    }
-                    pendingTieToNext = true;
-                }
-                else {
-                    warnings.push("line " + entry.lineNo + ": tie(-)  has no preceding note; skipped.");
-                }
-                idx += 1;
-                continue;
-            }
-            if (ch === "\"") {
-                const endQuote = text.indexOf("\"", idx + 1);
-                if (endQuote >= 0) {
-                    const rawAnnotation = text.slice(idx + 1, endQuote);
-                    const normalizedAnnotation = rawAnnotation.replace(/^[\^_<>@]/, "").trim();
-                    if (normalizedAnnotation) {
-                        if (isLikelyAbcChordSymbol(normalizedAnnotation)) {
-                            pendingChordSymbols.push(normalizedAnnotation);
-                        }
-                        else {
-                            pendingAnnotations.push(normalizedAnnotation);
-                        }
-                    }
-                    idx = endQuote + 1;
-                }
-                else {
-                    idx = text.length;
-                    warnings.push("line " + entry.lineNo + ': Unterminated inline string ("...").');
-                }
-                continue;
-            }
-            if (ch === "!" || ch === "+") {
-                const endMark = text.indexOf(ch, idx + 1);
-                if (endMark < 0) {
-                    idx += 1;
-                    warnings.push("line " + entry.lineNo + ": Unterminated decoration marker: " + ch);
-                    continue;
-                }
-                const rawDecoration = text.slice(idx + 1, endMark).trim();
-                const decoration = rawDecoration.toLowerCase();
-                if (decoration === "trill" || decoration === "tr" || decoration === "triller") {
-                    pendingTrill = true;
-                }
-                else if (decoration === "editorial") {
-                    pendingEditorialAccidental = true;
-                }
-                else if (decoration === "courtesy") {
+            pendingTremolo = {
+                type: matched[1],
+                marks: Math.max(1, Math.min(8, Number.parseInt(matched[2], 10) || 1))
+            };
+            return true;
+        };
+        const applyDecoration = (rawDecoration, decoration) => {
+            const exactDecorationAppliers = {
+                "caesura": () => {
+                    pendingCaesura = true;
+                },
+                "coda": () => {
+                    pendingCoda = true;
+                },
+                "courtesy": () => {
                     pendingCourtesyAccidental = true;
-                }
-                else if (decoration === "trill(") {
+                },
+                "editorial": () => {
+                    pendingEditorialAccidental = true;
+                },
+                "fermata": () => {
+                    pendingFermata = "normal";
+                },
+                "fine": () => {
+                    pendingFine = true;
+                },
+                "harmonic": () => {
+                    pendingHarmonic = true;
+                },
+                "heel": () => {
+                    pendingHeel = true;
+                },
+                "heel mark": () => {
+                    pendingHeel = true;
+                },
+                "schleifer": () => {
+                    pendingSchleifer = true;
+                },
+                "segno": () => {
+                    pendingSegno = true;
+                },
+                "sfz": () => {
+                    pendingSfz = true;
+                },
+                "shake": () => {
+                    pendingShake = true;
+                },
+                "slide-stop": () => {
+                    pendingSlideStop = true;
+                },
+                "stress": () => {
+                    pendingStress = true;
+                },
+                "tenuto": () => {
+                    pendingTenuto = true;
+                },
+                "toe": () => {
+                    pendingToe = true;
+                },
+                "toe mark": () => {
+                    pendingToe = true;
+                },
+                "trill(": () => {
                     pendingTrill = true;
                     pendingTrillLineStart = true;
-                }
-                else if (decoration === "trill)") {
+                },
+                "trill)": () => {
                     pendingTrillLineStop = true;
-                }
-                else if (decoration.startsWith("rehearsal:")) {
-                    const rehearsalText = rawDecoration.slice("rehearsal:".length).trim();
-                    if (rehearsalText) {
-                        pendingRehearsalMark = rehearsalText;
-                    }
-                }
-                else if (decoration === "delayedturn" || decoration === "delayed-turn") {
-                    pendingTurn = pendingTurn || "turn";
-                    pendingDelayedTurn = true;
-                }
-                else if (decoration === "delayedinvertedturn" || decoration === "delayed-inverted-turn") {
-                    pendingTurn = "inverted-turn";
-                    pendingDelayedTurn = true;
-                }
-                else if (decoration === "turn") {
-                    pendingTurn = "turn";
-                    pendingTurnSlash = false;
-                }
-                else if (decoration === "turnx") {
-                    pendingTurn = "turn";
-                    pendingTurnSlash = true;
-                }
-                else if (decoration === "invertedturn" || decoration === "inverted-turn" || decoration === "lowerturn") {
-                    pendingTurn = "inverted-turn";
-                    pendingTurnSlash = false;
-                }
-                else if (decoration === "invertedturnx" || decoration === "inverted-turnx") {
-                    pendingTurn = "inverted-turn";
-                    pendingTurnSlash = true;
-                }
-                else if (decoration === "mordent" || decoration === "lowermordent") {
-                    pendingMordent = "mordent";
-                }
-                else if (decoration === "pralltriller" ||
-                    decoration === "pralltrill" ||
-                    decoration === "prall" ||
-                    decoration === "uppermordent" ||
-                    decoration === "invertedmordent" ||
-                    decoration === "inverted-mordent") {
-                    pendingMordent = "inverted-mordent";
-                }
-                else if (/^tremolo-(single|start|stop)-([1-9]\d*)$/.test(decoration)) {
-                    const m = decoration.match(/^tremolo-(single|start|stop)-([1-9]\d*)$/);
-                    if (m) {
-                        pendingTremolo = {
-                            type: m[1],
-                            marks: Math.max(1, Math.min(8, Number.parseInt(m[2], 10) || 1))
-                        };
-                    }
-                }
-                else if (decoration === "gliss-start" || decoration === "glissando-start") {
-                    pendingGlissandoStart = true;
-                }
-                else if (decoration === "gliss-stop" || decoration === "glissando-stop") {
-                    pendingGlissandoStop = true;
-                }
-                else if (decoration === "slide" || decoration === "slide-start") {
-                    pendingSlideStart = true;
-                }
-                else if (decoration === "slide-stop") {
-                    pendingSlideStop = true;
-                }
-                else if (decoration === "schleifer") {
-                    pendingSchleifer = true;
-                }
-                else if (decoration === "shake") {
-                    pendingShake = true;
-                }
-                else if (decoration === "roll" || decoration === "arpeggio" || decoration === "arpeggiate") {
-                    pendingArpeggiate = true;
-                }
-                else if (decoration === "staccato" ||
-                    decoration === "stacc" ||
-                    decoration === "stac") {
-                    pendingStaccato = true;
-                }
-                else if (decoration === "staccatissimo" || decoration === "wedge" || decoration === "spiccato") {
-                    pendingStaccatissimo = true;
-                }
-                else if (decoration === "accent" || decoration === ">" || decoration === "emphasis") {
-                    pendingAccent = true;
-                }
-                else if (decoration === "tenuto") {
-                    pendingTenuto = true;
-                }
-                else if (decoration === "stress") {
-                    pendingStress = true;
-                }
-                else if (decoration === "unstress") {
+                },
+                "unstress": () => {
                     pendingUnstress = true;
-                }
-                else if (decoration === "fermata") {
-                    pendingFermata = "normal";
-                }
-                else if (decoration === "invertedfermata" ||
-                    decoration === "inverted-fermata" ||
-                    decoration === "inverted fermata") {
-                    pendingFermata = "inverted";
-                }
-                else if (decoration === "marcato" ||
-                    decoration === "strongaccent" ||
-                    decoration === "strong-accent" ||
-                    decoration === "strong accent") {
-                    pendingStrongAccent = true;
-                }
-                else if (decoration === "breath" ||
-                    decoration === "breath-mark" ||
-                    decoration === "breathmark" ||
-                    decoration === "breath mark") {
-                    pendingBreathMark = true;
-                }
-                else if (decoration === "caesura") {
-                    pendingCaesura = true;
-                }
-                else if (decoration === "shortphrase" || decoration === "mediumphrase" || decoration === "longphrase") {
-                    pendingPhraseMark = decoration;
-                }
-                else if (decoration === "segno") {
-                    pendingSegno = true;
-                }
-                else if (decoration === "coda") {
-                    pendingCoda = true;
-                }
-                else if (decoration === "fine") {
-                    pendingFine = true;
-                }
-                else if (decoration === "dacoda") {
-                    pendingDaCapo = true;
-                    pendingToCoda = true;
-                }
-                else if (decoration === "dacapo" || decoration === "da-capo" || decoration === "da capo" || decoration === "d.c.") {
-                    pendingDaCapo = true;
-                }
-                else if (decoration === "dalsegno" || decoration === "dal-segno" || decoration === "dal segno" || decoration === "d.s.") {
-                    pendingDalSegno = true;
-                }
-                else if (decoration === "tocoda" || decoration === "to-coda" || decoration === "to coda") {
-                    pendingToCoda = true;
-                }
-                else if (decoration === "crescendo(" || decoration === "cresc(" || decoration === "<(") {
-                    pendingCrescendoStart = true;
-                }
-                else if (decoration === "crescendo)" || decoration === "cresc)" || decoration === "<)") {
-                    pendingCrescendoStop = true;
-                }
-                else if (decoration === "diminuendo(" ||
-                    decoration === "decrescendo(" ||
-                    decoration === "dim(" ||
-                    decoration === "decresc(" ||
-                    decoration === ">(") {
-                    pendingDiminuendoStart = true;
-                }
-                else if (decoration === "diminuendo)" ||
-                    decoration === "decrescendo)" ||
-                    decoration === "dim)" ||
-                    decoration === "decresc)" ||
-                    decoration === ">)") {
-                    pendingDiminuendoStop = true;
-                }
-                else if (decoration === "pppp" ||
-                    decoration === "ppp" ||
-                    decoration === "p" ||
-                    decoration === "pp" ||
-                    decoration === "mp" ||
-                    decoration === "mf" ||
-                    decoration === "f" ||
-                    decoration === "ff" ||
-                    decoration === "fff" ||
-                    decoration === "ffff" ||
-                    decoration === "fp" ||
-                    decoration === "fz" ||
-                    decoration === "rfz" ||
-                    decoration === "sf" ||
-                    decoration === "sfp") {
-                    pendingDynamicMark = decoration;
-                }
-                else if (decoration === "sfz") {
-                    pendingSfz = true;
-                }
-                else if (decoration === "upbow" || decoration === "up-bow" || decoration === "up bow") {
-                    pendingUpBow = true;
-                }
-                else if (decoration === "downbow" || decoration === "down-bow" || decoration === "down bow") {
-                    pendingDownBow = true;
-                }
-                else if (decoration === "doubletongue" ||
-                    decoration === "double-tongue" ||
-                    decoration === "double tongue") {
-                    pendingDoubleTongue = true;
-                }
-                else if (decoration === "tripletongue" ||
-                    decoration === "triple-tongue" ||
-                    decoration === "triple tongue") {
-                    pendingTripleTongue = true;
-                }
-                else if (decoration === "heel" || decoration === "heel mark") {
-                    pendingHeel = true;
-                }
-                else if (decoration === "toe" || decoration === "toe mark") {
-                    pendingToe = true;
-                }
-                else if (/^[0-5]$/.test(decoration)) {
-                    pendingFingerings.push(decoration);
-                }
-                else if (decoration.startsWith("fingering:")) {
-                    const fingeringText = rawDecoration.slice("fingering:".length).trim();
-                    if (fingeringText)
-                        pendingFingerings.push(fingeringText);
-                }
-                else if (decoration.startsWith("string:")) {
-                    const stringText = rawDecoration.slice("string:".length).trim();
-                    if (stringText)
-                        pendingStrings.push(stringText);
-                }
-                else if (decoration.startsWith("pluck:")) {
-                    const pluckText = rawDecoration.slice("pluck:".length).trim();
-                    if (pluckText)
-                        pendingPlucks.push(pluckText);
-                }
-                else if (decoration === "open" ||
-                    decoration === "open-string" ||
-                    decoration === "openstring" ||
-                    decoration === "open string") {
-                    pendingOpenString = true;
-                }
-                else if (decoration === "snap" ||
-                    decoration === "snap-pizzicato" ||
-                    decoration === "snappizzicato" ||
-                    decoration === "snap pizzicato") {
-                    pendingSnapPizzicato = true;
-                }
-                else if (decoration === "harmonic") {
-                    pendingHarmonic = true;
-                }
-                else if (decoration === "stopped" ||
-                    decoration === "+" ||
-                    decoration === "plus" ||
-                    decoration === "stopped horn" ||
-                    decoration === "stopped-horn") {
-                    pendingStopped = true;
-                }
-                else if (decoration === "thumb" ||
-                    decoration === "thumbposition" ||
-                    decoration === "thumb-position" ||
-                    decoration === "thumbpos" ||
-                    decoration === "thumb pos" ||
-                    decoration === "thumb position") {
-                    pendingThumbPosition = true;
-                }
-                else if (decoration) {
-                    warnings.push("line " + entry.lineNo + ": Skipped decoration: " + ch + decoration + ch);
-                }
-                idx = endMark + 1;
-                continue;
+                },
+            };
+            const applyExactDecoration = exactDecorationAppliers[decoration];
+            if (applyExactDecoration) {
+                applyExactDecoration();
+                return true;
             }
-            if (ch === "{") {
-                const graceResult = parseGraceGroupAt(text, idx, entry.lineNo, activeUnitLength, activeKeySignatureAccidentals, measureAccidentals, entry.voiceId, warnings);
-                if (!graceResult) {
-                    warnings.push("line " + entry.lineNo + ": Failed to parse grace group; skipped.");
-                    idx += 1;
-                    continue;
-                }
-                idx = graceResult.nextIdx;
-                for (const graceNote of graceResult.notes) {
-                    currentMeasure.push(graceNote);
-                    noteCount += 1;
-                }
-                continue;
+            const setDecorationAppliers = [
+                [TRILL_DECORATIONS, () => {
+                        pendingTrill = true;
+                    }],
+                [LOWER_MORDENT_DECORATIONS, () => {
+                        pendingMordent = "mordent";
+                    }],
+                [UPPER_MORDENT_DECORATIONS, () => {
+                        pendingMordent = "inverted-mordent";
+                    }],
+                [GLISS_START_DECORATIONS, () => {
+                        pendingGlissandoStart = true;
+                    }],
+                [GLISS_STOP_DECORATIONS, () => {
+                        pendingGlissandoStop = true;
+                    }],
+                [SLIDE_START_DECORATIONS, () => {
+                        pendingSlideStart = true;
+                    }],
+                [ARPEGGIATE_DECORATIONS, () => {
+                        pendingArpeggiate = true;
+                    }],
+                [STACCATO_DECORATIONS, () => {
+                        pendingStaccato = true;
+                    }],
+                [STACCATISSIMO_DECORATIONS, () => {
+                        pendingStaccatissimo = true;
+                    }],
+                [ACCENT_DECORATIONS, () => {
+                        pendingAccent = true;
+                    }],
+                [INVERTED_FERMATA_DECORATIONS, () => {
+                        pendingFermata = "inverted";
+                    }],
+                [STRONG_ACCENT_DECORATIONS, () => {
+                        pendingStrongAccent = true;
+                    }],
+                [BREATH_DECORATIONS, () => {
+                        pendingBreathMark = true;
+                    }],
+                [DACAPO_DECORATIONS, () => {
+                        pendingDaCapo = true;
+                    }],
+                [DALSEGNO_DECORATIONS, () => {
+                        pendingDalSegno = true;
+                    }],
+                [TOCODA_DECORATIONS, () => {
+                        pendingToCoda = true;
+                    }],
+                [CRESC_START_DECORATIONS, () => {
+                        pendingCrescendoStart = true;
+                    }],
+                [CRESC_STOP_DECORATIONS, () => {
+                        pendingCrescendoStop = true;
+                    }],
+                [DIM_START_DECORATIONS, () => {
+                        pendingDiminuendoStart = true;
+                    }],
+                [DIM_STOP_DECORATIONS, () => {
+                        pendingDiminuendoStop = true;
+                    }],
+                [UPBOW_DECORATIONS, () => {
+                        pendingUpBow = true;
+                    }],
+                [DOWNBOW_DECORATIONS, () => {
+                        pendingDownBow = true;
+                    }],
+                [DOUBLE_TONGUE_DECORATIONS, () => {
+                        pendingDoubleTongue = true;
+                    }],
+                [TRIPLE_TONGUE_DECORATIONS, () => {
+                        pendingTripleTongue = true;
+                    }],
+                [OPEN_STRING_DECORATIONS, () => {
+                        pendingOpenString = true;
+                    }],
+                [SNAP_PIZZICATO_DECORATIONS, () => {
+                        pendingSnapPizzicato = true;
+                    }],
+                [STOPPED_DECORATIONS, () => {
+                        pendingStopped = true;
+                    }],
+                [THUMB_POSITION_DECORATIONS, () => {
+                        pendingThumbPosition = true;
+                    }],
+            ];
+            const applySetDecoration = setDecorationAppliers.find(([decorationSet]) => decorationSet.has(decoration));
+            if (applySetDecoration) {
+                applySetDecoration[1]();
+                return true;
             }
-            if (ch === ".") {
-                pendingStaccato = true;
-                idx += 1;
-                continue;
+            if (applyPrefixedDecoration(rawDecoration, decoration)) {
+                return true;
             }
-            if (ch === "[") {
-                const inlineField = parseInlineFieldAt(text, idx);
-                if (inlineField) {
-                    if (inlineField.fieldName === "K") {
-                        const inlineKeyInfo = parseKey(inlineField.fieldValue || "C", warnings);
-                        activeKeyFifths = inlineKeyInfo.fifths;
-                        activeKeySignatureAccidentals = keySignatureAlterByStep(activeKeyFifths);
-                        currentKeyFifthsByVoice[entry.voiceId] = activeKeyFifths;
-                        keyHintFifthsByKey.set(`${entry.voiceId}#${currentMeasureNo}`, activeKeyFifths);
-                        measureAccidentals = {};
-                    }
-                    else if (inlineField.fieldName === "L") {
-                        activeUnitLength = parseFraction(inlineField.fieldValue || "1/8", "L", warnings);
-                    }
-                    else if (inlineField.fieldName === "M") {
-                        activeMeter = parseMeter(inlineField.fieldValue || "4/4", warnings);
-                        ensureMeterByMeasure(entry.voiceId)[currentMeasureNo] = {
-                            beats: activeMeter.beats,
-                            beatType: activeMeter.beatType,
-                        };
-                    }
-                    else if (inlineField.fieldName === "Q") {
-                        activeTempoBpm = parseTempoFromQ(inlineField.fieldValue || "", warnings);
-                        if (Number.isFinite(activeTempoBpm)) {
-                            ensureTempoByMeasure(entry.voiceId)[currentMeasureNo] = Math.max(20, Math.min(300, Math.round(Number(activeTempoBpm))));
-                        }
-                    }
-                    else {
-                        warnings.push("line " + entry.lineNo + ": Skipped unsupported inline field: [" + inlineField.fieldName + ":" + inlineField.fieldValue + "]");
-                    }
-                    idx = inlineField.nextIdx;
-                    continue;
-                }
-                const repeatEndingMarker = parseRepeatEndingMarkerAt(text, idx);
-                if (repeatEndingMarker) {
-                    if (activeEndingMarker) {
-                        const stopMeasureNo = currentMeasure.length === 0 ? currentMeasureNo - 1 : currentMeasureNo;
-                        if (stopMeasureNo >= 1) {
-                            const prevMeta = ensureNotationMeasureMeta(entry.voiceId, stopMeasureNo);
-                            prevMeta.endingStop = activeEndingMarker;
-                            prevMeta.endingStopType = "stop";
-                        }
-                    }
-                    const measureMeta = ensureNotationMeasureMeta(entry.voiceId, currentMeasureNo);
-                    measureMeta.endingStart = repeatEndingMarker.marker;
-                    activeEndingMarker = repeatEndingMarker.marker;
-                    idx = repeatEndingMarker.nextIdx;
-                    beamRunActive = false;
-                    sawInterEventWhitespace = false;
-                    continue;
-                }
-                const chordResult = parseChordAt(text, idx, entry.lineNo);
-                if (!chordResult) {
-                    warnings.push("line " + entry.lineNo + ": Failed to parse chord notation; skipped.");
-                    idx += 1;
-                    continue;
-                }
-                idx = chordResult.nextIdx;
-                let chordLength = parseLengthToken(chordResult.lengthToken, entry.lineNo);
-                if (!chordResult.lengthToken && chordResult.notes.length > 0 && chordResult.notes[0].lengthToken) {
-                    chordLength = parseLengthToken(chordResult.notes[0].lengthToken, entry.lineNo);
-                }
-                let absoluteLength = multiplyFractions(activeUnitLength, chordLength);
-                if (pendingRhythmScale) {
-                    absoluteLength = multiplyFractions(absoluteLength, pendingRhythmScale);
-                    pendingRhythmScale = null;
-                }
-                const activeTuplet = tupletRemaining > 0 && tupletScale && tupletSpec
-                    ? { actual: tupletSpec.actual, normal: tupletSpec.normal, remaining: tupletSpec.remaining }
-                    : null;
-                if (tupletRemaining > 0 && tupletScale) {
-                    absoluteLength = multiplyFractions(absoluteLength, tupletScale);
-                    tupletRemaining -= 1;
-                    if (tupletSpec) {
-                        tupletSpec.remaining -= 1;
-                    }
-                    if (tupletRemaining <= 0) {
-                        tupletScale = null;
-                        tupletSpec = null;
-                    }
-                }
-                if (idx < text.length && (text[idx] === ">" || text[idx] === "<")) {
-                    const rhythmChar = text[idx];
-                    idx += 1;
-                    if (rhythmChar === ">") {
-                        absoluteLength = multiplyFractions(absoluteLength, { num: 3, den: 2 });
-                        pendingRhythmScale = { num: 1, den: 2 };
-                    }
-                    else {
-                        absoluteLength = multiplyFractions(absoluteLength, { num: 1, den: 2 });
-                        pendingRhythmScale = { num: 3, den: 2 };
-                    }
-                }
-                const dur = durationInDivisions(absoluteLength, 960);
-                if (dur <= 0) {
-                    warnings.push("line " + entry.lineNo + ": Skipped chord with invalid length.");
-                    continue;
-                }
-                const chordNotes = [];
-                currentEventNo += 1;
-                const trillHint = trillWidthHintByKey.get(`${entry.voiceId}#${currentMeasureNo}#${currentEventNo}`) || "";
-                for (let chordIndex = 0; chordIndex < chordResult.notes.length; chordIndex += 1) {
-                    const chordNote = chordResult.notes[chordIndex];
-                    let note;
-                    try {
-                        note = buildNoteData(chordNote.pitchChar, chordNote.accidentalText, chordNote.octaveShift, absoluteLength, dur, entry.lineNo, activeKeySignatureAccidentals, measureAccidentals);
-                    }
-                    catch (error) {
-                        if (error instanceof Error && /Octave out of range/i.test(error.message || "")) {
-                            warnings.push("line " + entry.lineNo + ": Skipped chord note with unsupported octave range.");
-                            chordNotes.length = 0;
-                            break;
-                        }
-                        throw error;
-                    }
-                    note.voice = entry.voiceId;
-                    if (chordIndex === 0) {
-                        applyBeamModeForEvent(note, dur);
-                    }
-                    if (chordIndex === 0 && pendingTrill && !note.isRest) {
-                        note.trill = true;
-                        note.trillLineStart = pendingTrillLineStart;
-                        pendingTrill = false;
-                        pendingTrillLineStart = false;
-                    }
-                    if (chordIndex === 0 && pendingTrillLineStop && !note.isRest) {
-                        note.trillLineStop = true;
-                        pendingTrillLineStop = false;
-                    }
-                    if (chordIndex === 0 && pendingTurn && !note.isRest) {
-                        note.turnType = pendingTurn;
-                        note.turnSlash = pendingTurnSlash;
-                        note.delayedTurn = pendingDelayedTurn;
-                        pendingTurn = "";
-                        pendingTurnSlash = false;
-                        pendingDelayedTurn = false;
-                    }
-                    if (chordIndex === 0 && !note.isRest && (pendingEditorialAccidental || pendingCourtesyAccidental)) {
-                        if (note.accidentalText) {
-                            note.accidentalEditorial = pendingEditorialAccidental || undefined;
-                            note.accidentalCautionary = pendingCourtesyAccidental || undefined;
-                        }
-                        pendingEditorialAccidental = false;
-                        pendingCourtesyAccidental = false;
-                    }
-                    if (chordIndex === 0 && pendingMordent && !note.isRest) {
-                        note.mordentType = pendingMordent;
-                        pendingMordent = "";
-                    }
-                    if (chordIndex === 0 && pendingPhraseMark && !note.isRest) {
-                        note.phraseMark = pendingPhraseMark;
-                        pendingPhraseMark = "";
-                    }
-                    if (chordIndex === 0 && pendingTremolo && !note.isRest) {
-                        note.tremoloType = pendingTremolo.type;
-                        note.tremoloMarks = pendingTremolo.marks;
-                        pendingTremolo = null;
-                    }
-                    if (chordIndex === 0 && pendingGlissandoStart && !note.isRest) {
-                        note.glissandoStart = true;
-                        pendingGlissandoStart = false;
-                    }
-                    if (chordIndex === 0 && pendingGlissandoStop && !note.isRest) {
-                        note.glissandoStop = true;
-                        pendingGlissandoStop = false;
-                    }
-                    if (chordIndex === 0 && pendingSlideStart && !note.isRest) {
-                        note.slideStart = true;
-                        pendingSlideStart = false;
-                    }
-                    if (chordIndex === 0 && pendingSlideStop && !note.isRest) {
-                        note.slideStop = true;
-                        pendingSlideStop = false;
-                    }
-                    if (chordIndex === 0 && pendingSchleifer && !note.isRest) {
-                        note.schleifer = true;
-                        pendingSchleifer = false;
-                    }
-                    if (chordIndex === 0 && pendingShake && !note.isRest) {
-                        note.shake = true;
-                        pendingShake = false;
-                    }
-                    if (chordIndex === 0 && pendingArpeggiate && !note.isRest) {
-                        note.arpeggiate = true;
-                        pendingArpeggiate = false;
-                    }
-                    if (chordIndex === 0 && pendingSlurStart > 0 && !note.isRest) {
-                        note.slurStart = true;
-                        pendingSlurStart = 0;
-                    }
-                    if (chordIndex === 0 && note.trill && trillHint) {
-                        note.trillAccidentalText = trillHint;
-                    }
-                    if (chordIndex === 0 && pendingStaccato && !note.isRest) {
-                        note.staccato = true;
-                        pendingStaccato = false;
-                    }
-                    if (chordIndex === 0 && pendingStaccatissimo && !note.isRest) {
-                        note.staccatissimo = true;
-                        pendingStaccatissimo = false;
-                    }
-                    if (chordIndex === 0 && pendingAccent && !note.isRest) {
-                        note.accent = true;
-                        pendingAccent = false;
-                    }
-                    if (chordIndex === 0 && pendingTenuto && !note.isRest) {
-                        note.tenuto = true;
-                        pendingTenuto = false;
-                    }
-                    if (chordIndex === 0 && pendingStress && !note.isRest) {
-                        note.stress = true;
-                        pendingStress = false;
-                    }
-                    if (chordIndex === 0 && pendingUnstress && !note.isRest) {
-                        note.unstress = true;
-                        pendingUnstress = false;
-                    }
-                    if (chordIndex === 0 && pendingFermata && !note.isRest) {
-                        note.fermataType = pendingFermata;
-                        pendingFermata = "";
-                    }
-                    if (chordIndex === 0 && pendingStrongAccent && !note.isRest) {
-                        note.strongAccent = true;
-                        pendingStrongAccent = false;
-                    }
-                    if (chordIndex === 0 && pendingBreathMark && !note.isRest) {
-                        note.breathMark = true;
-                        pendingBreathMark = false;
-                    }
-                    if (chordIndex === 0 && pendingCaesura && !note.isRest) {
-                        note.caesura = true;
-                        pendingCaesura = false;
-                    }
-                    if (chordIndex === 0 && pendingSegno && !note.isRest) {
-                        note.segno = true;
-                        pendingSegno = false;
-                    }
-                    if (chordIndex === 0 && pendingCoda && !note.isRest) {
-                        note.coda = true;
-                        pendingCoda = false;
-                    }
-                    if (chordIndex === 0 && pendingFine && !note.isRest) {
-                        note.fine = true;
-                        pendingFine = false;
-                    }
-                    if (chordIndex === 0 && pendingDaCapo && !note.isRest) {
-                        note.daCapo = true;
-                        pendingDaCapo = false;
-                    }
-                    if (chordIndex === 0 && pendingDalSegno && !note.isRest) {
-                        note.dalSegno = true;
-                        pendingDalSegno = false;
-                    }
-                    if (chordIndex === 0 && pendingToCoda && !note.isRest) {
-                        note.toCoda = true;
-                        pendingToCoda = false;
-                    }
-                    if (chordIndex === 0 && pendingCrescendoStart && !note.isRest) {
-                        note.crescendoStart = true;
-                        pendingCrescendoStart = false;
-                    }
-                    if (chordIndex === 0 && pendingCrescendoStop && !note.isRest) {
-                        note.crescendoStop = true;
-                        pendingCrescendoStop = false;
-                    }
-                    if (chordIndex === 0 && pendingDiminuendoStart && !note.isRest) {
-                        note.diminuendoStart = true;
-                        pendingDiminuendoStart = false;
-                    }
-                    if (chordIndex === 0 && pendingDiminuendoStop && !note.isRest) {
-                        note.diminuendoStop = true;
-                        pendingDiminuendoStop = false;
-                    }
-                    if (chordIndex === 0 && pendingDynamicMark && !note.isRest) {
-                        note.dynamicMark = pendingDynamicMark;
-                        pendingDynamicMark = "";
-                    }
-                    if (chordIndex === 0 && pendingSfz && !note.isRest) {
-                        note.sfz = true;
-                        pendingSfz = false;
-                    }
-                    if (chordIndex === 0 && pendingRehearsalMark && !note.isRest) {
-                        note.rehearsalMark = pendingRehearsalMark;
-                        pendingRehearsalMark = "";
-                    }
-                    if (chordIndex === 0 && pendingUpBow && !note.isRest) {
-                        note.upBow = true;
-                        pendingUpBow = false;
-                    }
-                    if (chordIndex === 0 && pendingDownBow && !note.isRest) {
-                        note.downBow = true;
-                        pendingDownBow = false;
-                    }
-                    if (chordIndex === 0 && pendingDoubleTongue && !note.isRest) {
-                        note.doubleTongue = true;
-                        pendingDoubleTongue = false;
-                    }
-                    if (chordIndex === 0 && pendingTripleTongue && !note.isRest) {
-                        note.tripleTongue = true;
-                        pendingTripleTongue = false;
-                    }
-                    if (chordIndex === 0 && pendingHeel && !note.isRest) {
-                        note.heel = true;
-                        pendingHeel = false;
-                    }
-                    if (chordIndex === 0 && pendingToe && !note.isRest) {
-                        note.toe = true;
-                        pendingToe = false;
-                    }
-                    if (chordIndex === 0 && pendingFingerings.length > 0 && !note.isRest) {
-                        note.fingerings = pendingFingerings.slice();
-                        pendingFingerings = [];
-                    }
-                    if (chordIndex === 0 && pendingStrings.length > 0 && !note.isRest) {
-                        note.strings = pendingStrings.slice();
-                        pendingStrings = [];
-                    }
-                    if (chordIndex === 0 && pendingPlucks.length > 0 && !note.isRest) {
-                        note.plucks = pendingPlucks.slice();
-                        pendingPlucks = [];
-                    }
-                    if (chordIndex === 0 && pendingChordSymbols.length > 0 && !note.isRest) {
-                        note.chordSymbols = pendingChordSymbols.slice();
-                        pendingChordSymbols = [];
-                    }
-                    if (chordIndex === 0 && pendingOpenString && !note.isRest) {
-                        note.openString = true;
-                        pendingOpenString = false;
-                    }
-                    if (chordIndex === 0 && pendingSnapPizzicato && !note.isRest) {
-                        note.snapPizzicato = true;
-                        pendingSnapPizzicato = false;
-                    }
-                    if (chordIndex === 0 && pendingHarmonic && !note.isRest) {
-                        note.harmonic = true;
-                        pendingHarmonic = false;
-                    }
-                    if (chordIndex === 0 && pendingStopped && !note.isRest) {
-                        note.stopped = true;
-                        pendingStopped = false;
-                    }
-                    if (chordIndex === 0 && pendingThumbPosition && !note.isRest) {
-                        note.thumbPosition = true;
-                        pendingThumbPosition = false;
-                    }
-                    if (chordIndex === 0 && pendingAnnotations.length > 0 && !note.isRest) {
-                        note.annotations = pendingAnnotations.slice();
-                        pendingAnnotations = [];
-                    }
-                    if (chordIndex > 0) {
-                        note.chord = true;
-                    }
-                    if (chordIndex === 0 && activeTuplet) {
-                        note.timeModification = { actual: activeTuplet.actual, normal: activeTuplet.normal };
-                        if (activeTuplet.remaining === activeTuplet.actual) {
-                            note.tupletStart = true;
-                        }
-                        if (activeTuplet.remaining === 1) {
-                            note.tupletStop = true;
-                        }
-                    }
-                    chordNotes.push(note);
-                }
-                if (pendingTieToNext && chordNotes.length > 0) {
-                    for (const chordNote of chordNotes) {
-                        if (!chordNote.isRest) {
-                            chordNote.tieStop = true;
-                        }
-                    }
-                    pendingTieToNext = false;
-                }
-                for (const note of chordNotes) {
-                    currentMeasure.push(note);
-                }
-                if (chordNotes.length === 0) {
-                    pendingTieToNext = false;
-                    lastNote = null;
-                    lastEventNotes = [];
-                    continue;
-                }
-                lastNote = chordNotes[0] || null;
-                lastEventNotes = chordNotes;
-                noteCount += chordNotes.length;
-                continue;
+            if (applyTurnDecoration(decoration)) {
+                return true;
             }
-            if (ch === ")") {
-                if (lastNote && !lastNote.isRest) {
-                    lastNote.slurStop = true;
-                }
-                else {
-                    warnings.push("line " + entry.lineNo + ": slur stop()) has no preceding note; skipped.");
-                }
-                idx += 1;
-                continue;
+            if (applyTremoloDecoration(decoration)) {
+                return true;
             }
-            if (ch === "]" || ch === "}") {
-                if (ch === "]" && activeEndingMarker) {
-                    const stopMeasureNo = currentMeasure.length === 0 ? currentMeasureNo - 1 : currentMeasureNo;
-                    if (stopMeasureNo >= 1) {
-                        const measureMeta = ensureNotationMeasureMeta(entry.voiceId, stopMeasureNo);
-                        measureMeta.endingStop = activeEndingMarker;
-                        measureMeta.endingStopType = "stop";
-                        activeEndingMarker = "";
-                    }
-                    idx += 1;
-                    beamRunActive = false;
-                    sawInterEventWhitespace = false;
-                    continue;
-                }
-                warnings.push("line " + entry.lineNo + ": Skipped unsupported notation: " + ch);
-                idx += 1;
-                beamRunActive = false;
-                sawInterEventWhitespace = false;
-                continue;
+            if (PHRASE_DECORATIONS.has(decoration)) {
+                pendingPhraseMark = decoration;
+                return true;
             }
-            if (ch === ";" || ch === "`" || ch === "?" || ch === "@" || ch === "#" || ch === "$" || ch === "*") {
-                warnings.push("line " + entry.lineNo + ": Skipped unsupported body punctuation: " + ch);
-                idx += 1;
-                beamRunActive = false;
-                sawInterEventWhitespace = false;
-                continue;
+            if (decoration === "dacoda") {
+                pendingDaCapo = true;
+                pendingToCoda = true;
+                return true;
             }
-            const noteResult = (0, abc_parser_1.parseAbcNoteAt)(text, idx);
-            if ((noteResult === null || noteResult === void 0 ? void 0 : noteResult.kind) === "malformed-accidental") {
-                warnings.push("line " + entry.lineNo + ": Skipped malformed accidental token: " + noteResult.accidentalText);
-                idx = noteResult.nextIdx;
-                continue;
+            if (DYNAMIC_DECORATIONS.has(decoration)) {
+                pendingDynamicMark = decoration;
+                return true;
             }
-            if (!noteResult || noteResult.kind !== "note") {
-                throw new Error("line " + entry.lineNo + ": Failed to parse note/rest: " + text.slice(idx, idx + 12));
+            if (/^[0-5]$/.test(decoration)) {
+                pendingFingerings.push(decoration);
+                return true;
             }
-            const { accidentalText, pitchChar, octaveShift, lengthToken, nextIdx } = noteResult.note;
-            idx = nextIdx;
-            const len = parseLengthToken(lengthToken, entry.lineNo);
-            let absoluteLength = multiplyFractions(activeUnitLength, len);
-            if (pendingRhythmScale) {
-                absoluteLength = multiplyFractions(absoluteLength, pendingRhythmScale);
-                pendingRhythmScale = null;
-            }
-            const activeTuplet = tupletRemaining > 0 && tupletScale && tupletSpec
-                ? { actual: tupletSpec.actual, normal: tupletSpec.normal, remaining: tupletSpec.remaining }
-                : null;
-            if (tupletRemaining > 0 && tupletScale) {
-                absoluteLength = multiplyFractions(absoluteLength, tupletScale);
-                tupletRemaining -= 1;
-                if (tupletSpec) {
-                    tupletSpec.remaining -= 1;
-                }
-                if (tupletRemaining <= 0) {
-                    tupletScale = null;
-                    tupletSpec = null;
-                }
-            }
-            if (idx < text.length && (text[idx] === ">" || text[idx] === "<")) {
-                const rhythmChar = text[idx];
-                idx += 1;
-                if (rhythmChar === ">") {
-                    absoluteLength = multiplyFractions(absoluteLength, { num: 3, den: 2 });
-                    pendingRhythmScale = { num: 1, den: 2 };
-                }
-                else {
-                    absoluteLength = multiplyFractions(absoluteLength, { num: 1, den: 2 });
-                    pendingRhythmScale = { num: 3, den: 2 };
-                }
-            }
-            const dur = durationInDivisions(absoluteLength, 960);
-            if (dur <= 0) {
-                warnings.push("line " + entry.lineNo + ": Skipped note with invalid length.");
-                continue;
-            }
-            let note;
-            try {
-                note = buildNoteData(pitchChar, accidentalText, octaveShift, absoluteLength, dur, entry.lineNo, activeKeySignatureAccidentals, measureAccidentals);
-            }
-            catch (error) {
-                if (error instanceof Error && /Octave out of range/i.test(error.message || "")) {
-                    warnings.push("line " + entry.lineNo + ": Skipped note with unsupported octave range.");
-                    pendingTieToNext = false;
-                    lastNote = null;
-                    lastEventNotes = [];
-                    continue;
-                }
-                throw error;
-            }
-            applyBeamModeForEvent(note, dur);
+            return false;
+        };
+        const applyPendingOrnamentState = (note, options = {}) => {
+            const { applySlurStart = true, trillHint = "" } = options;
             if (pendingTrill && !note.isRest) {
                 note.trill = true;
                 note.trillLineStart = pendingTrillLineStart;
@@ -31368,15 +30650,15 @@ function parseForMusicXml(source, settings) {
                 note.arpeggiate = true;
                 pendingArpeggiate = false;
             }
-            if (pendingSlurStart > 0 && !note.isRest) {
+            if (applySlurStart && pendingSlurStart > 0 && !note.isRest) {
                 note.slurStart = true;
                 pendingSlurStart = 0;
             }
-            currentEventNo += 1;
-            const trillHint = trillWidthHintByKey.get(`${entry.voiceId}#${currentMeasureNo}#${currentEventNo}`) || "";
             if (note.trill && trillHint) {
                 note.trillAccidentalText = trillHint;
             }
+        };
+        const applyPendingArticulationState = (note) => {
             if (pendingStaccato && !note.isRest) {
                 note.staccato = true;
                 pendingStaccato = false;
@@ -31417,6 +30699,8 @@ function parseForMusicXml(source, settings) {
                 note.caesura = true;
                 pendingCaesura = false;
             }
+        };
+        const applyPendingDirectionState = (note) => {
             if (pendingSegno && !note.isRest) {
                 note.segno = true;
                 pendingSegno = false;
@@ -31469,6 +30753,8 @@ function parseForMusicXml(source, settings) {
                 note.rehearsalMark = pendingRehearsalMark;
                 pendingRehearsalMark = "";
             }
+        };
+        const applyPendingTechnicalState = (note) => {
             if (pendingUpBow && !note.isRest) {
                 note.upBow = true;
                 pendingUpBow = false;
@@ -31533,28 +30819,629 @@ function parseForMusicXml(source, settings) {
                 note.annotations = pendingAnnotations.slice();
                 pendingAnnotations = [];
             }
-            if (pendingTieToNext && !note.isRest) {
+        };
+        const applyPendingToPlayableNote = (note, options = {}) => {
+            const { applySlurStart = true, applyTieStop = true, trillHint = "", } = options;
+            applyPendingOrnamentState(note, { applySlurStart, trillHint });
+            applyPendingArticulationState(note);
+            applyPendingDirectionState(note);
+            applyPendingTechnicalState(note);
+            if (applyTieStop && pendingTieToNext && !note.isRest) {
                 note.tieStop = true;
                 pendingTieToNext = false;
             }
-            else if (note.isRest && pendingTieToNext) {
-                warnings.push("line " + entry.lineNo + ": tie(-) was followed by a rest; tie removed.");
+            else if (applyTieStop && note.isRest && pendingTieToNext) {
+                warnBody("tie(-) was followed by a rest; tie removed.");
                 pendingTieToNext = false;
             }
-            if (activeTuplet) {
-                note.timeModification = { actual: activeTuplet.actual, normal: activeTuplet.normal };
-                if (activeTuplet.remaining === activeTuplet.actual) {
-                    note.tupletStart = true;
+        };
+        // Event construction and commit helpers.
+        const applySingleCharShorthand = (char) => {
+            const shorthand = (0, abc_parser_1.parseAbcSingleCharShorthandAt)(char, 0);
+            if (!shorthand) {
+                return false;
+            }
+            const shorthandAppliers = {
+                "accent": () => {
+                    pendingAccent = true;
+                },
+                "arpeggiate": () => {
+                    pendingArpeggiate = true;
+                },
+                "coda": () => {
+                    pendingCoda = true;
+                },
+                "downbow": () => {
+                    pendingDownBow = true;
+                },
+                "fermata": () => {
+                    pendingFermata = "normal";
+                },
+                "inverted-mordent": () => {
+                    pendingMordent = "inverted-mordent";
+                },
+                "mordent": () => {
+                    pendingMordent = "mordent";
+                },
+                "segno": () => {
+                    pendingSegno = true;
+                },
+                "staccato": () => {
+                    pendingStaccato = true;
+                },
+                "trill": () => {
+                    pendingTrill = true;
+                },
+                "upbow": () => {
+                    pendingUpBow = true;
+                },
+            };
+            const apply = shorthandAppliers[shorthand.kind];
+            if (!apply) {
+                return false;
+            }
+            apply();
+            return true;
+        };
+        const consumePlayableTiming = (rawLengthToken, tokenIdx) => {
+            const len = parseLengthToken(rawLengthToken, entry.lineNo);
+            let absoluteLength = multiplyFractions(activeUnitLength, len);
+            if (pendingRhythmScale) {
+                absoluteLength = multiplyFractions(absoluteLength, pendingRhythmScale);
+                pendingRhythmScale = null;
+            }
+            const activeTuplet = tupletRemaining > 0 && tupletScale && tupletSpec
+                ? { actual: tupletSpec.actual, normal: tupletSpec.normal, remaining: tupletSpec.remaining }
+                : null;
+            if (tupletRemaining > 0 && tupletScale) {
+                absoluteLength = multiplyFractions(absoluteLength, tupletScale);
+                tupletRemaining -= 1;
+                if (tupletSpec) {
+                    tupletSpec.remaining -= 1;
                 }
-                if (activeTuplet.remaining === 1) {
-                    note.tupletStop = true;
+                if (tupletRemaining <= 0) {
+                    tupletScale = null;
+                    tupletSpec = null;
                 }
             }
+            let nextIdx = tokenIdx;
+            const trailingBrokenRhythm = (0, abc_parser_1.parseAbcBrokenRhythmAt)(text, nextIdx);
+            if (trailingBrokenRhythm) {
+                absoluteLength = multiplyFractions(absoluteLength, trailingBrokenRhythm.leftScale);
+                pendingRhythmScale = trailingBrokenRhythm.rightScale;
+                nextIdx = trailingBrokenRhythm.nextIdx;
+            }
+            return {
+                absoluteLength,
+                dur: durationInDivisions(absoluteLength, 960),
+                activeTuplet,
+                nextIdx,
+            };
+        };
+        const applyTupletToEventStart = (note, activeTuplet) => {
+            if (!activeTuplet) {
+                return;
+            }
+            note.timeModification = { actual: activeTuplet.actual, normal: activeTuplet.normal };
+            if (activeTuplet.remaining === activeTuplet.actual) {
+                note.tupletStart = true;
+            }
+            if (activeTuplet.remaining === 1) {
+                note.tupletStop = true;
+            }
+        };
+        const finalizePlayableEventStart = (note, dur, activeTuplet, options = {}) => {
+            const applyTieStop = options.applyTieStop !== false;
+            applyBeamModeForEvent(note, dur);
+            currentEventNo += 1;
+            const trillHint = trillWidthHintByKey.get(`${entry.voiceId}#${currentMeasureNo}#${currentEventNo}`) || "";
+            applyPendingToPlayableNote(note, { applySlurStart: true, applyTieStop, trillHint });
+            applyTupletToEventStart(note, activeTuplet);
             note.voice = entry.voiceId;
-            currentMeasure.push(note);
-            lastNote = note;
-            lastEventNotes = [note];
-            noteCount += 1;
+        };
+        const buildPlayableNoteForBody = (pitchSource, absoluteLength, dur, octaveWarningMessage) => {
+            let note;
+            try {
+                note = buildNoteData(pitchSource.pitchChar, pitchSource.accidentalText, pitchSource.octaveShift, absoluteLength, dur, entry.lineNo, activeKeySignatureAccidentals, measureAccidentals);
+            }
+            catch (error) {
+                if (error instanceof Error && /Octave out of range/i.test(error.message || "")) {
+                    warnBody(octaveWarningMessage);
+                    return null;
+                }
+                throw error;
+            }
+            note.voice = entry.voiceId;
+            return note;
+        };
+        const clearLastEventState = (options = {}) => {
+            if (options.clearPendingTie !== false) {
+                pendingTieToNext = false;
+            }
+            lastNote = null;
+            lastEventNotes = [];
+        };
+        const commitPlayableEvent = (notes, options = {}) => {
+            const applyChordTieStop = options.applyChordTieStop === true;
+            if (applyChordTieStop && pendingTieToNext && notes.length > 0) {
+                for (const note of notes) {
+                    if (!note.isRest) {
+                        note.tieStop = true;
+                    }
+                }
+                pendingTieToNext = false;
+            }
+            for (const note of notes) {
+                currentMeasure.push(note);
+            }
+            if (notes.length === 0) {
+                clearLastEventState();
+                return false;
+            }
+            lastNote = notes[0] || null;
+            lastEventNotes = notes;
+            noteCount += notes.length;
+            return true;
+        };
+        const buildPlayableEventFromPitches = (pitchSources, timing, options = {}) => {
+            const octaveWarningMessage = options.octaveWarningMessage || "Skipped note with unsupported octave range.";
+            const firstNoteOptions = options.firstNoteOptions || {};
+            const notes = [];
+            for (let pitchIndex = 0; pitchIndex < pitchSources.length; pitchIndex += 1) {
+                const note = buildPlayableNoteForBody(pitchSources[pitchIndex], timing.absoluteLength, timing.dur, octaveWarningMessage);
+                if (!note) {
+                    notes.length = 0;
+                    break;
+                }
+                if (pitchIndex === 0) {
+                    finalizePlayableEventStart(note, timing.dur, timing.activeTuplet, firstNoteOptions);
+                }
+                else {
+                    note.chord = true;
+                }
+                notes.push(note);
+            }
+            return notes;
+        };
+        const playableEventOptionsForSource = (source) => ({
+            invalidLengthMessage: source === "chord" ? "Skipped chord with invalid length." : "Skipped note with invalid length.",
+            octaveWarningMessage: source === "chord"
+                ? "Skipped chord note with unsupported octave range."
+                : "Skipped note with unsupported octave range.",
+            firstNoteOptions: source === "chord" ? { applyTieStop: false } : {},
+            commitOptions: source === "chord" ? { applyChordTieStop: true } : {},
+        });
+        // Body token handlers.
+        const handleBrokenRhythmBodyToken = (bodyToken) => {
+            const { brokenRhythm } = bodyToken;
+            if (!lastEventNotes || lastEventNotes.length === 0 || lastEventNotes.some((n) => n.isRest)) {
+                warnBody("broken rhythm(" + brokenRhythm.symbol + ")  has no preceding note; skipped.");
+                idx = brokenRhythm.nextIdx;
+                return true;
+            }
+            scaleNotesDuration(lastEventNotes, brokenRhythm.leftScale);
+            pendingRhythmScale = brokenRhythm.rightScale;
+            idx = brokenRhythm.nextIdx;
+            return true;
+        };
+        const handleParenBodyToken = (bodyToken) => {
+            const { parenToken } = bodyToken;
+            if (parenToken.kind === "tuplet") {
+                const { tuplet } = parenToken;
+                if (tuplet.actual > 0 && tuplet.normal > 0 && tuplet.count > 0) {
+                    tupletScale = { num: tuplet.normal, den: tuplet.actual };
+                    tupletRemaining = tuplet.count;
+                    tupletSpec = { actual: tuplet.actual, normal: tuplet.normal, remaining: tuplet.count };
+                }
+                else {
+                    warnBody("Failed to parse tuplet notation: " + tuplet.raw);
+                }
+                idx = tuplet.nextIdx;
+                return true;
+            }
+            pendingSlurStart += 1;
+            idx = parenToken.nextIdx;
+            return true;
+        };
+        const enqueueQuotedBodyText = (normalizedText) => {
+            if (!normalizedText) {
+                return;
+            }
+            if (isLikelyAbcChordSymbol(normalizedText)) {
+                pendingChordSymbols.push(normalizedText);
+                return;
+            }
+            pendingAnnotations.push(normalizedText);
+        };
+        const markTieStartOnLastEvent = () => {
+            if (!lastEventNotes || lastEventNotes.length === 0 || !lastEventNotes.some((n) => !n.isRest)) {
+                return false;
+            }
+            for (const eventNote of lastEventNotes) {
+                if (!eventNote.isRest) {
+                    eventNote.tieStart = true;
+                }
+            }
+            pendingTieToNext = true;
+            return true;
+        };
+        const handleTieBodyToken = (bodyToken) => {
+            if (!markTieStartOnLastEvent()) {
+                warnBody("tie(-)  has no preceding note; skipped.");
+            }
+            idx = bodyToken.tie.nextIdx;
+            return true;
+        };
+        const handleQuotedStringBodyToken = (bodyToken) => {
+            const { quotedString } = bodyToken;
+            enqueueQuotedBodyText(quotedString.normalizedText);
+            if (!quotedString.terminated) {
+                warnBody('Unterminated inline string ("...").');
+            }
+            idx = quotedString.nextIdx;
+            return true;
+        };
+        const handleSingleCharShorthandBodyToken = (bodyToken, char) => {
+            applySingleCharShorthand(char);
+            idx = bodyToken.shorthand.nextIdx;
+            return true;
+        };
+        const handleDecorationBodyToken = (bodyToken, char) => {
+            const parsedDecoration = bodyToken.decoration;
+            if (!parsedDecoration.terminated) {
+                warnBody("Unterminated decoration marker: " + char);
+                idx = parsedDecoration.nextIdx;
+                return true;
+            }
+            const { rawDecoration, decoration } = parsedDecoration;
+            if (!applyDecoration(rawDecoration, decoration) && decoration) {
+                warnBody("Skipped decoration: " + char + decoration + char);
+            }
+            idx = parsedDecoration.nextIdx;
+            return true;
+        };
+        const markSlurStopOnLastNote = () => {
+            if (!lastNote || lastNote.isRest) {
+                return false;
+            }
+            lastNote.slurStop = true;
+            return true;
+        };
+        const handleSlurStopBodyToken = (bodyToken) => {
+            const { slurStop } = bodyToken;
+            if (!markSlurStopOnLastNote()) {
+                warnBody("slur stop()) has no preceding note; skipped.");
+            }
+            idx = slurStop.nextIdx;
+            return true;
+        };
+        const handleSimpleBodyToken = (bodyToken, char) => {
+            if (!bodyToken) {
+                return false;
+            }
+            const bodyTokenHandlers = {
+                "broken-rhythm": () => handleBrokenRhythmBodyToken(bodyToken),
+                "decoration": () => handleDecorationBodyToken(bodyToken, char),
+                "paren": () => handleParenBodyToken(bodyToken),
+                "quoted-string": () => handleQuotedStringBodyToken(bodyToken),
+                "single-char-shorthand": () => handleSingleCharShorthandBodyToken(bodyToken, char),
+                "slur-stop": () => handleSlurStopBodyToken(bodyToken),
+                "tie": () => handleTieBodyToken(bodyToken),
+            };
+            const handler = bodyTokenHandlers[bodyToken.kind];
+            return handler ? handler() : false;
+        };
+        const handleInlineFieldBracketToken = (bracketToken) => {
+            const { inlineField } = bracketToken;
+            if (!applyBodyField(inlineField.fieldName, inlineField.fieldValue)) {
+                warnBody("Skipped unsupported inline field: [" + inlineField.fieldName + ":" + inlineField.fieldValue + "]");
+            }
+            idx = inlineField.nextIdx;
+            return true;
+        };
+        const handleRepeatEndingBracketToken = (bracketToken) => {
+            const { repeatEndingMarker } = bracketToken;
+            return startEndingAtCurrentMeasure(repeatEndingMarker.marker, repeatEndingMarker.nextIdx);
+        };
+        const handleBracketBodyToken = (bodyToken) => {
+            if (!bodyToken || bodyToken.kind !== "bracket") {
+                return false;
+            }
+            const { bracketToken } = bodyToken;
+            if (bracketToken.kind === "inline-field") {
+                return handleInlineFieldBracketToken(bracketToken);
+            }
+            if (bracketToken.kind === "repeat-ending") {
+                return handleRepeatEndingBracketToken(bracketToken);
+            }
+            const playableEvent = (0, abc_parser_1.parseAbcPlayableEventAt)(text, idx);
+            return handlePlayableEvent(playableEvent, { fallbackToNextChar: true });
+        };
+        const handleGraceGroup = (char) => {
+            if (char !== "{") {
+                return false;
+            }
+            const graceResult = parseGraceGroupAt(text, idx, entry.lineNo, activeUnitLength, activeKeySignatureAccidentals, measureAccidentals, entry.voiceId, warnings);
+            if (!graceResult) {
+                warnBody("Failed to parse grace group; skipped.");
+                idx += 1;
+                return true;
+            }
+            idx = graceResult.nextIdx;
+            appendGraceNotes(graceResult.notes);
+            return true;
+        };
+        // Measure and ending state helpers.
+        const appendGraceNotes = (graceNotes) => {
+            for (const graceNote of graceNotes) {
+                currentMeasure.push(graceNote);
+                noteCount += 1;
+            }
+        };
+        const startEndingAtCurrentMeasure = (marker, nextIdx) => {
+            if (activeEndingMarker) {
+                const stopMeasureNo = currentMeasure.length === 0 ? currentMeasureNo - 1 : currentMeasureNo;
+                stopActiveEndingAtMeasure(stopMeasureNo);
+            }
+            const measureMeta = ensureNotationMeasureMeta(entry.voiceId, currentMeasureNo);
+            measureMeta.endingStart = marker;
+            activeEndingMarker = marker;
+            idx = nextIdx;
+            resetBeamContext();
+            return true;
+        };
+        const stopActiveEndingAtMeasure = (measureNo) => {
+            if (!activeEndingMarker || measureNo < 1) {
+                return false;
+            }
+            const measureMeta = ensureNotationMeasureMeta(entry.voiceId, measureNo);
+            measureMeta.endingStop = activeEndingMarker;
+            measureMeta.endingStopType = "stop";
+            activeEndingMarker = "";
+            return true;
+        };
+        const advanceToNextMeasure = () => {
+            currentMeasure = [];
+            measures.push(currentMeasure);
+            currentMeasureNo = Math.max(1, measures.length);
+            currentEventNo = 0;
+            beamCursorDiv = 0;
+        };
+        const resetBeamContext = () => {
+            beamRunActive = false;
+            sawInterEventWhitespace = false;
+        };
+        const applyBarlineRepeatMarkers = (barlineToken) => {
+            if (barlineToken.repeatEnd) {
+                ensureNotationMeasureMeta(entry.voiceId, currentMeasureNo).repeatEnd = true;
+            }
+            if (barlineToken.repeatStart) {
+                ensureNotationMeasureMeta(entry.voiceId, currentMeasureNo).repeatStart = true;
+            }
+        };
+        const applyBarlineMeasureBoundary = (barlineToken, bareRepeatEndingMarker) => {
+            if ((barlineToken.endingStop || bareRepeatEndingMarker) && activeEndingMarker) {
+                stopActiveEndingAtMeasure(currentMeasureNo);
+            }
+            if (barlineToken.endsMeasure && (currentMeasure.length > 0 || measures.length === 0)) {
+                advanceToNextMeasure();
+            }
+            if (barlineToken.endsMeasure) {
+                measureAccidentals = {};
+                lastNote = null;
+            }
+        };
+        const advanceAfterBarline = (barlineToken, bareRepeatEndingMarker) => {
+            if (bareRepeatEndingMarker) {
+                return startEndingAtCurrentMeasure(bareRepeatEndingMarker.marker, bareRepeatEndingMarker.nextIdx);
+            }
+            idx = barlineToken.nextIdx;
+            resetBeamContext();
+            return true;
+        };
+        const handleBarlineEntry = (bodyEntry) => {
+            if (!bodyEntry || bodyEntry.kind !== "barline") {
+                return false;
+            }
+            const { barlineToken } = bodyEntry;
+            const bareRepeatEndingMarker = barlineToken.endsMeasure ? (0, abc_parser_1.parseAbcBareRepeatEndingMarkerAt)(text, barlineToken.nextIdx) : null;
+            applyBarlineRepeatMarkers(barlineToken);
+            applyBarlineMeasureBoundary(barlineToken, bareRepeatEndingMarker);
+            return advanceAfterBarline(barlineToken, bareRepeatEndingMarker);
+        };
+        const handleStandaloneBodyFieldEntry = (bodyEntry) => {
+            const { standaloneBodyField } = bodyEntry;
+            if (!applyBodyField(standaloneBodyField.fieldName, standaloneBodyField.fieldValue)) {
+                warnBody("Skipped unsupported standalone body field token: " + standaloneBodyField.token);
+            }
+            idx = standaloneBodyField.nextIdx;
+            return true;
+        };
+        const handleUnsupportedTokenEntry = (bodyEntry) => {
+            if (bodyEntry.kind === "unsupported-body-token") {
+                const { unsupportedBodyToken } = bodyEntry;
+                warnBody("Skipped unsupported body token: " + unsupportedBodyToken.token);
+                idx = unsupportedBodyToken.nextIdx;
+                return true;
+            }
+            if (bodyEntry.kind === "unsupported-body-number") {
+                const { unsupportedBodyNumber } = bodyEntry;
+                warnBody("Skipped unsupported body number token: " + unsupportedBodyNumber.token);
+                idx = unsupportedBodyNumber.nextIdx;
+                return true;
+            }
+            return false;
+        };
+        const handleNonPlayableBodyEntry = (bodyEntry) => {
+            if (!bodyEntry) {
+                return false;
+            }
+            if (bodyEntry.kind === "standalone-body-field") {
+                return handleStandaloneBodyFieldEntry(bodyEntry);
+            }
+            return handleUnsupportedTokenEntry(bodyEntry);
+        };
+        // Playable-event and fallback handlers.
+        const handleResolvedPlayableEvent = (playableEvent) => {
+            const timing = consumePlayableTiming(playableEvent.rawLengthToken, playableEvent.nextIdx);
+            idx = timing.nextIdx;
+            const eventOptions = playableEventOptionsForSource(playableEvent.source);
+            if (timing.dur <= 0) {
+                warnBody(eventOptions.invalidLengthMessage);
+                return true;
+            }
+            const eventNotes = buildPlayableEventFromPitches(playableEvent.pitchSources, timing, {
+                octaveWarningMessage: eventOptions.octaveWarningMessage,
+                firstNoteOptions: eventOptions.firstNoteOptions,
+            });
+            if (eventNotes.length === 0) {
+                clearLastEventState();
+                return true;
+            }
+            commitPlayableEvent(eventNotes, eventOptions.commitOptions);
+            return true;
+        };
+        const skipInvalidPlayableEvent = (message, nextIdx) => {
+            warnBody(message);
+            idx = nextIdx;
+            return true;
+        };
+        const handleInvalidPlayableEvent = (playableEvent, options = {}) => {
+            const { fallbackToNextChar = false } = options;
+            if (!playableEvent) {
+                return false;
+            }
+            if (playableEvent.kind === "malformed-accidental") {
+                return skipInvalidPlayableEvent("Skipped malformed accidental token: " + playableEvent.accidentalText, playableEvent.nextIdx);
+            }
+            if (playableEvent.kind === "invalid-chord") {
+                return skipInvalidPlayableEvent("Failed to parse chord notation; skipped.", playableEvent.nextIdx);
+            }
+            if (fallbackToNextChar) {
+                idx += 1;
+                return true;
+            }
+            return false;
+        };
+        const handlePlayableEvent = (playableEvent, options = {}) => {
+            const { fallbackToNextChar = false } = options;
+            if (playableEvent.kind !== "playable") {
+                return handleInvalidPlayableEvent(playableEvent, { fallbackToNextChar });
+            }
+            return handleResolvedPlayableEvent(playableEvent);
+        };
+        const advanceBodyCursorWithWarning = (message, nextIdx = idx + 1) => {
+            warnBody(message);
+            idx = nextIdx;
+            resetBeamContext();
+            return true;
+        };
+        const handleClosingNotation = (char) => {
+            if (char !== "]" && char !== "}") {
+                return false;
+            }
+            if (char === "]" && activeEndingMarker) {
+                const stopMeasureNo = currentMeasure.length === 0 ? currentMeasureNo - 1 : currentMeasureNo;
+                stopActiveEndingAtMeasure(stopMeasureNo);
+                idx += 1;
+                resetBeamContext();
+                return true;
+            }
+            return advanceBodyCursorWithWarning("Skipped unsupported notation: " + char);
+        };
+        const handleUnsupportedPunctuation = (char) => {
+            if (char !== ";" && char !== "`" && char !== "?" && char !== "@" && char !== "#" && char !== "$" && char !== "*") {
+                return false;
+            }
+            return advanceBodyCursorWithWarning("Skipped unsupported body punctuation: " + char);
+        };
+        const handleBodyEntry = (bodyEntry, char) => {
+            const bodyToken = (bodyEntry === null || bodyEntry === void 0 ? void 0 : bodyEntry.kind) === "body-token" ? bodyEntry.bodyToken : null;
+            const entryHandlers = [
+                () => handleBarlineEntry(bodyEntry),
+                () => handleNonPlayableBodyEntry(bodyEntry),
+                () => handleSimpleBodyToken(bodyToken, char),
+                () => handleGraceGroup(char),
+                () => handleBracketBodyToken(bodyToken),
+                () => ((bodyEntry === null || bodyEntry === void 0 ? void 0 : bodyEntry.kind) === "playable-event" ? handlePlayableEvent(bodyEntry.playableEvent) : false),
+            ];
+            for (const handler of entryHandlers) {
+                if (handler()) {
+                    return true;
+                }
+            }
+            return false;
+        };
+        const throwBodyParseError = () => {
+            throw new Error("line " + entry.lineNo + ": Failed to parse note/rest: " + text.slice(idx, idx + 12));
+        };
+        const handleBodyFallback = (bodyEntry, char) => {
+            const fallbackHandlers = [
+                () => handleClosingNotation(char),
+                () => handleUnsupportedPunctuation(char),
+            ];
+            for (const handler of fallbackHandlers) {
+                if (handler()) {
+                    return true;
+                }
+            }
+            if (!bodyEntry) {
+                throwBodyParseError();
+            }
+            return false;
+        };
+        const consumeIgnorableBodyChar = (char) => {
+            if (char === " " || char === "\t") {
+                sawInterEventWhitespace = true;
+                idx += 1;
+                return true;
+            }
+            if (char === "\\") {
+                warnBody("Skipped stray body continuation marker: \\");
+                idx += 1;
+                return true;
+            }
+            if (char === "," || char === "'") {
+                // Lenient compatibility: some real-world sources include standalone octave marks.
+                // They are non-standard in strict ABC, but skipping them improves interoperability.
+                idx += 1;
+                return true;
+            }
+            return false;
+        };
+        const isBeamableAbcNote = (note) => Boolean(note &&
+            !note.isRest &&
+            !note.grace &&
+            ["eighth", "16th", "32nd", "64th"].includes(String(note.type || "").trim().toLowerCase()));
+        const applyBeamModeForEvent = (note, durationDiv) => {
+            const resolvedDurationDiv = Math.max(0, Math.round(Number(durationDiv) || 0));
+            const beatDiv = Math.max(1, Math.round((960 * 4) / Math.max(1, Math.round(Number(activeMeter === null || activeMeter === void 0 ? void 0 : activeMeter.beatType) || 4))));
+            const startsAtBeatBoundary = beamCursorDiv > 0 && beamCursorDiv % beatDiv === 0;
+            if (startsAtBeatBoundary) {
+                beamRunActive = false;
+            }
+            if (isBeamableAbcNote(note)) {
+                note.beamMode = !beamRunActive || sawInterEventWhitespace ? "begin" : "mid";
+                beamRunActive = true;
+            }
+            else {
+                beamRunActive = false;
+            }
+            sawInterEventWhitespace = false;
+            beamCursorDiv += resolvedDurationDiv;
+        };
+        while (idx < text.length) {
+            const ch = text[idx];
+            if (consumeIgnorableBodyChar(ch)) {
+                continue;
+            }
+            const bodyEntry = (0, abc_parser_1.parseAbcBodyEntryAt)(text, idx);
+            if (handleBodyEntry(bodyEntry, ch)) {
+                continue;
+            }
+            if (handleBodyFallback(bodyEntry, ch)) {
+                continue;
+            }
         }
         activeEndingByVoice[entry.voiceId] = activeEndingMarker;
         currentKeyFifthsByVoice[entry.voiceId] = activeKeyFifths;
@@ -31883,9 +31770,6 @@ function parseKey(raw, warnings) {
 }
 function parseLengthToken(token, lineNo) {
     return abcCommon.parseAbcLengthToken(token, lineNo);
-}
-function parseChordAt(text, startIdx, lineNo) {
-    return (0, abc_parser_1.parseAbcChordAt)(text, startIdx);
 }
 function parseGraceGroupAt(text, startIdx, lineNo, unitLength, keySignatureAccidentals, measureAccidentals, voiceId, warnings) {
     const parsedGrace = (0, abc_parser_1.parseAbcGraceGroupAt)(text, startIdx, lineNo, warnings);
@@ -33207,6 +33091,12 @@ const buildMusicXmlFromAbcParsed = (parsed, abcSource, options = {}) => {
             if (hintedTempo !== null) {
                 currentPartTempo = hintedTempo;
             }
+            const currentMeasureDurationDiv = Math.max(1, Math.round((960 * 4 * Math.max(1, Math.round(currentPartMeter.beats))) / Math.max(1, Math.round(currentPartMeter.beatType))));
+            const currentMeasureContentDiv = estimateAbcMeasureContentDiv(notes);
+            const inferredImplicitPickup = i === 0 &&
+                !(measureMeta === null || measureMeta === void 0 ? void 0 : measureMeta.implicit) &&
+                currentMeasureContentDiv > 0 &&
+                currentMeasureContentDiv < currentMeasureDurationDiv;
             const header = i === 0
                 ? [
                     "<attributes>",
@@ -33600,7 +33490,7 @@ const buildMusicXmlFromAbcParsed = (parsed, abcSource, options = {}) => {
                 })()
                 : `<note><rest/><duration>${measureDurationDiv}</duration><voice>1</voice><type>${emptyMeasureRestType}</type></note>`;
             const xmlMeasureNumber = xmlEscape(String((measureMeta === null || measureMeta === void 0 ? void 0 : measureMeta.number) || measureNo));
-            const implicitAttr = (measureMeta === null || measureMeta === void 0 ? void 0 : measureMeta.implicit) ? ' implicit="yes"' : "";
+            const implicitAttr = (measureMeta === null || measureMeta === void 0 ? void 0 : measureMeta.implicit) || inferredImplicitPickup ? ' implicit="yes"' : "";
             const leftBarlineChunks = [];
             if (measureMeta === null || measureMeta === void 0 ? void 0 : measureMeta.endingStart) {
                 leftBarlineChunks.push(`<ending number="${xmlEscape(String(measureMeta.endingStart))}" type="start"/>`);
@@ -33661,8 +33551,83 @@ exports.convertAbcToMusicXml = convertAbcToMusicXml;
   "src/ts/abc-parser.js": function (require, module, exports) {
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.parseAbcTupletAt = exports.parseAbcGraceGroupAt = exports.parseAbcChordAt = exports.parseAbcNoteAt = void 0;
+exports.parseAbcBodyEntryAt = exports.parseAbcPlayableEventAt = exports.parseAbcBodyTokenAt = exports.parseAbcBracketTokenAt = exports.parseAbcParenTokenAt = exports.parseAbcSlurStopAt = exports.parseAbcTieAt = exports.parseAbcSingleCharShorthandAt = exports.parseAbcBrokenRhythmAt = exports.parseAbcDecorationAt = exports.parseAbcQuotedStringAt = exports.parseAbcDelimitedSpanAt = exports.parseAbcUnsupportedBodyNumberAt = exports.parseAbcUnsupportedBodyTokenAt = exports.parseAbcStandaloneBodyFieldAt = exports.parseAbcBarlineTokenAt = exports.parseAbcInlineFieldAt = exports.parseAbcBareRepeatEndingMarkerAt = exports.parseAbcRepeatEndingMarkerAt = exports.parseAbcTupletAt = exports.parseAbcGraceGroupAt = exports.parseAbcChordAt = exports.parseAbcNoteAt = void 0;
 const abc_lexer_1 = require("./abc-lexer");
+// Shared parser utilities and static lookup tables.
+const toAbcParsedPitchSource = (note) => ({
+    accidentalText: note.accidentalText,
+    pitchChar: note.pitchChar,
+    octaveShift: note.octaveShift,
+});
+const firstMatch = (matchers) => {
+    for (const matcher of matchers) {
+        const matched = matcher();
+        if (matched) {
+            return matched;
+        }
+    }
+    return null;
+};
+const matchParsed = (parse, map) => {
+    const parsed = parse();
+    return parsed ? map(parsed) : null;
+};
+// Text access helpers.
+const rawText = (text) => String(text || "");
+const charAt = (text, idx) => rawText(text)[idx] || "";
+const sliceFrom = (text, startIdx) => rawText(text).slice(startIdx);
+const matchFrom = (text, startIdx, pattern) => sliceFrom(text, startIdx).match(pattern);
+// Wrapper builders for higher-level parser results.
+const withBracketToken = (kind, payload) => ({
+    kind,
+    ...payload,
+});
+const withBodyToken = (kind, payload) => ({
+    kind,
+    ...payload,
+});
+const withBodyEntry = (kind, payload) => ({
+    kind,
+    ...payload,
+});
+const withPlayableEvent = (source, pitchSources, rawLengthToken, nextIdx) => ({
+    kind: "playable",
+    pitchSources,
+    rawLengthToken,
+    nextIdx,
+    source,
+});
+const withInvalidChord = (nextIdx) => ({
+    kind: "invalid-chord",
+    nextIdx,
+});
+// Static lookup tables.
+const ABC_BARLINE_CANDIDATES = [
+    { token: ":|]", endsMeasure: true, repeatEnd: true, repeatStart: false, endingStop: true },
+    { token: ":|:", endsMeasure: true, repeatEnd: true, repeatStart: true, endingStop: false },
+    { token: "|:", endsMeasure: true, repeatEnd: false, repeatStart: true, endingStop: false },
+    { token: ":|", endsMeasure: true, repeatEnd: true, repeatStart: false, endingStop: false },
+    { token: "::", endsMeasure: true, repeatEnd: true, repeatStart: true, endingStop: false },
+    { token: "[|", endsMeasure: true, repeatEnd: false, repeatStart: false, endingStop: false },
+    { token: "|]", endsMeasure: true, repeatEnd: false, repeatStart: false, endingStop: false },
+    { token: "||", endsMeasure: true, repeatEnd: false, repeatStart: false, endingStop: false },
+    { token: "|", endsMeasure: true, repeatEnd: false, repeatStart: false, endingStop: false },
+    { token: ":", endsMeasure: false, repeatEnd: false, repeatStart: false, endingStop: false },
+];
+const ABC_SINGLE_CHAR_SHORTHAND_BY_CHAR = {
+    "~": "arpeggiate",
+    H: "fermata",
+    L: "accent",
+    M: "mordent",
+    O: "coda",
+    P: "inverted-mordent",
+    S: "segno",
+    T: "trill",
+    u: "upbow",
+    v: "downbow",
+    ".": "staccato",
+};
+// Low-level lexical and structural parsers.
 const parseAbcNoteAt = (text, startIdx) => {
     const note = (0, abc_lexer_1.lexAbcNote)(text, startIdx);
     if (note) {
@@ -33765,10 +33730,10 @@ const parseAbcGraceGroupAt = (text, startIdx, lineNo, warnings) => {
 };
 exports.parseAbcGraceGroupAt = parseAbcGraceGroupAt;
 const parseAbcTupletAt = (text, startIdx) => {
-    if (text[startIdx] !== "(") {
+    if (charAt(text, startIdx) !== "(") {
         return null;
     }
-    const match = text.slice(startIdx).match(/^\((\d)(?::(\d))?(?::(\d))?/);
+    const match = matchFrom(text, startIdx, /^\((\d)(?::(\d))?(?::(\d))?/);
     if (!match) {
         return null;
     }
@@ -33786,6 +33751,244 @@ const parseAbcTupletAt = (text, startIdx) => {
     };
 };
 exports.parseAbcTupletAt = parseAbcTupletAt;
+const parseAbcRepeatEndingMarkerAt = (text, startIdx) => {
+    const match = matchFrom(text, startIdx, /^\[(\d+(?:[,-]\d+)*)/);
+    if (!match) {
+        return null;
+    }
+    return {
+        marker: match[1],
+        nextIdx: startIdx + match[0].length,
+    };
+};
+exports.parseAbcRepeatEndingMarkerAt = parseAbcRepeatEndingMarkerAt;
+const parseAbcBareRepeatEndingMarkerAt = (text, startIdx) => {
+    const match = matchFrom(text, startIdx, /^(\d+(?:[,-]\d+)*)/);
+    if (!match) {
+        return null;
+    }
+    return {
+        marker: match[1],
+        nextIdx: startIdx + match[0].length,
+    };
+};
+exports.parseAbcBareRepeatEndingMarkerAt = parseAbcBareRepeatEndingMarkerAt;
+const parseAbcInlineFieldAt = (text, startIdx) => {
+    const match = matchFrom(text, startIdx, /^\[([A-Za-z]):([^\]]*)\]/);
+    if (!match) {
+        return null;
+    }
+    return {
+        fieldName: String(match[1] || "").toUpperCase(),
+        fieldValue: String(match[2] || "").trim(),
+        nextIdx: startIdx + match[0].length,
+    };
+};
+exports.parseAbcInlineFieldAt = parseAbcInlineFieldAt;
+const parseAbcBarlineTokenAt = (text, startIdx) => {
+    const slice = sliceFrom(text, startIdx);
+    for (const candidate of ABC_BARLINE_CANDIDATES) {
+        if (slice.startsWith(candidate.token)) {
+            return {
+                nextIdx: startIdx + candidate.token.length,
+                endsMeasure: candidate.endsMeasure,
+                repeatEnd: candidate.repeatEnd,
+                repeatStart: candidate.repeatStart,
+                endingStop: candidate.endingStop,
+            };
+        }
+    }
+    return null;
+};
+exports.parseAbcBarlineTokenAt = parseAbcBarlineTokenAt;
+const parseAbcStandaloneBodyFieldAt = (text, startIdx) => {
+    const match = matchFrom(text, startIdx, /^([A-Za-z]):([^\s\]|]+)/);
+    if (!match) {
+        return null;
+    }
+    return {
+        fieldName: String(match[1] || "").toUpperCase(),
+        fieldValue: String(match[2] || "").trim(),
+        token: match[0],
+        nextIdx: startIdx + match[0].length,
+    };
+};
+exports.parseAbcStandaloneBodyFieldAt = parseAbcStandaloneBodyFieldAt;
+const parseAbcUnsupportedBodyTokenAt = (text, startIdx) => {
+    const match = matchFrom(text, startIdx, /^([IJNQRWY][A-Za-z0-9_-]*|[h-jl-pr-twy][a-z][A-Za-z0-9_-]*)/);
+    if (!match) {
+        return null;
+    }
+    return {
+        token: match[1],
+        nextIdx: startIdx + match[1].length,
+    };
+};
+exports.parseAbcUnsupportedBodyTokenAt = parseAbcUnsupportedBodyTokenAt;
+const parseAbcUnsupportedBodyNumberAt = (text, startIdx) => {
+    const match = matchFrom(text, startIdx, /^(\d+)/);
+    if (!match) {
+        return null;
+    }
+    return {
+        token: match[1],
+        nextIdx: startIdx + match[1].length,
+    };
+};
+exports.parseAbcUnsupportedBodyNumberAt = parseAbcUnsupportedBodyNumberAt;
+const parseAbcDelimitedSpanAt = (text, startIdx, delimiter) => {
+    if (!delimiter || charAt(text, startIdx) !== delimiter) {
+        return null;
+    }
+    const raw = rawText(text);
+    let endIdx = startIdx + 1;
+    while (endIdx < raw.length && raw[endIdx] !== delimiter) {
+        endIdx += 1;
+    }
+    const nextIdx = Math.min(raw.length, endIdx + 1);
+    return {
+        delimiter,
+        text: raw.slice(startIdx, nextIdx),
+        nextIdx,
+    };
+};
+exports.parseAbcDelimitedSpanAt = parseAbcDelimitedSpanAt;
+const parseAbcQuotedStringAt = (text, startIdx) => {
+    const span = (0, exports.parseAbcDelimitedSpanAt)(text, startIdx, '"');
+    if (!span) {
+        return null;
+    }
+    const terminated = span.text.endsWith('"') && span.text.length >= 2;
+    const rawText = terminated ? span.text.slice(1, -1) : span.text.slice(1);
+    return {
+        rawText,
+        normalizedText: rawText.replace(/^[\^_<>@]/, "").trim(),
+        nextIdx: span.nextIdx,
+        terminated,
+    };
+};
+exports.parseAbcQuotedStringAt = parseAbcQuotedStringAt;
+const parseAbcDecorationAt = (text, startIdx) => {
+    const first = charAt(text, startIdx);
+    if (first !== "!" && first !== "+") {
+        return null;
+    }
+    const span = (0, exports.parseAbcDelimitedSpanAt)(text, startIdx, first);
+    if (!span) {
+        return null;
+    }
+    const terminated = span.text.endsWith(first) && span.text.length >= 2;
+    const rawDecoration = terminated ? span.text.slice(1, -1).trim() : span.text.slice(1).trim();
+    return {
+        rawDecoration,
+        decoration: rawDecoration.toLowerCase(),
+        delimiter: first,
+        nextIdx: span.nextIdx,
+        terminated,
+    };
+};
+exports.parseAbcDecorationAt = parseAbcDecorationAt;
+const parseAbcBrokenRhythmAt = (text, startIdx) => {
+    const symbol = charAt(text, startIdx);
+    if (symbol !== ">" && symbol !== "<") {
+        return null;
+    }
+    return {
+        symbol,
+        leftScale: symbol === ">" ? { num: 3, den: 2 } : { num: 1, den: 2 },
+        rightScale: symbol === ">" ? { num: 1, den: 2 } : { num: 3, den: 2 },
+        nextIdx: startIdx + 1,
+    };
+};
+exports.parseAbcBrokenRhythmAt = parseAbcBrokenRhythmAt;
+const parseAbcSingleCharShorthandAt = (text, startIdx) => {
+    const symbol = charAt(text, startIdx);
+    const kind = ABC_SINGLE_CHAR_SHORTHAND_BY_CHAR[symbol];
+    if (!kind) {
+        return null;
+    }
+    return {
+        kind,
+        nextIdx: startIdx + 1,
+    };
+};
+exports.parseAbcSingleCharShorthandAt = parseAbcSingleCharShorthandAt;
+const parseAbcTieAt = (text, startIdx) => {
+    if (charAt(text, startIdx) !== "-") {
+        return null;
+    }
+    return { nextIdx: startIdx + 1 };
+};
+exports.parseAbcTieAt = parseAbcTieAt;
+const parseAbcSlurStopAt = (text, startIdx) => {
+    if (charAt(text, startIdx) !== ")") {
+        return null;
+    }
+    return { nextIdx: startIdx + 1 };
+};
+exports.parseAbcSlurStopAt = parseAbcSlurStopAt;
+const parseAbcParenTokenAt = (text, startIdx) => {
+    if (charAt(text, startIdx) !== "(") {
+        return null;
+    }
+    return matchParsed(() => (0, exports.parseAbcTupletAt)(text, startIdx), (tuplet) => ({ kind: "tuplet", tuplet })) || {
+        kind: "slur-start",
+        nextIdx: startIdx + 1,
+    };
+};
+exports.parseAbcParenTokenAt = parseAbcParenTokenAt;
+const parseAbcBracketTokenAt = (text, startIdx) => {
+    if (charAt(text, startIdx) !== "[") {
+        return null;
+    }
+    return (matchParsed(() => (0, exports.parseAbcInlineFieldAt)(text, startIdx), (inlineField) => withBracketToken("inline-field", { inlineField })) ||
+        matchParsed(() => (0, exports.parseAbcRepeatEndingMarkerAt)(text, startIdx), (repeatEndingMarker) => withBracketToken("repeat-ending", { repeatEndingMarker })) ||
+        withBracketToken("chord-start", { nextIdx: startIdx + 1 }));
+};
+exports.parseAbcBracketTokenAt = parseAbcBracketTokenAt;
+// High-level body dispatchers.
+const parseAbcBodyTokenAt = (text, startIdx) => {
+    return firstMatch([
+        () => matchParsed(() => (0, exports.parseAbcBrokenRhythmAt)(text, startIdx), (brokenRhythm) => withBodyToken("broken-rhythm", { brokenRhythm })),
+        () => matchParsed(() => (0, exports.parseAbcParenTokenAt)(text, startIdx), (parenToken) => withBodyToken("paren", { parenToken })),
+        () => matchParsed(() => (0, exports.parseAbcSingleCharShorthandAt)(text, startIdx), (shorthand) => withBodyToken("single-char-shorthand", { shorthand })),
+        () => matchParsed(() => (0, exports.parseAbcTieAt)(text, startIdx), (tie) => withBodyToken("tie", { tie })),
+        () => matchParsed(() => (0, exports.parseAbcQuotedStringAt)(text, startIdx), (quotedString) => withBodyToken("quoted-string", { quotedString })),
+        () => matchParsed(() => (0, exports.parseAbcDecorationAt)(text, startIdx), (decoration) => withBodyToken("decoration", { decoration })),
+        () => matchParsed(() => (0, exports.parseAbcBracketTokenAt)(text, startIdx), (bracketToken) => withBodyToken("bracket", { bracketToken })),
+        () => matchParsed(() => (0, exports.parseAbcSlurStopAt)(text, startIdx), (slurStop) => withBodyToken("slur-stop", { slurStop })),
+    ]);
+};
+exports.parseAbcBodyTokenAt = parseAbcBodyTokenAt;
+const parseAbcPlayableEventAt = (text, startIdx) => {
+    if (charAt(text, startIdx) === "[") {
+        const chord = (0, exports.parseAbcChordAt)(text, startIdx);
+        if (!chord) {
+            return withInvalidChord(startIdx + 1);
+        }
+        return withPlayableEvent("chord", chord.notes.map(toAbcParsedPitchSource), chord.lengthToken || (chord.notes.length > 0 ? chord.notes[0].lengthToken : ""), chord.nextIdx);
+    }
+    const noteResult = (0, exports.parseAbcNoteAt)(text, startIdx);
+    if (!noteResult) {
+        return null;
+    }
+    if (noteResult.kind === "malformed-accidental") {
+        return noteResult;
+    }
+    return withPlayableEvent("note", [toAbcParsedPitchSource(noteResult.note)], noteResult.note.lengthToken, noteResult.note.nextIdx);
+};
+exports.parseAbcPlayableEventAt = parseAbcPlayableEventAt;
+const parseAbcBodyEntryAt = (text, startIdx) => {
+    return firstMatch([
+        () => matchParsed(() => (0, exports.parseAbcBarlineTokenAt)(text, startIdx), (barlineToken) => withBodyEntry("barline", { barlineToken })),
+        () => matchParsed(() => (0, exports.parseAbcStandaloneBodyFieldAt)(text, startIdx), (standaloneBodyField) => withBodyEntry("standalone-body-field", { standaloneBodyField })),
+        () => matchParsed(() => (0, exports.parseAbcUnsupportedBodyTokenAt)(text, startIdx), (unsupportedBodyToken) => withBodyEntry("unsupported-body-token", { unsupportedBodyToken })),
+        () => matchParsed(() => (0, exports.parseAbcUnsupportedBodyNumberAt)(text, startIdx), (unsupportedBodyNumber) => withBodyEntry("unsupported-body-number", { unsupportedBodyNumber })),
+        () => matchParsed(() => (0, exports.parseAbcBodyTokenAt)(text, startIdx), (bodyToken) => withBodyEntry("body-token", { bodyToken })),
+        () => matchParsed(() => (0, exports.parseAbcPlayableEventAt)(text, startIdx), (playableEvent) => withBodyEntry("playable-event", { playableEvent })),
+    ]);
+};
+exports.parseAbcBodyEntryAt = parseAbcBodyEntryAt;
 
   },
   "src/ts/abc-lexer.js": function (require, module, exports) {

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -21388,6 +21388,33 @@ const parseFractionText = (text, fallback = DEFAULT_UNIT) => {
     }
     return reduceFraction(num, den, fallback);
 };
+const isAbcjsWrapperLine = (text) => /^\[\s*\/?\s*abcjs(?:-[A-Za-z0-9_-]+)?(?:\s+[^\]]*)?\]$/i.test(String(text || "").trim());
+const estimateAbcMeasureContentDiv = (notes) => {
+    var _a, _b;
+    const byVoice = new Map();
+    const lastStartByVoice = new Map();
+    for (const note of Array.isArray(notes) ? notes : []) {
+        if (!note || note.grace)
+            continue;
+        const voice = String(note.voice || "1");
+        const durationDiv = Math.max(0, Math.round(Number(note.duration) || 0));
+        if (durationDiv <= 0)
+            continue;
+        const current = (_a = byVoice.get(voice)) !== null && _a !== void 0 ? _a : 0;
+        if (note.chord) {
+            const startDiv = (_b = lastStartByVoice.get(voice)) !== null && _b !== void 0 ? _b : current;
+            byVoice.set(voice, Math.max(current, startDiv + durationDiv));
+            continue;
+        }
+        lastStartByVoice.set(voice, current);
+        byVoice.set(voice, current + durationDiv);
+    }
+    let maxDiv = 0;
+    for (const value of byVoice.values()) {
+        maxDiv = Math.max(maxDiv, value);
+    }
+    return maxDiv;
+};
 const parseAbcLengthToken = (token, lineNo) => {
     if (!token) {
         return { num: 1, den: 1 };
@@ -21511,37 +21538,47 @@ if (typeof window !== "undefined") {
     window.AbcCommon = exports.AbcCommon;
 }
 const abcCommon = exports.AbcCommon;
-function parseRepeatEndingMarkerAt(text, idx) {
-    const match = String(text || "").slice(idx).match(/^\[(\d+(?:[,-]\d+)*)/);
-    if (!match) {
-        return null;
-    }
-    return {
-        marker: match[1],
-        nextIdx: idx + match[0].length,
-    };
-}
-function parseBareRepeatEndingMarkerAt(text, idx) {
-    const match = String(text || "").slice(idx).match(/^(\d+(?:[,-]\d+)*)/);
-    if (!match) {
-        return null;
-    }
-    return {
-        marker: match[1],
-        nextIdx: idx + match[0].length,
-    };
-}
-function parseInlineFieldAt(text, idx) {
-    const match = String(text || "").slice(idx).match(/^\[([A-Za-z]):([^\]]*)\]/);
-    if (!match) {
-        return null;
-    }
-    return {
-        fieldName: String(match[1] || "").toUpperCase(),
-        fieldValue: String(match[2] || "").trim(),
-        nextIdx: idx + match[0].length,
-    };
-}
+const TRILL_DECORATIONS = new Set(["trill", "tr", "triller"]);
+const TURN_DECORATIONS = new Set(["turn"]);
+const TURN_SLASH_DECORATIONS = new Set(["turnx"]);
+const INVERTED_TURN_DECORATIONS = new Set(["invertedturn", "inverted-turn", "lowerturn"]);
+const INVERTED_TURN_SLASH_DECORATIONS = new Set(["invertedturnx", "inverted-turnx"]);
+const LOWER_MORDENT_DECORATIONS = new Set(["mordent", "lowermordent"]);
+const UPPER_MORDENT_DECORATIONS = new Set([
+    "pralltriller",
+    "pralltrill",
+    "prall",
+    "uppermordent",
+    "invertedmordent",
+    "inverted-mordent",
+]);
+const GLISS_START_DECORATIONS = new Set(["gliss-start", "glissando-start"]);
+const GLISS_STOP_DECORATIONS = new Set(["gliss-stop", "glissando-stop"]);
+const SLIDE_START_DECORATIONS = new Set(["slide", "slide-start"]);
+const ARPEGGIATE_DECORATIONS = new Set(["roll", "arpeggio", "arpeggiate"]);
+const STACCATO_DECORATIONS = new Set(["staccato", "stacc", "stac"]);
+const STACCATISSIMO_DECORATIONS = new Set(["staccatissimo", "wedge", "spiccato"]);
+const ACCENT_DECORATIONS = new Set(["accent", ">", "emphasis"]);
+const INVERTED_FERMATA_DECORATIONS = new Set(["invertedfermata", "inverted-fermata", "inverted fermata"]);
+const STRONG_ACCENT_DECORATIONS = new Set(["marcato", "strongaccent", "strong-accent", "strong accent"]);
+const BREATH_DECORATIONS = new Set(["breath", "breath-mark", "breathmark", "breath mark"]);
+const PHRASE_DECORATIONS = new Set(["shortphrase", "mediumphrase", "longphrase"]);
+const DACAPO_DECORATIONS = new Set(["dacapo", "da-capo", "da capo", "d.c."]);
+const DALSEGNO_DECORATIONS = new Set(["dalsegno", "dal-segno", "dal segno", "d.s."]);
+const TOCODA_DECORATIONS = new Set(["tocoda", "to-coda", "to coda"]);
+const CRESC_START_DECORATIONS = new Set(["crescendo(", "cresc(", "<("]);
+const CRESC_STOP_DECORATIONS = new Set(["crescendo)", "cresc)", "<)"]);
+const DIM_START_DECORATIONS = new Set(["diminuendo(", "decrescendo(", "dim(", "decresc(", ">("]);
+const DIM_STOP_DECORATIONS = new Set(["diminuendo)", "decrescendo)", "dim)", "decresc)", ">)"]);
+const DYNAMIC_DECORATIONS = new Set(["pppp", "ppp", "p", "pp", "mp", "mf", "f", "ff", "fff", "ffff", "fp", "fz", "rfz", "sf", "sfp"]);
+const UPBOW_DECORATIONS = new Set(["upbow", "up-bow", "up bow"]);
+const DOWNBOW_DECORATIONS = new Set(["downbow", "down-bow", "down bow"]);
+const DOUBLE_TONGUE_DECORATIONS = new Set(["doubletongue", "double-tongue", "double tongue"]);
+const TRIPLE_TONGUE_DECORATIONS = new Set(["tripletongue", "triple-tongue", "triple tongue"]);
+const OPEN_STRING_DECORATIONS = new Set(["open", "open-string", "openstring", "open string"]);
+const SNAP_PIZZICATO_DECORATIONS = new Set(["snap", "snap-pizzicato", "snappizzicato", "snap pizzicato"]);
+const STOPPED_DECORATIONS = new Set(["stopped", "+", "plus", "stopped horn", "stopped-horn"]);
+const THUMB_POSITION_DECORATIONS = new Set(["thumb", "thumbposition", "thumb-position", "thumbpos", "thumb pos", "thumb position"]);
 function tokenizeAbcLyricLine(text) {
     const raw = String(text || "").trim();
     if (!raw)
@@ -21600,8 +21637,9 @@ function splitBodyTextByInlineVoice(text, initialVoiceId) {
     let idx = 0;
     while (idx < raw.length) {
         if (raw[idx] === "[") {
-            const inlineField = parseInlineFieldAt(raw, idx);
-            if (inlineField && inlineField.fieldName === "V") {
+            const bracketToken = (0, abc_parser_1.parseAbcBracketTokenAt)(raw, idx);
+            if (bracketToken.kind === "inline-field" && bracketToken.inlineField.fieldName === "V") {
+                const { inlineField } = bracketToken;
                 if (buffer.trim()) {
                     segments.push({ voiceId: activeVoiceId, text: buffer });
                 }
@@ -21640,28 +21678,28 @@ function splitBodyTextByOverlay(text, baseVoiceId) {
     while (idx < raw.length) {
         const ch = raw[idx];
         if (ch === '"') {
-            let endIdx = idx + 1;
-            while (endIdx < raw.length && raw[endIdx] !== '"') {
-                endIdx += 1;
+            const token = (0, abc_parser_1.parseAbcDelimitedSpanAt)(raw, idx, '"');
+            if (!token) {
+                idx += 1;
+                continue;
             }
-            const token = raw.slice(idx, Math.min(raw.length, endIdx + 1));
             ensureOverlayBuffer(activeOverlayIndex);
-            overlayBuffers[activeOverlayIndex] += token;
-            idx = Math.min(raw.length, endIdx + 1);
+            overlayBuffers[activeOverlayIndex] += token.text;
+            idx = token.nextIdx;
             continue;
         }
         if (ch === "!" || ch === "+") {
-            let endIdx = idx + 1;
-            while (endIdx < raw.length && raw[endIdx] !== ch) {
-                endIdx += 1;
+            const token = (0, abc_parser_1.parseAbcDelimitedSpanAt)(raw, idx, ch);
+            if (!token) {
+                idx += 1;
+                continue;
             }
-            const token = raw.slice(idx, Math.min(raw.length, endIdx + 1));
             ensureOverlayBuffer(activeOverlayIndex);
-            overlayBuffers[activeOverlayIndex] += token;
-            idx = Math.min(raw.length, endIdx + 1);
+            overlayBuffers[activeOverlayIndex] += token.text;
+            idx = token.nextIdx;
             continue;
         }
-        const barlineToken = parseBarlineTokenAt(raw, idx);
+        const barlineToken = (0, abc_parser_1.parseAbcBarlineTokenAt)(raw, idx);
         if (barlineToken) {
             const tokenText = raw.slice(idx, barlineToken.nextIdx);
             if (barlineToken.endsMeasure) {
@@ -21723,12 +21761,14 @@ function expandUserDefinedDecorationSymbols(text, userDefinedDecorationBySymbol)
     while (idx < raw.length) {
         const ch = raw[idx];
         if (ch === '"' || ch === "!" || ch === "+") {
-            let endIdx = idx + 1;
-            while (endIdx < raw.length && raw[endIdx] !== ch) {
-                endIdx += 1;
+            const token = (0, abc_parser_1.parseAbcDelimitedSpanAt)(raw, idx, ch);
+            if (!token) {
+                out += ch;
+                idx += 1;
+                continue;
             }
-            out += raw.slice(idx, Math.min(raw.length, endIdx + 1));
-            idx = Math.min(raw.length, endIdx + 1);
+            out += token.text;
+            idx = token.nextIdx;
             continue;
         }
         if (Object.prototype.hasOwnProperty.call(symbolMap, ch)) {
@@ -21740,33 +21780,6 @@ function expandUserDefinedDecorationSymbols(text, userDefinedDecorationBySymbol)
         idx += 1;
     }
     return out;
-}
-function parseBarlineTokenAt(text, idx) {
-    const slice = String(text || "").slice(idx);
-    const candidates = [
-        { token: ":|]", endsMeasure: true, repeatEnd: true, repeatStart: false, endingStop: true },
-        { token: ":|:", endsMeasure: true, repeatEnd: true, repeatStart: true, endingStop: false },
-        { token: "|:", endsMeasure: true, repeatEnd: false, repeatStart: true, endingStop: false },
-        { token: ":|", endsMeasure: true, repeatEnd: true, repeatStart: false, endingStop: false },
-        { token: "::", endsMeasure: true, repeatEnd: true, repeatStart: true, endingStop: false },
-        { token: "[|", endsMeasure: true, repeatEnd: false, repeatStart: false, endingStop: false },
-        { token: "|]", endsMeasure: true, repeatEnd: false, repeatStart: false, endingStop: false },
-        { token: "||", endsMeasure: true, repeatEnd: false, repeatStart: false, endingStop: false },
-        { token: "|", endsMeasure: true, repeatEnd: false, repeatStart: false, endingStop: false },
-        { token: ":", endsMeasure: false, repeatEnd: false, repeatStart: false, endingStop: false },
-    ];
-    for (const candidate of candidates) {
-        if (slice.startsWith(candidate.token)) {
-            return {
-                nextIdx: idx + candidate.token.length,
-                endsMeasure: candidate.endsMeasure,
-                repeatEnd: candidate.repeatEnd,
-                repeatStart: candidate.repeatStart,
-                endingStop: candidate.endingStop,
-            };
-        }
-    }
-    return null;
 }
 function parseTempoFromQ(rawQ, warnings) {
     const raw = String(rawQ || "").trim();
@@ -21855,6 +21868,11 @@ function parseForMusicXml(source, settings) {
         const raw = lines[i];
         const rawTrimmed = raw.trim();
         if (!rawTrimmed) {
+            pendingUnsupportedContinuedFieldName = "";
+            continue;
+        }
+        if (isAbcjsWrapperLine(rawTrimmed)) {
+            warnings.push("line " + lineNo + ": Skipped unsupported abcjs wrapper line: " + rawTrimmed);
             pendingUnsupportedContinuedFieldName = "";
             continue;
         }
@@ -22198,1037 +22216,301 @@ function parseForMusicXml(source, settings) {
         let activeEndingMarker = String(activeEndingByVoice[entry.voiceId] || "");
         let idx = 0;
         const text = entry.text;
-        const isBeamableAbcNote = (note) => Boolean(note &&
-            !note.isRest &&
-            !note.grace &&
-            ["eighth", "16th", "32nd", "64th"].includes(String(note.type || "").trim().toLowerCase()));
-        const applyBeamModeForEvent = (note, durationDiv) => {
-            const resolvedDurationDiv = Math.max(0, Math.round(Number(durationDiv) || 0));
-            const beatDiv = Math.max(1, Math.round((960 * 4) / Math.max(1, Math.round(Number(activeMeter === null || activeMeter === void 0 ? void 0 : activeMeter.beatType) || 4))));
-            const startsAtBeatBoundary = beamCursorDiv > 0 && beamCursorDiv % beatDiv === 0;
-            if (startsAtBeatBoundary) {
-                beamRunActive = false;
-            }
-            if (isBeamableAbcNote(note)) {
-                note.beamMode = !beamRunActive || sawInterEventWhitespace ? "begin" : "mid";
-                beamRunActive = true;
-            }
-            else {
-                beamRunActive = false;
-            }
-            sawInterEventWhitespace = false;
-            beamCursorDiv += resolvedDurationDiv;
+        const warnBody = (message) => {
+            warnings.push("line " + entry.lineNo + ": " + message);
         };
-        while (idx < text.length) {
-            const ch = text[idx];
-            if (ch === " " || ch === "\t") {
-                sawInterEventWhitespace = true;
-                idx += 1;
-                continue;
+        // Field and decoration application.
+        const applyBodyField = (fieldName, fieldValue) => {
+            if (fieldName === "K") {
+                const inlineKeyInfo = parseKey(fieldValue || "C", warnings);
+                activeKeyFifths = inlineKeyInfo.fifths;
+                activeKeySignatureAccidentals = keySignatureAlterByStep(activeKeyFifths);
+                currentKeyFifthsByVoice[entry.voiceId] = activeKeyFifths;
+                keyHintFifthsByKey.set(`${entry.voiceId}#${currentMeasureNo}`, activeKeyFifths);
+                measureAccidentals = {};
+                return true;
             }
-            if (ch === "\\") {
-                warnings.push("line " + entry.lineNo + ": Skipped stray body continuation marker: \\");
-                idx += 1;
-                continue;
+            if (fieldName === "L") {
+                activeUnitLength = parseFraction(fieldValue || "1/8", "L", warnings);
+                return true;
             }
-            if (ch === "," || ch === "'") {
-                // Lenient compatibility: some real-world sources include standalone octave marks.
-                // They are non-standard in strict ABC, but skipping them improves interoperability.
-                idx += 1;
-                continue;
+            if (fieldName === "M") {
+                activeMeter = parseMeter(fieldValue || "4/4", warnings);
+                ensureMeterByMeasure(entry.voiceId)[currentMeasureNo] = {
+                    beats: activeMeter.beats,
+                    beatType: activeMeter.beatType,
+                };
+                return true;
             }
-            if (ch === "|" || ch === ":") {
-                const barlineToken = parseBarlineTokenAt(text, idx);
-                if (!barlineToken) {
-                    idx += 1;
-                    continue;
+            if (fieldName === "Q") {
+                activeTempoBpm = parseTempoFromQ(fieldValue || "", warnings);
+                if (Number.isFinite(activeTempoBpm)) {
+                    ensureTempoByMeasure(entry.voiceId)[currentMeasureNo] = Math.max(20, Math.min(300, Math.round(Number(activeTempoBpm))));
                 }
-                const bareRepeatEndingMarker = barlineToken.endsMeasure ? parseBareRepeatEndingMarkerAt(text, barlineToken.nextIdx) : null;
-                if (barlineToken.repeatEnd) {
-                    ensureNotationMeasureMeta(entry.voiceId, currentMeasureNo).repeatEnd = true;
-                }
-                if ((barlineToken.endingStop || bareRepeatEndingMarker) && activeEndingMarker) {
-                    const measureMeta = ensureNotationMeasureMeta(entry.voiceId, currentMeasureNo);
-                    measureMeta.endingStop = activeEndingMarker;
-                    measureMeta.endingStopType = "stop";
-                    activeEndingMarker = "";
-                }
-                if (barlineToken.endsMeasure && (currentMeasure.length > 0 || measures.length === 0)) {
-                    currentMeasure = [];
-                    measures.push(currentMeasure);
-                    currentMeasureNo = Math.max(1, measures.length);
-                    currentEventNo = 0;
-                    beamCursorDiv = 0;
-                }
-                if (barlineToken.endsMeasure) {
-                    measureAccidentals = {};
-                    lastNote = null;
-                }
-                if (barlineToken.repeatStart) {
-                    ensureNotationMeasureMeta(entry.voiceId, currentMeasureNo).repeatStart = true;
-                }
-                if (bareRepeatEndingMarker) {
-                    const measureMeta = ensureNotationMeasureMeta(entry.voiceId, currentMeasureNo);
-                    measureMeta.endingStart = bareRepeatEndingMarker.marker;
-                    activeEndingMarker = bareRepeatEndingMarker.marker;
-                    idx = bareRepeatEndingMarker.nextIdx;
-                }
-                else {
-                    idx = barlineToken.nextIdx;
-                }
-                beamRunActive = false;
-                sawInterEventWhitespace = false;
-                continue;
+                return true;
             }
-            const standaloneBodyFieldMatch = text.slice(idx).match(/^([A-Za-z]):([^\s\]|]+)/);
-            if (standaloneBodyFieldMatch) {
-                const standaloneFieldName = String(standaloneBodyFieldMatch[1] || "").toUpperCase();
-                const standaloneFieldValue = String(standaloneBodyFieldMatch[2] || "").trim();
-                const standaloneFieldToken = standaloneBodyFieldMatch[0];
-                if (standaloneFieldName === "K") {
-                    const inlineKeyInfo = parseKey(standaloneFieldValue || "C", warnings);
-                    activeKeyFifths = inlineKeyInfo.fifths;
-                    activeKeySignatureAccidentals = keySignatureAlterByStep(activeKeyFifths);
-                    currentKeyFifthsByVoice[entry.voiceId] = activeKeyFifths;
-                    keyHintFifthsByKey.set(`${entry.voiceId}#${currentMeasureNo}`, activeKeyFifths);
-                    measureAccidentals = {};
+            return false;
+        };
+        const applyPrefixedDecoration = (rawDecoration, decoration) => {
+            if (decoration.startsWith("rehearsal:")) {
+                const rehearsalText = rawDecoration.slice("rehearsal:".length).trim();
+                if (rehearsalText) {
+                    pendingRehearsalMark = rehearsalText;
                 }
-                else if (standaloneFieldName === "L") {
-                    activeUnitLength = parseFraction(standaloneFieldValue || "1/8", "L", warnings);
+                return true;
+            }
+            if (decoration.startsWith("fingering:")) {
+                const fingeringText = rawDecoration.slice("fingering:".length).trim();
+                if (fingeringText) {
+                    pendingFingerings.push(fingeringText);
                 }
-                else if (standaloneFieldName === "M") {
-                    activeMeter = parseMeter(standaloneFieldValue || "4/4", warnings);
-                    ensureMeterByMeasure(entry.voiceId)[currentMeasureNo] = {
-                        beats: activeMeter.beats,
-                        beatType: activeMeter.beatType,
-                    };
+                return true;
+            }
+            if (decoration.startsWith("string:")) {
+                const stringText = rawDecoration.slice("string:".length).trim();
+                if (stringText) {
+                    pendingStrings.push(stringText);
                 }
-                else if (standaloneFieldName === "Q") {
-                    activeTempoBpm = parseTempoFromQ(standaloneFieldValue || "", warnings);
-                    if (Number.isFinite(activeTempoBpm)) {
-                        ensureTempoByMeasure(entry.voiceId)[currentMeasureNo] = Math.max(20, Math.min(300, Math.round(Number(activeTempoBpm))));
-                    }
+                return true;
+            }
+            if (decoration.startsWith("pluck:")) {
+                const pluckText = rawDecoration.slice("pluck:".length).trim();
+                if (pluckText) {
+                    pendingPlucks.push(pluckText);
                 }
-                else {
-                    warnings.push("line " + entry.lineNo + ": Skipped unsupported standalone body field token: " + standaloneFieldToken);
-                }
-                idx += standaloneFieldToken.length;
-                continue;
+                return true;
             }
-            const unsupportedBodyWordMatch = text
-                .slice(idx)
-                .match(/^([IJNQRWY][A-Za-z0-9_-]*|[h-jl-pr-twy][a-z][A-Za-z0-9_-]*)/);
-            if (unsupportedBodyWordMatch) {
-                warnings.push("line " + entry.lineNo + ": Skipped unsupported body token: " + unsupportedBodyWordMatch[1]);
-                idx += unsupportedBodyWordMatch[1].length;
-                continue;
+            return false;
+        };
+        const applyTurnDecoration = (decoration) => {
+            if (decoration === "delayedturn" || decoration === "delayed-turn") {
+                pendingTurn = pendingTurn || "turn";
+                pendingDelayedTurn = true;
+                return true;
             }
-            const unsupportedBodyNumberMatch = text.slice(idx).match(/^(\d+)/);
-            if (unsupportedBodyNumberMatch) {
-                warnings.push("line " + entry.lineNo + ": Skipped unsupported body number token: " + unsupportedBodyNumberMatch[1]);
-                idx += unsupportedBodyNumberMatch[1].length;
-                continue;
+            if (decoration === "delayedinvertedturn" || decoration === "delayed-inverted-turn") {
+                pendingTurn = "inverted-turn";
+                pendingDelayedTurn = true;
+                return true;
             }
-            if (ch === ">" || ch === "<") {
-                if (!lastEventNotes || lastEventNotes.length === 0 || lastEventNotes.some((n) => n.isRest)) {
-                    warnings.push("line " + entry.lineNo + ": broken rhythm(" + ch + ")  has no preceding note; skipped.");
-                    idx += 1;
-                    continue;
-                }
-                const lastScale = ch === ">" ? { num: 3, den: 2 } : { num: 1, den: 2 };
-                pendingRhythmScale = ch === ">" ? { num: 1, den: 2 } : { num: 3, den: 2 };
-                scaleNotesDuration(lastEventNotes, lastScale);
-                idx += 1;
-                continue;
+            const turnDecorationAppliers = [
+                [TURN_DECORATIONS, "turn", false],
+                [TURN_SLASH_DECORATIONS, "turn", true],
+                [INVERTED_TURN_DECORATIONS, "inverted-turn", false],
+                [INVERTED_TURN_SLASH_DECORATIONS, "inverted-turn", true],
+            ];
+            const matchedTurn = turnDecorationAppliers.find(([decorationSet]) => decorationSet.has(decoration));
+            if (!matchedTurn) {
+                return false;
             }
-            if (ch === "(") {
-                const tuplet = (0, abc_parser_1.parseAbcTupletAt)(text, idx);
-                if (tuplet) {
-                    if (tuplet.actual > 0 && tuplet.normal > 0 && tuplet.count > 0) {
-                        tupletScale = { num: tuplet.normal, den: tuplet.actual };
-                        tupletRemaining = tuplet.count;
-                        tupletSpec = { actual: tuplet.actual, normal: tuplet.normal, remaining: tuplet.count };
-                    }
-                    else {
-                        warnings.push("line " + entry.lineNo + ": Failed to parse tuplet notation: " + tuplet.raw);
-                    }
-                    idx = tuplet.nextIdx;
-                    continue;
-                }
-                pendingSlurStart += 1;
-                idx += 1;
-                continue;
+            pendingTurn = matchedTurn[1];
+            pendingTurnSlash = matchedTurn[2];
+            return true;
+        };
+        const applyTremoloDecoration = (decoration) => {
+            const matched = decoration.match(/^tremolo-(single|start|stop)-([1-9]\d*)$/);
+            if (!matched) {
+                return false;
             }
-            if (ch === "~") {
-                pendingArpeggiate = true;
-                idx += 1;
-                continue;
-            }
-            if (ch === "H") {
-                pendingFermata = "normal";
-                idx += 1;
-                continue;
-            }
-            if (ch === "L") {
-                pendingAccent = true;
-                idx += 1;
-                continue;
-            }
-            if (ch === "M") {
-                pendingMordent = "mordent";
-                idx += 1;
-                continue;
-            }
-            if (ch === "O") {
-                pendingCoda = true;
-                idx += 1;
-                continue;
-            }
-            if (ch === "P") {
-                pendingMordent = "inverted-mordent";
-                idx += 1;
-                continue;
-            }
-            if (ch === "S") {
-                pendingSegno = true;
-                idx += 1;
-                continue;
-            }
-            if (ch === "T") {
-                pendingTrill = true;
-                idx += 1;
-                continue;
-            }
-            if (ch === "u") {
-                pendingUpBow = true;
-                idx += 1;
-                continue;
-            }
-            if (ch === "v") {
-                pendingDownBow = true;
-                idx += 1;
-                continue;
-            }
-            if (ch === "-") {
-                if (lastEventNotes && lastEventNotes.length > 0 && lastEventNotes.some((n) => !n.isRest)) {
-                    for (const eventNote of lastEventNotes) {
-                        if (!eventNote.isRest) {
-                            eventNote.tieStart = true;
-                        }
-                    }
-                    pendingTieToNext = true;
-                }
-                else {
-                    warnings.push("line " + entry.lineNo + ": tie(-)  has no preceding note; skipped.");
-                }
-                idx += 1;
-                continue;
-            }
-            if (ch === "\"") {
-                const endQuote = text.indexOf("\"", idx + 1);
-                if (endQuote >= 0) {
-                    const rawAnnotation = text.slice(idx + 1, endQuote);
-                    const normalizedAnnotation = rawAnnotation.replace(/^[\^_<>@]/, "").trim();
-                    if (normalizedAnnotation) {
-                        if (isLikelyAbcChordSymbol(normalizedAnnotation)) {
-                            pendingChordSymbols.push(normalizedAnnotation);
-                        }
-                        else {
-                            pendingAnnotations.push(normalizedAnnotation);
-                        }
-                    }
-                    idx = endQuote + 1;
-                }
-                else {
-                    idx = text.length;
-                    warnings.push("line " + entry.lineNo + ': Unterminated inline string ("...").');
-                }
-                continue;
-            }
-            if (ch === "!" || ch === "+") {
-                const endMark = text.indexOf(ch, idx + 1);
-                if (endMark < 0) {
-                    idx += 1;
-                    warnings.push("line " + entry.lineNo + ": Unterminated decoration marker: " + ch);
-                    continue;
-                }
-                const rawDecoration = text.slice(idx + 1, endMark).trim();
-                const decoration = rawDecoration.toLowerCase();
-                if (decoration === "trill" || decoration === "tr" || decoration === "triller") {
-                    pendingTrill = true;
-                }
-                else if (decoration === "editorial") {
-                    pendingEditorialAccidental = true;
-                }
-                else if (decoration === "courtesy") {
+            pendingTremolo = {
+                type: matched[1],
+                marks: Math.max(1, Math.min(8, Number.parseInt(matched[2], 10) || 1))
+            };
+            return true;
+        };
+        const applyDecoration = (rawDecoration, decoration) => {
+            const exactDecorationAppliers = {
+                "caesura": () => {
+                    pendingCaesura = true;
+                },
+                "coda": () => {
+                    pendingCoda = true;
+                },
+                "courtesy": () => {
                     pendingCourtesyAccidental = true;
-                }
-                else if (decoration === "trill(") {
+                },
+                "editorial": () => {
+                    pendingEditorialAccidental = true;
+                },
+                "fermata": () => {
+                    pendingFermata = "normal";
+                },
+                "fine": () => {
+                    pendingFine = true;
+                },
+                "harmonic": () => {
+                    pendingHarmonic = true;
+                },
+                "heel": () => {
+                    pendingHeel = true;
+                },
+                "heel mark": () => {
+                    pendingHeel = true;
+                },
+                "schleifer": () => {
+                    pendingSchleifer = true;
+                },
+                "segno": () => {
+                    pendingSegno = true;
+                },
+                "sfz": () => {
+                    pendingSfz = true;
+                },
+                "shake": () => {
+                    pendingShake = true;
+                },
+                "slide-stop": () => {
+                    pendingSlideStop = true;
+                },
+                "stress": () => {
+                    pendingStress = true;
+                },
+                "tenuto": () => {
+                    pendingTenuto = true;
+                },
+                "toe": () => {
+                    pendingToe = true;
+                },
+                "toe mark": () => {
+                    pendingToe = true;
+                },
+                "trill(": () => {
                     pendingTrill = true;
                     pendingTrillLineStart = true;
-                }
-                else if (decoration === "trill)") {
+                },
+                "trill)": () => {
                     pendingTrillLineStop = true;
-                }
-                else if (decoration.startsWith("rehearsal:")) {
-                    const rehearsalText = rawDecoration.slice("rehearsal:".length).trim();
-                    if (rehearsalText) {
-                        pendingRehearsalMark = rehearsalText;
-                    }
-                }
-                else if (decoration === "delayedturn" || decoration === "delayed-turn") {
-                    pendingTurn = pendingTurn || "turn";
-                    pendingDelayedTurn = true;
-                }
-                else if (decoration === "delayedinvertedturn" || decoration === "delayed-inverted-turn") {
-                    pendingTurn = "inverted-turn";
-                    pendingDelayedTurn = true;
-                }
-                else if (decoration === "turn") {
-                    pendingTurn = "turn";
-                    pendingTurnSlash = false;
-                }
-                else if (decoration === "turnx") {
-                    pendingTurn = "turn";
-                    pendingTurnSlash = true;
-                }
-                else if (decoration === "invertedturn" || decoration === "inverted-turn" || decoration === "lowerturn") {
-                    pendingTurn = "inverted-turn";
-                    pendingTurnSlash = false;
-                }
-                else if (decoration === "invertedturnx" || decoration === "inverted-turnx") {
-                    pendingTurn = "inverted-turn";
-                    pendingTurnSlash = true;
-                }
-                else if (decoration === "mordent" || decoration === "lowermordent") {
-                    pendingMordent = "mordent";
-                }
-                else if (decoration === "pralltriller" ||
-                    decoration === "pralltrill" ||
-                    decoration === "prall" ||
-                    decoration === "uppermordent" ||
-                    decoration === "invertedmordent" ||
-                    decoration === "inverted-mordent") {
-                    pendingMordent = "inverted-mordent";
-                }
-                else if (/^tremolo-(single|start|stop)-([1-9]\d*)$/.test(decoration)) {
-                    const m = decoration.match(/^tremolo-(single|start|stop)-([1-9]\d*)$/);
-                    if (m) {
-                        pendingTremolo = {
-                            type: m[1],
-                            marks: Math.max(1, Math.min(8, Number.parseInt(m[2], 10) || 1))
-                        };
-                    }
-                }
-                else if (decoration === "gliss-start" || decoration === "glissando-start") {
-                    pendingGlissandoStart = true;
-                }
-                else if (decoration === "gliss-stop" || decoration === "glissando-stop") {
-                    pendingGlissandoStop = true;
-                }
-                else if (decoration === "slide" || decoration === "slide-start") {
-                    pendingSlideStart = true;
-                }
-                else if (decoration === "slide-stop") {
-                    pendingSlideStop = true;
-                }
-                else if (decoration === "schleifer") {
-                    pendingSchleifer = true;
-                }
-                else if (decoration === "shake") {
-                    pendingShake = true;
-                }
-                else if (decoration === "roll" || decoration === "arpeggio" || decoration === "arpeggiate") {
-                    pendingArpeggiate = true;
-                }
-                else if (decoration === "staccato" ||
-                    decoration === "stacc" ||
-                    decoration === "stac") {
-                    pendingStaccato = true;
-                }
-                else if (decoration === "staccatissimo" || decoration === "wedge" || decoration === "spiccato") {
-                    pendingStaccatissimo = true;
-                }
-                else if (decoration === "accent" || decoration === ">" || decoration === "emphasis") {
-                    pendingAccent = true;
-                }
-                else if (decoration === "tenuto") {
-                    pendingTenuto = true;
-                }
-                else if (decoration === "stress") {
-                    pendingStress = true;
-                }
-                else if (decoration === "unstress") {
+                },
+                "unstress": () => {
                     pendingUnstress = true;
-                }
-                else if (decoration === "fermata") {
-                    pendingFermata = "normal";
-                }
-                else if (decoration === "invertedfermata" ||
-                    decoration === "inverted-fermata" ||
-                    decoration === "inverted fermata") {
-                    pendingFermata = "inverted";
-                }
-                else if (decoration === "marcato" ||
-                    decoration === "strongaccent" ||
-                    decoration === "strong-accent" ||
-                    decoration === "strong accent") {
-                    pendingStrongAccent = true;
-                }
-                else if (decoration === "breath" ||
-                    decoration === "breath-mark" ||
-                    decoration === "breathmark" ||
-                    decoration === "breath mark") {
-                    pendingBreathMark = true;
-                }
-                else if (decoration === "caesura") {
-                    pendingCaesura = true;
-                }
-                else if (decoration === "shortphrase" || decoration === "mediumphrase" || decoration === "longphrase") {
-                    pendingPhraseMark = decoration;
-                }
-                else if (decoration === "segno") {
-                    pendingSegno = true;
-                }
-                else if (decoration === "coda") {
-                    pendingCoda = true;
-                }
-                else if (decoration === "fine") {
-                    pendingFine = true;
-                }
-                else if (decoration === "dacoda") {
-                    pendingDaCapo = true;
-                    pendingToCoda = true;
-                }
-                else if (decoration === "dacapo" || decoration === "da-capo" || decoration === "da capo" || decoration === "d.c.") {
-                    pendingDaCapo = true;
-                }
-                else if (decoration === "dalsegno" || decoration === "dal-segno" || decoration === "dal segno" || decoration === "d.s.") {
-                    pendingDalSegno = true;
-                }
-                else if (decoration === "tocoda" || decoration === "to-coda" || decoration === "to coda") {
-                    pendingToCoda = true;
-                }
-                else if (decoration === "crescendo(" || decoration === "cresc(" || decoration === "<(") {
-                    pendingCrescendoStart = true;
-                }
-                else if (decoration === "crescendo)" || decoration === "cresc)" || decoration === "<)") {
-                    pendingCrescendoStop = true;
-                }
-                else if (decoration === "diminuendo(" ||
-                    decoration === "decrescendo(" ||
-                    decoration === "dim(" ||
-                    decoration === "decresc(" ||
-                    decoration === ">(") {
-                    pendingDiminuendoStart = true;
-                }
-                else if (decoration === "diminuendo)" ||
-                    decoration === "decrescendo)" ||
-                    decoration === "dim)" ||
-                    decoration === "decresc)" ||
-                    decoration === ">)") {
-                    pendingDiminuendoStop = true;
-                }
-                else if (decoration === "pppp" ||
-                    decoration === "ppp" ||
-                    decoration === "p" ||
-                    decoration === "pp" ||
-                    decoration === "mp" ||
-                    decoration === "mf" ||
-                    decoration === "f" ||
-                    decoration === "ff" ||
-                    decoration === "fff" ||
-                    decoration === "ffff" ||
-                    decoration === "fp" ||
-                    decoration === "fz" ||
-                    decoration === "rfz" ||
-                    decoration === "sf" ||
-                    decoration === "sfp") {
-                    pendingDynamicMark = decoration;
-                }
-                else if (decoration === "sfz") {
-                    pendingSfz = true;
-                }
-                else if (decoration === "upbow" || decoration === "up-bow" || decoration === "up bow") {
-                    pendingUpBow = true;
-                }
-                else if (decoration === "downbow" || decoration === "down-bow" || decoration === "down bow") {
-                    pendingDownBow = true;
-                }
-                else if (decoration === "doubletongue" ||
-                    decoration === "double-tongue" ||
-                    decoration === "double tongue") {
-                    pendingDoubleTongue = true;
-                }
-                else if (decoration === "tripletongue" ||
-                    decoration === "triple-tongue" ||
-                    decoration === "triple tongue") {
-                    pendingTripleTongue = true;
-                }
-                else if (decoration === "heel" || decoration === "heel mark") {
-                    pendingHeel = true;
-                }
-                else if (decoration === "toe" || decoration === "toe mark") {
-                    pendingToe = true;
-                }
-                else if (/^[0-5]$/.test(decoration)) {
-                    pendingFingerings.push(decoration);
-                }
-                else if (decoration.startsWith("fingering:")) {
-                    const fingeringText = rawDecoration.slice("fingering:".length).trim();
-                    if (fingeringText)
-                        pendingFingerings.push(fingeringText);
-                }
-                else if (decoration.startsWith("string:")) {
-                    const stringText = rawDecoration.slice("string:".length).trim();
-                    if (stringText)
-                        pendingStrings.push(stringText);
-                }
-                else if (decoration.startsWith("pluck:")) {
-                    const pluckText = rawDecoration.slice("pluck:".length).trim();
-                    if (pluckText)
-                        pendingPlucks.push(pluckText);
-                }
-                else if (decoration === "open" ||
-                    decoration === "open-string" ||
-                    decoration === "openstring" ||
-                    decoration === "open string") {
-                    pendingOpenString = true;
-                }
-                else if (decoration === "snap" ||
-                    decoration === "snap-pizzicato" ||
-                    decoration === "snappizzicato" ||
-                    decoration === "snap pizzicato") {
-                    pendingSnapPizzicato = true;
-                }
-                else if (decoration === "harmonic") {
-                    pendingHarmonic = true;
-                }
-                else if (decoration === "stopped" ||
-                    decoration === "+" ||
-                    decoration === "plus" ||
-                    decoration === "stopped horn" ||
-                    decoration === "stopped-horn") {
-                    pendingStopped = true;
-                }
-                else if (decoration === "thumb" ||
-                    decoration === "thumbposition" ||
-                    decoration === "thumb-position" ||
-                    decoration === "thumbpos" ||
-                    decoration === "thumb pos" ||
-                    decoration === "thumb position") {
-                    pendingThumbPosition = true;
-                }
-                else if (decoration) {
-                    warnings.push("line " + entry.lineNo + ": Skipped decoration: " + ch + decoration + ch);
-                }
-                idx = endMark + 1;
-                continue;
+                },
+            };
+            const applyExactDecoration = exactDecorationAppliers[decoration];
+            if (applyExactDecoration) {
+                applyExactDecoration();
+                return true;
             }
-            if (ch === "{") {
-                const graceResult = parseGraceGroupAt(text, idx, entry.lineNo, activeUnitLength, activeKeySignatureAccidentals, measureAccidentals, entry.voiceId, warnings);
-                if (!graceResult) {
-                    warnings.push("line " + entry.lineNo + ": Failed to parse grace group; skipped.");
-                    idx += 1;
-                    continue;
-                }
-                idx = graceResult.nextIdx;
-                for (const graceNote of graceResult.notes) {
-                    currentMeasure.push(graceNote);
-                    noteCount += 1;
-                }
-                continue;
+            const setDecorationAppliers = [
+                [TRILL_DECORATIONS, () => {
+                        pendingTrill = true;
+                    }],
+                [LOWER_MORDENT_DECORATIONS, () => {
+                        pendingMordent = "mordent";
+                    }],
+                [UPPER_MORDENT_DECORATIONS, () => {
+                        pendingMordent = "inverted-mordent";
+                    }],
+                [GLISS_START_DECORATIONS, () => {
+                        pendingGlissandoStart = true;
+                    }],
+                [GLISS_STOP_DECORATIONS, () => {
+                        pendingGlissandoStop = true;
+                    }],
+                [SLIDE_START_DECORATIONS, () => {
+                        pendingSlideStart = true;
+                    }],
+                [ARPEGGIATE_DECORATIONS, () => {
+                        pendingArpeggiate = true;
+                    }],
+                [STACCATO_DECORATIONS, () => {
+                        pendingStaccato = true;
+                    }],
+                [STACCATISSIMO_DECORATIONS, () => {
+                        pendingStaccatissimo = true;
+                    }],
+                [ACCENT_DECORATIONS, () => {
+                        pendingAccent = true;
+                    }],
+                [INVERTED_FERMATA_DECORATIONS, () => {
+                        pendingFermata = "inverted";
+                    }],
+                [STRONG_ACCENT_DECORATIONS, () => {
+                        pendingStrongAccent = true;
+                    }],
+                [BREATH_DECORATIONS, () => {
+                        pendingBreathMark = true;
+                    }],
+                [DACAPO_DECORATIONS, () => {
+                        pendingDaCapo = true;
+                    }],
+                [DALSEGNO_DECORATIONS, () => {
+                        pendingDalSegno = true;
+                    }],
+                [TOCODA_DECORATIONS, () => {
+                        pendingToCoda = true;
+                    }],
+                [CRESC_START_DECORATIONS, () => {
+                        pendingCrescendoStart = true;
+                    }],
+                [CRESC_STOP_DECORATIONS, () => {
+                        pendingCrescendoStop = true;
+                    }],
+                [DIM_START_DECORATIONS, () => {
+                        pendingDiminuendoStart = true;
+                    }],
+                [DIM_STOP_DECORATIONS, () => {
+                        pendingDiminuendoStop = true;
+                    }],
+                [UPBOW_DECORATIONS, () => {
+                        pendingUpBow = true;
+                    }],
+                [DOWNBOW_DECORATIONS, () => {
+                        pendingDownBow = true;
+                    }],
+                [DOUBLE_TONGUE_DECORATIONS, () => {
+                        pendingDoubleTongue = true;
+                    }],
+                [TRIPLE_TONGUE_DECORATIONS, () => {
+                        pendingTripleTongue = true;
+                    }],
+                [OPEN_STRING_DECORATIONS, () => {
+                        pendingOpenString = true;
+                    }],
+                [SNAP_PIZZICATO_DECORATIONS, () => {
+                        pendingSnapPizzicato = true;
+                    }],
+                [STOPPED_DECORATIONS, () => {
+                        pendingStopped = true;
+                    }],
+                [THUMB_POSITION_DECORATIONS, () => {
+                        pendingThumbPosition = true;
+                    }],
+            ];
+            const applySetDecoration = setDecorationAppliers.find(([decorationSet]) => decorationSet.has(decoration));
+            if (applySetDecoration) {
+                applySetDecoration[1]();
+                return true;
             }
-            if (ch === ".") {
-                pendingStaccato = true;
-                idx += 1;
-                continue;
+            if (applyPrefixedDecoration(rawDecoration, decoration)) {
+                return true;
             }
-            if (ch === "[") {
-                const inlineField = parseInlineFieldAt(text, idx);
-                if (inlineField) {
-                    if (inlineField.fieldName === "K") {
-                        const inlineKeyInfo = parseKey(inlineField.fieldValue || "C", warnings);
-                        activeKeyFifths = inlineKeyInfo.fifths;
-                        activeKeySignatureAccidentals = keySignatureAlterByStep(activeKeyFifths);
-                        currentKeyFifthsByVoice[entry.voiceId] = activeKeyFifths;
-                        keyHintFifthsByKey.set(`${entry.voiceId}#${currentMeasureNo}`, activeKeyFifths);
-                        measureAccidentals = {};
-                    }
-                    else if (inlineField.fieldName === "L") {
-                        activeUnitLength = parseFraction(inlineField.fieldValue || "1/8", "L", warnings);
-                    }
-                    else if (inlineField.fieldName === "M") {
-                        activeMeter = parseMeter(inlineField.fieldValue || "4/4", warnings);
-                        ensureMeterByMeasure(entry.voiceId)[currentMeasureNo] = {
-                            beats: activeMeter.beats,
-                            beatType: activeMeter.beatType,
-                        };
-                    }
-                    else if (inlineField.fieldName === "Q") {
-                        activeTempoBpm = parseTempoFromQ(inlineField.fieldValue || "", warnings);
-                        if (Number.isFinite(activeTempoBpm)) {
-                            ensureTempoByMeasure(entry.voiceId)[currentMeasureNo] = Math.max(20, Math.min(300, Math.round(Number(activeTempoBpm))));
-                        }
-                    }
-                    else {
-                        warnings.push("line " + entry.lineNo + ": Skipped unsupported inline field: [" + inlineField.fieldName + ":" + inlineField.fieldValue + "]");
-                    }
-                    idx = inlineField.nextIdx;
-                    continue;
-                }
-                const repeatEndingMarker = parseRepeatEndingMarkerAt(text, idx);
-                if (repeatEndingMarker) {
-                    if (activeEndingMarker) {
-                        const stopMeasureNo = currentMeasure.length === 0 ? currentMeasureNo - 1 : currentMeasureNo;
-                        if (stopMeasureNo >= 1) {
-                            const prevMeta = ensureNotationMeasureMeta(entry.voiceId, stopMeasureNo);
-                            prevMeta.endingStop = activeEndingMarker;
-                            prevMeta.endingStopType = "stop";
-                        }
-                    }
-                    const measureMeta = ensureNotationMeasureMeta(entry.voiceId, currentMeasureNo);
-                    measureMeta.endingStart = repeatEndingMarker.marker;
-                    activeEndingMarker = repeatEndingMarker.marker;
-                    idx = repeatEndingMarker.nextIdx;
-                    beamRunActive = false;
-                    sawInterEventWhitespace = false;
-                    continue;
-                }
-                const chordResult = parseChordAt(text, idx, entry.lineNo);
-                if (!chordResult) {
-                    warnings.push("line " + entry.lineNo + ": Failed to parse chord notation; skipped.");
-                    idx += 1;
-                    continue;
-                }
-                idx = chordResult.nextIdx;
-                let chordLength = parseLengthToken(chordResult.lengthToken, entry.lineNo);
-                if (!chordResult.lengthToken && chordResult.notes.length > 0 && chordResult.notes[0].lengthToken) {
-                    chordLength = parseLengthToken(chordResult.notes[0].lengthToken, entry.lineNo);
-                }
-                let absoluteLength = multiplyFractions(activeUnitLength, chordLength);
-                if (pendingRhythmScale) {
-                    absoluteLength = multiplyFractions(absoluteLength, pendingRhythmScale);
-                    pendingRhythmScale = null;
-                }
-                const activeTuplet = tupletRemaining > 0 && tupletScale && tupletSpec
-                    ? { actual: tupletSpec.actual, normal: tupletSpec.normal, remaining: tupletSpec.remaining }
-                    : null;
-                if (tupletRemaining > 0 && tupletScale) {
-                    absoluteLength = multiplyFractions(absoluteLength, tupletScale);
-                    tupletRemaining -= 1;
-                    if (tupletSpec) {
-                        tupletSpec.remaining -= 1;
-                    }
-                    if (tupletRemaining <= 0) {
-                        tupletScale = null;
-                        tupletSpec = null;
-                    }
-                }
-                if (idx < text.length && (text[idx] === ">" || text[idx] === "<")) {
-                    const rhythmChar = text[idx];
-                    idx += 1;
-                    if (rhythmChar === ">") {
-                        absoluteLength = multiplyFractions(absoluteLength, { num: 3, den: 2 });
-                        pendingRhythmScale = { num: 1, den: 2 };
-                    }
-                    else {
-                        absoluteLength = multiplyFractions(absoluteLength, { num: 1, den: 2 });
-                        pendingRhythmScale = { num: 3, den: 2 };
-                    }
-                }
-                const dur = durationInDivisions(absoluteLength, 960);
-                if (dur <= 0) {
-                    warnings.push("line " + entry.lineNo + ": Skipped chord with invalid length.");
-                    continue;
-                }
-                const chordNotes = [];
-                currentEventNo += 1;
-                const trillHint = trillWidthHintByKey.get(`${entry.voiceId}#${currentMeasureNo}#${currentEventNo}`) || "";
-                for (let chordIndex = 0; chordIndex < chordResult.notes.length; chordIndex += 1) {
-                    const chordNote = chordResult.notes[chordIndex];
-                    let note;
-                    try {
-                        note = buildNoteData(chordNote.pitchChar, chordNote.accidentalText, chordNote.octaveShift, absoluteLength, dur, entry.lineNo, activeKeySignatureAccidentals, measureAccidentals);
-                    }
-                    catch (error) {
-                        if (error instanceof Error && /Octave out of range/i.test(error.message || "")) {
-                            warnings.push("line " + entry.lineNo + ": Skipped chord note with unsupported octave range.");
-                            chordNotes.length = 0;
-                            break;
-                        }
-                        throw error;
-                    }
-                    note.voice = entry.voiceId;
-                    if (chordIndex === 0) {
-                        applyBeamModeForEvent(note, dur);
-                    }
-                    if (chordIndex === 0 && pendingTrill && !note.isRest) {
-                        note.trill = true;
-                        note.trillLineStart = pendingTrillLineStart;
-                        pendingTrill = false;
-                        pendingTrillLineStart = false;
-                    }
-                    if (chordIndex === 0 && pendingTrillLineStop && !note.isRest) {
-                        note.trillLineStop = true;
-                        pendingTrillLineStop = false;
-                    }
-                    if (chordIndex === 0 && pendingTurn && !note.isRest) {
-                        note.turnType = pendingTurn;
-                        note.turnSlash = pendingTurnSlash;
-                        note.delayedTurn = pendingDelayedTurn;
-                        pendingTurn = "";
-                        pendingTurnSlash = false;
-                        pendingDelayedTurn = false;
-                    }
-                    if (chordIndex === 0 && !note.isRest && (pendingEditorialAccidental || pendingCourtesyAccidental)) {
-                        if (note.accidentalText) {
-                            note.accidentalEditorial = pendingEditorialAccidental || undefined;
-                            note.accidentalCautionary = pendingCourtesyAccidental || undefined;
-                        }
-                        pendingEditorialAccidental = false;
-                        pendingCourtesyAccidental = false;
-                    }
-                    if (chordIndex === 0 && pendingMordent && !note.isRest) {
-                        note.mordentType = pendingMordent;
-                        pendingMordent = "";
-                    }
-                    if (chordIndex === 0 && pendingPhraseMark && !note.isRest) {
-                        note.phraseMark = pendingPhraseMark;
-                        pendingPhraseMark = "";
-                    }
-                    if (chordIndex === 0 && pendingTremolo && !note.isRest) {
-                        note.tremoloType = pendingTremolo.type;
-                        note.tremoloMarks = pendingTremolo.marks;
-                        pendingTremolo = null;
-                    }
-                    if (chordIndex === 0 && pendingGlissandoStart && !note.isRest) {
-                        note.glissandoStart = true;
-                        pendingGlissandoStart = false;
-                    }
-                    if (chordIndex === 0 && pendingGlissandoStop && !note.isRest) {
-                        note.glissandoStop = true;
-                        pendingGlissandoStop = false;
-                    }
-                    if (chordIndex === 0 && pendingSlideStart && !note.isRest) {
-                        note.slideStart = true;
-                        pendingSlideStart = false;
-                    }
-                    if (chordIndex === 0 && pendingSlideStop && !note.isRest) {
-                        note.slideStop = true;
-                        pendingSlideStop = false;
-                    }
-                    if (chordIndex === 0 && pendingSchleifer && !note.isRest) {
-                        note.schleifer = true;
-                        pendingSchleifer = false;
-                    }
-                    if (chordIndex === 0 && pendingShake && !note.isRest) {
-                        note.shake = true;
-                        pendingShake = false;
-                    }
-                    if (chordIndex === 0 && pendingArpeggiate && !note.isRest) {
-                        note.arpeggiate = true;
-                        pendingArpeggiate = false;
-                    }
-                    if (chordIndex === 0 && pendingSlurStart > 0 && !note.isRest) {
-                        note.slurStart = true;
-                        pendingSlurStart = 0;
-                    }
-                    if (chordIndex === 0 && note.trill && trillHint) {
-                        note.trillAccidentalText = trillHint;
-                    }
-                    if (chordIndex === 0 && pendingStaccato && !note.isRest) {
-                        note.staccato = true;
-                        pendingStaccato = false;
-                    }
-                    if (chordIndex === 0 && pendingStaccatissimo && !note.isRest) {
-                        note.staccatissimo = true;
-                        pendingStaccatissimo = false;
-                    }
-                    if (chordIndex === 0 && pendingAccent && !note.isRest) {
-                        note.accent = true;
-                        pendingAccent = false;
-                    }
-                    if (chordIndex === 0 && pendingTenuto && !note.isRest) {
-                        note.tenuto = true;
-                        pendingTenuto = false;
-                    }
-                    if (chordIndex === 0 && pendingStress && !note.isRest) {
-                        note.stress = true;
-                        pendingStress = false;
-                    }
-                    if (chordIndex === 0 && pendingUnstress && !note.isRest) {
-                        note.unstress = true;
-                        pendingUnstress = false;
-                    }
-                    if (chordIndex === 0 && pendingFermata && !note.isRest) {
-                        note.fermataType = pendingFermata;
-                        pendingFermata = "";
-                    }
-                    if (chordIndex === 0 && pendingStrongAccent && !note.isRest) {
-                        note.strongAccent = true;
-                        pendingStrongAccent = false;
-                    }
-                    if (chordIndex === 0 && pendingBreathMark && !note.isRest) {
-                        note.breathMark = true;
-                        pendingBreathMark = false;
-                    }
-                    if (chordIndex === 0 && pendingCaesura && !note.isRest) {
-                        note.caesura = true;
-                        pendingCaesura = false;
-                    }
-                    if (chordIndex === 0 && pendingSegno && !note.isRest) {
-                        note.segno = true;
-                        pendingSegno = false;
-                    }
-                    if (chordIndex === 0 && pendingCoda && !note.isRest) {
-                        note.coda = true;
-                        pendingCoda = false;
-                    }
-                    if (chordIndex === 0 && pendingFine && !note.isRest) {
-                        note.fine = true;
-                        pendingFine = false;
-                    }
-                    if (chordIndex === 0 && pendingDaCapo && !note.isRest) {
-                        note.daCapo = true;
-                        pendingDaCapo = false;
-                    }
-                    if (chordIndex === 0 && pendingDalSegno && !note.isRest) {
-                        note.dalSegno = true;
-                        pendingDalSegno = false;
-                    }
-                    if (chordIndex === 0 && pendingToCoda && !note.isRest) {
-                        note.toCoda = true;
-                        pendingToCoda = false;
-                    }
-                    if (chordIndex === 0 && pendingCrescendoStart && !note.isRest) {
-                        note.crescendoStart = true;
-                        pendingCrescendoStart = false;
-                    }
-                    if (chordIndex === 0 && pendingCrescendoStop && !note.isRest) {
-                        note.crescendoStop = true;
-                        pendingCrescendoStop = false;
-                    }
-                    if (chordIndex === 0 && pendingDiminuendoStart && !note.isRest) {
-                        note.diminuendoStart = true;
-                        pendingDiminuendoStart = false;
-                    }
-                    if (chordIndex === 0 && pendingDiminuendoStop && !note.isRest) {
-                        note.diminuendoStop = true;
-                        pendingDiminuendoStop = false;
-                    }
-                    if (chordIndex === 0 && pendingDynamicMark && !note.isRest) {
-                        note.dynamicMark = pendingDynamicMark;
-                        pendingDynamicMark = "";
-                    }
-                    if (chordIndex === 0 && pendingSfz && !note.isRest) {
-                        note.sfz = true;
-                        pendingSfz = false;
-                    }
-                    if (chordIndex === 0 && pendingRehearsalMark && !note.isRest) {
-                        note.rehearsalMark = pendingRehearsalMark;
-                        pendingRehearsalMark = "";
-                    }
-                    if (chordIndex === 0 && pendingUpBow && !note.isRest) {
-                        note.upBow = true;
-                        pendingUpBow = false;
-                    }
-                    if (chordIndex === 0 && pendingDownBow && !note.isRest) {
-                        note.downBow = true;
-                        pendingDownBow = false;
-                    }
-                    if (chordIndex === 0 && pendingDoubleTongue && !note.isRest) {
-                        note.doubleTongue = true;
-                        pendingDoubleTongue = false;
-                    }
-                    if (chordIndex === 0 && pendingTripleTongue && !note.isRest) {
-                        note.tripleTongue = true;
-                        pendingTripleTongue = false;
-                    }
-                    if (chordIndex === 0 && pendingHeel && !note.isRest) {
-                        note.heel = true;
-                        pendingHeel = false;
-                    }
-                    if (chordIndex === 0 && pendingToe && !note.isRest) {
-                        note.toe = true;
-                        pendingToe = false;
-                    }
-                    if (chordIndex === 0 && pendingFingerings.length > 0 && !note.isRest) {
-                        note.fingerings = pendingFingerings.slice();
-                        pendingFingerings = [];
-                    }
-                    if (chordIndex === 0 && pendingStrings.length > 0 && !note.isRest) {
-                        note.strings = pendingStrings.slice();
-                        pendingStrings = [];
-                    }
-                    if (chordIndex === 0 && pendingPlucks.length > 0 && !note.isRest) {
-                        note.plucks = pendingPlucks.slice();
-                        pendingPlucks = [];
-                    }
-                    if (chordIndex === 0 && pendingChordSymbols.length > 0 && !note.isRest) {
-                        note.chordSymbols = pendingChordSymbols.slice();
-                        pendingChordSymbols = [];
-                    }
-                    if (chordIndex === 0 && pendingOpenString && !note.isRest) {
-                        note.openString = true;
-                        pendingOpenString = false;
-                    }
-                    if (chordIndex === 0 && pendingSnapPizzicato && !note.isRest) {
-                        note.snapPizzicato = true;
-                        pendingSnapPizzicato = false;
-                    }
-                    if (chordIndex === 0 && pendingHarmonic && !note.isRest) {
-                        note.harmonic = true;
-                        pendingHarmonic = false;
-                    }
-                    if (chordIndex === 0 && pendingStopped && !note.isRest) {
-                        note.stopped = true;
-                        pendingStopped = false;
-                    }
-                    if (chordIndex === 0 && pendingThumbPosition && !note.isRest) {
-                        note.thumbPosition = true;
-                        pendingThumbPosition = false;
-                    }
-                    if (chordIndex === 0 && pendingAnnotations.length > 0 && !note.isRest) {
-                        note.annotations = pendingAnnotations.slice();
-                        pendingAnnotations = [];
-                    }
-                    if (chordIndex > 0) {
-                        note.chord = true;
-                    }
-                    if (chordIndex === 0 && activeTuplet) {
-                        note.timeModification = { actual: activeTuplet.actual, normal: activeTuplet.normal };
-                        if (activeTuplet.remaining === activeTuplet.actual) {
-                            note.tupletStart = true;
-                        }
-                        if (activeTuplet.remaining === 1) {
-                            note.tupletStop = true;
-                        }
-                    }
-                    chordNotes.push(note);
-                }
-                if (pendingTieToNext && chordNotes.length > 0) {
-                    for (const chordNote of chordNotes) {
-                        if (!chordNote.isRest) {
-                            chordNote.tieStop = true;
-                        }
-                    }
-                    pendingTieToNext = false;
-                }
-                for (const note of chordNotes) {
-                    currentMeasure.push(note);
-                }
-                if (chordNotes.length === 0) {
-                    pendingTieToNext = false;
-                    lastNote = null;
-                    lastEventNotes = [];
-                    continue;
-                }
-                lastNote = chordNotes[0] || null;
-                lastEventNotes = chordNotes;
-                noteCount += chordNotes.length;
-                continue;
+            if (applyTurnDecoration(decoration)) {
+                return true;
             }
-            if (ch === ")") {
-                if (lastNote && !lastNote.isRest) {
-                    lastNote.slurStop = true;
-                }
-                else {
-                    warnings.push("line " + entry.lineNo + ": slur stop()) has no preceding note; skipped.");
-                }
-                idx += 1;
-                continue;
+            if (applyTremoloDecoration(decoration)) {
+                return true;
             }
-            if (ch === "]" || ch === "}") {
-                if (ch === "]" && activeEndingMarker) {
-                    const stopMeasureNo = currentMeasure.length === 0 ? currentMeasureNo - 1 : currentMeasureNo;
-                    if (stopMeasureNo >= 1) {
-                        const measureMeta = ensureNotationMeasureMeta(entry.voiceId, stopMeasureNo);
-                        measureMeta.endingStop = activeEndingMarker;
-                        measureMeta.endingStopType = "stop";
-                        activeEndingMarker = "";
-                    }
-                    idx += 1;
-                    beamRunActive = false;
-                    sawInterEventWhitespace = false;
-                    continue;
-                }
-                warnings.push("line " + entry.lineNo + ": Skipped unsupported notation: " + ch);
-                idx += 1;
-                beamRunActive = false;
-                sawInterEventWhitespace = false;
-                continue;
+            if (PHRASE_DECORATIONS.has(decoration)) {
+                pendingPhraseMark = decoration;
+                return true;
             }
-            if (ch === ";" || ch === "`" || ch === "?" || ch === "@" || ch === "#" || ch === "$" || ch === "*") {
-                warnings.push("line " + entry.lineNo + ": Skipped unsupported body punctuation: " + ch);
-                idx += 1;
-                beamRunActive = false;
-                sawInterEventWhitespace = false;
-                continue;
+            if (decoration === "dacoda") {
+                pendingDaCapo = true;
+                pendingToCoda = true;
+                return true;
             }
-            const noteResult = (0, abc_parser_1.parseAbcNoteAt)(text, idx);
-            if ((noteResult === null || noteResult === void 0 ? void 0 : noteResult.kind) === "malformed-accidental") {
-                warnings.push("line " + entry.lineNo + ": Skipped malformed accidental token: " + noteResult.accidentalText);
-                idx = noteResult.nextIdx;
-                continue;
+            if (DYNAMIC_DECORATIONS.has(decoration)) {
+                pendingDynamicMark = decoration;
+                return true;
             }
-            if (!noteResult || noteResult.kind !== "note") {
-                throw new Error("line " + entry.lineNo + ": Failed to parse note/rest: " + text.slice(idx, idx + 12));
+            if (/^[0-5]$/.test(decoration)) {
+                pendingFingerings.push(decoration);
+                return true;
             }
-            const { accidentalText, pitchChar, octaveShift, lengthToken, nextIdx } = noteResult.note;
-            idx = nextIdx;
-            const len = parseLengthToken(lengthToken, entry.lineNo);
-            let absoluteLength = multiplyFractions(activeUnitLength, len);
-            if (pendingRhythmScale) {
-                absoluteLength = multiplyFractions(absoluteLength, pendingRhythmScale);
-                pendingRhythmScale = null;
-            }
-            const activeTuplet = tupletRemaining > 0 && tupletScale && tupletSpec
-                ? { actual: tupletSpec.actual, normal: tupletSpec.normal, remaining: tupletSpec.remaining }
-                : null;
-            if (tupletRemaining > 0 && tupletScale) {
-                absoluteLength = multiplyFractions(absoluteLength, tupletScale);
-                tupletRemaining -= 1;
-                if (tupletSpec) {
-                    tupletSpec.remaining -= 1;
-                }
-                if (tupletRemaining <= 0) {
-                    tupletScale = null;
-                    tupletSpec = null;
-                }
-            }
-            if (idx < text.length && (text[idx] === ">" || text[idx] === "<")) {
-                const rhythmChar = text[idx];
-                idx += 1;
-                if (rhythmChar === ">") {
-                    absoluteLength = multiplyFractions(absoluteLength, { num: 3, den: 2 });
-                    pendingRhythmScale = { num: 1, den: 2 };
-                }
-                else {
-                    absoluteLength = multiplyFractions(absoluteLength, { num: 1, den: 2 });
-                    pendingRhythmScale = { num: 3, den: 2 };
-                }
-            }
-            const dur = durationInDivisions(absoluteLength, 960);
-            if (dur <= 0) {
-                warnings.push("line " + entry.lineNo + ": Skipped note with invalid length.");
-                continue;
-            }
-            let note;
-            try {
-                note = buildNoteData(pitchChar, accidentalText, octaveShift, absoluteLength, dur, entry.lineNo, activeKeySignatureAccidentals, measureAccidentals);
-            }
-            catch (error) {
-                if (error instanceof Error && /Octave out of range/i.test(error.message || "")) {
-                    warnings.push("line " + entry.lineNo + ": Skipped note with unsupported octave range.");
-                    pendingTieToNext = false;
-                    lastNote = null;
-                    lastEventNotes = [];
-                    continue;
-                }
-                throw error;
-            }
-            applyBeamModeForEvent(note, dur);
+            return false;
+        };
+        const applyPendingOrnamentState = (note, options = {}) => {
+            const { applySlurStart = true, trillHint = "" } = options;
             if (pendingTrill && !note.isRest) {
                 note.trill = true;
                 note.trillLineStart = pendingTrillLineStart;
@@ -23296,15 +22578,15 @@ function parseForMusicXml(source, settings) {
                 note.arpeggiate = true;
                 pendingArpeggiate = false;
             }
-            if (pendingSlurStart > 0 && !note.isRest) {
+            if (applySlurStart && pendingSlurStart > 0 && !note.isRest) {
                 note.slurStart = true;
                 pendingSlurStart = 0;
             }
-            currentEventNo += 1;
-            const trillHint = trillWidthHintByKey.get(`${entry.voiceId}#${currentMeasureNo}#${currentEventNo}`) || "";
             if (note.trill && trillHint) {
                 note.trillAccidentalText = trillHint;
             }
+        };
+        const applyPendingArticulationState = (note) => {
             if (pendingStaccato && !note.isRest) {
                 note.staccato = true;
                 pendingStaccato = false;
@@ -23345,6 +22627,8 @@ function parseForMusicXml(source, settings) {
                 note.caesura = true;
                 pendingCaesura = false;
             }
+        };
+        const applyPendingDirectionState = (note) => {
             if (pendingSegno && !note.isRest) {
                 note.segno = true;
                 pendingSegno = false;
@@ -23397,6 +22681,8 @@ function parseForMusicXml(source, settings) {
                 note.rehearsalMark = pendingRehearsalMark;
                 pendingRehearsalMark = "";
             }
+        };
+        const applyPendingTechnicalState = (note) => {
             if (pendingUpBow && !note.isRest) {
                 note.upBow = true;
                 pendingUpBow = false;
@@ -23461,28 +22747,629 @@ function parseForMusicXml(source, settings) {
                 note.annotations = pendingAnnotations.slice();
                 pendingAnnotations = [];
             }
-            if (pendingTieToNext && !note.isRest) {
+        };
+        const applyPendingToPlayableNote = (note, options = {}) => {
+            const { applySlurStart = true, applyTieStop = true, trillHint = "", } = options;
+            applyPendingOrnamentState(note, { applySlurStart, trillHint });
+            applyPendingArticulationState(note);
+            applyPendingDirectionState(note);
+            applyPendingTechnicalState(note);
+            if (applyTieStop && pendingTieToNext && !note.isRest) {
                 note.tieStop = true;
                 pendingTieToNext = false;
             }
-            else if (note.isRest && pendingTieToNext) {
-                warnings.push("line " + entry.lineNo + ": tie(-) was followed by a rest; tie removed.");
+            else if (applyTieStop && note.isRest && pendingTieToNext) {
+                warnBody("tie(-) was followed by a rest; tie removed.");
                 pendingTieToNext = false;
             }
-            if (activeTuplet) {
-                note.timeModification = { actual: activeTuplet.actual, normal: activeTuplet.normal };
-                if (activeTuplet.remaining === activeTuplet.actual) {
-                    note.tupletStart = true;
+        };
+        // Event construction and commit helpers.
+        const applySingleCharShorthand = (char) => {
+            const shorthand = (0, abc_parser_1.parseAbcSingleCharShorthandAt)(char, 0);
+            if (!shorthand) {
+                return false;
+            }
+            const shorthandAppliers = {
+                "accent": () => {
+                    pendingAccent = true;
+                },
+                "arpeggiate": () => {
+                    pendingArpeggiate = true;
+                },
+                "coda": () => {
+                    pendingCoda = true;
+                },
+                "downbow": () => {
+                    pendingDownBow = true;
+                },
+                "fermata": () => {
+                    pendingFermata = "normal";
+                },
+                "inverted-mordent": () => {
+                    pendingMordent = "inverted-mordent";
+                },
+                "mordent": () => {
+                    pendingMordent = "mordent";
+                },
+                "segno": () => {
+                    pendingSegno = true;
+                },
+                "staccato": () => {
+                    pendingStaccato = true;
+                },
+                "trill": () => {
+                    pendingTrill = true;
+                },
+                "upbow": () => {
+                    pendingUpBow = true;
+                },
+            };
+            const apply = shorthandAppliers[shorthand.kind];
+            if (!apply) {
+                return false;
+            }
+            apply();
+            return true;
+        };
+        const consumePlayableTiming = (rawLengthToken, tokenIdx) => {
+            const len = parseLengthToken(rawLengthToken, entry.lineNo);
+            let absoluteLength = multiplyFractions(activeUnitLength, len);
+            if (pendingRhythmScale) {
+                absoluteLength = multiplyFractions(absoluteLength, pendingRhythmScale);
+                pendingRhythmScale = null;
+            }
+            const activeTuplet = tupletRemaining > 0 && tupletScale && tupletSpec
+                ? { actual: tupletSpec.actual, normal: tupletSpec.normal, remaining: tupletSpec.remaining }
+                : null;
+            if (tupletRemaining > 0 && tupletScale) {
+                absoluteLength = multiplyFractions(absoluteLength, tupletScale);
+                tupletRemaining -= 1;
+                if (tupletSpec) {
+                    tupletSpec.remaining -= 1;
                 }
-                if (activeTuplet.remaining === 1) {
-                    note.tupletStop = true;
+                if (tupletRemaining <= 0) {
+                    tupletScale = null;
+                    tupletSpec = null;
                 }
             }
+            let nextIdx = tokenIdx;
+            const trailingBrokenRhythm = (0, abc_parser_1.parseAbcBrokenRhythmAt)(text, nextIdx);
+            if (trailingBrokenRhythm) {
+                absoluteLength = multiplyFractions(absoluteLength, trailingBrokenRhythm.leftScale);
+                pendingRhythmScale = trailingBrokenRhythm.rightScale;
+                nextIdx = trailingBrokenRhythm.nextIdx;
+            }
+            return {
+                absoluteLength,
+                dur: durationInDivisions(absoluteLength, 960),
+                activeTuplet,
+                nextIdx,
+            };
+        };
+        const applyTupletToEventStart = (note, activeTuplet) => {
+            if (!activeTuplet) {
+                return;
+            }
+            note.timeModification = { actual: activeTuplet.actual, normal: activeTuplet.normal };
+            if (activeTuplet.remaining === activeTuplet.actual) {
+                note.tupletStart = true;
+            }
+            if (activeTuplet.remaining === 1) {
+                note.tupletStop = true;
+            }
+        };
+        const finalizePlayableEventStart = (note, dur, activeTuplet, options = {}) => {
+            const applyTieStop = options.applyTieStop !== false;
+            applyBeamModeForEvent(note, dur);
+            currentEventNo += 1;
+            const trillHint = trillWidthHintByKey.get(`${entry.voiceId}#${currentMeasureNo}#${currentEventNo}`) || "";
+            applyPendingToPlayableNote(note, { applySlurStart: true, applyTieStop, trillHint });
+            applyTupletToEventStart(note, activeTuplet);
             note.voice = entry.voiceId;
-            currentMeasure.push(note);
-            lastNote = note;
-            lastEventNotes = [note];
-            noteCount += 1;
+        };
+        const buildPlayableNoteForBody = (pitchSource, absoluteLength, dur, octaveWarningMessage) => {
+            let note;
+            try {
+                note = buildNoteData(pitchSource.pitchChar, pitchSource.accidentalText, pitchSource.octaveShift, absoluteLength, dur, entry.lineNo, activeKeySignatureAccidentals, measureAccidentals);
+            }
+            catch (error) {
+                if (error instanceof Error && /Octave out of range/i.test(error.message || "")) {
+                    warnBody(octaveWarningMessage);
+                    return null;
+                }
+                throw error;
+            }
+            note.voice = entry.voiceId;
+            return note;
+        };
+        const clearLastEventState = (options = {}) => {
+            if (options.clearPendingTie !== false) {
+                pendingTieToNext = false;
+            }
+            lastNote = null;
+            lastEventNotes = [];
+        };
+        const commitPlayableEvent = (notes, options = {}) => {
+            const applyChordTieStop = options.applyChordTieStop === true;
+            if (applyChordTieStop && pendingTieToNext && notes.length > 0) {
+                for (const note of notes) {
+                    if (!note.isRest) {
+                        note.tieStop = true;
+                    }
+                }
+                pendingTieToNext = false;
+            }
+            for (const note of notes) {
+                currentMeasure.push(note);
+            }
+            if (notes.length === 0) {
+                clearLastEventState();
+                return false;
+            }
+            lastNote = notes[0] || null;
+            lastEventNotes = notes;
+            noteCount += notes.length;
+            return true;
+        };
+        const buildPlayableEventFromPitches = (pitchSources, timing, options = {}) => {
+            const octaveWarningMessage = options.octaveWarningMessage || "Skipped note with unsupported octave range.";
+            const firstNoteOptions = options.firstNoteOptions || {};
+            const notes = [];
+            for (let pitchIndex = 0; pitchIndex < pitchSources.length; pitchIndex += 1) {
+                const note = buildPlayableNoteForBody(pitchSources[pitchIndex], timing.absoluteLength, timing.dur, octaveWarningMessage);
+                if (!note) {
+                    notes.length = 0;
+                    break;
+                }
+                if (pitchIndex === 0) {
+                    finalizePlayableEventStart(note, timing.dur, timing.activeTuplet, firstNoteOptions);
+                }
+                else {
+                    note.chord = true;
+                }
+                notes.push(note);
+            }
+            return notes;
+        };
+        const playableEventOptionsForSource = (source) => ({
+            invalidLengthMessage: source === "chord" ? "Skipped chord with invalid length." : "Skipped note with invalid length.",
+            octaveWarningMessage: source === "chord"
+                ? "Skipped chord note with unsupported octave range."
+                : "Skipped note with unsupported octave range.",
+            firstNoteOptions: source === "chord" ? { applyTieStop: false } : {},
+            commitOptions: source === "chord" ? { applyChordTieStop: true } : {},
+        });
+        // Body token handlers.
+        const handleBrokenRhythmBodyToken = (bodyToken) => {
+            const { brokenRhythm } = bodyToken;
+            if (!lastEventNotes || lastEventNotes.length === 0 || lastEventNotes.some((n) => n.isRest)) {
+                warnBody("broken rhythm(" + brokenRhythm.symbol + ")  has no preceding note; skipped.");
+                idx = brokenRhythm.nextIdx;
+                return true;
+            }
+            scaleNotesDuration(lastEventNotes, brokenRhythm.leftScale);
+            pendingRhythmScale = brokenRhythm.rightScale;
+            idx = brokenRhythm.nextIdx;
+            return true;
+        };
+        const handleParenBodyToken = (bodyToken) => {
+            const { parenToken } = bodyToken;
+            if (parenToken.kind === "tuplet") {
+                const { tuplet } = parenToken;
+                if (tuplet.actual > 0 && tuplet.normal > 0 && tuplet.count > 0) {
+                    tupletScale = { num: tuplet.normal, den: tuplet.actual };
+                    tupletRemaining = tuplet.count;
+                    tupletSpec = { actual: tuplet.actual, normal: tuplet.normal, remaining: tuplet.count };
+                }
+                else {
+                    warnBody("Failed to parse tuplet notation: " + tuplet.raw);
+                }
+                idx = tuplet.nextIdx;
+                return true;
+            }
+            pendingSlurStart += 1;
+            idx = parenToken.nextIdx;
+            return true;
+        };
+        const enqueueQuotedBodyText = (normalizedText) => {
+            if (!normalizedText) {
+                return;
+            }
+            if (isLikelyAbcChordSymbol(normalizedText)) {
+                pendingChordSymbols.push(normalizedText);
+                return;
+            }
+            pendingAnnotations.push(normalizedText);
+        };
+        const markTieStartOnLastEvent = () => {
+            if (!lastEventNotes || lastEventNotes.length === 0 || !lastEventNotes.some((n) => !n.isRest)) {
+                return false;
+            }
+            for (const eventNote of lastEventNotes) {
+                if (!eventNote.isRest) {
+                    eventNote.tieStart = true;
+                }
+            }
+            pendingTieToNext = true;
+            return true;
+        };
+        const handleTieBodyToken = (bodyToken) => {
+            if (!markTieStartOnLastEvent()) {
+                warnBody("tie(-)  has no preceding note; skipped.");
+            }
+            idx = bodyToken.tie.nextIdx;
+            return true;
+        };
+        const handleQuotedStringBodyToken = (bodyToken) => {
+            const { quotedString } = bodyToken;
+            enqueueQuotedBodyText(quotedString.normalizedText);
+            if (!quotedString.terminated) {
+                warnBody('Unterminated inline string ("...").');
+            }
+            idx = quotedString.nextIdx;
+            return true;
+        };
+        const handleSingleCharShorthandBodyToken = (bodyToken, char) => {
+            applySingleCharShorthand(char);
+            idx = bodyToken.shorthand.nextIdx;
+            return true;
+        };
+        const handleDecorationBodyToken = (bodyToken, char) => {
+            const parsedDecoration = bodyToken.decoration;
+            if (!parsedDecoration.terminated) {
+                warnBody("Unterminated decoration marker: " + char);
+                idx = parsedDecoration.nextIdx;
+                return true;
+            }
+            const { rawDecoration, decoration } = parsedDecoration;
+            if (!applyDecoration(rawDecoration, decoration) && decoration) {
+                warnBody("Skipped decoration: " + char + decoration + char);
+            }
+            idx = parsedDecoration.nextIdx;
+            return true;
+        };
+        const markSlurStopOnLastNote = () => {
+            if (!lastNote || lastNote.isRest) {
+                return false;
+            }
+            lastNote.slurStop = true;
+            return true;
+        };
+        const handleSlurStopBodyToken = (bodyToken) => {
+            const { slurStop } = bodyToken;
+            if (!markSlurStopOnLastNote()) {
+                warnBody("slur stop()) has no preceding note; skipped.");
+            }
+            idx = slurStop.nextIdx;
+            return true;
+        };
+        const handleSimpleBodyToken = (bodyToken, char) => {
+            if (!bodyToken) {
+                return false;
+            }
+            const bodyTokenHandlers = {
+                "broken-rhythm": () => handleBrokenRhythmBodyToken(bodyToken),
+                "decoration": () => handleDecorationBodyToken(bodyToken, char),
+                "paren": () => handleParenBodyToken(bodyToken),
+                "quoted-string": () => handleQuotedStringBodyToken(bodyToken),
+                "single-char-shorthand": () => handleSingleCharShorthandBodyToken(bodyToken, char),
+                "slur-stop": () => handleSlurStopBodyToken(bodyToken),
+                "tie": () => handleTieBodyToken(bodyToken),
+            };
+            const handler = bodyTokenHandlers[bodyToken.kind];
+            return handler ? handler() : false;
+        };
+        const handleInlineFieldBracketToken = (bracketToken) => {
+            const { inlineField } = bracketToken;
+            if (!applyBodyField(inlineField.fieldName, inlineField.fieldValue)) {
+                warnBody("Skipped unsupported inline field: [" + inlineField.fieldName + ":" + inlineField.fieldValue + "]");
+            }
+            idx = inlineField.nextIdx;
+            return true;
+        };
+        const handleRepeatEndingBracketToken = (bracketToken) => {
+            const { repeatEndingMarker } = bracketToken;
+            return startEndingAtCurrentMeasure(repeatEndingMarker.marker, repeatEndingMarker.nextIdx);
+        };
+        const handleBracketBodyToken = (bodyToken) => {
+            if (!bodyToken || bodyToken.kind !== "bracket") {
+                return false;
+            }
+            const { bracketToken } = bodyToken;
+            if (bracketToken.kind === "inline-field") {
+                return handleInlineFieldBracketToken(bracketToken);
+            }
+            if (bracketToken.kind === "repeat-ending") {
+                return handleRepeatEndingBracketToken(bracketToken);
+            }
+            const playableEvent = (0, abc_parser_1.parseAbcPlayableEventAt)(text, idx);
+            return handlePlayableEvent(playableEvent, { fallbackToNextChar: true });
+        };
+        const handleGraceGroup = (char) => {
+            if (char !== "{") {
+                return false;
+            }
+            const graceResult = parseGraceGroupAt(text, idx, entry.lineNo, activeUnitLength, activeKeySignatureAccidentals, measureAccidentals, entry.voiceId, warnings);
+            if (!graceResult) {
+                warnBody("Failed to parse grace group; skipped.");
+                idx += 1;
+                return true;
+            }
+            idx = graceResult.nextIdx;
+            appendGraceNotes(graceResult.notes);
+            return true;
+        };
+        // Measure and ending state helpers.
+        const appendGraceNotes = (graceNotes) => {
+            for (const graceNote of graceNotes) {
+                currentMeasure.push(graceNote);
+                noteCount += 1;
+            }
+        };
+        const startEndingAtCurrentMeasure = (marker, nextIdx) => {
+            if (activeEndingMarker) {
+                const stopMeasureNo = currentMeasure.length === 0 ? currentMeasureNo - 1 : currentMeasureNo;
+                stopActiveEndingAtMeasure(stopMeasureNo);
+            }
+            const measureMeta = ensureNotationMeasureMeta(entry.voiceId, currentMeasureNo);
+            measureMeta.endingStart = marker;
+            activeEndingMarker = marker;
+            idx = nextIdx;
+            resetBeamContext();
+            return true;
+        };
+        const stopActiveEndingAtMeasure = (measureNo) => {
+            if (!activeEndingMarker || measureNo < 1) {
+                return false;
+            }
+            const measureMeta = ensureNotationMeasureMeta(entry.voiceId, measureNo);
+            measureMeta.endingStop = activeEndingMarker;
+            measureMeta.endingStopType = "stop";
+            activeEndingMarker = "";
+            return true;
+        };
+        const advanceToNextMeasure = () => {
+            currentMeasure = [];
+            measures.push(currentMeasure);
+            currentMeasureNo = Math.max(1, measures.length);
+            currentEventNo = 0;
+            beamCursorDiv = 0;
+        };
+        const resetBeamContext = () => {
+            beamRunActive = false;
+            sawInterEventWhitespace = false;
+        };
+        const applyBarlineRepeatMarkers = (barlineToken) => {
+            if (barlineToken.repeatEnd) {
+                ensureNotationMeasureMeta(entry.voiceId, currentMeasureNo).repeatEnd = true;
+            }
+            if (barlineToken.repeatStart) {
+                ensureNotationMeasureMeta(entry.voiceId, currentMeasureNo).repeatStart = true;
+            }
+        };
+        const applyBarlineMeasureBoundary = (barlineToken, bareRepeatEndingMarker) => {
+            if ((barlineToken.endingStop || bareRepeatEndingMarker) && activeEndingMarker) {
+                stopActiveEndingAtMeasure(currentMeasureNo);
+            }
+            if (barlineToken.endsMeasure && (currentMeasure.length > 0 || measures.length === 0)) {
+                advanceToNextMeasure();
+            }
+            if (barlineToken.endsMeasure) {
+                measureAccidentals = {};
+                lastNote = null;
+            }
+        };
+        const advanceAfterBarline = (barlineToken, bareRepeatEndingMarker) => {
+            if (bareRepeatEndingMarker) {
+                return startEndingAtCurrentMeasure(bareRepeatEndingMarker.marker, bareRepeatEndingMarker.nextIdx);
+            }
+            idx = barlineToken.nextIdx;
+            resetBeamContext();
+            return true;
+        };
+        const handleBarlineEntry = (bodyEntry) => {
+            if (!bodyEntry || bodyEntry.kind !== "barline") {
+                return false;
+            }
+            const { barlineToken } = bodyEntry;
+            const bareRepeatEndingMarker = barlineToken.endsMeasure ? (0, abc_parser_1.parseAbcBareRepeatEndingMarkerAt)(text, barlineToken.nextIdx) : null;
+            applyBarlineRepeatMarkers(barlineToken);
+            applyBarlineMeasureBoundary(barlineToken, bareRepeatEndingMarker);
+            return advanceAfterBarline(barlineToken, bareRepeatEndingMarker);
+        };
+        const handleStandaloneBodyFieldEntry = (bodyEntry) => {
+            const { standaloneBodyField } = bodyEntry;
+            if (!applyBodyField(standaloneBodyField.fieldName, standaloneBodyField.fieldValue)) {
+                warnBody("Skipped unsupported standalone body field token: " + standaloneBodyField.token);
+            }
+            idx = standaloneBodyField.nextIdx;
+            return true;
+        };
+        const handleUnsupportedTokenEntry = (bodyEntry) => {
+            if (bodyEntry.kind === "unsupported-body-token") {
+                const { unsupportedBodyToken } = bodyEntry;
+                warnBody("Skipped unsupported body token: " + unsupportedBodyToken.token);
+                idx = unsupportedBodyToken.nextIdx;
+                return true;
+            }
+            if (bodyEntry.kind === "unsupported-body-number") {
+                const { unsupportedBodyNumber } = bodyEntry;
+                warnBody("Skipped unsupported body number token: " + unsupportedBodyNumber.token);
+                idx = unsupportedBodyNumber.nextIdx;
+                return true;
+            }
+            return false;
+        };
+        const handleNonPlayableBodyEntry = (bodyEntry) => {
+            if (!bodyEntry) {
+                return false;
+            }
+            if (bodyEntry.kind === "standalone-body-field") {
+                return handleStandaloneBodyFieldEntry(bodyEntry);
+            }
+            return handleUnsupportedTokenEntry(bodyEntry);
+        };
+        // Playable-event and fallback handlers.
+        const handleResolvedPlayableEvent = (playableEvent) => {
+            const timing = consumePlayableTiming(playableEvent.rawLengthToken, playableEvent.nextIdx);
+            idx = timing.nextIdx;
+            const eventOptions = playableEventOptionsForSource(playableEvent.source);
+            if (timing.dur <= 0) {
+                warnBody(eventOptions.invalidLengthMessage);
+                return true;
+            }
+            const eventNotes = buildPlayableEventFromPitches(playableEvent.pitchSources, timing, {
+                octaveWarningMessage: eventOptions.octaveWarningMessage,
+                firstNoteOptions: eventOptions.firstNoteOptions,
+            });
+            if (eventNotes.length === 0) {
+                clearLastEventState();
+                return true;
+            }
+            commitPlayableEvent(eventNotes, eventOptions.commitOptions);
+            return true;
+        };
+        const skipInvalidPlayableEvent = (message, nextIdx) => {
+            warnBody(message);
+            idx = nextIdx;
+            return true;
+        };
+        const handleInvalidPlayableEvent = (playableEvent, options = {}) => {
+            const { fallbackToNextChar = false } = options;
+            if (!playableEvent) {
+                return false;
+            }
+            if (playableEvent.kind === "malformed-accidental") {
+                return skipInvalidPlayableEvent("Skipped malformed accidental token: " + playableEvent.accidentalText, playableEvent.nextIdx);
+            }
+            if (playableEvent.kind === "invalid-chord") {
+                return skipInvalidPlayableEvent("Failed to parse chord notation; skipped.", playableEvent.nextIdx);
+            }
+            if (fallbackToNextChar) {
+                idx += 1;
+                return true;
+            }
+            return false;
+        };
+        const handlePlayableEvent = (playableEvent, options = {}) => {
+            const { fallbackToNextChar = false } = options;
+            if (playableEvent.kind !== "playable") {
+                return handleInvalidPlayableEvent(playableEvent, { fallbackToNextChar });
+            }
+            return handleResolvedPlayableEvent(playableEvent);
+        };
+        const advanceBodyCursorWithWarning = (message, nextIdx = idx + 1) => {
+            warnBody(message);
+            idx = nextIdx;
+            resetBeamContext();
+            return true;
+        };
+        const handleClosingNotation = (char) => {
+            if (char !== "]" && char !== "}") {
+                return false;
+            }
+            if (char === "]" && activeEndingMarker) {
+                const stopMeasureNo = currentMeasure.length === 0 ? currentMeasureNo - 1 : currentMeasureNo;
+                stopActiveEndingAtMeasure(stopMeasureNo);
+                idx += 1;
+                resetBeamContext();
+                return true;
+            }
+            return advanceBodyCursorWithWarning("Skipped unsupported notation: " + char);
+        };
+        const handleUnsupportedPunctuation = (char) => {
+            if (char !== ";" && char !== "`" && char !== "?" && char !== "@" && char !== "#" && char !== "$" && char !== "*") {
+                return false;
+            }
+            return advanceBodyCursorWithWarning("Skipped unsupported body punctuation: " + char);
+        };
+        const handleBodyEntry = (bodyEntry, char) => {
+            const bodyToken = (bodyEntry === null || bodyEntry === void 0 ? void 0 : bodyEntry.kind) === "body-token" ? bodyEntry.bodyToken : null;
+            const entryHandlers = [
+                () => handleBarlineEntry(bodyEntry),
+                () => handleNonPlayableBodyEntry(bodyEntry),
+                () => handleSimpleBodyToken(bodyToken, char),
+                () => handleGraceGroup(char),
+                () => handleBracketBodyToken(bodyToken),
+                () => ((bodyEntry === null || bodyEntry === void 0 ? void 0 : bodyEntry.kind) === "playable-event" ? handlePlayableEvent(bodyEntry.playableEvent) : false),
+            ];
+            for (const handler of entryHandlers) {
+                if (handler()) {
+                    return true;
+                }
+            }
+            return false;
+        };
+        const throwBodyParseError = () => {
+            throw new Error("line " + entry.lineNo + ": Failed to parse note/rest: " + text.slice(idx, idx + 12));
+        };
+        const handleBodyFallback = (bodyEntry, char) => {
+            const fallbackHandlers = [
+                () => handleClosingNotation(char),
+                () => handleUnsupportedPunctuation(char),
+            ];
+            for (const handler of fallbackHandlers) {
+                if (handler()) {
+                    return true;
+                }
+            }
+            if (!bodyEntry) {
+                throwBodyParseError();
+            }
+            return false;
+        };
+        const consumeIgnorableBodyChar = (char) => {
+            if (char === " " || char === "\t") {
+                sawInterEventWhitespace = true;
+                idx += 1;
+                return true;
+            }
+            if (char === "\\") {
+                warnBody("Skipped stray body continuation marker: \\");
+                idx += 1;
+                return true;
+            }
+            if (char === "," || char === "'") {
+                // Lenient compatibility: some real-world sources include standalone octave marks.
+                // They are non-standard in strict ABC, but skipping them improves interoperability.
+                idx += 1;
+                return true;
+            }
+            return false;
+        };
+        const isBeamableAbcNote = (note) => Boolean(note &&
+            !note.isRest &&
+            !note.grace &&
+            ["eighth", "16th", "32nd", "64th"].includes(String(note.type || "").trim().toLowerCase()));
+        const applyBeamModeForEvent = (note, durationDiv) => {
+            const resolvedDurationDiv = Math.max(0, Math.round(Number(durationDiv) || 0));
+            const beatDiv = Math.max(1, Math.round((960 * 4) / Math.max(1, Math.round(Number(activeMeter === null || activeMeter === void 0 ? void 0 : activeMeter.beatType) || 4))));
+            const startsAtBeatBoundary = beamCursorDiv > 0 && beamCursorDiv % beatDiv === 0;
+            if (startsAtBeatBoundary) {
+                beamRunActive = false;
+            }
+            if (isBeamableAbcNote(note)) {
+                note.beamMode = !beamRunActive || sawInterEventWhitespace ? "begin" : "mid";
+                beamRunActive = true;
+            }
+            else {
+                beamRunActive = false;
+            }
+            sawInterEventWhitespace = false;
+            beamCursorDiv += resolvedDurationDiv;
+        };
+        while (idx < text.length) {
+            const ch = text[idx];
+            if (consumeIgnorableBodyChar(ch)) {
+                continue;
+            }
+            const bodyEntry = (0, abc_parser_1.parseAbcBodyEntryAt)(text, idx);
+            if (handleBodyEntry(bodyEntry, ch)) {
+                continue;
+            }
+            if (handleBodyFallback(bodyEntry, ch)) {
+                continue;
+            }
         }
         activeEndingByVoice[entry.voiceId] = activeEndingMarker;
         currentKeyFifthsByVoice[entry.voiceId] = activeKeyFifths;
@@ -23811,9 +23698,6 @@ function parseKey(raw, warnings) {
 }
 function parseLengthToken(token, lineNo) {
     return abcCommon.parseAbcLengthToken(token, lineNo);
-}
-function parseChordAt(text, startIdx, lineNo) {
-    return (0, abc_parser_1.parseAbcChordAt)(text, startIdx);
 }
 function parseGraceGroupAt(text, startIdx, lineNo, unitLength, keySignatureAccidentals, measureAccidentals, voiceId, warnings) {
     const parsedGrace = (0, abc_parser_1.parseAbcGraceGroupAt)(text, startIdx, lineNo, warnings);
@@ -25135,6 +25019,12 @@ const buildMusicXmlFromAbcParsed = (parsed, abcSource, options = {}) => {
             if (hintedTempo !== null) {
                 currentPartTempo = hintedTempo;
             }
+            const currentMeasureDurationDiv = Math.max(1, Math.round((960 * 4 * Math.max(1, Math.round(currentPartMeter.beats))) / Math.max(1, Math.round(currentPartMeter.beatType))));
+            const currentMeasureContentDiv = estimateAbcMeasureContentDiv(notes);
+            const inferredImplicitPickup = i === 0 &&
+                !(measureMeta === null || measureMeta === void 0 ? void 0 : measureMeta.implicit) &&
+                currentMeasureContentDiv > 0 &&
+                currentMeasureContentDiv < currentMeasureDurationDiv;
             const header = i === 0
                 ? [
                     "<attributes>",
@@ -25528,7 +25418,7 @@ const buildMusicXmlFromAbcParsed = (parsed, abcSource, options = {}) => {
                 })()
                 : `<note><rest/><duration>${measureDurationDiv}</duration><voice>1</voice><type>${emptyMeasureRestType}</type></note>`;
             const xmlMeasureNumber = xmlEscape(String((measureMeta === null || measureMeta === void 0 ? void 0 : measureMeta.number) || measureNo));
-            const implicitAttr = (measureMeta === null || measureMeta === void 0 ? void 0 : measureMeta.implicit) ? ' implicit="yes"' : "";
+            const implicitAttr = (measureMeta === null || measureMeta === void 0 ? void 0 : measureMeta.implicit) || inferredImplicitPickup ? ' implicit="yes"' : "";
             const leftBarlineChunks = [];
             if (measureMeta === null || measureMeta === void 0 ? void 0 : measureMeta.endingStart) {
                 leftBarlineChunks.push(`<ending number="${xmlEscape(String(measureMeta.endingStart))}" type="start"/>`);
@@ -25589,8 +25479,83 @@ exports.convertAbcToMusicXml = convertAbcToMusicXml;
   "src/ts/abc-parser.js": function (require, module, exports) {
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.parseAbcTupletAt = exports.parseAbcGraceGroupAt = exports.parseAbcChordAt = exports.parseAbcNoteAt = void 0;
+exports.parseAbcBodyEntryAt = exports.parseAbcPlayableEventAt = exports.parseAbcBodyTokenAt = exports.parseAbcBracketTokenAt = exports.parseAbcParenTokenAt = exports.parseAbcSlurStopAt = exports.parseAbcTieAt = exports.parseAbcSingleCharShorthandAt = exports.parseAbcBrokenRhythmAt = exports.parseAbcDecorationAt = exports.parseAbcQuotedStringAt = exports.parseAbcDelimitedSpanAt = exports.parseAbcUnsupportedBodyNumberAt = exports.parseAbcUnsupportedBodyTokenAt = exports.parseAbcStandaloneBodyFieldAt = exports.parseAbcBarlineTokenAt = exports.parseAbcInlineFieldAt = exports.parseAbcBareRepeatEndingMarkerAt = exports.parseAbcRepeatEndingMarkerAt = exports.parseAbcTupletAt = exports.parseAbcGraceGroupAt = exports.parseAbcChordAt = exports.parseAbcNoteAt = void 0;
 const abc_lexer_1 = require("./abc-lexer");
+// Shared parser utilities and static lookup tables.
+const toAbcParsedPitchSource = (note) => ({
+    accidentalText: note.accidentalText,
+    pitchChar: note.pitchChar,
+    octaveShift: note.octaveShift,
+});
+const firstMatch = (matchers) => {
+    for (const matcher of matchers) {
+        const matched = matcher();
+        if (matched) {
+            return matched;
+        }
+    }
+    return null;
+};
+const matchParsed = (parse, map) => {
+    const parsed = parse();
+    return parsed ? map(parsed) : null;
+};
+// Text access helpers.
+const rawText = (text) => String(text || "");
+const charAt = (text, idx) => rawText(text)[idx] || "";
+const sliceFrom = (text, startIdx) => rawText(text).slice(startIdx);
+const matchFrom = (text, startIdx, pattern) => sliceFrom(text, startIdx).match(pattern);
+// Wrapper builders for higher-level parser results.
+const withBracketToken = (kind, payload) => ({
+    kind,
+    ...payload,
+});
+const withBodyToken = (kind, payload) => ({
+    kind,
+    ...payload,
+});
+const withBodyEntry = (kind, payload) => ({
+    kind,
+    ...payload,
+});
+const withPlayableEvent = (source, pitchSources, rawLengthToken, nextIdx) => ({
+    kind: "playable",
+    pitchSources,
+    rawLengthToken,
+    nextIdx,
+    source,
+});
+const withInvalidChord = (nextIdx) => ({
+    kind: "invalid-chord",
+    nextIdx,
+});
+// Static lookup tables.
+const ABC_BARLINE_CANDIDATES = [
+    { token: ":|]", endsMeasure: true, repeatEnd: true, repeatStart: false, endingStop: true },
+    { token: ":|:", endsMeasure: true, repeatEnd: true, repeatStart: true, endingStop: false },
+    { token: "|:", endsMeasure: true, repeatEnd: false, repeatStart: true, endingStop: false },
+    { token: ":|", endsMeasure: true, repeatEnd: true, repeatStart: false, endingStop: false },
+    { token: "::", endsMeasure: true, repeatEnd: true, repeatStart: true, endingStop: false },
+    { token: "[|", endsMeasure: true, repeatEnd: false, repeatStart: false, endingStop: false },
+    { token: "|]", endsMeasure: true, repeatEnd: false, repeatStart: false, endingStop: false },
+    { token: "||", endsMeasure: true, repeatEnd: false, repeatStart: false, endingStop: false },
+    { token: "|", endsMeasure: true, repeatEnd: false, repeatStart: false, endingStop: false },
+    { token: ":", endsMeasure: false, repeatEnd: false, repeatStart: false, endingStop: false },
+];
+const ABC_SINGLE_CHAR_SHORTHAND_BY_CHAR = {
+    "~": "arpeggiate",
+    H: "fermata",
+    L: "accent",
+    M: "mordent",
+    O: "coda",
+    P: "inverted-mordent",
+    S: "segno",
+    T: "trill",
+    u: "upbow",
+    v: "downbow",
+    ".": "staccato",
+};
+// Low-level lexical and structural parsers.
 const parseAbcNoteAt = (text, startIdx) => {
     const note = (0, abc_lexer_1.lexAbcNote)(text, startIdx);
     if (note) {
@@ -25693,10 +25658,10 @@ const parseAbcGraceGroupAt = (text, startIdx, lineNo, warnings) => {
 };
 exports.parseAbcGraceGroupAt = parseAbcGraceGroupAt;
 const parseAbcTupletAt = (text, startIdx) => {
-    if (text[startIdx] !== "(") {
+    if (charAt(text, startIdx) !== "(") {
         return null;
     }
-    const match = text.slice(startIdx).match(/^\((\d)(?::(\d))?(?::(\d))?/);
+    const match = matchFrom(text, startIdx, /^\((\d)(?::(\d))?(?::(\d))?/);
     if (!match) {
         return null;
     }
@@ -25714,6 +25679,244 @@ const parseAbcTupletAt = (text, startIdx) => {
     };
 };
 exports.parseAbcTupletAt = parseAbcTupletAt;
+const parseAbcRepeatEndingMarkerAt = (text, startIdx) => {
+    const match = matchFrom(text, startIdx, /^\[(\d+(?:[,-]\d+)*)/);
+    if (!match) {
+        return null;
+    }
+    return {
+        marker: match[1],
+        nextIdx: startIdx + match[0].length,
+    };
+};
+exports.parseAbcRepeatEndingMarkerAt = parseAbcRepeatEndingMarkerAt;
+const parseAbcBareRepeatEndingMarkerAt = (text, startIdx) => {
+    const match = matchFrom(text, startIdx, /^(\d+(?:[,-]\d+)*)/);
+    if (!match) {
+        return null;
+    }
+    return {
+        marker: match[1],
+        nextIdx: startIdx + match[0].length,
+    };
+};
+exports.parseAbcBareRepeatEndingMarkerAt = parseAbcBareRepeatEndingMarkerAt;
+const parseAbcInlineFieldAt = (text, startIdx) => {
+    const match = matchFrom(text, startIdx, /^\[([A-Za-z]):([^\]]*)\]/);
+    if (!match) {
+        return null;
+    }
+    return {
+        fieldName: String(match[1] || "").toUpperCase(),
+        fieldValue: String(match[2] || "").trim(),
+        nextIdx: startIdx + match[0].length,
+    };
+};
+exports.parseAbcInlineFieldAt = parseAbcInlineFieldAt;
+const parseAbcBarlineTokenAt = (text, startIdx) => {
+    const slice = sliceFrom(text, startIdx);
+    for (const candidate of ABC_BARLINE_CANDIDATES) {
+        if (slice.startsWith(candidate.token)) {
+            return {
+                nextIdx: startIdx + candidate.token.length,
+                endsMeasure: candidate.endsMeasure,
+                repeatEnd: candidate.repeatEnd,
+                repeatStart: candidate.repeatStart,
+                endingStop: candidate.endingStop,
+            };
+        }
+    }
+    return null;
+};
+exports.parseAbcBarlineTokenAt = parseAbcBarlineTokenAt;
+const parseAbcStandaloneBodyFieldAt = (text, startIdx) => {
+    const match = matchFrom(text, startIdx, /^([A-Za-z]):([^\s\]|]+)/);
+    if (!match) {
+        return null;
+    }
+    return {
+        fieldName: String(match[1] || "").toUpperCase(),
+        fieldValue: String(match[2] || "").trim(),
+        token: match[0],
+        nextIdx: startIdx + match[0].length,
+    };
+};
+exports.parseAbcStandaloneBodyFieldAt = parseAbcStandaloneBodyFieldAt;
+const parseAbcUnsupportedBodyTokenAt = (text, startIdx) => {
+    const match = matchFrom(text, startIdx, /^([IJNQRWY][A-Za-z0-9_-]*|[h-jl-pr-twy][a-z][A-Za-z0-9_-]*)/);
+    if (!match) {
+        return null;
+    }
+    return {
+        token: match[1],
+        nextIdx: startIdx + match[1].length,
+    };
+};
+exports.parseAbcUnsupportedBodyTokenAt = parseAbcUnsupportedBodyTokenAt;
+const parseAbcUnsupportedBodyNumberAt = (text, startIdx) => {
+    const match = matchFrom(text, startIdx, /^(\d+)/);
+    if (!match) {
+        return null;
+    }
+    return {
+        token: match[1],
+        nextIdx: startIdx + match[1].length,
+    };
+};
+exports.parseAbcUnsupportedBodyNumberAt = parseAbcUnsupportedBodyNumberAt;
+const parseAbcDelimitedSpanAt = (text, startIdx, delimiter) => {
+    if (!delimiter || charAt(text, startIdx) !== delimiter) {
+        return null;
+    }
+    const raw = rawText(text);
+    let endIdx = startIdx + 1;
+    while (endIdx < raw.length && raw[endIdx] !== delimiter) {
+        endIdx += 1;
+    }
+    const nextIdx = Math.min(raw.length, endIdx + 1);
+    return {
+        delimiter,
+        text: raw.slice(startIdx, nextIdx),
+        nextIdx,
+    };
+};
+exports.parseAbcDelimitedSpanAt = parseAbcDelimitedSpanAt;
+const parseAbcQuotedStringAt = (text, startIdx) => {
+    const span = (0, exports.parseAbcDelimitedSpanAt)(text, startIdx, '"');
+    if (!span) {
+        return null;
+    }
+    const terminated = span.text.endsWith('"') && span.text.length >= 2;
+    const rawText = terminated ? span.text.slice(1, -1) : span.text.slice(1);
+    return {
+        rawText,
+        normalizedText: rawText.replace(/^[\^_<>@]/, "").trim(),
+        nextIdx: span.nextIdx,
+        terminated,
+    };
+};
+exports.parseAbcQuotedStringAt = parseAbcQuotedStringAt;
+const parseAbcDecorationAt = (text, startIdx) => {
+    const first = charAt(text, startIdx);
+    if (first !== "!" && first !== "+") {
+        return null;
+    }
+    const span = (0, exports.parseAbcDelimitedSpanAt)(text, startIdx, first);
+    if (!span) {
+        return null;
+    }
+    const terminated = span.text.endsWith(first) && span.text.length >= 2;
+    const rawDecoration = terminated ? span.text.slice(1, -1).trim() : span.text.slice(1).trim();
+    return {
+        rawDecoration,
+        decoration: rawDecoration.toLowerCase(),
+        delimiter: first,
+        nextIdx: span.nextIdx,
+        terminated,
+    };
+};
+exports.parseAbcDecorationAt = parseAbcDecorationAt;
+const parseAbcBrokenRhythmAt = (text, startIdx) => {
+    const symbol = charAt(text, startIdx);
+    if (symbol !== ">" && symbol !== "<") {
+        return null;
+    }
+    return {
+        symbol,
+        leftScale: symbol === ">" ? { num: 3, den: 2 } : { num: 1, den: 2 },
+        rightScale: symbol === ">" ? { num: 1, den: 2 } : { num: 3, den: 2 },
+        nextIdx: startIdx + 1,
+    };
+};
+exports.parseAbcBrokenRhythmAt = parseAbcBrokenRhythmAt;
+const parseAbcSingleCharShorthandAt = (text, startIdx) => {
+    const symbol = charAt(text, startIdx);
+    const kind = ABC_SINGLE_CHAR_SHORTHAND_BY_CHAR[symbol];
+    if (!kind) {
+        return null;
+    }
+    return {
+        kind,
+        nextIdx: startIdx + 1,
+    };
+};
+exports.parseAbcSingleCharShorthandAt = parseAbcSingleCharShorthandAt;
+const parseAbcTieAt = (text, startIdx) => {
+    if (charAt(text, startIdx) !== "-") {
+        return null;
+    }
+    return { nextIdx: startIdx + 1 };
+};
+exports.parseAbcTieAt = parseAbcTieAt;
+const parseAbcSlurStopAt = (text, startIdx) => {
+    if (charAt(text, startIdx) !== ")") {
+        return null;
+    }
+    return { nextIdx: startIdx + 1 };
+};
+exports.parseAbcSlurStopAt = parseAbcSlurStopAt;
+const parseAbcParenTokenAt = (text, startIdx) => {
+    if (charAt(text, startIdx) !== "(") {
+        return null;
+    }
+    return matchParsed(() => (0, exports.parseAbcTupletAt)(text, startIdx), (tuplet) => ({ kind: "tuplet", tuplet })) || {
+        kind: "slur-start",
+        nextIdx: startIdx + 1,
+    };
+};
+exports.parseAbcParenTokenAt = parseAbcParenTokenAt;
+const parseAbcBracketTokenAt = (text, startIdx) => {
+    if (charAt(text, startIdx) !== "[") {
+        return null;
+    }
+    return (matchParsed(() => (0, exports.parseAbcInlineFieldAt)(text, startIdx), (inlineField) => withBracketToken("inline-field", { inlineField })) ||
+        matchParsed(() => (0, exports.parseAbcRepeatEndingMarkerAt)(text, startIdx), (repeatEndingMarker) => withBracketToken("repeat-ending", { repeatEndingMarker })) ||
+        withBracketToken("chord-start", { nextIdx: startIdx + 1 }));
+};
+exports.parseAbcBracketTokenAt = parseAbcBracketTokenAt;
+// High-level body dispatchers.
+const parseAbcBodyTokenAt = (text, startIdx) => {
+    return firstMatch([
+        () => matchParsed(() => (0, exports.parseAbcBrokenRhythmAt)(text, startIdx), (brokenRhythm) => withBodyToken("broken-rhythm", { brokenRhythm })),
+        () => matchParsed(() => (0, exports.parseAbcParenTokenAt)(text, startIdx), (parenToken) => withBodyToken("paren", { parenToken })),
+        () => matchParsed(() => (0, exports.parseAbcSingleCharShorthandAt)(text, startIdx), (shorthand) => withBodyToken("single-char-shorthand", { shorthand })),
+        () => matchParsed(() => (0, exports.parseAbcTieAt)(text, startIdx), (tie) => withBodyToken("tie", { tie })),
+        () => matchParsed(() => (0, exports.parseAbcQuotedStringAt)(text, startIdx), (quotedString) => withBodyToken("quoted-string", { quotedString })),
+        () => matchParsed(() => (0, exports.parseAbcDecorationAt)(text, startIdx), (decoration) => withBodyToken("decoration", { decoration })),
+        () => matchParsed(() => (0, exports.parseAbcBracketTokenAt)(text, startIdx), (bracketToken) => withBodyToken("bracket", { bracketToken })),
+        () => matchParsed(() => (0, exports.parseAbcSlurStopAt)(text, startIdx), (slurStop) => withBodyToken("slur-stop", { slurStop })),
+    ]);
+};
+exports.parseAbcBodyTokenAt = parseAbcBodyTokenAt;
+const parseAbcPlayableEventAt = (text, startIdx) => {
+    if (charAt(text, startIdx) === "[") {
+        const chord = (0, exports.parseAbcChordAt)(text, startIdx);
+        if (!chord) {
+            return withInvalidChord(startIdx + 1);
+        }
+        return withPlayableEvent("chord", chord.notes.map(toAbcParsedPitchSource), chord.lengthToken || (chord.notes.length > 0 ? chord.notes[0].lengthToken : ""), chord.nextIdx);
+    }
+    const noteResult = (0, exports.parseAbcNoteAt)(text, startIdx);
+    if (!noteResult) {
+        return null;
+    }
+    if (noteResult.kind === "malformed-accidental") {
+        return noteResult;
+    }
+    return withPlayableEvent("note", [toAbcParsedPitchSource(noteResult.note)], noteResult.note.lengthToken, noteResult.note.nextIdx);
+};
+exports.parseAbcPlayableEventAt = parseAbcPlayableEventAt;
+const parseAbcBodyEntryAt = (text, startIdx) => {
+    return firstMatch([
+        () => matchParsed(() => (0, exports.parseAbcBarlineTokenAt)(text, startIdx), (barlineToken) => withBodyEntry("barline", { barlineToken })),
+        () => matchParsed(() => (0, exports.parseAbcStandaloneBodyFieldAt)(text, startIdx), (standaloneBodyField) => withBodyEntry("standalone-body-field", { standaloneBodyField })),
+        () => matchParsed(() => (0, exports.parseAbcUnsupportedBodyTokenAt)(text, startIdx), (unsupportedBodyToken) => withBodyEntry("unsupported-body-token", { unsupportedBodyToken })),
+        () => matchParsed(() => (0, exports.parseAbcUnsupportedBodyNumberAt)(text, startIdx), (unsupportedBodyNumber) => withBodyEntry("unsupported-body-number", { unsupportedBodyNumber })),
+        () => matchParsed(() => (0, exports.parseAbcBodyTokenAt)(text, startIdx), (bodyToken) => withBodyEntry("body-token", { bodyToken })),
+        () => matchParsed(() => (0, exports.parseAbcPlayableEventAt)(text, startIdx), (playableEvent) => withBodyEntry("playable-event", { playableEvent })),
+    ]);
+};
+exports.parseAbcBodyEntryAt = parseAbcBodyEntryAt;
 
   },
   "src/ts/abc-lexer.js": function (require, module, exports) {

--- a/src/ts/abc-io.ts
+++ b/src/ts/abc-io.ts
@@ -1,6 +1,16 @@
 // @ts-nocheck
 import { computeBeamAssignments } from "./beam-common";
-import { parseAbcChordAt, parseAbcGraceGroupAt, parseAbcNoteAt, parseAbcTupletAt } from "./abc-parser";
+import {
+  parseAbcBodyEntryAt,
+  parseAbcBracketTokenAt,
+  parseAbcBrokenRhythmAt,
+  parseAbcDelimitedSpanAt,
+  parseAbcBareRepeatEndingMarkerAt,
+  parseAbcBarlineTokenAt,
+  parseAbcGraceGroupAt,
+  parseAbcPlayableEventAt,
+  parseAbcSingleCharShorthandAt,
+} from "./abc-parser";
 import { chooseSingleClefByKeys } from "../../core/staffClefPolicy";
 
 export type Fraction = { num: number; den: number };
@@ -49,6 +59,33 @@ const parseFractionText = (text: string, fallback: Fraction = DEFAULT_UNIT): Fra
     return { num: fallback.num, den: fallback.den };
   }
   return reduceFraction(num, den, fallback);
+};
+
+const isAbcjsWrapperLine = (text: string): boolean =>
+  /^\[\s*\/?\s*abcjs(?:-[A-Za-z0-9_-]+)?(?:\s+[^\]]*)?\]$/i.test(String(text || "").trim());
+
+const estimateAbcMeasureContentDiv = (notes: any[]): number => {
+  const byVoice = new Map<string, number>();
+  const lastStartByVoice = new Map<string, number>();
+  for (const note of Array.isArray(notes) ? notes : []) {
+    if (!note || note.grace) continue;
+    const voice = String(note.voice || "1");
+    const durationDiv = Math.max(0, Math.round(Number(note.duration) || 0));
+    if (durationDiv <= 0) continue;
+    const current = byVoice.get(voice) ?? 0;
+    if (note.chord) {
+      const startDiv = lastStartByVoice.get(voice) ?? current;
+      byVoice.set(voice, Math.max(current, startDiv + durationDiv));
+      continue;
+    }
+    lastStartByVoice.set(voice, current);
+    byVoice.set(voice, current + durationDiv);
+  }
+  let maxDiv = 0;
+  for (const value of byVoice.values()) {
+    maxDiv = Math.max(maxDiv, value);
+  }
+  return maxDiv;
 };
 
 const parseAbcLengthToken = (token: string, lineNo: number): Fraction => {
@@ -184,39 +221,47 @@ if (typeof window !== "undefined") {
 
 const abcCommon = AbcCommon;
 
-  function parseRepeatEndingMarkerAt(text, idx) {
-    const match = String(text || "").slice(idx).match(/^\[(\d+(?:[,-]\d+)*)/);
-    if (!match) {
-      return null;
-    }
-    return {
-      marker: match[1],
-      nextIdx: idx + match[0].length,
-    };
-  }
-
-  function parseBareRepeatEndingMarkerAt(text, idx) {
-    const match = String(text || "").slice(idx).match(/^(\d+(?:[,-]\d+)*)/);
-    if (!match) {
-      return null;
-    }
-    return {
-      marker: match[1],
-      nextIdx: idx + match[0].length,
-    };
-  }
-
-  function parseInlineFieldAt(text, idx) {
-    const match = String(text || "").slice(idx).match(/^\[([A-Za-z]):([^\]]*)\]/);
-    if (!match) {
-      return null;
-    }
-    return {
-      fieldName: String(match[1] || "").toUpperCase(),
-      fieldValue: String(match[2] || "").trim(),
-      nextIdx: idx + match[0].length,
-    };
-  }
+const TRILL_DECORATIONS = new Set(["trill", "tr", "triller"]);
+const TURN_DECORATIONS = new Set(["turn"]);
+const TURN_SLASH_DECORATIONS = new Set(["turnx"]);
+const INVERTED_TURN_DECORATIONS = new Set(["invertedturn", "inverted-turn", "lowerturn"]);
+const INVERTED_TURN_SLASH_DECORATIONS = new Set(["invertedturnx", "inverted-turnx"]);
+const LOWER_MORDENT_DECORATIONS = new Set(["mordent", "lowermordent"]);
+const UPPER_MORDENT_DECORATIONS = new Set([
+  "pralltriller",
+  "pralltrill",
+  "prall",
+  "uppermordent",
+  "invertedmordent",
+  "inverted-mordent",
+]);
+const GLISS_START_DECORATIONS = new Set(["gliss-start", "glissando-start"]);
+const GLISS_STOP_DECORATIONS = new Set(["gliss-stop", "glissando-stop"]);
+const SLIDE_START_DECORATIONS = new Set(["slide", "slide-start"]);
+const ARPEGGIATE_DECORATIONS = new Set(["roll", "arpeggio", "arpeggiate"]);
+const STACCATO_DECORATIONS = new Set(["staccato", "stacc", "stac"]);
+const STACCATISSIMO_DECORATIONS = new Set(["staccatissimo", "wedge", "spiccato"]);
+const ACCENT_DECORATIONS = new Set(["accent", ">", "emphasis"]);
+const INVERTED_FERMATA_DECORATIONS = new Set(["invertedfermata", "inverted-fermata", "inverted fermata"]);
+const STRONG_ACCENT_DECORATIONS = new Set(["marcato", "strongaccent", "strong-accent", "strong accent"]);
+const BREATH_DECORATIONS = new Set(["breath", "breath-mark", "breathmark", "breath mark"]);
+const PHRASE_DECORATIONS = new Set(["shortphrase", "mediumphrase", "longphrase"]);
+const DACAPO_DECORATIONS = new Set(["dacapo", "da-capo", "da capo", "d.c."]);
+const DALSEGNO_DECORATIONS = new Set(["dalsegno", "dal-segno", "dal segno", "d.s."]);
+const TOCODA_DECORATIONS = new Set(["tocoda", "to-coda", "to coda"]);
+const CRESC_START_DECORATIONS = new Set(["crescendo(", "cresc(", "<("]);
+const CRESC_STOP_DECORATIONS = new Set(["crescendo)", "cresc)", "<)"]);
+const DIM_START_DECORATIONS = new Set(["diminuendo(", "decrescendo(", "dim(", "decresc(", ">("]);
+const DIM_STOP_DECORATIONS = new Set(["diminuendo)", "decrescendo)", "dim)", "decresc)", ">)"]);
+const DYNAMIC_DECORATIONS = new Set(["pppp", "ppp", "p", "pp", "mp", "mf", "f", "ff", "fff", "ffff", "fp", "fz", "rfz", "sf", "sfp"]);
+const UPBOW_DECORATIONS = new Set(["upbow", "up-bow", "up bow"]);
+const DOWNBOW_DECORATIONS = new Set(["downbow", "down-bow", "down bow"]);
+const DOUBLE_TONGUE_DECORATIONS = new Set(["doubletongue", "double-tongue", "double tongue"]);
+const TRIPLE_TONGUE_DECORATIONS = new Set(["tripletongue", "triple-tongue", "triple tongue"]);
+const OPEN_STRING_DECORATIONS = new Set(["open", "open-string", "openstring", "open string"]);
+const SNAP_PIZZICATO_DECORATIONS = new Set(["snap", "snap-pizzicato", "snappizzicato", "snap pizzicato"]);
+const STOPPED_DECORATIONS = new Set(["stopped", "+", "plus", "stopped horn", "stopped-horn"]);
+const THUMB_POSITION_DECORATIONS = new Set(["thumb", "thumbposition", "thumb-position", "thumbpos", "thumb pos", "thumb position"]);
 
   function tokenizeAbcLyricLine(text) {
     const raw = String(text || "").trim();
@@ -277,8 +322,9 @@ const abcCommon = AbcCommon;
     let idx = 0;
     while (idx < raw.length) {
       if (raw[idx] === "[") {
-        const inlineField = parseInlineFieldAt(raw, idx);
-        if (inlineField && inlineField.fieldName === "V") {
+        const bracketToken = parseAbcBracketTokenAt(raw, idx);
+        if (bracketToken.kind === "inline-field" && bracketToken.inlineField.fieldName === "V") {
+          const { inlineField } = bracketToken;
           if (buffer.trim()) {
             segments.push({ voiceId: activeVoiceId, text: buffer });
           }
@@ -320,30 +366,30 @@ const abcCommon = AbcCommon;
       const ch = raw[idx];
 
       if (ch === '"') {
-        let endIdx = idx + 1;
-        while (endIdx < raw.length && raw[endIdx] !== '"') {
-          endIdx += 1;
+        const token = parseAbcDelimitedSpanAt(raw, idx, '"');
+        if (!token) {
+          idx += 1;
+          continue;
         }
-        const token = raw.slice(idx, Math.min(raw.length, endIdx + 1));
         ensureOverlayBuffer(activeOverlayIndex);
-        overlayBuffers[activeOverlayIndex] += token;
-        idx = Math.min(raw.length, endIdx + 1);
+        overlayBuffers[activeOverlayIndex] += token.text;
+        idx = token.nextIdx;
         continue;
       }
 
       if (ch === "!" || ch === "+") {
-        let endIdx = idx + 1;
-        while (endIdx < raw.length && raw[endIdx] !== ch) {
-          endIdx += 1;
+        const token = parseAbcDelimitedSpanAt(raw, idx, ch);
+        if (!token) {
+          idx += 1;
+          continue;
         }
-        const token = raw.slice(idx, Math.min(raw.length, endIdx + 1));
         ensureOverlayBuffer(activeOverlayIndex);
-        overlayBuffers[activeOverlayIndex] += token;
-        idx = Math.min(raw.length, endIdx + 1);
+        overlayBuffers[activeOverlayIndex] += token.text;
+        idx = token.nextIdx;
         continue;
       }
 
-      const barlineToken = parseBarlineTokenAt(raw, idx);
+      const barlineToken = parseAbcBarlineTokenAt(raw, idx);
       if (barlineToken) {
         const tokenText = raw.slice(idx, barlineToken.nextIdx);
         if (barlineToken.endsMeasure) {
@@ -406,12 +452,14 @@ const abcCommon = AbcCommon;
     while (idx < raw.length) {
       const ch = raw[idx];
       if (ch === '"' || ch === "!" || ch === "+") {
-        let endIdx = idx + 1;
-        while (endIdx < raw.length && raw[endIdx] !== ch) {
-          endIdx += 1;
+        const token = parseAbcDelimitedSpanAt(raw, idx, ch);
+        if (!token) {
+          out += ch;
+          idx += 1;
+          continue;
         }
-        out += raw.slice(idx, Math.min(raw.length, endIdx + 1));
-        idx = Math.min(raw.length, endIdx + 1);
+        out += token.text;
+        idx = token.nextIdx;
         continue;
       }
       if (Object.prototype.hasOwnProperty.call(symbolMap, ch)) {
@@ -423,34 +471,6 @@ const abcCommon = AbcCommon;
       idx += 1;
     }
     return out;
-  }
-
-  function parseBarlineTokenAt(text, idx) {
-    const slice = String(text || "").slice(idx);
-    const candidates = [
-      { token: ":|]", endsMeasure: true, repeatEnd: true, repeatStart: false, endingStop: true },
-      { token: ":|:", endsMeasure: true, repeatEnd: true, repeatStart: true, endingStop: false },
-      { token: "|:", endsMeasure: true, repeatEnd: false, repeatStart: true, endingStop: false },
-      { token: ":|", endsMeasure: true, repeatEnd: true, repeatStart: false, endingStop: false },
-      { token: "::", endsMeasure: true, repeatEnd: true, repeatStart: true, endingStop: false },
-      { token: "[|", endsMeasure: true, repeatEnd: false, repeatStart: false, endingStop: false },
-      { token: "|]", endsMeasure: true, repeatEnd: false, repeatStart: false, endingStop: false },
-      { token: "||", endsMeasure: true, repeatEnd: false, repeatStart: false, endingStop: false },
-      { token: "|", endsMeasure: true, repeatEnd: false, repeatStart: false, endingStop: false },
-      { token: ":", endsMeasure: false, repeatEnd: false, repeatStart: false, endingStop: false },
-    ];
-    for (const candidate of candidates) {
-      if (slice.startsWith(candidate.token)) {
-        return {
-          nextIdx: idx + candidate.token.length,
-          endsMeasure: candidate.endsMeasure,
-          repeatEnd: candidate.repeatEnd,
-          repeatStart: candidate.repeatStart,
-          endingStop: candidate.endingStop,
-        };
-      }
-    }
-    return null;
   }
 
   function parseTempoFromQ(rawQ, warnings) {
@@ -546,6 +566,11 @@ const abcCommon = AbcCommon;
       const raw = lines[i];
       const rawTrimmed = raw.trim();
       if (!rawTrimmed) {
+        pendingUnsupportedContinuedFieldName = "";
+        continue;
+      }
+      if (isAbcjsWrapperLine(rawTrimmed)) {
+        warnings.push("line " + lineNo + ": Skipped unsupported abcjs wrapper line: " + rawTrimmed);
         pendingUnsupportedContinuedFieldName = "";
         continue;
       }
@@ -911,1056 +936,307 @@ const abcCommon = AbcCommon;
       let idx = 0;
       const text = entry.text;
 
-      const isBeamableAbcNote = (note) =>
-        Boolean(
-          note &&
-          !note.isRest &&
-          !note.grace &&
-          ["eighth", "16th", "32nd", "64th"].includes(String(note.type || "").trim().toLowerCase())
-        );
-      const applyBeamModeForEvent = (note, durationDiv) => {
-        const resolvedDurationDiv = Math.max(0, Math.round(Number(durationDiv) || 0));
-        const beatDiv = Math.max(1, Math.round((960 * 4) / Math.max(1, Math.round(Number(activeMeter?.beatType) || 4))));
-        const startsAtBeatBoundary = beamCursorDiv > 0 && beamCursorDiv % beatDiv === 0;
-        if (startsAtBeatBoundary) {
-          beamRunActive = false;
-        }
-        if (isBeamableAbcNote(note)) {
-          note.beamMode = !beamRunActive || sawInterEventWhitespace ? "begin" : "mid";
-          beamRunActive = true;
-        } else {
-          beamRunActive = false;
-        }
-        sawInterEventWhitespace = false;
-        beamCursorDiv += resolvedDurationDiv;
+      const warnBody = (message) => {
+        warnings.push("line " + entry.lineNo + ": " + message);
       };
 
-      while (idx < text.length) {
-        const ch = text[idx];
-
-        if (ch === " " || ch === "\t") {
-          sawInterEventWhitespace = true;
-          idx += 1;
-          continue;
+      // Field and decoration application.
+      const applyBodyField = (fieldName, fieldValue) => {
+        if (fieldName === "K") {
+          const inlineKeyInfo = parseKey(fieldValue || "C", warnings);
+          activeKeyFifths = inlineKeyInfo.fifths;
+          activeKeySignatureAccidentals = keySignatureAlterByStep(activeKeyFifths);
+          currentKeyFifthsByVoice[entry.voiceId] = activeKeyFifths;
+          keyHintFifthsByKey.set(`${entry.voiceId}#${currentMeasureNo}`, activeKeyFifths);
+          measureAccidentals = {};
+          return true;
         }
-
-        if (ch === "\\") {
-          warnings.push("line " + entry.lineNo + ": Skipped stray body continuation marker: \\");
-          idx += 1;
-          continue;
+        if (fieldName === "L") {
+          activeUnitLength = parseFraction(fieldValue || "1/8", "L", warnings);
+          return true;
         }
-
-        if (ch === "," || ch === "'") {
-          // Lenient compatibility: some real-world sources include standalone octave marks.
-          // They are non-standard in strict ABC, but skipping them improves interoperability.
-          idx += 1;
-          continue;
+        if (fieldName === "M") {
+          activeMeter = parseMeter(fieldValue || "4/4", warnings);
+          ensureMeterByMeasure(entry.voiceId)[currentMeasureNo] = {
+            beats: activeMeter.beats,
+            beatType: activeMeter.beatType,
+          };
+          return true;
         }
-
-        if (ch === "|" || ch === ":") {
-          const barlineToken = parseBarlineTokenAt(text, idx);
-          if (!barlineToken) {
-            idx += 1;
-            continue;
+        if (fieldName === "Q") {
+          activeTempoBpm = parseTempoFromQ(fieldValue || "", warnings);
+          if (Number.isFinite(activeTempoBpm)) {
+            ensureTempoByMeasure(entry.voiceId)[currentMeasureNo] = Math.max(20, Math.min(300, Math.round(Number(activeTempoBpm))));
           }
-          const bareRepeatEndingMarker =
-            barlineToken.endsMeasure ? parseBareRepeatEndingMarkerAt(text, barlineToken.nextIdx) : null;
-          if (barlineToken.repeatEnd) {
-            ensureNotationMeasureMeta(entry.voiceId, currentMeasureNo).repeatEnd = true;
+          return true;
+        }
+        return false;
+      };
+
+      const applyPrefixedDecoration = (rawDecoration, decoration) => {
+        if (decoration.startsWith("rehearsal:")) {
+          const rehearsalText = rawDecoration.slice("rehearsal:".length).trim();
+          if (rehearsalText) {
+            pendingRehearsalMark = rehearsalText;
           }
-          if ((barlineToken.endingStop || bareRepeatEndingMarker) && activeEndingMarker) {
-            const measureMeta = ensureNotationMeasureMeta(entry.voiceId, currentMeasureNo);
-            measureMeta.endingStop = activeEndingMarker;
-            measureMeta.endingStopType = "stop";
-            activeEndingMarker = "";
+          return true;
+        }
+        if (decoration.startsWith("fingering:")) {
+          const fingeringText = rawDecoration.slice("fingering:".length).trim();
+          if (fingeringText) {
+            pendingFingerings.push(fingeringText);
           }
-          if (barlineToken.endsMeasure && (currentMeasure.length > 0 || measures.length === 0)) {
-            currentMeasure = [];
-            measures.push(currentMeasure);
-            currentMeasureNo = Math.max(1, measures.length);
-            currentEventNo = 0;
-            beamCursorDiv = 0;
+          return true;
+        }
+        if (decoration.startsWith("string:")) {
+          const stringText = rawDecoration.slice("string:".length).trim();
+          if (stringText) {
+            pendingStrings.push(stringText);
           }
-          if (barlineToken.endsMeasure) {
-            measureAccidentals = {};
-            lastNote = null;
+          return true;
+        }
+        if (decoration.startsWith("pluck:")) {
+          const pluckText = rawDecoration.slice("pluck:".length).trim();
+          if (pluckText) {
+            pendingPlucks.push(pluckText);
           }
-          if (barlineToken.repeatStart) {
-            ensureNotationMeasureMeta(entry.voiceId, currentMeasureNo).repeatStart = true;
-          }
-          if (bareRepeatEndingMarker) {
-            const measureMeta = ensureNotationMeasureMeta(entry.voiceId, currentMeasureNo);
-            measureMeta.endingStart = bareRepeatEndingMarker.marker;
-            activeEndingMarker = bareRepeatEndingMarker.marker;
-            idx = bareRepeatEndingMarker.nextIdx;
-          } else {
-            idx = barlineToken.nextIdx;
-          }
-          beamRunActive = false;
-          sawInterEventWhitespace = false;
-          continue;
+          return true;
         }
+        return false;
+      };
 
-        const standaloneBodyFieldMatch = text.slice(idx).match(/^([A-Za-z]):([^\s\]|]+)/);
-        if (standaloneBodyFieldMatch) {
-          const standaloneFieldName = String(standaloneBodyFieldMatch[1] || "").toUpperCase();
-          const standaloneFieldValue = String(standaloneBodyFieldMatch[2] || "").trim();
-          const standaloneFieldToken = standaloneBodyFieldMatch[0];
-          if (standaloneFieldName === "K") {
-            const inlineKeyInfo = parseKey(standaloneFieldValue || "C", warnings);
-            activeKeyFifths = inlineKeyInfo.fifths;
-            activeKeySignatureAccidentals = keySignatureAlterByStep(activeKeyFifths);
-            currentKeyFifthsByVoice[entry.voiceId] = activeKeyFifths;
-            keyHintFifthsByKey.set(`${entry.voiceId}#${currentMeasureNo}`, activeKeyFifths);
-            measureAccidentals = {};
-          } else if (standaloneFieldName === "L") {
-            activeUnitLength = parseFraction(standaloneFieldValue || "1/8", "L", warnings);
-          } else if (standaloneFieldName === "M") {
-            activeMeter = parseMeter(standaloneFieldValue || "4/4", warnings);
-            ensureMeterByMeasure(entry.voiceId)[currentMeasureNo] = {
-              beats: activeMeter.beats,
-              beatType: activeMeter.beatType,
-            };
-          } else if (standaloneFieldName === "Q") {
-            activeTempoBpm = parseTempoFromQ(standaloneFieldValue || "", warnings);
-            if (Number.isFinite(activeTempoBpm)) {
-              ensureTempoByMeasure(entry.voiceId)[currentMeasureNo] = Math.max(20, Math.min(300, Math.round(Number(activeTempoBpm))));
-            }
-          } else {
-            warnings.push(
-              "line " + entry.lineNo + ": Skipped unsupported standalone body field token: " + standaloneFieldToken
-            );
-          }
-          idx += standaloneFieldToken.length;
-          continue;
+      const applyTurnDecoration = (decoration) => {
+        if (decoration === "delayedturn" || decoration === "delayed-turn") {
+          pendingTurn = pendingTurn || "turn";
+          pendingDelayedTurn = true;
+          return true;
         }
-
-        const unsupportedBodyWordMatch = text
-          .slice(idx)
-          .match(/^([IJNQRWY][A-Za-z0-9_-]*|[h-jl-pr-twy][a-z][A-Za-z0-9_-]*)/);
-        if (unsupportedBodyWordMatch) {
-          warnings.push(
-            "line " + entry.lineNo + ": Skipped unsupported body token: " + unsupportedBodyWordMatch[1]
-          );
-          idx += unsupportedBodyWordMatch[1].length;
-          continue;
+        if (decoration === "delayedinvertedturn" || decoration === "delayed-inverted-turn") {
+          pendingTurn = "inverted-turn";
+          pendingDelayedTurn = true;
+          return true;
         }
-
-        const unsupportedBodyNumberMatch = text.slice(idx).match(/^(\d+)/);
-        if (unsupportedBodyNumberMatch) {
-          warnings.push(
-            "line " + entry.lineNo + ": Skipped unsupported body number token: " + unsupportedBodyNumberMatch[1]
-          );
-          idx += unsupportedBodyNumberMatch[1].length;
-          continue;
+        const turnDecorationAppliers = [
+          [TURN_DECORATIONS, "turn", false],
+          [TURN_SLASH_DECORATIONS, "turn", true],
+          [INVERTED_TURN_DECORATIONS, "inverted-turn", false],
+          [INVERTED_TURN_SLASH_DECORATIONS, "inverted-turn", true],
+        ];
+        const matchedTurn = turnDecorationAppliers.find(([decorationSet]) => decorationSet.has(decoration));
+        if (!matchedTurn) {
+          return false;
         }
+        pendingTurn = matchedTurn[1];
+        pendingTurnSlash = matchedTurn[2];
+        return true;
+      };
 
-        if (ch === ">" || ch === "<") {
-          if (!lastEventNotes || lastEventNotes.length === 0 || lastEventNotes.some((n) => n.isRest)) {
-            warnings.push("line " + entry.lineNo + ": broken rhythm(" + ch + ")  has no preceding note; skipped.");
-            idx += 1;
-            continue;
-          }
-          const lastScale = ch === ">" ? { num: 3, den: 2 } : { num: 1, den: 2 };
-          pendingRhythmScale = ch === ">" ? { num: 1, den: 2 } : { num: 3, den: 2 };
-          scaleNotesDuration(lastEventNotes, lastScale);
-          idx += 1;
-          continue;
+      const applyTremoloDecoration = (decoration) => {
+        const matched = decoration.match(/^tremolo-(single|start|stop)-([1-9]\d*)$/);
+        if (!matched) {
+          return false;
         }
+        pendingTremolo = {
+          type: matched[1] as "single" | "start" | "stop",
+          marks: Math.max(1, Math.min(8, Number.parseInt(matched[2], 10) || 1))
+        };
+        return true;
+      };
 
-        if (ch === "(") {
-          const tuplet = parseAbcTupletAt(text, idx);
-          if (tuplet) {
-            if (tuplet.actual > 0 && tuplet.normal > 0 && tuplet.count > 0) {
-              tupletScale = { num: tuplet.normal, den: tuplet.actual };
-              tupletRemaining = tuplet.count;
-              tupletSpec = { actual: tuplet.actual, normal: tuplet.normal, remaining: tuplet.count };
-            } else {
-              warnings.push("line " + entry.lineNo + ": Failed to parse tuplet notation: " + tuplet.raw);
-            }
-            idx = tuplet.nextIdx;
-            continue;
-          }
-          pendingSlurStart += 1;
-          idx += 1;
-          continue;
-        }
-
-        if (ch === "~") {
-          pendingArpeggiate = true;
-          idx += 1;
-          continue;
-        }
-
-        if (ch === "H") {
-          pendingFermata = "normal";
-          idx += 1;
-          continue;
-        }
-
-        if (ch === "L") {
-          pendingAccent = true;
-          idx += 1;
-          continue;
-        }
-
-        if (ch === "M") {
-          pendingMordent = "mordent";
-          idx += 1;
-          continue;
-        }
-
-        if (ch === "O") {
-          pendingCoda = true;
-          idx += 1;
-          continue;
-        }
-
-        if (ch === "P") {
-          pendingMordent = "inverted-mordent";
-          idx += 1;
-          continue;
-        }
-
-        if (ch === "S") {
-          pendingSegno = true;
-          idx += 1;
-          continue;
-        }
-
-        if (ch === "T") {
-          pendingTrill = true;
-          idx += 1;
-          continue;
-        }
-
-        if (ch === "u") {
-          pendingUpBow = true;
-          idx += 1;
-          continue;
-        }
-
-        if (ch === "v") {
-          pendingDownBow = true;
-          idx += 1;
-          continue;
-        }
-
-        if (ch === "-") {
-          if (lastEventNotes && lastEventNotes.length > 0 && lastEventNotes.some((n) => !n.isRest)) {
-            for (const eventNote of lastEventNotes) {
-              if (!eventNote.isRest) {
-                eventNote.tieStart = true;
-              }
-            }
-            pendingTieToNext = true;
-          } else {
-            warnings.push("line " + entry.lineNo + ": tie(-)  has no preceding note; skipped.");
-          }
-          idx += 1;
-          continue;
-        }
-
-        if (ch === "\"") {
-          const endQuote = text.indexOf("\"", idx + 1);
-          if (endQuote >= 0) {
-            const rawAnnotation = text.slice(idx + 1, endQuote);
-            const normalizedAnnotation = rawAnnotation.replace(/^[\^_<>@]/, "").trim();
-            if (normalizedAnnotation) {
-              if (isLikelyAbcChordSymbol(normalizedAnnotation)) {
-                pendingChordSymbols.push(normalizedAnnotation);
-              } else {
-                pendingAnnotations.push(normalizedAnnotation);
-              }
-            }
-            idx = endQuote + 1;
-          } else {
-            idx = text.length;
-            warnings.push("line " + entry.lineNo + ': Unterminated inline string ("...").');
-          }
-          continue;
-        }
-
-        if (ch === "!" || ch === "+") {
-          const endMark = text.indexOf(ch, idx + 1);
-          if (endMark < 0) {
-            idx += 1;
-            warnings.push("line " + entry.lineNo + ": Unterminated decoration marker: " + ch);
-            continue;
-          }
-          const rawDecoration = text.slice(idx + 1, endMark).trim();
-          const decoration = rawDecoration.toLowerCase();
-          if (decoration === "trill" || decoration === "tr" || decoration === "triller") {
-            pendingTrill = true;
-          } else if (decoration === "editorial") {
-            pendingEditorialAccidental = true;
-          } else if (decoration === "courtesy") {
+      const applyDecoration = (rawDecoration, decoration) => {
+        const exactDecorationAppliers = {
+          "caesura": () => {
+            pendingCaesura = true;
+          },
+          "coda": () => {
+            pendingCoda = true;
+          },
+          "courtesy": () => {
             pendingCourtesyAccidental = true;
-          } else if (decoration === "trill(") {
+          },
+          "editorial": () => {
+            pendingEditorialAccidental = true;
+          },
+          "fermata": () => {
+            pendingFermata = "normal";
+          },
+          "fine": () => {
+            pendingFine = true;
+          },
+          "harmonic": () => {
+            pendingHarmonic = true;
+          },
+          "heel": () => {
+            pendingHeel = true;
+          },
+          "heel mark": () => {
+            pendingHeel = true;
+          },
+          "schleifer": () => {
+            pendingSchleifer = true;
+          },
+          "segno": () => {
+            pendingSegno = true;
+          },
+          "sfz": () => {
+            pendingSfz = true;
+          },
+          "shake": () => {
+            pendingShake = true;
+          },
+          "slide-stop": () => {
+            pendingSlideStop = true;
+          },
+          "stress": () => {
+            pendingStress = true;
+          },
+          "tenuto": () => {
+            pendingTenuto = true;
+          },
+          "toe": () => {
+            pendingToe = true;
+          },
+          "toe mark": () => {
+            pendingToe = true;
+          },
+          "trill(": () => {
             pendingTrill = true;
             pendingTrillLineStart = true;
-          } else if (decoration === "trill)") {
+          },
+          "trill)": () => {
             pendingTrillLineStop = true;
-          } else if (decoration.startsWith("rehearsal:")) {
-            const rehearsalText = rawDecoration.slice("rehearsal:".length).trim();
-            if (rehearsalText) {
-              pendingRehearsalMark = rehearsalText;
-            }
-          } else if (decoration === "delayedturn" || decoration === "delayed-turn") {
-            pendingTurn = pendingTurn || "turn";
-            pendingDelayedTurn = true;
-          } else if (decoration === "delayedinvertedturn" || decoration === "delayed-inverted-turn") {
-            pendingTurn = "inverted-turn";
-            pendingDelayedTurn = true;
-          } else if (decoration === "turn") {
-            pendingTurn = "turn";
-            pendingTurnSlash = false;
-          } else if (decoration === "turnx") {
-            pendingTurn = "turn";
-            pendingTurnSlash = true;
-          } else if (decoration === "invertedturn" || decoration === "inverted-turn" || decoration === "lowerturn") {
-            pendingTurn = "inverted-turn";
-            pendingTurnSlash = false;
-          } else if (decoration === "invertedturnx" || decoration === "inverted-turnx") {
-            pendingTurn = "inverted-turn";
-            pendingTurnSlash = true;
-          } else if (decoration === "mordent" || decoration === "lowermordent") {
-            pendingMordent = "mordent";
-          } else if (
-            decoration === "pralltriller" ||
-            decoration === "pralltrill" ||
-            decoration === "prall" ||
-            decoration === "uppermordent" ||
-            decoration === "invertedmordent" ||
-            decoration === "inverted-mordent"
-          ) {
-            pendingMordent = "inverted-mordent";
-          } else if (/^tremolo-(single|start|stop)-([1-9]\d*)$/.test(decoration)) {
-            const m = decoration.match(/^tremolo-(single|start|stop)-([1-9]\d*)$/);
-            if (m) {
-              pendingTremolo = {
-                type: m[1] as "single" | "start" | "stop",
-                marks: Math.max(1, Math.min(8, Number.parseInt(m[2], 10) || 1))
-              };
-            }
-          } else if (decoration === "gliss-start" || decoration === "glissando-start") {
-            pendingGlissandoStart = true;
-          } else if (decoration === "gliss-stop" || decoration === "glissando-stop") {
-            pendingGlissandoStop = true;
-          } else if (decoration === "slide" || decoration === "slide-start") {
-            pendingSlideStart = true;
-          } else if (decoration === "slide-stop") {
-            pendingSlideStop = true;
-          } else if (decoration === "schleifer") {
-            pendingSchleifer = true;
-          } else if (decoration === "shake") {
-            pendingShake = true;
-          } else if (decoration === "roll" || decoration === "arpeggio" || decoration === "arpeggiate") {
-            pendingArpeggiate = true;
-          } else if (
-            decoration === "staccato" ||
-            decoration === "stacc" ||
-            decoration === "stac"
-          ) {
-            pendingStaccato = true;
-          } else if (decoration === "staccatissimo" || decoration === "wedge" || decoration === "spiccato") {
-            pendingStaccatissimo = true;
-          } else if (decoration === "accent" || decoration === ">" || decoration === "emphasis") {
-            pendingAccent = true;
-          } else if (decoration === "tenuto") {
-            pendingTenuto = true;
-          } else if (decoration === "stress") {
-            pendingStress = true;
-          } else if (decoration === "unstress") {
+          },
+          "unstress": () => {
             pendingUnstress = true;
-          } else if (decoration === "fermata") {
-            pendingFermata = "normal";
-          } else if (
-            decoration === "invertedfermata" ||
-            decoration === "inverted-fermata" ||
-            decoration === "inverted fermata"
-          ) {
+          },
+        };
+        const applyExactDecoration = exactDecorationAppliers[decoration];
+        if (applyExactDecoration) {
+          applyExactDecoration();
+          return true;
+        }
+        const setDecorationAppliers = [
+          [TRILL_DECORATIONS, () => {
+            pendingTrill = true;
+          }],
+          [LOWER_MORDENT_DECORATIONS, () => {
+            pendingMordent = "mordent";
+          }],
+          [UPPER_MORDENT_DECORATIONS, () => {
+            pendingMordent = "inverted-mordent";
+          }],
+          [GLISS_START_DECORATIONS, () => {
+            pendingGlissandoStart = true;
+          }],
+          [GLISS_STOP_DECORATIONS, () => {
+            pendingGlissandoStop = true;
+          }],
+          [SLIDE_START_DECORATIONS, () => {
+            pendingSlideStart = true;
+          }],
+          [ARPEGGIATE_DECORATIONS, () => {
+            pendingArpeggiate = true;
+          }],
+          [STACCATO_DECORATIONS, () => {
+            pendingStaccato = true;
+          }],
+          [STACCATISSIMO_DECORATIONS, () => {
+            pendingStaccatissimo = true;
+          }],
+          [ACCENT_DECORATIONS, () => {
+            pendingAccent = true;
+          }],
+          [INVERTED_FERMATA_DECORATIONS, () => {
             pendingFermata = "inverted";
-          } else if (
-            decoration === "marcato" ||
-            decoration === "strongaccent" ||
-            decoration === "strong-accent" ||
-            decoration === "strong accent"
-          ) {
+          }],
+          [STRONG_ACCENT_DECORATIONS, () => {
             pendingStrongAccent = true;
-          } else if (
-            decoration === "breath" ||
-            decoration === "breath-mark" ||
-            decoration === "breathmark" ||
-            decoration === "breath mark"
-          ) {
+          }],
+          [BREATH_DECORATIONS, () => {
             pendingBreathMark = true;
-          } else if (decoration === "caesura") {
-            pendingCaesura = true;
-          } else if (decoration === "shortphrase" || decoration === "mediumphrase" || decoration === "longphrase") {
-            pendingPhraseMark = decoration as "shortphrase" | "mediumphrase" | "longphrase";
-          } else if (decoration === "segno") {
-            pendingSegno = true;
-          } else if (decoration === "coda") {
-            pendingCoda = true;
-          } else if (decoration === "fine") {
-            pendingFine = true;
-          } else if (decoration === "dacoda") {
+          }],
+          [DACAPO_DECORATIONS, () => {
             pendingDaCapo = true;
-            pendingToCoda = true;
-          } else if (decoration === "dacapo" || decoration === "da-capo" || decoration === "da capo" || decoration === "d.c.") {
-            pendingDaCapo = true;
-          } else if (decoration === "dalsegno" || decoration === "dal-segno" || decoration === "dal segno" || decoration === "d.s.") {
+          }],
+          [DALSEGNO_DECORATIONS, () => {
             pendingDalSegno = true;
-          } else if (decoration === "tocoda" || decoration === "to-coda" || decoration === "to coda") {
+          }],
+          [TOCODA_DECORATIONS, () => {
             pendingToCoda = true;
-          } else if (decoration === "crescendo(" || decoration === "cresc(" || decoration === "<(") {
+          }],
+          [CRESC_START_DECORATIONS, () => {
             pendingCrescendoStart = true;
-          } else if (decoration === "crescendo)" || decoration === "cresc)" || decoration === "<)") {
+          }],
+          [CRESC_STOP_DECORATIONS, () => {
             pendingCrescendoStop = true;
-          } else if (
-            decoration === "diminuendo(" ||
-            decoration === "decrescendo(" ||
-            decoration === "dim(" ||
-            decoration === "decresc(" ||
-            decoration === ">("
-          ) {
+          }],
+          [DIM_START_DECORATIONS, () => {
             pendingDiminuendoStart = true;
-          } else if (
-            decoration === "diminuendo)" ||
-            decoration === "decrescendo)" ||
-            decoration === "dim)" ||
-            decoration === "decresc)" ||
-            decoration === ">)"
-          ) {
+          }],
+          [DIM_STOP_DECORATIONS, () => {
             pendingDiminuendoStop = true;
-          } else if (
-            decoration === "pppp" ||
-            decoration === "ppp" ||
-            decoration === "p" ||
-            decoration === "pp" ||
-            decoration === "mp" ||
-            decoration === "mf" ||
-            decoration === "f" ||
-            decoration === "ff" ||
-            decoration === "fff" ||
-            decoration === "ffff" ||
-            decoration === "fp" ||
-            decoration === "fz" ||
-            decoration === "rfz" ||
-            decoration === "sf" ||
-            decoration === "sfp"
-          ) {
-            pendingDynamicMark = decoration;
-          } else if (decoration === "sfz") {
-            pendingSfz = true;
-          } else if (decoration === "upbow" || decoration === "up-bow" || decoration === "up bow") {
+          }],
+          [UPBOW_DECORATIONS, () => {
             pendingUpBow = true;
-          } else if (decoration === "downbow" || decoration === "down-bow" || decoration === "down bow") {
+          }],
+          [DOWNBOW_DECORATIONS, () => {
             pendingDownBow = true;
-          } else if (
-            decoration === "doubletongue" ||
-            decoration === "double-tongue" ||
-            decoration === "double tongue"
-          ) {
+          }],
+          [DOUBLE_TONGUE_DECORATIONS, () => {
             pendingDoubleTongue = true;
-          } else if (
-            decoration === "tripletongue" ||
-            decoration === "triple-tongue" ||
-            decoration === "triple tongue"
-          ) {
+          }],
+          [TRIPLE_TONGUE_DECORATIONS, () => {
             pendingTripleTongue = true;
-          } else if (decoration === "heel" || decoration === "heel mark") {
-            pendingHeel = true;
-          } else if (decoration === "toe" || decoration === "toe mark") {
-            pendingToe = true;
-          } else if (/^[0-5]$/.test(decoration)) {
-            pendingFingerings.push(decoration);
-          } else if (decoration.startsWith("fingering:")) {
-            const fingeringText = rawDecoration.slice("fingering:".length).trim();
-            if (fingeringText) pendingFingerings.push(fingeringText);
-          } else if (decoration.startsWith("string:")) {
-            const stringText = rawDecoration.slice("string:".length).trim();
-            if (stringText) pendingStrings.push(stringText);
-          } else if (decoration.startsWith("pluck:")) {
-            const pluckText = rawDecoration.slice("pluck:".length).trim();
-            if (pluckText) pendingPlucks.push(pluckText);
-          } else if (
-            decoration === "open" ||
-            decoration === "open-string" ||
-            decoration === "openstring" ||
-            decoration === "open string"
-          ) {
+          }],
+          [OPEN_STRING_DECORATIONS, () => {
             pendingOpenString = true;
-          } else if (
-            decoration === "snap" ||
-            decoration === "snap-pizzicato" ||
-            decoration === "snappizzicato" ||
-            decoration === "snap pizzicato"
-          ) {
+          }],
+          [SNAP_PIZZICATO_DECORATIONS, () => {
             pendingSnapPizzicato = true;
-          } else if (decoration === "harmonic") {
-            pendingHarmonic = true;
-          } else if (
-            decoration === "stopped" ||
-            decoration === "+" ||
-            decoration === "plus" ||
-            decoration === "stopped horn" ||
-            decoration === "stopped-horn"
-          ) {
+          }],
+          [STOPPED_DECORATIONS, () => {
             pendingStopped = true;
-          } else if (
-            decoration === "thumb" ||
-            decoration === "thumbposition" ||
-            decoration === "thumb-position" ||
-            decoration === "thumbpos" ||
-            decoration === "thumb pos" ||
-            decoration === "thumb position"
-          ) {
+          }],
+          [THUMB_POSITION_DECORATIONS, () => {
             pendingThumbPosition = true;
-          } else if (decoration) {
-            warnings.push("line " + entry.lineNo + ": Skipped decoration: " + ch + decoration + ch);
-          }
-          idx = endMark + 1;
-          continue;
+          }],
+        ];
+        const applySetDecoration = setDecorationAppliers.find(([decorationSet]) => decorationSet.has(decoration));
+        if (applySetDecoration) {
+          applySetDecoration[1]();
+          return true;
         }
+        if (applyPrefixedDecoration(rawDecoration, decoration)) {
+          return true;
+        }
+        if (applyTurnDecoration(decoration)) {
+          return true;
+        }
+        if (applyTremoloDecoration(decoration)) {
+          return true;
+        }
+        if (PHRASE_DECORATIONS.has(decoration)) {
+          pendingPhraseMark = decoration as "shortphrase" | "mediumphrase" | "longphrase";
+          return true;
+        }
+        if (decoration === "dacoda") {
+          pendingDaCapo = true;
+          pendingToCoda = true;
+          return true;
+        }
+        if (DYNAMIC_DECORATIONS.has(decoration)) {
+          pendingDynamicMark = decoration;
+          return true;
+        }
+        if (/^[0-5]$/.test(decoration)) {
+          pendingFingerings.push(decoration);
+          return true;
+        }
+        return false;
+      };
 
-        if (ch === "{") {
-          const graceResult = parseGraceGroupAt(
-            text,
-            idx,
-            entry.lineNo,
-            activeUnitLength,
-            activeKeySignatureAccidentals,
-            measureAccidentals,
-            entry.voiceId,
-            warnings
-          );
-          if (!graceResult) {
-            warnings.push("line " + entry.lineNo + ": Failed to parse grace group; skipped.");
-            idx += 1;
-            continue;
-          }
-          idx = graceResult.nextIdx;
-          for (const graceNote of graceResult.notes) {
-            currentMeasure.push(graceNote);
-            noteCount += 1;
-          }
-          continue;
-        }
-
-        if (ch === ".") {
-          pendingStaccato = true;
-          idx += 1;
-          continue;
-        }
-
-        if (ch === "[") {
-          const inlineField = parseInlineFieldAt(text, idx);
-          if (inlineField) {
-            if (inlineField.fieldName === "K") {
-              const inlineKeyInfo = parseKey(inlineField.fieldValue || "C", warnings);
-              activeKeyFifths = inlineKeyInfo.fifths;
-              activeKeySignatureAccidentals = keySignatureAlterByStep(activeKeyFifths);
-              currentKeyFifthsByVoice[entry.voiceId] = activeKeyFifths;
-              keyHintFifthsByKey.set(`${entry.voiceId}#${currentMeasureNo}`, activeKeyFifths);
-              measureAccidentals = {};
-            } else if (inlineField.fieldName === "L") {
-              activeUnitLength = parseFraction(inlineField.fieldValue || "1/8", "L", warnings);
-            } else if (inlineField.fieldName === "M") {
-              activeMeter = parseMeter(inlineField.fieldValue || "4/4", warnings);
-              ensureMeterByMeasure(entry.voiceId)[currentMeasureNo] = {
-                beats: activeMeter.beats,
-                beatType: activeMeter.beatType,
-              };
-            } else if (inlineField.fieldName === "Q") {
-              activeTempoBpm = parseTempoFromQ(inlineField.fieldValue || "", warnings);
-              if (Number.isFinite(activeTempoBpm)) {
-                ensureTempoByMeasure(entry.voiceId)[currentMeasureNo] = Math.max(20, Math.min(300, Math.round(Number(activeTempoBpm))));
-              }
-            } else {
-              warnings.push(
-                "line " + entry.lineNo + ": Skipped unsupported inline field: [" + inlineField.fieldName + ":" + inlineField.fieldValue + "]"
-              );
-            }
-            idx = inlineField.nextIdx;
-            continue;
-          }
-          const repeatEndingMarker = parseRepeatEndingMarkerAt(text, idx);
-          if (repeatEndingMarker) {
-            if (activeEndingMarker) {
-              const stopMeasureNo = currentMeasure.length === 0 ? currentMeasureNo - 1 : currentMeasureNo;
-              if (stopMeasureNo >= 1) {
-                const prevMeta = ensureNotationMeasureMeta(entry.voiceId, stopMeasureNo);
-                prevMeta.endingStop = activeEndingMarker;
-                prevMeta.endingStopType = "stop";
-              }
-            }
-            const measureMeta = ensureNotationMeasureMeta(entry.voiceId, currentMeasureNo);
-            measureMeta.endingStart = repeatEndingMarker.marker;
-            activeEndingMarker = repeatEndingMarker.marker;
-            idx = repeatEndingMarker.nextIdx;
-            beamRunActive = false;
-            sawInterEventWhitespace = false;
-            continue;
-          }
-          const chordResult = parseChordAt(text, idx, entry.lineNo);
-          if (!chordResult) {
-            warnings.push("line " + entry.lineNo + ": Failed to parse chord notation; skipped.");
-            idx += 1;
-            continue;
-          }
-          idx = chordResult.nextIdx;
-          let chordLength = parseLengthToken(chordResult.lengthToken, entry.lineNo);
-          if (!chordResult.lengthToken && chordResult.notes.length > 0 && chordResult.notes[0].lengthToken) {
-            chordLength = parseLengthToken(chordResult.notes[0].lengthToken, entry.lineNo);
-          }
-          let absoluteLength = multiplyFractions(activeUnitLength, chordLength);
-          if (pendingRhythmScale) {
-            absoluteLength = multiplyFractions(absoluteLength, pendingRhythmScale);
-            pendingRhythmScale = null;
-          }
-          const activeTuplet =
-            tupletRemaining > 0 && tupletScale && tupletSpec
-              ? { actual: tupletSpec.actual, normal: tupletSpec.normal, remaining: tupletSpec.remaining }
-              : null;
-          if (tupletRemaining > 0 && tupletScale) {
-            absoluteLength = multiplyFractions(absoluteLength, tupletScale);
-            tupletRemaining -= 1;
-            if (tupletSpec) {
-              tupletSpec.remaining -= 1;
-            }
-            if (tupletRemaining <= 0) {
-              tupletScale = null;
-              tupletSpec = null;
-            }
-          }
-          if (idx < text.length && (text[idx] === ">" || text[idx] === "<")) {
-            const rhythmChar = text[idx];
-            idx += 1;
-            if (rhythmChar === ">") {
-              absoluteLength = multiplyFractions(absoluteLength, { num: 3, den: 2 });
-              pendingRhythmScale = { num: 1, den: 2 };
-            } else {
-              absoluteLength = multiplyFractions(absoluteLength, { num: 1, den: 2 });
-              pendingRhythmScale = { num: 3, den: 2 };
-            }
-          }
-          const dur = durationInDivisions(absoluteLength, 960);
-          if (dur <= 0) {
-            warnings.push("line " + entry.lineNo + ": Skipped chord with invalid length.");
-            continue;
-          }
-          const chordNotes = [];
-          currentEventNo += 1;
-          const trillHint = trillWidthHintByKey.get(`${entry.voiceId}#${currentMeasureNo}#${currentEventNo}`) || "";
-          for (let chordIndex = 0; chordIndex < chordResult.notes.length; chordIndex += 1) {
-            const chordNote = chordResult.notes[chordIndex];
-            let note;
-            try {
-              note = buildNoteData(
-                chordNote.pitchChar,
-                chordNote.accidentalText,
-                chordNote.octaveShift,
-                absoluteLength,
-                dur,
-                entry.lineNo,
-                activeKeySignatureAccidentals,
-                measureAccidentals
-              );
-            } catch (error) {
-              if (error instanceof Error && /Octave out of range/i.test(error.message || "")) {
-                warnings.push("line " + entry.lineNo + ": Skipped chord note with unsupported octave range.");
-                chordNotes.length = 0;
-                break;
-              }
-              throw error;
-            }
-            note.voice = entry.voiceId;
-            if (chordIndex === 0) {
-              applyBeamModeForEvent(note, dur);
-            }
-            if (chordIndex === 0 && pendingTrill && !note.isRest) {
-              note.trill = true;
-              note.trillLineStart = pendingTrillLineStart;
-              pendingTrill = false;
-              pendingTrillLineStart = false;
-            }
-            if (chordIndex === 0 && pendingTrillLineStop && !note.isRest) {
-              note.trillLineStop = true;
-              pendingTrillLineStop = false;
-            }
-            if (chordIndex === 0 && pendingTurn && !note.isRest) {
-              note.turnType = pendingTurn;
-              note.turnSlash = pendingTurnSlash;
-              note.delayedTurn = pendingDelayedTurn;
-              pendingTurn = "";
-              pendingTurnSlash = false;
-              pendingDelayedTurn = false;
-            }
-            if (chordIndex === 0 && !note.isRest && (pendingEditorialAccidental || pendingCourtesyAccidental)) {
-              if (note.accidentalText) {
-                note.accidentalEditorial = pendingEditorialAccidental || undefined;
-                note.accidentalCautionary = pendingCourtesyAccidental || undefined;
-              }
-              pendingEditorialAccidental = false;
-              pendingCourtesyAccidental = false;
-            }
-            if (chordIndex === 0 && pendingMordent && !note.isRest) {
-              note.mordentType = pendingMordent;
-              pendingMordent = "";
-            }
-            if (chordIndex === 0 && pendingPhraseMark && !note.isRest) {
-              note.phraseMark = pendingPhraseMark;
-              pendingPhraseMark = "";
-            }
-            if (chordIndex === 0 && pendingTremolo && !note.isRest) {
-              note.tremoloType = pendingTremolo.type;
-              note.tremoloMarks = pendingTremolo.marks;
-              pendingTremolo = null;
-            }
-            if (chordIndex === 0 && pendingGlissandoStart && !note.isRest) {
-              note.glissandoStart = true;
-              pendingGlissandoStart = false;
-            }
-            if (chordIndex === 0 && pendingGlissandoStop && !note.isRest) {
-              note.glissandoStop = true;
-              pendingGlissandoStop = false;
-            }
-            if (chordIndex === 0 && pendingSlideStart && !note.isRest) {
-              note.slideStart = true;
-              pendingSlideStart = false;
-            }
-            if (chordIndex === 0 && pendingSlideStop && !note.isRest) {
-              note.slideStop = true;
-              pendingSlideStop = false;
-            }
-            if (chordIndex === 0 && pendingSchleifer && !note.isRest) {
-              note.schleifer = true;
-              pendingSchleifer = false;
-            }
-            if (chordIndex === 0 && pendingShake && !note.isRest) {
-              note.shake = true;
-              pendingShake = false;
-            }
-            if (chordIndex === 0 && pendingArpeggiate && !note.isRest) {
-              note.arpeggiate = true;
-              pendingArpeggiate = false;
-            }
-            if (chordIndex === 0 && pendingSlurStart > 0 && !note.isRest) {
-              note.slurStart = true;
-              pendingSlurStart = 0;
-            }
-            if (chordIndex === 0 && note.trill && trillHint) {
-              note.trillAccidentalText = trillHint;
-            }
-            if (chordIndex === 0 && pendingStaccato && !note.isRest) {
-              note.staccato = true;
-              pendingStaccato = false;
-            }
-            if (chordIndex === 0 && pendingStaccatissimo && !note.isRest) {
-              note.staccatissimo = true;
-              pendingStaccatissimo = false;
-            }
-            if (chordIndex === 0 && pendingAccent && !note.isRest) {
-              note.accent = true;
-              pendingAccent = false;
-            }
-            if (chordIndex === 0 && pendingTenuto && !note.isRest) {
-              note.tenuto = true;
-              pendingTenuto = false;
-            }
-            if (chordIndex === 0 && pendingStress && !note.isRest) {
-              note.stress = true;
-              pendingStress = false;
-            }
-            if (chordIndex === 0 && pendingUnstress && !note.isRest) {
-              note.unstress = true;
-              pendingUnstress = false;
-            }
-            if (chordIndex === 0 && pendingFermata && !note.isRest) {
-              note.fermataType = pendingFermata;
-              pendingFermata = "";
-            }
-            if (chordIndex === 0 && pendingStrongAccent && !note.isRest) {
-              note.strongAccent = true;
-              pendingStrongAccent = false;
-            }
-            if (chordIndex === 0 && pendingBreathMark && !note.isRest) {
-              note.breathMark = true;
-              pendingBreathMark = false;
-            }
-            if (chordIndex === 0 && pendingCaesura && !note.isRest) {
-              note.caesura = true;
-              pendingCaesura = false;
-            }
-            if (chordIndex === 0 && pendingSegno && !note.isRest) {
-              note.segno = true;
-              pendingSegno = false;
-            }
-            if (chordIndex === 0 && pendingCoda && !note.isRest) {
-              note.coda = true;
-              pendingCoda = false;
-            }
-            if (chordIndex === 0 && pendingFine && !note.isRest) {
-              note.fine = true;
-              pendingFine = false;
-            }
-            if (chordIndex === 0 && pendingDaCapo && !note.isRest) {
-              note.daCapo = true;
-              pendingDaCapo = false;
-            }
-            if (chordIndex === 0 && pendingDalSegno && !note.isRest) {
-              note.dalSegno = true;
-              pendingDalSegno = false;
-            }
-            if (chordIndex === 0 && pendingToCoda && !note.isRest) {
-              note.toCoda = true;
-              pendingToCoda = false;
-            }
-            if (chordIndex === 0 && pendingCrescendoStart && !note.isRest) {
-              note.crescendoStart = true;
-              pendingCrescendoStart = false;
-            }
-            if (chordIndex === 0 && pendingCrescendoStop && !note.isRest) {
-              note.crescendoStop = true;
-              pendingCrescendoStop = false;
-            }
-            if (chordIndex === 0 && pendingDiminuendoStart && !note.isRest) {
-              note.diminuendoStart = true;
-              pendingDiminuendoStart = false;
-            }
-            if (chordIndex === 0 && pendingDiminuendoStop && !note.isRest) {
-              note.diminuendoStop = true;
-              pendingDiminuendoStop = false;
-            }
-            if (chordIndex === 0 && pendingDynamicMark && !note.isRest) {
-              note.dynamicMark = pendingDynamicMark;
-              pendingDynamicMark = "";
-            }
-            if (chordIndex === 0 && pendingSfz && !note.isRest) {
-              note.sfz = true;
-              pendingSfz = false;
-            }
-            if (chordIndex === 0 && pendingRehearsalMark && !note.isRest) {
-              note.rehearsalMark = pendingRehearsalMark;
-              pendingRehearsalMark = "";
-            }
-            if (chordIndex === 0 && pendingUpBow && !note.isRest) {
-              note.upBow = true;
-              pendingUpBow = false;
-            }
-            if (chordIndex === 0 && pendingDownBow && !note.isRest) {
-              note.downBow = true;
-              pendingDownBow = false;
-            }
-            if (chordIndex === 0 && pendingDoubleTongue && !note.isRest) {
-              note.doubleTongue = true;
-              pendingDoubleTongue = false;
-            }
-            if (chordIndex === 0 && pendingTripleTongue && !note.isRest) {
-              note.tripleTongue = true;
-              pendingTripleTongue = false;
-            }
-            if (chordIndex === 0 && pendingHeel && !note.isRest) {
-              note.heel = true;
-              pendingHeel = false;
-            }
-            if (chordIndex === 0 && pendingToe && !note.isRest) {
-              note.toe = true;
-              pendingToe = false;
-            }
-            if (chordIndex === 0 && pendingFingerings.length > 0 && !note.isRest) {
-              note.fingerings = pendingFingerings.slice();
-              pendingFingerings = [];
-            }
-            if (chordIndex === 0 && pendingStrings.length > 0 && !note.isRest) {
-              note.strings = pendingStrings.slice();
-              pendingStrings = [];
-            }
-            if (chordIndex === 0 && pendingPlucks.length > 0 && !note.isRest) {
-              note.plucks = pendingPlucks.slice();
-              pendingPlucks = [];
-            }
-            if (chordIndex === 0 && pendingChordSymbols.length > 0 && !note.isRest) {
-              note.chordSymbols = pendingChordSymbols.slice();
-              pendingChordSymbols = [];
-            }
-            if (chordIndex === 0 && pendingOpenString && !note.isRest) {
-              note.openString = true;
-              pendingOpenString = false;
-            }
-            if (chordIndex === 0 && pendingSnapPizzicato && !note.isRest) {
-              note.snapPizzicato = true;
-              pendingSnapPizzicato = false;
-            }
-            if (chordIndex === 0 && pendingHarmonic && !note.isRest) {
-              note.harmonic = true;
-              pendingHarmonic = false;
-            }
-            if (chordIndex === 0 && pendingStopped && !note.isRest) {
-              note.stopped = true;
-              pendingStopped = false;
-            }
-            if (chordIndex === 0 && pendingThumbPosition && !note.isRest) {
-              note.thumbPosition = true;
-              pendingThumbPosition = false;
-            }
-            if (chordIndex === 0 && pendingAnnotations.length > 0 && !note.isRest) {
-              note.annotations = pendingAnnotations.slice();
-              pendingAnnotations = [];
-            }
-            if (chordIndex > 0) {
-              note.chord = true;
-            }
-            if (chordIndex === 0 && activeTuplet) {
-              note.timeModification = { actual: activeTuplet.actual, normal: activeTuplet.normal };
-              if (activeTuplet.remaining === activeTuplet.actual) {
-                note.tupletStart = true;
-              }
-              if (activeTuplet.remaining === 1) {
-                note.tupletStop = true;
-              }
-            }
-            chordNotes.push(note);
-          }
-          if (pendingTieToNext && chordNotes.length > 0) {
-            for (const chordNote of chordNotes) {
-              if (!chordNote.isRest) {
-                chordNote.tieStop = true;
-              }
-            }
-            pendingTieToNext = false;
-          }
-          for (const note of chordNotes) {
-            currentMeasure.push(note);
-          }
-          if (chordNotes.length === 0) {
-            pendingTieToNext = false;
-            lastNote = null;
-            lastEventNotes = [];
-            continue;
-          }
-          lastNote = chordNotes[0] || null;
-          lastEventNotes = chordNotes;
-          noteCount += chordNotes.length;
-          continue;
-        }
-
-        if (ch === ")") {
-          if (lastNote && !lastNote.isRest) {
-            lastNote.slurStop = true;
-          } else {
-            warnings.push("line " + entry.lineNo + ": slur stop()) has no preceding note; skipped.");
-          }
-          idx += 1;
-          continue;
-        }
-
-        if (ch === "]" || ch === "}") {
-          if (ch === "]" && activeEndingMarker) {
-            const stopMeasureNo = currentMeasure.length === 0 ? currentMeasureNo - 1 : currentMeasureNo;
-            if (stopMeasureNo >= 1) {
-              const measureMeta = ensureNotationMeasureMeta(entry.voiceId, stopMeasureNo);
-              measureMeta.endingStop = activeEndingMarker;
-              measureMeta.endingStopType = "stop";
-              activeEndingMarker = "";
-            }
-            idx += 1;
-            beamRunActive = false;
-            sawInterEventWhitespace = false;
-            continue;
-          }
-          warnings.push("line " + entry.lineNo + ": Skipped unsupported notation: " + ch);
-          idx += 1;
-          beamRunActive = false;
-          sawInterEventWhitespace = false;
-          continue;
-        }
-
-        if (ch === ";" || ch === "`" || ch === "?" || ch === "@" || ch === "#" || ch === "$" || ch === "*") {
-          warnings.push("line " + entry.lineNo + ": Skipped unsupported body punctuation: " + ch);
-          idx += 1;
-          beamRunActive = false;
-          sawInterEventWhitespace = false;
-          continue;
-        }
-
-        const noteResult = parseAbcNoteAt(text, idx);
-        if (noteResult?.kind === "malformed-accidental") {
-          warnings.push("line " + entry.lineNo + ": Skipped malformed accidental token: " + noteResult.accidentalText);
-          idx = noteResult.nextIdx;
-          continue;
-        }
-        if (!noteResult || noteResult.kind !== "note") {
-          throw new Error("line " + entry.lineNo + ": Failed to parse note/rest: " + text.slice(idx, idx + 12));
-        }
-        const { accidentalText, pitchChar, octaveShift, lengthToken, nextIdx } = noteResult.note;
-        idx = nextIdx;
-
-        const len = parseLengthToken(lengthToken, entry.lineNo);
-        let absoluteLength = multiplyFractions(activeUnitLength, len);
-        if (pendingRhythmScale) {
-          absoluteLength = multiplyFractions(absoluteLength, pendingRhythmScale);
-          pendingRhythmScale = null;
-        }
-        const activeTuplet =
-          tupletRemaining > 0 && tupletScale && tupletSpec
-            ? { actual: tupletSpec.actual, normal: tupletSpec.normal, remaining: tupletSpec.remaining }
-            : null;
-        if (tupletRemaining > 0 && tupletScale) {
-          absoluteLength = multiplyFractions(absoluteLength, tupletScale);
-          tupletRemaining -= 1;
-          if (tupletSpec) {
-            tupletSpec.remaining -= 1;
-          }
-          if (tupletRemaining <= 0) {
-            tupletScale = null;
-            tupletSpec = null;
-          }
-        }
-
-        if (idx < text.length && (text[idx] === ">" || text[idx] === "<")) {
-          const rhythmChar = text[idx];
-          idx += 1;
-          if (rhythmChar === ">") {
-            absoluteLength = multiplyFractions(absoluteLength, { num: 3, den: 2 });
-            pendingRhythmScale = { num: 1, den: 2 };
-          } else {
-            absoluteLength = multiplyFractions(absoluteLength, { num: 1, den: 2 });
-            pendingRhythmScale = { num: 3, den: 2 };
-          }
-        }
-
-        const dur = durationInDivisions(absoluteLength, 960);
-        if (dur <= 0) {
-          warnings.push("line " + entry.lineNo + ": Skipped note with invalid length.");
-          continue;
-        }
-
-        let note;
-        try {
-          note = buildNoteData(
-            pitchChar,
-            accidentalText,
-            octaveShift,
-            absoluteLength,
-            dur,
-            entry.lineNo,
-            activeKeySignatureAccidentals,
-            measureAccidentals
-          );
-        } catch (error) {
-          if (error instanceof Error && /Octave out of range/i.test(error.message || "")) {
-            warnings.push("line " + entry.lineNo + ": Skipped note with unsupported octave range.");
-            pendingTieToNext = false;
-            lastNote = null;
-            lastEventNotes = [];
-            continue;
-          }
-          throw error;
-        }
-        applyBeamModeForEvent(note, dur);
+      const applyPendingOrnamentState = (note, options = {}) => {
+        const { applySlurStart = true, trillHint = "" } = options;
         if (pendingTrill && !note.isRest) {
           note.trill = true;
           note.trillLineStart = pendingTrillLineStart;
@@ -2028,15 +1304,16 @@ const abcCommon = AbcCommon;
           note.arpeggiate = true;
           pendingArpeggiate = false;
         }
-        if (pendingSlurStart > 0 && !note.isRest) {
+        if (applySlurStart && pendingSlurStart > 0 && !note.isRest) {
           note.slurStart = true;
           pendingSlurStart = 0;
         }
-        currentEventNo += 1;
-        const trillHint = trillWidthHintByKey.get(`${entry.voiceId}#${currentMeasureNo}#${currentEventNo}`) || "";
         if (note.trill && trillHint) {
           note.trillAccidentalText = trillHint;
         }
+      };
+
+      const applyPendingArticulationState = (note) => {
         if (pendingStaccato && !note.isRest) {
           note.staccato = true;
           pendingStaccato = false;
@@ -2077,6 +1354,9 @@ const abcCommon = AbcCommon;
           note.caesura = true;
           pendingCaesura = false;
         }
+      };
+
+      const applyPendingDirectionState = (note) => {
         if (pendingSegno && !note.isRest) {
           note.segno = true;
           pendingSegno = false;
@@ -2129,6 +1409,9 @@ const abcCommon = AbcCommon;
           note.rehearsalMark = pendingRehearsalMark;
           pendingRehearsalMark = "";
         }
+      };
+
+      const applyPendingTechnicalState = (note) => {
         if (pendingUpBow && !note.isRest) {
           note.upBow = true;
           pendingUpBow = false;
@@ -2193,27 +1476,710 @@ const abcCommon = AbcCommon;
           note.annotations = pendingAnnotations.slice();
           pendingAnnotations = [];
         }
-        if (pendingTieToNext && !note.isRest) {
+      };
+
+      const applyPendingToPlayableNote = (note, options = {}) => {
+        const {
+          applySlurStart = true,
+          applyTieStop = true,
+          trillHint = "",
+        } = options;
+
+        applyPendingOrnamentState(note, { applySlurStart, trillHint });
+        applyPendingArticulationState(note);
+        applyPendingDirectionState(note);
+        applyPendingTechnicalState(note);
+
+        if (applyTieStop && pendingTieToNext && !note.isRest) {
           note.tieStop = true;
           pendingTieToNext = false;
-        } else if (note.isRest && pendingTieToNext) {
-          warnings.push("line " + entry.lineNo + ": tie(-) was followed by a rest; tie removed.");
+        } else if (applyTieStop && note.isRest && pendingTieToNext) {
+          warnBody("tie(-) was followed by a rest; tie removed.");
           pendingTieToNext = false;
         }
-        if (activeTuplet) {
-          note.timeModification = { actual: activeTuplet.actual, normal: activeTuplet.normal };
-          if (activeTuplet.remaining === activeTuplet.actual) {
-            note.tupletStart = true;
+      };
+
+      // Event construction and commit helpers.
+      const applySingleCharShorthand = (char) => {
+        const shorthand = parseAbcSingleCharShorthandAt(char, 0);
+        if (!shorthand) {
+          return false;
+        }
+        const shorthandAppliers = {
+          "accent": () => {
+            pendingAccent = true;
+          },
+          "arpeggiate": () => {
+            pendingArpeggiate = true;
+          },
+          "coda": () => {
+            pendingCoda = true;
+          },
+          "downbow": () => {
+            pendingDownBow = true;
+          },
+          "fermata": () => {
+            pendingFermata = "normal";
+          },
+          "inverted-mordent": () => {
+            pendingMordent = "inverted-mordent";
+          },
+          "mordent": () => {
+            pendingMordent = "mordent";
+          },
+          "segno": () => {
+            pendingSegno = true;
+          },
+          "staccato": () => {
+            pendingStaccato = true;
+          },
+          "trill": () => {
+            pendingTrill = true;
+          },
+          "upbow": () => {
+            pendingUpBow = true;
+          },
+        };
+        const apply = shorthandAppliers[shorthand.kind];
+        if (!apply) {
+          return false;
+        }
+        apply();
+        return true;
+      };
+
+      const consumePlayableTiming = (rawLengthToken, tokenIdx) => {
+        const len = parseLengthToken(rawLengthToken, entry.lineNo);
+        let absoluteLength = multiplyFractions(activeUnitLength, len);
+        if (pendingRhythmScale) {
+          absoluteLength = multiplyFractions(absoluteLength, pendingRhythmScale);
+          pendingRhythmScale = null;
+        }
+        const activeTuplet =
+          tupletRemaining > 0 && tupletScale && tupletSpec
+            ? { actual: tupletSpec.actual, normal: tupletSpec.normal, remaining: tupletSpec.remaining }
+            : null;
+        if (tupletRemaining > 0 && tupletScale) {
+          absoluteLength = multiplyFractions(absoluteLength, tupletScale);
+          tupletRemaining -= 1;
+          if (tupletSpec) {
+            tupletSpec.remaining -= 1;
           }
-          if (activeTuplet.remaining === 1) {
-            note.tupletStop = true;
+          if (tupletRemaining <= 0) {
+            tupletScale = null;
+            tupletSpec = null;
           }
         }
+
+        let nextIdx = tokenIdx;
+        const trailingBrokenRhythm = parseAbcBrokenRhythmAt(text, nextIdx);
+        if (trailingBrokenRhythm) {
+          absoluteLength = multiplyFractions(absoluteLength, trailingBrokenRhythm.leftScale);
+          pendingRhythmScale = trailingBrokenRhythm.rightScale;
+          nextIdx = trailingBrokenRhythm.nextIdx;
+        }
+
+        return {
+          absoluteLength,
+          dur: durationInDivisions(absoluteLength, 960),
+          activeTuplet,
+          nextIdx,
+        };
+      };
+
+      const applyTupletToEventStart = (note, activeTuplet) => {
+        if (!activeTuplet) {
+          return;
+        }
+        note.timeModification = { actual: activeTuplet.actual, normal: activeTuplet.normal };
+        if (activeTuplet.remaining === activeTuplet.actual) {
+          note.tupletStart = true;
+        }
+        if (activeTuplet.remaining === 1) {
+          note.tupletStop = true;
+        }
+      };
+
+      const finalizePlayableEventStart = (note, dur, activeTuplet, options = {}) => {
+        const applyTieStop = options.applyTieStop !== false;
+        applyBeamModeForEvent(note, dur);
+        currentEventNo += 1;
+        const trillHint = trillWidthHintByKey.get(`${entry.voiceId}#${currentMeasureNo}#${currentEventNo}`) || "";
+        applyPendingToPlayableNote(note, { applySlurStart: true, applyTieStop, trillHint });
+        applyTupletToEventStart(note, activeTuplet);
         note.voice = entry.voiceId;
-        currentMeasure.push(note);
-        lastNote = note;
-        lastEventNotes = [note];
-        noteCount += 1;
+      };
+
+      const buildPlayableNoteForBody = (pitchSource, absoluteLength, dur, octaveWarningMessage) => {
+        let note;
+        try {
+          note = buildNoteData(
+            pitchSource.pitchChar,
+            pitchSource.accidentalText,
+            pitchSource.octaveShift,
+            absoluteLength,
+            dur,
+            entry.lineNo,
+            activeKeySignatureAccidentals,
+            measureAccidentals
+          );
+        } catch (error) {
+          if (error instanceof Error && /Octave out of range/i.test(error.message || "")) {
+            warnBody(octaveWarningMessage);
+            return null;
+          }
+          throw error;
+        }
+        note.voice = entry.voiceId;
+        return note;
+      };
+
+      const clearLastEventState = (options = {}) => {
+        if (options.clearPendingTie !== false) {
+          pendingTieToNext = false;
+        }
+        lastNote = null;
+        lastEventNotes = [];
+      };
+
+      const commitPlayableEvent = (notes, options = {}) => {
+        const applyChordTieStop = options.applyChordTieStop === true;
+        if (applyChordTieStop && pendingTieToNext && notes.length > 0) {
+          for (const note of notes) {
+            if (!note.isRest) {
+              note.tieStop = true;
+            }
+          }
+          pendingTieToNext = false;
+        }
+        for (const note of notes) {
+          currentMeasure.push(note);
+        }
+        if (notes.length === 0) {
+          clearLastEventState();
+          return false;
+        }
+        lastNote = notes[0] || null;
+        lastEventNotes = notes;
+        noteCount += notes.length;
+        return true;
+      };
+
+      const buildPlayableEventFromPitches = (pitchSources, timing, options = {}) => {
+        const octaveWarningMessage = options.octaveWarningMessage || "Skipped note with unsupported octave range.";
+        const firstNoteOptions = options.firstNoteOptions || {};
+        const notes = [];
+        for (let pitchIndex = 0; pitchIndex < pitchSources.length; pitchIndex += 1) {
+          const note = buildPlayableNoteForBody(pitchSources[pitchIndex], timing.absoluteLength, timing.dur, octaveWarningMessage);
+          if (!note) {
+            notes.length = 0;
+            break;
+          }
+          if (pitchIndex === 0) {
+            finalizePlayableEventStart(note, timing.dur, timing.activeTuplet, firstNoteOptions);
+          } else {
+            note.chord = true;
+          }
+          notes.push(note);
+        }
+        return notes;
+      };
+
+      const playableEventOptionsForSource = (source) => ({
+        invalidLengthMessage: source === "chord" ? "Skipped chord with invalid length." : "Skipped note with invalid length.",
+        octaveWarningMessage:
+          source === "chord"
+            ? "Skipped chord note with unsupported octave range."
+            : "Skipped note with unsupported octave range.",
+        firstNoteOptions: source === "chord" ? { applyTieStop: false } : {},
+        commitOptions: source === "chord" ? { applyChordTieStop: true } : {},
+      });
+
+      // Body token handlers.
+      const handleBrokenRhythmBodyToken = (bodyToken) => {
+        const { brokenRhythm } = bodyToken;
+        if (!lastEventNotes || lastEventNotes.length === 0 || lastEventNotes.some((n) => n.isRest)) {
+          warnBody("broken rhythm(" + brokenRhythm.symbol + ")  has no preceding note; skipped.");
+          idx = brokenRhythm.nextIdx;
+          return true;
+        }
+        scaleNotesDuration(lastEventNotes, brokenRhythm.leftScale);
+        pendingRhythmScale = brokenRhythm.rightScale;
+        idx = brokenRhythm.nextIdx;
+        return true;
+      };
+
+      const handleParenBodyToken = (bodyToken) => {
+        const { parenToken } = bodyToken;
+        if (parenToken.kind === "tuplet") {
+          const { tuplet } = parenToken;
+          if (tuplet.actual > 0 && tuplet.normal > 0 && tuplet.count > 0) {
+            tupletScale = { num: tuplet.normal, den: tuplet.actual };
+            tupletRemaining = tuplet.count;
+            tupletSpec = { actual: tuplet.actual, normal: tuplet.normal, remaining: tuplet.count };
+          } else {
+            warnBody("Failed to parse tuplet notation: " + tuplet.raw);
+          }
+          idx = tuplet.nextIdx;
+          return true;
+        }
+        pendingSlurStart += 1;
+        idx = parenToken.nextIdx;
+        return true;
+      };
+
+      const enqueueQuotedBodyText = (normalizedText) => {
+        if (!normalizedText) {
+          return;
+        }
+        if (isLikelyAbcChordSymbol(normalizedText)) {
+          pendingChordSymbols.push(normalizedText);
+          return;
+        }
+        pendingAnnotations.push(normalizedText);
+      };
+
+      const markTieStartOnLastEvent = () => {
+        if (!lastEventNotes || lastEventNotes.length === 0 || !lastEventNotes.some((n) => !n.isRest)) {
+          return false;
+        }
+        for (const eventNote of lastEventNotes) {
+          if (!eventNote.isRest) {
+            eventNote.tieStart = true;
+          }
+        }
+        pendingTieToNext = true;
+        return true;
+      };
+
+      const handleTieBodyToken = (bodyToken) => {
+        if (!markTieStartOnLastEvent()) {
+          warnBody("tie(-)  has no preceding note; skipped.");
+        }
+        idx = bodyToken.tie.nextIdx;
+        return true;
+      };
+
+      const handleQuotedStringBodyToken = (bodyToken) => {
+        const { quotedString } = bodyToken;
+        enqueueQuotedBodyText(quotedString.normalizedText);
+        if (!quotedString.terminated) {
+          warnBody('Unterminated inline string ("...").');
+        }
+        idx = quotedString.nextIdx;
+        return true;
+      };
+
+      const handleSingleCharShorthandBodyToken = (bodyToken, char) => {
+        applySingleCharShorthand(char);
+        idx = bodyToken.shorthand.nextIdx;
+        return true;
+      };
+
+      const handleDecorationBodyToken = (bodyToken, char) => {
+        const parsedDecoration = bodyToken.decoration;
+        if (!parsedDecoration.terminated) {
+          warnBody("Unterminated decoration marker: " + char);
+          idx = parsedDecoration.nextIdx;
+          return true;
+        }
+        const { rawDecoration, decoration } = parsedDecoration;
+        if (!applyDecoration(rawDecoration, decoration) && decoration) {
+          warnBody("Skipped decoration: " + char + decoration + char);
+        }
+        idx = parsedDecoration.nextIdx;
+        return true;
+      };
+
+      const markSlurStopOnLastNote = () => {
+        if (!lastNote || lastNote.isRest) {
+          return false;
+        }
+        lastNote.slurStop = true;
+        return true;
+      };
+
+      const handleSlurStopBodyToken = (bodyToken) => {
+        const { slurStop } = bodyToken;
+        if (!markSlurStopOnLastNote()) {
+          warnBody("slur stop()) has no preceding note; skipped.");
+        }
+        idx = slurStop.nextIdx;
+        return true;
+      };
+
+      const handleSimpleBodyToken = (bodyToken, char) => {
+        if (!bodyToken) {
+          return false;
+        }
+        const bodyTokenHandlers = {
+          "broken-rhythm": () => handleBrokenRhythmBodyToken(bodyToken),
+          "decoration": () => handleDecorationBodyToken(bodyToken, char),
+          "paren": () => handleParenBodyToken(bodyToken),
+          "quoted-string": () => handleQuotedStringBodyToken(bodyToken),
+          "single-char-shorthand": () => handleSingleCharShorthandBodyToken(bodyToken, char),
+          "slur-stop": () => handleSlurStopBodyToken(bodyToken),
+          "tie": () => handleTieBodyToken(bodyToken),
+        };
+        const handler = bodyTokenHandlers[bodyToken.kind];
+        return handler ? handler() : false;
+      };
+
+      const handleInlineFieldBracketToken = (bracketToken) => {
+        const { inlineField } = bracketToken;
+        if (!applyBodyField(inlineField.fieldName, inlineField.fieldValue)) {
+          warnBody("Skipped unsupported inline field: [" + inlineField.fieldName + ":" + inlineField.fieldValue + "]");
+        }
+        idx = inlineField.nextIdx;
+        return true;
+      };
+
+      const handleRepeatEndingBracketToken = (bracketToken) => {
+        const { repeatEndingMarker } = bracketToken;
+        return startEndingAtCurrentMeasure(repeatEndingMarker.marker, repeatEndingMarker.nextIdx);
+      };
+
+      const handleBracketBodyToken = (bodyToken) => {
+        if (!bodyToken || bodyToken.kind !== "bracket") {
+          return false;
+        }
+        const { bracketToken } = bodyToken;
+        if (bracketToken.kind === "inline-field") {
+          return handleInlineFieldBracketToken(bracketToken);
+        }
+        if (bracketToken.kind === "repeat-ending") {
+          return handleRepeatEndingBracketToken(bracketToken);
+        }
+        const playableEvent = parseAbcPlayableEventAt(text, idx);
+        return handlePlayableEvent(playableEvent, { fallbackToNextChar: true });
+      };
+
+      const handleGraceGroup = (char) => {
+        if (char !== "{") {
+          return false;
+        }
+        const graceResult = parseGraceGroupAt(
+          text,
+          idx,
+          entry.lineNo,
+          activeUnitLength,
+          activeKeySignatureAccidentals,
+          measureAccidentals,
+          entry.voiceId,
+          warnings
+        );
+        if (!graceResult) {
+          warnBody("Failed to parse grace group; skipped.");
+          idx += 1;
+          return true;
+        }
+        idx = graceResult.nextIdx;
+        appendGraceNotes(graceResult.notes);
+        return true;
+      };
+
+      // Measure and ending state helpers.
+      const appendGraceNotes = (graceNotes) => {
+        for (const graceNote of graceNotes) {
+          currentMeasure.push(graceNote);
+          noteCount += 1;
+        }
+      };
+
+      const startEndingAtCurrentMeasure = (marker, nextIdx) => {
+        if (activeEndingMarker) {
+          const stopMeasureNo = currentMeasure.length === 0 ? currentMeasureNo - 1 : currentMeasureNo;
+          stopActiveEndingAtMeasure(stopMeasureNo);
+        }
+        const measureMeta = ensureNotationMeasureMeta(entry.voiceId, currentMeasureNo);
+        measureMeta.endingStart = marker;
+        activeEndingMarker = marker;
+        idx = nextIdx;
+        resetBeamContext();
+        return true;
+      };
+
+      const stopActiveEndingAtMeasure = (measureNo) => {
+        if (!activeEndingMarker || measureNo < 1) {
+          return false;
+        }
+        const measureMeta = ensureNotationMeasureMeta(entry.voiceId, measureNo);
+        measureMeta.endingStop = activeEndingMarker;
+        measureMeta.endingStopType = "stop";
+        activeEndingMarker = "";
+        return true;
+      };
+
+      const advanceToNextMeasure = () => {
+        currentMeasure = [];
+        measures.push(currentMeasure);
+        currentMeasureNo = Math.max(1, measures.length);
+        currentEventNo = 0;
+        beamCursorDiv = 0;
+      };
+
+      const resetBeamContext = () => {
+        beamRunActive = false;
+        sawInterEventWhitespace = false;
+      };
+
+      const applyBarlineRepeatMarkers = (barlineToken) => {
+        if (barlineToken.repeatEnd) {
+          ensureNotationMeasureMeta(entry.voiceId, currentMeasureNo).repeatEnd = true;
+        }
+        if (barlineToken.repeatStart) {
+          ensureNotationMeasureMeta(entry.voiceId, currentMeasureNo).repeatStart = true;
+        }
+      };
+
+      const applyBarlineMeasureBoundary = (barlineToken, bareRepeatEndingMarker) => {
+        if ((barlineToken.endingStop || bareRepeatEndingMarker) && activeEndingMarker) {
+          stopActiveEndingAtMeasure(currentMeasureNo);
+        }
+        if (barlineToken.endsMeasure && (currentMeasure.length > 0 || measures.length === 0)) {
+          advanceToNextMeasure();
+        }
+        if (barlineToken.endsMeasure) {
+          measureAccidentals = {};
+          lastNote = null;
+        }
+      };
+
+      const advanceAfterBarline = (barlineToken, bareRepeatEndingMarker) => {
+        if (bareRepeatEndingMarker) {
+          return startEndingAtCurrentMeasure(bareRepeatEndingMarker.marker, bareRepeatEndingMarker.nextIdx);
+        }
+        idx = barlineToken.nextIdx;
+        resetBeamContext();
+        return true;
+      };
+
+      const handleBarlineEntry = (bodyEntry) => {
+        if (!bodyEntry || bodyEntry.kind !== "barline") {
+          return false;
+        }
+        const { barlineToken } = bodyEntry;
+        const bareRepeatEndingMarker =
+          barlineToken.endsMeasure ? parseAbcBareRepeatEndingMarkerAt(text, barlineToken.nextIdx) : null;
+        applyBarlineRepeatMarkers(barlineToken);
+        applyBarlineMeasureBoundary(barlineToken, bareRepeatEndingMarker);
+        return advanceAfterBarline(barlineToken, bareRepeatEndingMarker);
+      };
+
+      const handleStandaloneBodyFieldEntry = (bodyEntry) => {
+        const { standaloneBodyField } = bodyEntry;
+        if (!applyBodyField(standaloneBodyField.fieldName, standaloneBodyField.fieldValue)) {
+          warnBody("Skipped unsupported standalone body field token: " + standaloneBodyField.token);
+        }
+        idx = standaloneBodyField.nextIdx;
+        return true;
+      };
+
+      const handleUnsupportedTokenEntry = (bodyEntry) => {
+        if (bodyEntry.kind === "unsupported-body-token") {
+          const { unsupportedBodyToken } = bodyEntry;
+          warnBody("Skipped unsupported body token: " + unsupportedBodyToken.token);
+          idx = unsupportedBodyToken.nextIdx;
+          return true;
+        }
+        if (bodyEntry.kind === "unsupported-body-number") {
+          const { unsupportedBodyNumber } = bodyEntry;
+          warnBody("Skipped unsupported body number token: " + unsupportedBodyNumber.token);
+          idx = unsupportedBodyNumber.nextIdx;
+          return true;
+        }
+        return false;
+      };
+
+      const handleNonPlayableBodyEntry = (bodyEntry) => {
+        if (!bodyEntry) {
+          return false;
+        }
+        if (bodyEntry.kind === "standalone-body-field") {
+          return handleStandaloneBodyFieldEntry(bodyEntry);
+        }
+        return handleUnsupportedTokenEntry(bodyEntry);
+      };
+
+      // Playable-event and fallback handlers.
+      const handleResolvedPlayableEvent = (playableEvent) => {
+        const timing = consumePlayableTiming(playableEvent.rawLengthToken, playableEvent.nextIdx);
+        idx = timing.nextIdx;
+        const eventOptions = playableEventOptionsForSource(playableEvent.source);
+        if (timing.dur <= 0) {
+          warnBody(eventOptions.invalidLengthMessage);
+          return true;
+        }
+        const eventNotes = buildPlayableEventFromPitches(playableEvent.pitchSources, timing, {
+          octaveWarningMessage: eventOptions.octaveWarningMessage,
+          firstNoteOptions: eventOptions.firstNoteOptions,
+        });
+        if (eventNotes.length === 0) {
+          clearLastEventState();
+          return true;
+        }
+        commitPlayableEvent(eventNotes, eventOptions.commitOptions);
+        return true;
+      };
+
+      const skipInvalidPlayableEvent = (message, nextIdx) => {
+        warnBody(message);
+        idx = nextIdx;
+        return true;
+      };
+
+      const handleInvalidPlayableEvent = (playableEvent, options = {}) => {
+        const { fallbackToNextChar = false } = options;
+        if (!playableEvent) {
+          return false;
+        }
+        if (playableEvent.kind === "malformed-accidental") {
+          return skipInvalidPlayableEvent("Skipped malformed accidental token: " + playableEvent.accidentalText, playableEvent.nextIdx);
+        }
+        if (playableEvent.kind === "invalid-chord") {
+          return skipInvalidPlayableEvent("Failed to parse chord notation; skipped.", playableEvent.nextIdx);
+        }
+        if (fallbackToNextChar) {
+          idx += 1;
+          return true;
+        }
+        return false;
+      };
+
+      const handlePlayableEvent = (playableEvent, options = {}) => {
+        const { fallbackToNextChar = false } = options;
+        if (playableEvent.kind !== "playable") {
+          return handleInvalidPlayableEvent(playableEvent, { fallbackToNextChar });
+        }
+        return handleResolvedPlayableEvent(playableEvent);
+      };
+
+      const advanceBodyCursorWithWarning = (message, nextIdx = idx + 1) => {
+        warnBody(message);
+        idx = nextIdx;
+        resetBeamContext();
+        return true;
+      };
+
+      const handleClosingNotation = (char) => {
+        if (char !== "]" && char !== "}") {
+          return false;
+        }
+        if (char === "]" && activeEndingMarker) {
+          const stopMeasureNo = currentMeasure.length === 0 ? currentMeasureNo - 1 : currentMeasureNo;
+          stopActiveEndingAtMeasure(stopMeasureNo);
+          idx += 1;
+          resetBeamContext();
+          return true;
+        }
+        return advanceBodyCursorWithWarning("Skipped unsupported notation: " + char);
+      };
+
+      const handleUnsupportedPunctuation = (char) => {
+        if (char !== ";" && char !== "`" && char !== "?" && char !== "@" && char !== "#" && char !== "$" && char !== "*") {
+          return false;
+        }
+        return advanceBodyCursorWithWarning("Skipped unsupported body punctuation: " + char);
+      };
+
+      const handleBodyEntry = (bodyEntry, char) => {
+        const bodyToken = bodyEntry?.kind === "body-token" ? bodyEntry.bodyToken : null;
+        const entryHandlers = [
+          () => handleBarlineEntry(bodyEntry),
+          () => handleNonPlayableBodyEntry(bodyEntry),
+          () => handleSimpleBodyToken(bodyToken, char),
+          () => handleGraceGroup(char),
+          () => handleBracketBodyToken(bodyToken),
+          () => (bodyEntry?.kind === "playable-event" ? handlePlayableEvent(bodyEntry.playableEvent) : false),
+        ];
+        for (const handler of entryHandlers) {
+          if (handler()) {
+            return true;
+          }
+        }
+        return false;
+      };
+
+      const throwBodyParseError = () => {
+        throw new Error("line " + entry.lineNo + ": Failed to parse note/rest: " + text.slice(idx, idx + 12));
+      };
+
+      const handleBodyFallback = (bodyEntry, char) => {
+        const fallbackHandlers = [
+          () => handleClosingNotation(char),
+          () => handleUnsupportedPunctuation(char),
+        ];
+        for (const handler of fallbackHandlers) {
+          if (handler()) {
+            return true;
+          }
+        }
+        if (!bodyEntry) {
+          throwBodyParseError();
+        }
+        return false;
+      };
+
+      const consumeIgnorableBodyChar = (char) => {
+        if (char === " " || char === "\t") {
+          sawInterEventWhitespace = true;
+          idx += 1;
+          return true;
+        }
+        if (char === "\\") {
+          warnBody("Skipped stray body continuation marker: \\");
+          idx += 1;
+          return true;
+        }
+        if (char === "," || char === "'") {
+          // Lenient compatibility: some real-world sources include standalone octave marks.
+          // They are non-standard in strict ABC, but skipping them improves interoperability.
+          idx += 1;
+          return true;
+        }
+        return false;
+      };
+
+      const isBeamableAbcNote = (note) =>
+        Boolean(
+          note &&
+          !note.isRest &&
+          !note.grace &&
+          ["eighth", "16th", "32nd", "64th"].includes(String(note.type || "").trim().toLowerCase())
+        );
+      const applyBeamModeForEvent = (note, durationDiv) => {
+        const resolvedDurationDiv = Math.max(0, Math.round(Number(durationDiv) || 0));
+        const beatDiv = Math.max(1, Math.round((960 * 4) / Math.max(1, Math.round(Number(activeMeter?.beatType) || 4))));
+        const startsAtBeatBoundary = beamCursorDiv > 0 && beamCursorDiv % beatDiv === 0;
+        if (startsAtBeatBoundary) {
+          beamRunActive = false;
+        }
+        if (isBeamableAbcNote(note)) {
+          note.beamMode = !beamRunActive || sawInterEventWhitespace ? "begin" : "mid";
+          beamRunActive = true;
+        } else {
+          beamRunActive = false;
+        }
+        sawInterEventWhitespace = false;
+        beamCursorDiv += resolvedDurationDiv;
+      };
+
+      while (idx < text.length) {
+        const ch = text[idx];
+
+        if (consumeIgnorableBodyChar(ch)) {
+          continue;
+        }
+
+        const bodyEntry = parseAbcBodyEntryAt(text, idx);
+
+        if (handleBodyEntry(bodyEntry, ch)) {
+          continue;
+        }
+
+        if (handleBodyFallback(bodyEntry, ch)) {
+          continue;
+        }
       }
       activeEndingByVoice[entry.voiceId] = activeEndingMarker;
       currentKeyFifthsByVoice[entry.voiceId] = activeKeyFifths;
@@ -2563,10 +2529,6 @@ const abcCommon = AbcCommon;
 
   function parseLengthToken(token, lineNo) {
     return abcCommon.parseAbcLengthToken(token, lineNo);
-  }
-
-  function parseChordAt(text, startIdx, lineNo) {
-    return parseAbcChordAt(text, startIdx);
   }
 
   function parseGraceGroupAt(text, startIdx, lineNo, unitLength, keySignatureAccidentals, measureAccidentals, voiceId, warnings) {
@@ -4069,6 +4031,16 @@ const buildMusicXmlFromAbcParsed = (
         if (hintedTempo !== null) {
           currentPartTempo = hintedTempo;
         }
+        const currentMeasureDurationDiv = Math.max(
+          1,
+          Math.round((960 * 4 * Math.max(1, Math.round(currentPartMeter.beats))) / Math.max(1, Math.round(currentPartMeter.beatType)))
+        );
+        const currentMeasureContentDiv = estimateAbcMeasureContentDiv(notes);
+        const inferredImplicitPickup =
+          i === 0 &&
+          !measureMeta?.implicit &&
+          currentMeasureContentDiv > 0 &&
+          currentMeasureContentDiv < currentMeasureDurationDiv;
         const header =
           i === 0
             ? [
@@ -4449,7 +4421,7 @@ const buildMusicXmlFromAbcParsed = (
             : `<note><rest/><duration>${measureDurationDiv}</duration><voice>1</voice><type>${emptyMeasureRestType}</type></note>`;
 
         const xmlMeasureNumber = xmlEscape(String(measureMeta?.number || measureNo));
-        const implicitAttr = measureMeta?.implicit ? ' implicit="yes"' : "";
+        const implicitAttr = measureMeta?.implicit || inferredImplicitPickup ? ' implicit="yes"' : "";
         const leftBarlineChunks: string[] = [];
         if (measureMeta?.endingStart) {
           leftBarlineChunks.push(`<ending number="${xmlEscape(String(measureMeta.endingStart))}" type="start"/>`);

--- a/src/ts/abc-parser.ts
+++ b/src/ts/abc-parser.ts
@@ -1,10 +1,24 @@
 import { lexAbcAccidental, lexAbcLengthToken, lexAbcNote } from "./abc-lexer";
 
+// Low-level parsed note and pitch data.
 export type AbcParsedNote = {
   accidentalText: string;
   pitchChar: string;
   octaveShift: string;
   lengthToken: string;
+  nextIdx: number;
+};
+
+export type AbcParsedPitchSource = Pick<AbcParsedNote, "accidentalText" | "pitchChar" | "octaveShift">;
+
+export type AbcMalformedAccidental = {
+  kind: "malformed-accidental";
+  accidentalText: string;
+  nextIdx: number;
+};
+
+export type AbcInvalidChord = {
+  kind: "invalid-chord";
   nextIdx: number;
 };
 
@@ -23,6 +37,7 @@ export type AbcParsedGraceGroup = {
   nextIdx: number;
 };
 
+// Structural tokens and body-level parser results.
 export type AbcParsedTuplet = {
   actual: number;
   normal: number;
@@ -31,11 +46,248 @@ export type AbcParsedTuplet = {
   raw: string;
 };
 
-export type AbcNoteParseResult =
-  | { kind: "note"; note: AbcParsedNote }
-  | { kind: "malformed-accidental"; accidentalText: string; nextIdx: number }
+export type AbcParsedRepeatEndingMarker = {
+  marker: string;
+  nextIdx: number;
+};
+
+export type AbcParsedInlineField = {
+  fieldName: string;
+  fieldValue: string;
+  nextIdx: number;
+};
+
+export type AbcParsedBarlineToken = {
+  nextIdx: number;
+  endsMeasure: boolean;
+  repeatEnd: boolean;
+  repeatStart: boolean;
+  endingStop: boolean;
+};
+
+export type AbcParsedStandaloneBodyField = {
+  fieldName: string;
+  fieldValue: string;
+  token: string;
+  nextIdx: number;
+};
+
+export type AbcParsedUnsupportedBodyToken = {
+  token: string;
+  nextIdx: number;
+};
+
+export type AbcParsedDelimitedSpan = {
+  delimiter: string;
+  text: string;
+  nextIdx: number;
+};
+
+export type AbcParsedQuotedString = {
+  rawText: string;
+  normalizedText: string;
+  nextIdx: number;
+  terminated: boolean;
+};
+
+export type AbcParsedDecoration = {
+  rawDecoration: string;
+  decoration: string;
+  delimiter: string;
+  nextIdx: number;
+  terminated: boolean;
+};
+
+export type AbcParsedBrokenRhythm = {
+  symbol: ">" | "<";
+  leftScale: { num: number; den: number };
+  rightScale: { num: number; den: number };
+  nextIdx: number;
+};
+
+export type AbcParsedSingleCharShorthand = {
+  kind:
+    | "arpeggiate"
+    | "fermata"
+    | "accent"
+    | "mordent"
+    | "inverted-mordent"
+    | "coda"
+    | "segno"
+    | "trill"
+    | "upbow"
+    | "downbow"
+    | "staccato";
+  nextIdx: number;
+};
+
+export type AbcParsedTie = {
+  nextIdx: number;
+};
+
+export type AbcParsedSlurStop = {
+  nextIdx: number;
+};
+
+export type AbcParsedParenToken =
+  | { kind: "tuplet"; tuplet: AbcParsedTuplet }
+  | { kind: "slur-start"; nextIdx: number };
+
+export type AbcParsedBracketToken =
+  | { kind: "inline-field"; inlineField: AbcParsedInlineField }
+  | { kind: "repeat-ending"; repeatEndingMarker: AbcParsedRepeatEndingMarker }
+  | { kind: "chord-start"; nextIdx: number };
+
+export type AbcParsedBodyToken =
+  | { kind: "broken-rhythm"; brokenRhythm: AbcParsedBrokenRhythm }
+  | { kind: "paren"; parenToken: AbcParsedParenToken }
+  | { kind: "single-char-shorthand"; shorthand: AbcParsedSingleCharShorthand }
+  | { kind: "tie"; tie: AbcParsedTie }
+  | { kind: "quoted-string"; quotedString: AbcParsedQuotedString }
+  | { kind: "decoration"; decoration: AbcParsedDecoration }
+  | { kind: "bracket"; bracketToken: AbcParsedBracketToken }
+  | { kind: "slur-stop"; slurStop: AbcParsedSlurStop };
+
+export type AbcParsedPlayableEvent =
+  | {
+      kind: "playable";
+      pitchSources: AbcParsedPitchSource[];
+      rawLengthToken: string;
+      nextIdx: number;
+      source: "note" | "chord";
+    }
+  | AbcMalformedAccidental
+  | AbcInvalidChord
   | null;
 
+export type AbcParsedBodyEntry =
+  | { kind: "barline"; barlineToken: AbcParsedBarlineToken }
+  | { kind: "standalone-body-field"; standaloneBodyField: AbcParsedStandaloneBodyField }
+  | { kind: "unsupported-body-token"; unsupportedBodyToken: AbcParsedUnsupportedBodyToken }
+  | { kind: "unsupported-body-number"; unsupportedBodyNumber: AbcParsedUnsupportedBodyToken }
+  | { kind: "body-token"; bodyToken: AbcParsedBodyToken }
+  | { kind: "playable-event"; playableEvent: Exclude<AbcParsedPlayableEvent, null> }
+  | null;
+
+// Narrow parser return types.
+export type AbcNoteParseResult =
+  | { kind: "note"; note: AbcParsedNote }
+  | AbcMalformedAccidental
+  | null;
+
+// Shared parser utilities and static lookup tables.
+const toAbcParsedPitchSource = (note: AbcParsedPitchSource): AbcParsedPitchSource => ({
+  accidentalText: note.accidentalText,
+  pitchChar: note.pitchChar,
+  octaveShift: note.octaveShift,
+});
+
+const firstMatch = <T>(matchers: Array<() => T | null>): T | null => {
+  for (const matcher of matchers) {
+    const matched = matcher();
+    if (matched) {
+      return matched;
+    }
+  }
+  return null;
+};
+
+const matchParsed = <TSource, TResult>(
+  parse: () => TSource | null,
+  map: (parsed: TSource) => TResult
+): TResult | null => {
+  const parsed = parse();
+  return parsed ? map(parsed) : null;
+};
+
+// Text access helpers.
+const rawText = (text: string): string => String(text || "");
+const charAt = (text: string, idx: number): string => rawText(text)[idx] || "";
+const sliceFrom = (text: string, startIdx: number): string => rawText(text).slice(startIdx);
+const matchFrom = (text: string, startIdx: number, pattern: RegExp): RegExpMatchArray | null =>
+  sliceFrom(text, startIdx).match(pattern);
+
+// Wrapper builders for higher-level parser results.
+const withBracketToken = <TKind extends AbcParsedBracketToken["kind"]>(
+  kind: TKind,
+  payload: Omit<Extract<AbcParsedBracketToken, { kind: TKind }>, "kind">
+): Extract<AbcParsedBracketToken, { kind: TKind }> =>
+  ({
+    kind,
+    ...payload,
+  }) as Extract<AbcParsedBracketToken, { kind: TKind }>;
+
+const withBodyToken = <TKind extends AbcParsedBodyToken["kind"]>(
+  kind: TKind,
+  payload: Omit<Extract<AbcParsedBodyToken, { kind: TKind }>, "kind">
+): Extract<AbcParsedBodyToken, { kind: TKind }> =>
+  ({
+    kind,
+    ...payload,
+  }) as Extract<AbcParsedBodyToken, { kind: TKind }>;
+
+const withBodyEntry = <TKind extends Exclude<AbcParsedBodyEntry, null>["kind"]>(
+  kind: TKind,
+  payload: Omit<Extract<Exclude<AbcParsedBodyEntry, null>, { kind: TKind }>, "kind">
+): Extract<Exclude<AbcParsedBodyEntry, null>, { kind: TKind }> =>
+  ({
+    kind,
+    ...payload,
+  }) as Extract<Exclude<AbcParsedBodyEntry, null>, { kind: TKind }>;
+
+const withPlayableEvent = (
+  source: "note" | "chord",
+  pitchSources: AbcParsedPitchSource[],
+  rawLengthToken: string,
+  nextIdx: number
+): Extract<AbcParsedPlayableEvent, { kind: "playable" }> => ({
+  kind: "playable",
+  pitchSources,
+  rawLengthToken,
+  nextIdx,
+  source,
+});
+
+const withInvalidChord = (nextIdx: number): Extract<AbcParsedPlayableEvent, { kind: "invalid-chord" }> => ({
+  kind: "invalid-chord",
+  nextIdx,
+});
+
+// Static lookup tables.
+const ABC_BARLINE_CANDIDATES: Array<{
+  token: string;
+  endsMeasure: boolean;
+  repeatEnd: boolean;
+  repeatStart: boolean;
+  endingStop: boolean;
+}> = [
+  { token: ":|]", endsMeasure: true, repeatEnd: true, repeatStart: false, endingStop: true },
+  { token: ":|:", endsMeasure: true, repeatEnd: true, repeatStart: true, endingStop: false },
+  { token: "|:", endsMeasure: true, repeatEnd: false, repeatStart: true, endingStop: false },
+  { token: ":|", endsMeasure: true, repeatEnd: true, repeatStart: false, endingStop: false },
+  { token: "::", endsMeasure: true, repeatEnd: true, repeatStart: true, endingStop: false },
+  { token: "[|", endsMeasure: true, repeatEnd: false, repeatStart: false, endingStop: false },
+  { token: "|]", endsMeasure: true, repeatEnd: false, repeatStart: false, endingStop: false },
+  { token: "||", endsMeasure: true, repeatEnd: false, repeatStart: false, endingStop: false },
+  { token: "|", endsMeasure: true, repeatEnd: false, repeatStart: false, endingStop: false },
+  { token: ":", endsMeasure: false, repeatEnd: false, repeatStart: false, endingStop: false },
+];
+
+const ABC_SINGLE_CHAR_SHORTHAND_BY_CHAR: Record<string, AbcParsedSingleCharShorthand["kind"]> = {
+  "~": "arpeggiate",
+  H: "fermata",
+  L: "accent",
+  M: "mordent",
+  O: "coda",
+  P: "inverted-mordent",
+  S: "segno",
+  T: "trill",
+  u: "upbow",
+  v: "downbow",
+  ".": "staccato",
+};
+
+// Low-level lexical and structural parsers.
 export const parseAbcNoteAt = (text: string, startIdx: number): AbcNoteParseResult => {
   const note = lexAbcNote(text, startIdx);
   if (note) {
@@ -141,10 +393,10 @@ export const parseAbcGraceGroupAt = (
 };
 
 export const parseAbcTupletAt = (text: string, startIdx: number): AbcParsedTuplet | null => {
-  if (text[startIdx] !== "(") {
+  if (charAt(text, startIdx) !== "(") {
     return null;
   }
-  const match = text.slice(startIdx).match(/^\((\d)(?::(\d))?(?::(\d))?/);
+  const match = matchFrom(text, startIdx, /^\((\d)(?::(\d))?(?::(\d))?/);
   if (!match) {
     return null;
   }
@@ -160,4 +412,320 @@ export const parseAbcTupletAt = (text: string, startIdx: number): AbcParsedTuple
     nextIdx: startIdx + match[0].length,
     raw: match[0],
   };
+};
+
+export const parseAbcRepeatEndingMarkerAt = (
+  text: string,
+  startIdx: number
+): AbcParsedRepeatEndingMarker | null => {
+  const match = matchFrom(text, startIdx, /^\[(\d+(?:[,-]\d+)*)/);
+  if (!match) {
+    return null;
+  }
+  return {
+    marker: match[1],
+    nextIdx: startIdx + match[0].length,
+  };
+};
+
+export const parseAbcBareRepeatEndingMarkerAt = (
+  text: string,
+  startIdx: number
+): AbcParsedRepeatEndingMarker | null => {
+  const match = matchFrom(text, startIdx, /^(\d+(?:[,-]\d+)*)/);
+  if (!match) {
+    return null;
+  }
+  return {
+    marker: match[1],
+    nextIdx: startIdx + match[0].length,
+  };
+};
+
+export const parseAbcInlineFieldAt = (text: string, startIdx: number): AbcParsedInlineField | null => {
+  const match = matchFrom(text, startIdx, /^\[([A-Za-z]):([^\]]*)\]/);
+  if (!match) {
+    return null;
+  }
+  return {
+    fieldName: String(match[1] || "").toUpperCase(),
+    fieldValue: String(match[2] || "").trim(),
+    nextIdx: startIdx + match[0].length,
+  };
+};
+
+export const parseAbcBarlineTokenAt = (text: string, startIdx: number): AbcParsedBarlineToken | null => {
+  const slice = sliceFrom(text, startIdx);
+  for (const candidate of ABC_BARLINE_CANDIDATES) {
+    if (slice.startsWith(candidate.token)) {
+      return {
+        nextIdx: startIdx + candidate.token.length,
+        endsMeasure: candidate.endsMeasure,
+        repeatEnd: candidate.repeatEnd,
+        repeatStart: candidate.repeatStart,
+        endingStop: candidate.endingStop,
+      };
+    }
+  }
+  return null;
+};
+
+export const parseAbcStandaloneBodyFieldAt = (
+  text: string,
+  startIdx: number
+): AbcParsedStandaloneBodyField | null => {
+  const match = matchFrom(text, startIdx, /^([A-Za-z]):([^\s\]|]+)/);
+  if (!match) {
+    return null;
+  }
+  return {
+    fieldName: String(match[1] || "").toUpperCase(),
+    fieldValue: String(match[2] || "").trim(),
+    token: match[0],
+    nextIdx: startIdx + match[0].length,
+  };
+};
+
+export const parseAbcUnsupportedBodyTokenAt = (
+  text: string,
+  startIdx: number
+): AbcParsedUnsupportedBodyToken | null => {
+  const match = matchFrom(text, startIdx, /^([IJNQRWY][A-Za-z0-9_-]*|[h-jl-pr-twy][a-z][A-Za-z0-9_-]*)/);
+  if (!match) {
+    return null;
+  }
+  return {
+    token: match[1],
+    nextIdx: startIdx + match[1].length,
+  };
+};
+
+export const parseAbcUnsupportedBodyNumberAt = (
+  text: string,
+  startIdx: number
+): AbcParsedUnsupportedBodyToken | null => {
+  const match = matchFrom(text, startIdx, /^(\d+)/);
+  if (!match) {
+    return null;
+  }
+  return {
+    token: match[1],
+    nextIdx: startIdx + match[1].length,
+  };
+};
+
+export const parseAbcDelimitedSpanAt = (
+  text: string,
+  startIdx: number,
+  delimiter: string
+): AbcParsedDelimitedSpan | null => {
+  if (!delimiter || charAt(text, startIdx) !== delimiter) {
+    return null;
+  }
+  const raw = rawText(text);
+  let endIdx = startIdx + 1;
+  while (endIdx < raw.length && raw[endIdx] !== delimiter) {
+    endIdx += 1;
+  }
+  const nextIdx = Math.min(raw.length, endIdx + 1);
+  return {
+    delimiter,
+    text: raw.slice(startIdx, nextIdx),
+    nextIdx,
+  };
+};
+
+export const parseAbcQuotedStringAt = (text: string, startIdx: number): AbcParsedQuotedString | null => {
+  const span = parseAbcDelimitedSpanAt(text, startIdx, '"');
+  if (!span) {
+    return null;
+  }
+  const terminated = span.text.endsWith('"') && span.text.length >= 2;
+  const rawText = terminated ? span.text.slice(1, -1) : span.text.slice(1);
+  return {
+    rawText,
+    normalizedText: rawText.replace(/^[\^_<>@]/, "").trim(),
+    nextIdx: span.nextIdx,
+    terminated,
+  };
+};
+
+export const parseAbcDecorationAt = (text: string, startIdx: number): AbcParsedDecoration | null => {
+  const first = charAt(text, startIdx);
+  if (first !== "!" && first !== "+") {
+    return null;
+  }
+  const span = parseAbcDelimitedSpanAt(text, startIdx, first);
+  if (!span) {
+    return null;
+  }
+  const terminated = span.text.endsWith(first) && span.text.length >= 2;
+  const rawDecoration = terminated ? span.text.slice(1, -1).trim() : span.text.slice(1).trim();
+  return {
+    rawDecoration,
+    decoration: rawDecoration.toLowerCase(),
+    delimiter: first,
+    nextIdx: span.nextIdx,
+    terminated,
+  };
+};
+
+export const parseAbcBrokenRhythmAt = (text: string, startIdx: number): AbcParsedBrokenRhythm | null => {
+  const symbol = charAt(text, startIdx);
+  if (symbol !== ">" && symbol !== "<") {
+    return null;
+  }
+  return {
+    symbol,
+    leftScale: symbol === ">" ? { num: 3, den: 2 } : { num: 1, den: 2 },
+    rightScale: symbol === ">" ? { num: 1, den: 2 } : { num: 3, den: 2 },
+    nextIdx: startIdx + 1,
+  };
+};
+
+export const parseAbcSingleCharShorthandAt = (
+  text: string,
+  startIdx: number
+): AbcParsedSingleCharShorthand | null => {
+  const symbol = charAt(text, startIdx);
+  const kind = ABC_SINGLE_CHAR_SHORTHAND_BY_CHAR[symbol];
+  if (!kind) {
+    return null;
+  }
+  return {
+    kind,
+    nextIdx: startIdx + 1,
+  };
+};
+
+export const parseAbcTieAt = (text: string, startIdx: number): AbcParsedTie | null => {
+  if (charAt(text, startIdx) !== "-") {
+    return null;
+  }
+  return { nextIdx: startIdx + 1 };
+};
+
+export const parseAbcSlurStopAt = (text: string, startIdx: number): AbcParsedSlurStop | null => {
+  if (charAt(text, startIdx) !== ")") {
+    return null;
+  }
+  return { nextIdx: startIdx + 1 };
+};
+
+export const parseAbcParenTokenAt = (text: string, startIdx: number): AbcParsedParenToken | null => {
+  if (charAt(text, startIdx) !== "(") {
+    return null;
+  }
+  return matchParsed(() => parseAbcTupletAt(text, startIdx), (tuplet) => ({ kind: "tuplet", tuplet })) || {
+    kind: "slur-start",
+    nextIdx: startIdx + 1,
+  };
+};
+
+export const parseAbcBracketTokenAt = (text: string, startIdx: number): AbcParsedBracketToken | null => {
+  if (charAt(text, startIdx) !== "[") {
+    return null;
+  }
+  return (
+    matchParsed(() => parseAbcInlineFieldAt(text, startIdx), (inlineField) =>
+      withBracketToken("inline-field", { inlineField })
+    ) ||
+    matchParsed(() => parseAbcRepeatEndingMarkerAt(text, startIdx), (repeatEndingMarker) =>
+      withBracketToken("repeat-ending", { repeatEndingMarker })
+    ) ||
+    withBracketToken("chord-start", { nextIdx: startIdx + 1 })
+  );
+};
+
+// High-level body dispatchers.
+export const parseAbcBodyTokenAt = (text: string, startIdx: number): AbcParsedBodyToken | null => {
+  return firstMatch<AbcParsedBodyToken>([
+    () =>
+      matchParsed(() => parseAbcBrokenRhythmAt(text, startIdx), (brokenRhythm) =>
+        withBodyToken("broken-rhythm", { brokenRhythm })
+      ),
+    () =>
+      matchParsed(() => parseAbcParenTokenAt(text, startIdx), (parenToken) =>
+        withBodyToken("paren", { parenToken })
+      ),
+    () =>
+      matchParsed(() => parseAbcSingleCharShorthandAt(text, startIdx), (shorthand) =>
+        withBodyToken("single-char-shorthand", { shorthand })
+      ),
+    () => matchParsed(() => parseAbcTieAt(text, startIdx), (tie) => withBodyToken("tie", { tie })),
+    () =>
+      matchParsed(() => parseAbcQuotedStringAt(text, startIdx), (quotedString) =>
+        withBodyToken("quoted-string", { quotedString })
+      ),
+    () =>
+      matchParsed(() => parseAbcDecorationAt(text, startIdx), (decoration) =>
+        withBodyToken("decoration", { decoration })
+      ),
+    () =>
+      matchParsed(() => parseAbcBracketTokenAt(text, startIdx), (bracketToken) =>
+        withBodyToken("bracket", { bracketToken })
+      ),
+    () =>
+      matchParsed(() => parseAbcSlurStopAt(text, startIdx), (slurStop) =>
+        withBodyToken("slur-stop", { slurStop })
+      ),
+  ]);
+};
+
+export const parseAbcPlayableEventAt = (text: string, startIdx: number): AbcParsedPlayableEvent => {
+  if (charAt(text, startIdx) === "[") {
+    const chord = parseAbcChordAt(text, startIdx);
+    if (!chord) {
+      return withInvalidChord(startIdx + 1);
+    }
+    return withPlayableEvent(
+      "chord",
+      chord.notes.map(toAbcParsedPitchSource),
+      chord.lengthToken || (chord.notes.length > 0 ? chord.notes[0].lengthToken : ""),
+      chord.nextIdx
+    );
+  }
+
+  const noteResult = parseAbcNoteAt(text, startIdx);
+  if (!noteResult) {
+    return null;
+  }
+  if (noteResult.kind === "malformed-accidental") {
+    return noteResult;
+  }
+  return withPlayableEvent(
+    "note",
+    [toAbcParsedPitchSource(noteResult.note)],
+    noteResult.note.lengthToken,
+    noteResult.note.nextIdx
+  );
+};
+
+export const parseAbcBodyEntryAt = (text: string, startIdx: number): AbcParsedBodyEntry => {
+  return firstMatch<AbcParsedBodyEntry>([
+    () =>
+      matchParsed(() => parseAbcBarlineTokenAt(text, startIdx), (barlineToken) =>
+        withBodyEntry("barline", { barlineToken })
+      ),
+    () =>
+      matchParsed(() => parseAbcStandaloneBodyFieldAt(text, startIdx), (standaloneBodyField) =>
+        withBodyEntry("standalone-body-field", { standaloneBodyField })
+      ),
+    () =>
+      matchParsed(() => parseAbcUnsupportedBodyTokenAt(text, startIdx), (unsupportedBodyToken) =>
+        withBodyEntry("unsupported-body-token", { unsupportedBodyToken })
+      ),
+    () =>
+      matchParsed(() => parseAbcUnsupportedBodyNumberAt(text, startIdx), (unsupportedBodyNumber) =>
+        withBodyEntry("unsupported-body-number", { unsupportedBodyNumber })
+      ),
+    () =>
+      matchParsed(() => parseAbcBodyTokenAt(text, startIdx), (bodyToken) =>
+        withBodyEntry("body-token", { bodyToken })
+      ),
+    () =>
+      matchParsed(() => parseAbcPlayableEventAt(text, startIdx), (playableEvent) =>
+        withBodyEntry("playable-event", { playableEvent })
+      ),
+  ]);
 };

--- a/tests/unit/abc-io.spec.ts
+++ b/tests/unit/abc-io.spec.ts
@@ -1261,6 +1261,44 @@ K:C
     );
   });
 
+  it("ABC->MusicXML skips abcjs wrapper lines with warning instead of failing", () => {
+    const abc = `[abcjs-audio engraver="{responsive:'resize'}"]
+X:1
+T:Kaeru
+M:4/4
+L:1/4
+Q:1/4=100
+K:C
+|CDEF | EDCz| EFGA | GFEz |
+| CzCz | CzCz | C/2C/2D/2D/2 E/2E/2F/2F/2 | EDCz||
+[/abcjs-audio]`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    expect(outDoc.querySelectorAll("part > measure").length).toBeGreaterThan(0);
+    expect(outDoc.querySelector('miscellaneous-field[name="mks:diag:count"]')).not.toBeNull();
+    expect(outDoc.querySelector('miscellaneous-field[name="mks:diag:0001"]')?.textContent).toContain(
+      "Skipped unsupported abcjs wrapper line"
+    );
+  });
+
+  it("ABC->MusicXML marks an underfull first bar as implicit pickup", () => {
+    const abc = `X:1
+K:D
+D | G3F E3
+w: Hey ho, hey ho!`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    expect(outDoc.querySelector('part > measure[number="1"]')?.getAttribute("implicit")).toBe("yes");
+  });
+
   it("ABC->MusicXML warns on unsupported standalone body fields instead of treating them as header metadata", () => {
     const abc = `X:1
 T:Standalone unsupported body field

--- a/tests/unit/abc-parser.spec.ts
+++ b/tests/unit/abc-parser.spec.ts
@@ -1,0 +1,328 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseAbcBareRepeatEndingMarkerAt,
+  parseAbcBodyEntryAt,
+  parseAbcBodyTokenAt,
+  parseAbcBracketTokenAt,
+  parseAbcBrokenRhythmAt,
+  parseAbcBarlineTokenAt,
+  parseAbcDecorationAt,
+  parseAbcDelimitedSpanAt,
+  parseAbcInlineFieldAt,
+  parseAbcParenTokenAt,
+  parseAbcPlayableEventAt,
+  parseAbcQuotedStringAt,
+  parseAbcRepeatEndingMarkerAt,
+  parseAbcSingleCharShorthandAt,
+  parseAbcSlurStopAt,
+  parseAbcStandaloneBodyFieldAt,
+  parseAbcTieAt,
+  parseAbcUnsupportedBodyNumberAt,
+  parseAbcUnsupportedBodyTokenAt,
+} from "../../src/ts/abc-parser";
+
+// Atomic token and payload helpers.
+const pitchSource = (pitchChar: string, accidentalText = "", octaveShift = "") => ({
+  accidentalText,
+  pitchChar,
+  octaveShift,
+});
+
+// Playable-event helpers.
+const playableEvent = (
+  source: "note" | "chord",
+  pitchChars: string[],
+  rawLengthToken: string,
+  nextIdx: number
+) => ({
+  kind: "playable" as const,
+  pitchSources: pitchChars.map((pitchChar) => pitchSource(pitchChar)),
+  rawLengthToken,
+  nextIdx,
+  source,
+});
+
+const malformedAccidental = (accidentalText: string, nextIdx: number) => ({
+  kind: "malformed-accidental" as const,
+  accidentalText,
+  nextIdx,
+});
+
+const invalidChord = (nextIdx: number) => ({
+  kind: "invalid-chord" as const,
+  nextIdx,
+});
+
+// Token result helpers.
+const barlineToken = (
+  nextIdx: number,
+  endsMeasure: boolean,
+  repeatEnd: boolean,
+  repeatStart: boolean,
+  endingStop: boolean
+) => ({
+  nextIdx,
+  endsMeasure,
+  repeatEnd,
+  repeatStart,
+  endingStop,
+});
+
+const brokenRhythmToken = (symbol: ">" | "<", nextIdx: number) => ({
+  symbol,
+  leftScale: symbol === ">" ? { num: 3, den: 2 } : { num: 1, den: 2 },
+  rightScale: symbol === ">" ? { num: 1, den: 2 } : { num: 3, den: 2 },
+  nextIdx,
+});
+
+const inlineField = (fieldName: string, fieldValue: string, nextIdx: number) => ({
+  fieldName,
+  fieldValue,
+  nextIdx,
+});
+
+const repeatEndingMarker = (marker: string, nextIdx: number) => ({
+  marker,
+  nextIdx,
+});
+
+const standaloneBodyField = (fieldName: string, fieldValue: string, token: string, nextIdx: number) => ({
+  fieldName,
+  fieldValue,
+  token,
+  nextIdx,
+});
+
+const unsupportedBodyToken = (token: string, nextIdx: number) => ({
+  token,
+  nextIdx,
+});
+
+const nextIdxToken = (nextIdx: number) => ({
+  nextIdx,
+});
+
+const delimitedSpan = (delimiter: string, text: string, nextIdx: number) => ({
+  delimiter,
+  text,
+  nextIdx,
+});
+
+const quotedStringToken = (
+  rawText: string,
+  normalizedText: string,
+  nextIdx: number,
+  terminated: boolean
+) => ({
+  rawText,
+  normalizedText,
+  nextIdx,
+  terminated,
+});
+
+const singleCharShorthandToken = (kind: string, nextIdx: number) => ({
+  kind,
+  nextIdx,
+});
+
+// Structural token helpers.
+const tupletToken = (actual: number, normal: number, count: number, nextIdx: number, raw: string) => ({
+  actual,
+  normal,
+  count,
+  nextIdx,
+  raw,
+});
+
+const parenToken = (kind: string, payload: Record<string, unknown>) => ({
+  kind,
+  ...payload,
+});
+
+// Dispatcher wrapper helpers.
+const bracketToken = (kind: string, payload: Record<string, unknown>) => ({
+  kind,
+  ...payload,
+});
+
+const bodyToken = (kind: string, payload: Record<string, unknown>) => ({
+  kind,
+  ...payload,
+});
+
+const bodyEntry = (kind: string, payload: Record<string, unknown>) => ({
+  kind,
+  ...payload,
+});
+
+const decorationToken = (
+  rawDecoration: string,
+  decoration: string,
+  delimiter: string,
+  nextIdx: number,
+  terminated: boolean
+) => ({
+  rawDecoration,
+  decoration,
+  delimiter,
+  nextIdx,
+  terminated,
+});
+
+describe("ABC parser helpers", () => {
+  describe("field and barline helpers", () => {
+    it("parses inline body fields with normalized field names", () => {
+      expect(parseAbcInlineFieldAt("[k: Cmaj ] rest", 0)).toEqual(inlineField("K", "Cmaj", 10));
+    });
+
+    it("parses repeat ending markers in bracketed and bare forms", () => {
+      expect(parseAbcRepeatEndingMarkerAt("[1,2 C", 0)).toEqual(repeatEndingMarker("1,2", 4));
+      expect(parseAbcBareRepeatEndingMarkerAt("2-3 z", 0)).toEqual(repeatEndingMarker("2-3", 3));
+    });
+
+    it("parses barline tokens with repeat metadata", () => {
+      expect(parseAbcBarlineTokenAt(":|] next", 0)).toEqual(barlineToken(3, true, true, false, true));
+      expect(parseAbcBarlineTokenAt(":: next", 0)).toEqual(barlineToken(2, true, true, true, false));
+      expect(parseAbcBarlineTokenAt(": orphan", 0)).toEqual(barlineToken(1, false, false, false, false));
+    });
+
+    it("returns null when field and barline helpers do not match", () => {
+      expect(parseAbcInlineFieldAt("K:C", 0)).toBeNull();
+      expect(parseAbcRepeatEndingMarkerAt("|1", 0)).toBeNull();
+      expect(parseAbcBareRepeatEndingMarkerAt("abc", 0)).toBeNull();
+      expect(parseAbcBarlineTokenAt("abc", 0)).toBeNull();
+    });
+
+    it("parses standalone body fields and unsupported fallback tokens", () => {
+      expect(parseAbcStandaloneBodyFieldAt("q:120 rest", 0)).toEqual(
+        standaloneBodyField("Q", "120", "q:120", 5)
+      );
+      expect(parseAbcUnsupportedBodyTokenAt("restLike next", 0)).toEqual(unsupportedBodyToken("restLike", 8));
+      expect(parseAbcUnsupportedBodyNumberAt("123 abc", 0)).toEqual(unsupportedBodyToken("123", 3));
+    });
+  });
+
+  describe("span and token helpers", () => {
+    it("parses delimited quoted and decoration spans", () => {
+      expect(parseAbcDelimitedSpanAt("\"text\" tail", 0, '"')).toEqual(delimitedSpan('"', "\"text\"", 6));
+      expect(parseAbcDelimitedSpanAt("!trill!C", 0, "!")).toEqual(delimitedSpan("!", "!trill!", 7));
+      expect(parseAbcDelimitedSpanAt("+sym", 0, "+")).toEqual(delimitedSpan("+", "+sym", 4));
+    });
+
+    it("parses quoted strings and decorations with termination state", () => {
+      expect(parseAbcQuotedStringAt("\"^Cmaj7\" tail", 0)).toEqual(
+        quotedStringToken("^Cmaj7", "Cmaj7", 8, true)
+      );
+      expect(parseAbcQuotedStringAt("\"unterminated", 0)).toEqual(
+        quotedStringToken("unterminated", "unterminated", 13, false)
+      );
+      expect(parseAbcDecorationAt("!Trill!C", 0)).toEqual(decorationToken("Trill", "trill", "!", 7, true));
+      expect(parseAbcDecorationAt("+unterminated", 0)).toEqual(
+        decorationToken("unterminated", "unterminated", "+", 13, false)
+      );
+    });
+
+    it("parses broken-rhythm shorthand", () => {
+      expect(parseAbcBrokenRhythmAt("> next", 0)).toEqual(brokenRhythmToken(">", 1));
+      expect(parseAbcBrokenRhythmAt("< next", 0)).toEqual(brokenRhythmToken("<", 1));
+    });
+
+    it("parses single-character body shorthand tokens", () => {
+      expect(parseAbcSingleCharShorthandAt("~", 0)).toEqual(singleCharShorthandToken("arpeggiate", 1));
+      expect(parseAbcSingleCharShorthandAt("P", 0)).toEqual(singleCharShorthandToken("inverted-mordent", 1));
+      expect(parseAbcSingleCharShorthandAt(".", 0)).toEqual(singleCharShorthandToken("staccato", 1));
+      expect(parseAbcSingleCharShorthandAt("x", 0)).toBeNull();
+    });
+
+    it("parses tie and slur-stop tokens", () => {
+      expect(parseAbcTieAt("-", 0)).toEqual(nextIdxToken(1));
+      expect(parseAbcSlurStopAt(")", 0)).toEqual(nextIdxToken(1));
+      expect(parseAbcTieAt("x", 0)).toBeNull();
+      expect(parseAbcSlurStopAt("x", 0)).toBeNull();
+    });
+  });
+
+  describe("structural token helpers", () => {
+    it("parses parenthesis tokens as tuplet or slur-start", () => {
+      expect(parseAbcParenTokenAt("(3ABC", 0)).toEqual(
+        parenToken("tuplet", { tuplet: tupletToken(3, 2, 3, 2, "(3") })
+      );
+      expect(parseAbcParenTokenAt("(C", 0)).toEqual(parenToken("slur-start", { nextIdx: 1 }));
+      expect(parseAbcParenTokenAt("(", 0)).toEqual(parenToken("slur-start", { nextIdx: 1 }));
+      expect(parseAbcParenTokenAt("C", 0)).toBeNull();
+    });
+
+    it("parses bracket tokens as inline-field, repeat-ending, or chord-start", () => {
+      expect(parseAbcBracketTokenAt("[K:C] C", 0)).toEqual(
+        bracketToken("inline-field", { inlineField: inlineField("K", "C", 5) })
+      );
+      expect(parseAbcBracketTokenAt("[1,2 C", 0)).toEqual(
+        bracketToken("repeat-ending", { repeatEndingMarker: repeatEndingMarker("1,2", 4) })
+      );
+      expect(parseAbcBracketTokenAt("[CEG]2", 0)).toEqual(bracketToken("chord-start", { nextIdx: 1 }));
+      expect(parseAbcBracketTokenAt("[", 0)).toEqual(bracketToken("chord-start", { nextIdx: 1 }));
+      expect(parseAbcBracketTokenAt("C", 0)).toBeNull();
+    });
+
+    it("dispatches common body tokens through a single parser entrypoint", () => {
+      expect(parseAbcBodyTokenAt(">A", 0)).toEqual(
+        bodyToken("broken-rhythm", { brokenRhythm: brokenRhythmToken(">", 1) })
+      );
+      expect(parseAbcBodyTokenAt("\"txt\"", 0)).toEqual(
+        bodyToken("quoted-string", { quotedString: quotedStringToken("txt", "txt", 5, true) })
+      );
+      expect(parseAbcBodyTokenAt("!trill!", 0)).toEqual(
+        bodyToken("decoration", { decoration: decorationToken("trill", "trill", "!", 7, true) })
+      );
+      expect(parseAbcBodyTokenAt("[K:C]", 0)).toEqual(
+        bodyToken("bracket", {
+          bracketToken: bracketToken("inline-field", { inlineField: inlineField("K", "C", 5) }),
+        })
+      );
+      expect(parseAbcBodyTokenAt(")", 0)).toEqual(bodyToken("slur-stop", { slurStop: nextIdxToken(1) }));
+      expect(parseAbcBodyTokenAt("-", 0)).toEqual(bodyToken("tie", { tie: nextIdxToken(1) }));
+      expect(parseAbcBodyTokenAt("C", 0)).toBeNull();
+    });
+  });
+
+  describe("high-level entrypoints", () => {
+    it("parses playable note and chord events through a shared parser entrypoint", () => {
+      expect(parseAbcPlayableEventAt("C2", 0)).toEqual(playableEvent("note", ["C"], "2", 2));
+      expect(parseAbcPlayableEventAt("[CEG]2", 0)).toEqual(playableEvent("chord", ["C", "E", "G"], "2", 6));
+      expect(parseAbcPlayableEventAt("^", 0)).toEqual(malformedAccidental("^", 1));
+      expect(parseAbcPlayableEventAt("[", 0)).toEqual(invalidChord(1));
+      expect(parseAbcPlayableEventAt("x", 0)).toEqual(playableEvent("note", ["x"], "", 1));
+      expect(parseAbcPlayableEventAt("!", 0)).toBeNull();
+    });
+
+    it("dispatches body entries through a higher-level parser entrypoint", () => {
+      expect(parseAbcBodyEntryAt("|: C", 0)).toEqual(
+        bodyEntry("barline", { barlineToken: barlineToken(2, true, false, true, false) })
+      );
+      expect(parseAbcBodyEntryAt("Q:120 C", 0)).toEqual(
+        bodyEntry("standalone-body-field", {
+          standaloneBodyField: standaloneBodyField("Q", "120", "Q:120", 5),
+        })
+      );
+      expect(parseAbcBodyEntryAt("restLike", 0)).toEqual(
+        bodyEntry("unsupported-body-token", { unsupportedBodyToken: unsupportedBodyToken("restLike", 8) })
+      );
+      expect(parseAbcBodyEntryAt("123abc", 0)).toEqual(
+        bodyEntry("unsupported-body-number", { unsupportedBodyNumber: unsupportedBodyToken("123", 3) })
+      );
+      expect(parseAbcBodyEntryAt(">A", 0)).toEqual(
+        bodyEntry("body-token", {
+          bodyToken: bodyToken("broken-rhythm", { brokenRhythm: brokenRhythmToken(">", 1) }),
+        })
+      );
+      expect(parseAbcBodyEntryAt("C2", 0)).toEqual(
+        bodyEntry("playable-event", { playableEvent: playableEvent("note", ["C"], "2", 2) })
+      );
+      expect(parseAbcBodyEntryAt("!", 0)).toEqual(
+        bodyEntry("body-token", {
+          bodyToken: bodyToken("decoration", { decoration: decorationToken("", "", "!", 1, false) }),
+        })
+      );
+    });
+  });
+});


### PR DESCRIPTION
### 概要

ABC 取り込み処理について、`src/ts/abc-parser.ts` の parser helper / dispatcher を拡張し、`src/ts/abc-io.ts` のボディ解析を parser ベースの構成へ整理します。あわせて parser / import の回帰テストを追加し、関連ドキュメントの現状追従を行います。

### 変更内容

- `src/ts/abc-parser.ts`
  - ABC ボディ解析向けの型定義を拡張
  - note / chord / grace / tuplet に加えて、以下の parser helper / dispatcher を追加・整理
    - repeat ending marker
    - inline field
    - barline token
    - standalone body field
    - unsupported body token / number
    - delimited span
    - quoted string
    - decoration
    - broken rhythm
    - single-char shorthand
    - tie / slur-stop
    - paren token
    - bracket token
    - body token
    - playable event
    - body entry
  - parser 内の utility / wrapper builder / lookup table を整理し、読み順を改善

- `src/ts/abc-io.ts`
  - ABC body import を parser helper / dispatcher 利用前提へ整理
  - body loop を handler ベースに分割し、state 適用と event 組み立ての責務を明確化
  - unsupported な `abcjs` wrapper 行を、警告付きで skip する処理を追加
  - 先頭の underfull 小節を、弱起として `implicit="yes"` 推定できるよう調整

- `tests/unit/abc-parser.spec.ts`
  - parser helper 向けの単体テストを新規追加
  - body token / body entry / playable event を含む parser 単位の挙動を固定

- `tests/unit/abc-io.spec.ts`
  - `abcjs` wrapper 行を含む入力の warn-and-skip 回帰テストを追加
  - 先頭 underfull 小節を弱起として扱う回帰テストを追加

- ドキュメント更新
  - `TODO.md`
    - ABC lexer/parser 移行タスクの進捗と再開メモを現状に追従
  - `docs/spec/abc-compat-parser-ebnf.md`
    - この文書が practical grammar baseline であり、実装と完全同期の仕様書ではない旨の注意書きを追加

- 生成物更新
  - `src/js/main.js`
  - `mikuscore.html`

### 期待する効果

- `abc-io.ts` 側のボディ解析を、手書き分岐中心の構造から parser-driven な構造へ整理
- ABC parser helper を `src/ts/abc-parser.ts` に集約し、保守しやすくする
- unsupported 入力や弱起ケースに対する回帰を追加し、挙動を固定する

### 影響範囲

- ABC import
- ABC parser helper
- ABC import / parser の unit test
- 関連ドキュメント
- 生成物

### テスト

- `tests/unit/abc-parser.spec.ts` を追加
- `tests/unit/abc-io.spec.ts` を更新