### PR TITLE
ABCのinline voice処理を修正し、CLIテストとビルド負荷を軽減

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -12,6 +12,13 @@
     - `scripts/lib/load-cli-api.mjs`
   - Re-evaluate whether Step 2 should keep this loader or move to a build-produced CLI entry.
 
+- [ ] Investigate the root cause of `load-cli-api.mjs` runtime fragility before changing its compilation strategy.
+  - Scope:
+    - `scripts/lib/load-cli-api.mjs`
+  - Current stance:
+    - do not switch to a `tsc` CLI subprocess workaround without a clearer root-cause explanation
+    - prefer understanding why direct runtime TypeScript loading fails in some environments before accepting a different bootstrap path
+
 - [ ] Harden Step 2 MIDI conversion pairs.
   - Current first cut exists for:
     - `mikuscore convert --from midi --to musicxml`

--- a/mikuscore.html
+++ b/mikuscore.html
@@ -19064,7 +19064,14 @@ const firstDirectChildByTag = (parent, tagName) => {
 const readFirstVBoxTextByStyle = (score, styleName) => {
     var _a, _b, _c, _d;
     const lowerStyle = styleName.trim().toLowerCase();
-    const textNodes = directChildrenByTag(score, "Staff").flatMap((staff) => directChildrenByTag(staff, "VBox").flatMap((vbox) => directChildrenByTag(vbox, "Text")));
+    const textNodes = [];
+    for (const staff of directChildrenByTag(score, "Staff")) {
+        for (const vbox of directChildrenByTag(staff, "VBox")) {
+            for (const textNode of directChildrenByTag(vbox, "Text")) {
+                textNodes.push(textNode);
+            }
+        }
+    }
     for (const textNode of textNodes) {
         const style = ((_b = (_a = firstDirectChildByTag(textNode, "style")) === null || _a === void 0 ? void 0 : _a.textContent) !== null && _b !== void 0 ? _b : "").trim().toLowerCase();
         if (style !== lowerStyle)
@@ -29418,7 +29425,10 @@ function splitBodyTextByInlineVoice(text, initialVoiceId) {
     if (buffer.trim()) {
         segments.push({ voiceId: activeVoiceId, text: buffer });
     }
-    return segments;
+    return {
+        segments,
+        finalVoiceId: activeVoiceId,
+    };
 }
 function splitBodyTextByOverlay(text, baseVoiceId) {
     const raw = String(text || "");
@@ -29597,7 +29607,7 @@ function parseForMusicXml(source, settings) {
             return;
         }
         bodyStarted = true;
-        const inlineVoiceSegments = splitBodyTextByInlineVoice(normalizedBodyText, voiceId);
+        const { segments: inlineVoiceSegments, finalVoiceId } = splitBodyTextByInlineVoice(normalizedBodyText, voiceId);
         for (const segment of inlineVoiceSegments) {
             const overlaySegments = splitBodyTextByOverlay(segment.text, segment.voiceId);
             for (const overlaySegment of overlaySegments) {
@@ -29619,6 +29629,7 @@ function parseForMusicXml(source, settings) {
                 bodyEntries.push({ text: overlaySegment.text, lineNo, voiceId: overlaySegment.voiceId });
             }
         }
+        currentVoiceId = String(finalVoiceId || voiceId || "1").trim() || "1";
     }
     for (let i = 0; i < lines.length; i += 1) {
         const lineNo = i + 1;

--- a/scripts/lib/load-cli-api.mjs
+++ b/scripts/lib/load-cli-api.mjs
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import crypto from "node:crypto";
 import { createRequire } from "node:module";
 import { fileURLToPath } from "node:url";
 
@@ -83,6 +84,67 @@ function compileGraph(rootDir) {
   return tempDir;
 }
 
+function buildGraphFingerprint(rootDir, graph) {
+  const hash = crypto.createHash("sha256");
+  for (const tsId of graph) {
+    const absPath = path.resolve(rootDir, tsId);
+    const stat = fs.statSync(absPath);
+    hash.update(tsId);
+    hash.update("\0");
+    hash.update(String(stat.mtimeMs));
+    hash.update("\0");
+    hash.update(String(stat.size));
+    hash.update("\0");
+  }
+
+  const verovioStat = fs.statSync(path.resolve(rootDir, VEROVIO_JS));
+  hash.update(VEROVIO_JS);
+  hash.update("\0");
+  hash.update(String(verovioStat.mtimeMs));
+  hash.update("\0");
+  hash.update(String(verovioStat.size));
+  hash.update("\0");
+
+  return hash.digest("hex");
+}
+
+function ensureCompiledCache(rootDir) {
+  const graph = collectGraph(rootDir);
+  const fingerprint = buildGraphFingerprint(rootDir, graph);
+  const cacheDir = path.join(os.tmpdir(), "mikuscore-cli-api-cache", fingerprint);
+  const packageJsonPath = path.join(cacheDir, "package.json");
+  const entryPath = path.join(cacheDir, ENTRY_TS.replace(/\.ts$/, ".js"));
+  const verovioCjsPath = path.join(cacheDir, "verovio.cjs");
+
+  if (fs.existsSync(packageJsonPath) && fs.existsSync(entryPath) && fs.existsSync(verovioCjsPath)) {
+    return cacheDir;
+  }
+
+  fs.rmSync(cacheDir, { recursive: true, force: true });
+  fs.mkdirSync(cacheDir, { recursive: true });
+  fs.writeFileSync(packageJsonPath, JSON.stringify({ type: "commonjs" }), "utf8");
+
+  for (const tsId of graph) {
+    const src = readText(rootDir, tsId);
+    const transpiled = ts.transpileModule(src, {
+      fileName: tsId,
+      compilerOptions: {
+        target: ts.ScriptTarget.ES2018,
+        module: ts.ModuleKind.CommonJS,
+        moduleResolution: ts.ModuleResolutionKind.NodeJs,
+        lib: ["DOM", "DOM.Iterable", "ES2018"],
+        esModuleInterop: true,
+      },
+    });
+    const outPath = path.join(cacheDir, tsId.replace(/\.ts$/, ".js"));
+    fs.mkdirSync(path.dirname(outPath), { recursive: true });
+    fs.writeFileSync(outPath, transpiled.outputText, "utf8");
+  }
+
+  fs.copyFileSync(path.resolve(rootDir, VEROVIO_JS), verovioCjsPath);
+  return cacheDir;
+}
+
 function installWindowGlobals(window) {
   const previous = new Map();
   const keys = [
@@ -123,11 +185,9 @@ function installWindowGlobals(window) {
   };
 }
 
-function installVerovioRuntime(rootDir, tempDir) {
-  const verovioSourcePath = path.resolve(rootDir, VEROVIO_JS);
-  const verovioCjsPath = path.join(tempDir, "verovio.cjs");
-  fs.copyFileSync(verovioSourcePath, verovioCjsPath);
-  const requireFromTemp = createRequire(path.join(tempDir, "package.json"));
+function installVerovioRuntime(cacheDir) {
+  const verovioCjsPath = path.join(cacheDir, "verovio.cjs");
+  const requireFromTemp = createRequire(path.join(cacheDir, "package.json"));
   const verovio = requireFromTemp(verovioCjsPath);
   const previous = globalThis.window?.verovio;
   globalThis.window.verovio = verovio;
@@ -147,12 +207,12 @@ export function loadCliApi(options = {}) {
     url: "http://localhost/",
   });
   const restoreWindowGlobals = installWindowGlobals(dom.window);
-  const tempDir = compileGraph(rootDir);
-  const restoreVerovioRuntime = installVerovioRuntime(rootDir, tempDir);
-  const requireFromTemp = createRequire(path.join(tempDir, "package.json"));
+  const cacheDir = ensureCompiledCache(rootDir);
+  const restoreVerovioRuntime = installVerovioRuntime(cacheDir);
+  const requireFromTemp = createRequire(path.join(cacheDir, "package.json"));
 
   try {
-    const entryPath = path.join(tempDir, ENTRY_TS.replace(/\.ts$/, ".js"));
+    const entryPath = path.join(cacheDir, ENTRY_TS.replace(/\.ts$/, ".js"));
     const apiModule = requireFromTemp(entryPath);
     return {
       api: apiModule.cliApi,
@@ -160,14 +220,12 @@ export function loadCliApi(options = {}) {
         restoreVerovioRuntime();
         restoreWindowGlobals();
         dom.window.close();
-        fs.rmSync(tempDir, { recursive: true, force: true });
       },
     };
   } catch (error) {
     restoreVerovioRuntime();
     restoreWindowGlobals();
     dom.window.close();
-    fs.rmSync(tempDir, { recursive: true, force: true });
     throw error;
   }
 }

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -11014,7 +11014,14 @@ const firstDirectChildByTag = (parent, tagName) => {
 const readFirstVBoxTextByStyle = (score, styleName) => {
     var _a, _b, _c, _d;
     const lowerStyle = styleName.trim().toLowerCase();
-    const textNodes = directChildrenByTag(score, "Staff").flatMap((staff) => directChildrenByTag(staff, "VBox").flatMap((vbox) => directChildrenByTag(vbox, "Text")));
+    const textNodes = [];
+    for (const staff of directChildrenByTag(score, "Staff")) {
+        for (const vbox of directChildrenByTag(staff, "VBox")) {
+            for (const textNode of directChildrenByTag(vbox, "Text")) {
+                textNodes.push(textNode);
+            }
+        }
+    }
     for (const textNode of textNodes) {
         const style = ((_b = (_a = firstDirectChildByTag(textNode, "style")) === null || _a === void 0 ? void 0 : _a.textContent) !== null && _b !== void 0 ? _b : "").trim().toLowerCase();
         if (style !== lowerStyle)
@@ -21368,7 +21375,10 @@ function splitBodyTextByInlineVoice(text, initialVoiceId) {
     if (buffer.trim()) {
         segments.push({ voiceId: activeVoiceId, text: buffer });
     }
-    return segments;
+    return {
+        segments,
+        finalVoiceId: activeVoiceId,
+    };
 }
 function splitBodyTextByOverlay(text, baseVoiceId) {
     const raw = String(text || "");
@@ -21547,7 +21557,7 @@ function parseForMusicXml(source, settings) {
             return;
         }
         bodyStarted = true;
-        const inlineVoiceSegments = splitBodyTextByInlineVoice(normalizedBodyText, voiceId);
+        const { segments: inlineVoiceSegments, finalVoiceId } = splitBodyTextByInlineVoice(normalizedBodyText, voiceId);
         for (const segment of inlineVoiceSegments) {
             const overlaySegments = splitBodyTextByOverlay(segment.text, segment.voiceId);
             for (const overlaySegment of overlaySegments) {
@@ -21569,6 +21579,7 @@ function parseForMusicXml(source, settings) {
                 bodyEntries.push({ text: overlaySegment.text, lineNo, voiceId: overlaySegment.voiceId });
             }
         }
+        currentVoiceId = String(finalVoiceId || voiceId || "1").trim() || "1";
     }
     for (let i = 0; i < lines.length; i += 1) {
         const lineNo = i + 1;

--- a/src/ts/abc-io.ts
+++ b/src/ts/abc-io.ts
@@ -345,7 +345,10 @@ const THUMB_POSITION_DECORATIONS = new Set(["thumb", "thumbposition", "thumb-pos
     if (buffer.trim()) {
       segments.push({ voiceId: activeVoiceId, text: buffer });
     }
-    return segments;
+    return {
+      segments,
+      finalVoiceId: activeVoiceId,
+    };
   }
 
   function splitBodyTextByOverlay(text, baseVoiceId) {
@@ -537,7 +540,7 @@ const THUMB_POSITION_DECORATIONS = new Set(["thumb", "thumbposition", "thumb-pos
         return;
       }
       bodyStarted = true;
-      const inlineVoiceSegments = splitBodyTextByInlineVoice(normalizedBodyText, voiceId);
+      const { segments: inlineVoiceSegments, finalVoiceId } = splitBodyTextByInlineVoice(normalizedBodyText, voiceId);
       for (const segment of inlineVoiceSegments) {
         const overlaySegments = splitBodyTextByOverlay(segment.text, segment.voiceId);
         for (const overlaySegment of overlaySegments) {
@@ -559,6 +562,7 @@ const THUMB_POSITION_DECORATIONS = new Set(["thumb", "thumbposition", "thumb-pos
           bodyEntries.push({ text: overlaySegment.text, lineNo, voiceId: overlaySegment.voiceId });
         }
       }
+      currentVoiceId = String(finalVoiceId || voiceId || "1").trim() || "1";
     }
 
     for (let i = 0; i < lines.length; i += 1) {

--- a/src/ts/musescore-io.ts
+++ b/src/ts/musescore-io.ts
@@ -132,9 +132,14 @@ const firstDirectChildByTag = (parent: ParentNode, tagName: string): Element | n
 
 const readFirstVBoxTextByStyle = (score: Element, styleName: string): string => {
   const lowerStyle = styleName.trim().toLowerCase();
-  const textNodes = directChildrenByTag(score, "Staff").flatMap((staff) =>
-    directChildrenByTag(staff, "VBox").flatMap((vbox) => directChildrenByTag(vbox, "Text"))
-  );
+  const textNodes: Element[] = [];
+  for (const staff of directChildrenByTag(score, "Staff")) {
+    for (const vbox of directChildrenByTag(staff, "VBox")) {
+      for (const textNode of directChildrenByTag(vbox, "Text")) {
+        textNodes.push(textNode);
+      }
+    }
+  }
   for (const textNode of textNodes) {
     const style = (firstDirectChildByTag(textNode, "style")?.textContent ?? "").trim().toLowerCase();
     if (style !== lowerStyle) continue;

--- a/tests/unit/abc-inline-voice-switch.spec.ts
+++ b/tests/unit/abc-inline-voice-switch.spec.ts
@@ -1,0 +1,43 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from "vitest";
+import { convertAbcToMusicXml } from "../../src/ts/abc-io";
+import { parseMusicXmlDocument } from "../../src/ts/musicxml-io";
+
+describe("ABC inline voice switching across lines", () => {
+  it("keeps standalone [V:...] lines as the active voice for following body lines", () => {
+    const abc = `X:1
+T:April Window
+C:Codex
+M:3/4
+L:1/8
+Q:1/4=96
+K:Dm
+V:1 clef=treble name="Melody"
+V:2 clef=bass name="Accompaniment"
+
+[V:1]
+A2 d2 f2 | e2 d2 A2 |
+
+[V:2]
+D,2 A,2 d2 | C2 G,2 c2 |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const upperSteps = Array.from(outDoc.querySelectorAll('part[id="P1"] > measure > note > pitch > step')).map((node) =>
+      node.textContent?.trim()
+    );
+    const lowerSteps = Array.from(outDoc.querySelectorAll('part[id="P2"] > measure > note > pitch > step')).map((node) =>
+      node.textContent?.trim()
+    );
+    const upperRests = outDoc.querySelectorAll('part[id="P1"] > measure > note > rest');
+    const lowerRests = outDoc.querySelectorAll('part[id="P2"] > measure > note > rest');
+
+    expect(upperSteps).toEqual(["A", "D", "F", "E", "D", "A"]);
+    expect(lowerSteps).toEqual(["D", "A", "D", "C", "G", "C"]);
+    expect(upperRests.length).toBe(0);
+    expect(lowerRests.length).toBe(0);
+  });
+});

--- a/tests/unit/mikuscore-cli.spec.ts
+++ b/tests/unit/mikuscore-cli.spec.ts
@@ -20,136 +20,34 @@ afterEach(() => {
 });
 
 describe("mikuscore cli", () => {
-  it("prints top-level help", () => {
-    const result = runCli(["--help"]);
+  it("prints top-level and command help", () => {
+    const topLevel = runCli(["--help"]);
+    const convertHelp = runCli(["convert", "--help"]);
+    const renderHelp = runCli(["render", "--help"]);
 
-    expect(result.status).toBe(0);
-    expect(result.stdout).toContain("mikuscore convert --from abc --to musicxml");
-    expect(result.stdout).toContain("mikuscore convert --from midi --to musicxml");
-    expect(result.stdout).toContain("mikuscore convert --from musescore --to musicxml");
-    expect(result.stdout).toContain("mikuscore render svg");
-    expect(result.stderr).toBe("");
-  });
+    expect(topLevel.status).toBe(0);
+    expect(topLevel.stdout).toContain("mikuscore convert --from abc --to musicxml");
+    expect(topLevel.stdout).toContain("mikuscore convert --from midi --to musicxml");
+    expect(topLevel.stdout).toContain("mikuscore convert --from musescore --to musicxml");
+    expect(topLevel.stdout).toContain("mikuscore render svg");
+    expect(topLevel.stderr).toBe("");
 
-  it("prints convert help", () => {
-    const result = runCli(["convert", "--help"]);
+    expect(convertHelp.status).toBe(0);
+    expect(convertHelp.stdout).toContain("Convert score text between supported formats");
+    expect(convertHelp.stderr).toBe("");
 
-    expect(result.status).toBe(0);
-    expect(result.stdout).toContain("Convert score text between supported formats");
-    expect(result.stderr).toBe("");
-  });
+    expect(renderHelp.status).toBe(0);
+    expect(renderHelp.stdout).toContain("Render derived outputs from canonical MusicXML input");
+    expect(renderHelp.stderr).toBe("");
+  }, 10000);
 
-  it("prints render help", () => {
-    const result = runCli(["render", "--help"]);
-
-    expect(result.status).toBe(0);
-    expect(result.stdout).toContain("Render derived outputs from canonical MusicXML input");
-    expect(result.stderr).toBe("");
-  });
-
-  it("converts ABC to MusicXML from file", () => {
-    const inputPath = writeTempFile("score.abc", "X:1\nT:CLI\nM:4/4\nL:1/4\nK:C\nC D E F|\n");
-
-    const result = runCli(["convert", "--from", "abc", "--to", "musicxml", "--in", inputPath]);
-
-    expect(result.status).toBe(0);
-    expect(result.stdout).toContain("<score-partwise");
-  });
-
-  it("converts ABC to MusicXML from stdin", () => {
+  it("converts stdin to stdout for a supported pair", () => {
     const result = runCli(["convert", "--from", "abc", "--to", "musicxml"], {
       input: "X:1\nT:STDIN\nM:4/4\nL:1/4\nK:C\nC D E F|\n",
     });
 
     expect(result.status).toBe(0);
     expect(result.stdout).toContain("<work-title>STDIN</work-title>");
-  });
-
-  it("converts MusicXML to ABC from file", () => {
-    const inputPath = writeTempFile("score.musicxml", validMusicXml("CLI export"));
-
-    const result = runCli(["convert", "--from", "musicxml", "--to", "abc", "--in", inputPath]);
-
-    expect(result.status).toBe(0);
-    expect(result.stdout).toContain("K:C");
-  });
-
-  it("converts MusicXML to ABC from stdin", () => {
-    const result = runCli(["convert", "--from", "musicxml", "--to", "abc"], {
-      input: validMusicXml("STDIN export"),
-    });
-
-    expect(result.status).toBe(0);
-    expect(result.stdout).toContain("T:STDIN export");
-  });
-
-  it("converts MIDI to MusicXML from file", () => {
-    const inputPath = writeTempBinaryFile("score.mid", buildSimpleMidi());
-
-    const result = runCli(["convert", "--from", "midi", "--to", "musicxml", "--in", inputPath]);
-
-    expect(result.status).toBe(0);
-    expect(result.stdout).toContain("<score-partwise");
-  });
-
-  it("converts MIDI to MusicXML from stdin", () => {
-    const result = runCliRaw(["convert", "--from", "midi", "--to", "musicxml"], {
-      input: buildSimpleMidi(),
-    });
-
-    expect(result.status).toBe(0);
-    expect(result.stdout.toString("utf8")).toContain("<score-partwise");
-    expect(result.stderr.toString("utf8")).toBe("");
-  });
-
-  it("converts MusicXML to MIDI via --out", () => {
-    const inputPath = writeTempFile("score.musicxml", validMusicXml("MIDI out"));
-    const outPath = tempPath("out.mid");
-
-    const result = runCli(["convert", "--from", "musicxml", "--to", "midi", "--in", inputPath, "--out", outPath]);
-
-    expect(result.status).toBe(0);
-    expect(result.stdout).toBe("");
-    expect(Array.from(readFileSync(outPath).slice(0, 4))).toEqual([0x4d, 0x54, 0x68, 0x64]);
-  });
-
-  it("converts MusicXML to MIDI via stdout", () => {
-    const result = runCliRaw(["convert", "--from", "musicxml", "--to", "midi"], {
-      input: Buffer.from(validMusicXml("MIDI stdout"), "utf8"),
-    });
-
-    expect(result.status).toBe(0);
-    expect(Array.from(result.stdout.slice(0, 4))).toEqual([0x4d, 0x54, 0x68, 0x64]);
-    expect(result.stderr.toString("utf8")).toBe("");
-  });
-
-  it("converts MuseScore to MusicXML from file", () => {
-    const inputPath = writeTempFile("score.mscx", validMuseScoreXml("Muse file"));
-
-    const result = runCli(["convert", "--from", "musescore", "--to", "musicxml", "--in", inputPath]);
-
-    expect(result.status).toBe(0);
-    expect(result.stdout).toContain("<score-partwise");
-    expect(result.stdout).toContain("<work-title>Muse file</work-title>");
-  });
-
-  it("converts MusicXML to MuseScore via stdout", () => {
-    const result = runCli(["convert", "--from", "musicxml", "--to", "musescore"], {
-      input: validMusicXml("Muse stdout"),
-    });
-
-    expect(result.status).toBe(0);
-    expect(result.stdout).toContain("<museScore version=\"4.0\">");
-    expect(result.stdout).toContain("<metaTag name=\"workTitle\">Muse stdout</metaTag>");
-  });
-
-  it("renders SVG from MusicXML via stdout", () => {
-    const result = runCli(["render", "svg"], {
-      input: validMusicXml("SVG stdout"),
-    });
-
-    expect(result.status).toBe(0);
-    expect(result.stdout).toContain("<svg");
   });
 
   it("writes output via --out", () => {
@@ -163,61 +61,45 @@ describe("mikuscore cli", () => {
     expect(readFileSync(outPath, "utf8")).toContain("<score-partwise");
   });
 
-  it("fails on missing input", () => {
-    const result = runCli(["convert", "--from", "abc", "--to", "musicxml"]);
+  it("renders SVG from stdin to stdout", () => {
+    const result = runCli(["render", "svg"], {
+      input: validMusicXml("SVG stdout"),
+    });
 
-    expect(result.status).toBe(1);
-    expect(result.stderr).toContain("Input is required");
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("<svg");
   });
 
-  it("fails on invalid ABC", () => {
+  it("reports expected CLI failures", () => {
+    const missingInput = runCli(["convert", "--from", "abc", "--to", "musicxml"]);
     const inputPath = writeTempFile("invalid.abc", "");
-
-    const result = runCli(["convert", "--from", "abc", "--to", "musicxml", "--in", inputPath]);
-
-    expect(result.status).toBe(1);
-    expect(result.stderr).toContain("Failed to parse ABC");
-  });
-
-  it("fails on invalid MusicXML", () => {
-    const inputPath = writeTempFile("invalid.musicxml", "<not-xml");
-
-    const result = runCli(["convert", "--from", "musicxml", "--to", "abc", "--in", inputPath]);
-
-    expect(result.status).toBe(1);
-    expect(result.stderr).toContain("Failed to parse MusicXML");
-  });
-
-  it("fails on unsupported conversion pair", () => {
-    const result = runCli(["convert", "--from", "abc", "--to", "midi"], {
+    const invalidAbc = runCli(["convert", "--from", "abc", "--to", "musicxml", "--in", inputPath]);
+    const invalidMusicXmlPath = writeTempFile("invalid.musicxml", "<not-xml");
+    const invalidMusicXml = runCli(["convert", "--from", "musicxml", "--to", "abc", "--in", invalidMusicXmlPath]);
+    const unsupportedPair = runCli(["convert", "--from", "abc", "--to", "midi"], {
+      input: "X:1\nT:Bad\nM:4/4\nL:1/4\nK:C\nC D E F|\n",
+    });
+    const missingFromTo = runCli(["convert", "--from", "abc"], {
       input: "X:1\nT:Bad\nM:4/4\nL:1/4\nK:C\nC D E F|\n",
     });
 
-    expect(result.status).toBe(1);
-    expect(result.stderr).toContain("Unsupported conversion pair");
-  });
-
-  it("fails when --from or --to is missing", () => {
-    const result = runCli(["convert", "--from", "abc"], {
-      input: "X:1\nT:Bad\nM:4/4\nL:1/4\nK:C\nC D E F|\n",
-    });
-
-    expect(result.status).toBe(1);
-    expect(result.stderr).toContain("convert requires both --from <format> and --to <format>");
-  });
+    expect(missingInput.status).toBe(1);
+    expect(missingInput.stderr).toContain("Input is required");
+    expect(invalidAbc.status).toBe(1);
+    expect(invalidAbc.stderr).toContain("Failed to parse ABC");
+    expect(invalidMusicXml.status).toBe(1);
+    expect(invalidMusicXml.stderr).toContain("Failed to parse MusicXML");
+    expect(unsupportedPair.status).toBe(1);
+    expect(unsupportedPair.stderr).toContain("Unsupported conversion pair");
+    expect(missingFromTo.status).toBe(1);
+    expect(missingFromTo.stderr).toContain("convert requires both --from <format> and --to <format>");
+  }, 15000);
 });
 
 function runCli(args: string[], options: { input?: string } = {}) {
   return spawnSync(process.execPath, [cliPath, ...args], {
     cwd: repoRoot,
     encoding: "utf8",
-    input: options.input,
-  });
-}
-
-function runCliRaw(args: string[], options: { input?: Uint8Array | Buffer } = {}) {
-  return spawnSync(process.execPath, [cliPath, ...args], {
-    cwd: repoRoot,
     input: options.input,
   });
 }
@@ -266,42 +148,4 @@ function validMusicXml(title: string) {
   </measure>
  </part>
 </score-partwise>`;
-}
-
-function validMuseScoreXml(title: string) {
-  return `<?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.0">
-  <Score>
-    <metaTag name="workTitle">${title}</metaTag>
-    <Division>480</Division>
-    <Staff id="1">
-      <Measure>
-        <voice>
-          <Chord>
-            <durationType>quarter</durationType>
-            <Note><pitch>60</pitch></Note>
-          </Chord>
-          <Rest>
-            <durationType>quarter</durationType>
-          </Rest>
-        </voice>
-      </Measure>
-    </Staff>
-  </Score>
-</museScore>`;
-}
-
-function buildSimpleMidi() {
-  return Uint8Array.from([
-    0x4d, 0x54, 0x68, 0x64,
-    0x00, 0x00, 0x00, 0x06,
-    0x00, 0x00,
-    0x00, 0x01,
-    0x01, 0xe0,
-    0x4d, 0x54, 0x72, 0x6b,
-    0x00, 0x00, 0x00, 0x0d,
-    0x00, 0x90, 0x3c, 0x60,
-    0x83, 0x60, 0x80, 0x3c, 0x00,
-    0x00, 0xff, 0x2f, 0x00,
-  ]);
 }


### PR DESCRIPTION
## 概要

- standalone な `[V:...]` 行の後続行でも voice 切り替えが維持されるように ABC import を修正
- 上記ケースの回帰テストを追加
- MuseScore import の VBox テキスト走査から `flatMap` を除去し、ES2018 互換の実装に変更
- `load-cli-api.mjs` に一時コンパイル結果のキャッシュを導入し、繰り返し実行時のコストを削減
- CLI テストの責務を絞り、テスト時間と負荷を軽減
- `load-cli-api.mjs` のランタイム不安定性については、コンパイル戦略の変更前に原因調査を行う TODO を追加

## 変更内容

### ABC import の修正

`src/ts/abc-io.ts` にて、inline voice マーカーの解析後に最終的な active voice を保持し、`currentVoiceId` を更新するようにしました。

これにより、`[V:1]` や `[V:2]` が単独行で現れ、その次の行以降に本文が続くケースでも、意図した voice にノートが割り当てられるようになります。

### 回帰テストの追加

追加したテスト:

- `tests/unit/abc-inline-voice-switch.spec.ts`

このテストでは、standalone な `[V:...]` 行が後続行にも有効であること、およびノートが正しい part に入り、不要な rest に化けないことを確認しています。

### MuseScore import の ES2018 互換化

更新対象:

- `src/ts/musescore-io.ts`

`readFirstVBoxTextByStyle(...)` 内の VBox テキスト走査で使用していた `flatMap` を、明示的なループに置き換えました。走査の挙動は変えず、現在の ES2018 前提の構成に合わせた変更です。

### CLI loader のキャッシュ導入

更新対象:

- `scripts/lib/load-cli-api.mjs`

一時的にコンパイルする CLI API 出力について、入力が変わらない場合は再利用できるよう、fingerprint ベースのキャッシュを追加しました。あわせて `verovio.cjs` もキャッシュ済みの出力を再利用するようにしています。

### CLI テストの責務整理

更新対象:

- `tests/unit/mikuscore-cli.spec.ts`

CLI テストは、CLI 自身の責務に絞って見直しました。具体的には以下を残しています。

- help 出力
- stdin から stdout への変換経路
- `--out` によるファイル出力経路
- SVG render 経路
- 代表的な失敗時の挙動

一方で、下位レイヤで既に確認しているフォーマットごとの変換内容検証は、CLI レイヤのテストから外しました。

### TODO の追加

更新対象:

- `TODO.md`

`load-cli-api.mjs` のランタイム不安定性については、追加のコンパイル戦略変更を行う前に、まず根本原因を調査するための TODO を追加しました。

## 確認内容

この変更では、以下の実行を確認しました。

- `npm run typecheck`
- `npm run test:build`
- `npm run build`

## 補足

このコミットには、生成物の更新も含まれます。

- `src/js/main.js`
- `mikuscore.html`