### PR TITLE
記事メタ情報を `mikuscore-skills` 表記に合わせて整理

### DIFF
--- a/docs/articles/note/20260412-ai-score-abc-first.md
+++ b/docs/articles/note/20260412-ai-score-abc-first.md
@@ -2,7 +2,7 @@
 
 - 掲載先: Note
 - URL: https://note.com/toshikiigaa/n/n5362ea076328
-- タイトル: `[mikuscore] 生成AI に譜面対応させたくて、まず ABC 記譜法に寄っていった話`
+- タイトル: `[mikuscore-skills] 生成AI に譜面対応させたくて、まず ABC 記譜法に寄っていった話`
 - ハッシュタグ: `生成AI`, `ABC記譜法`, `譜面`, `MusicXML`, `MIDI`, `musescore`, `mikuku`, `文字譜`, `mikuscore`
 
 ----------------------------------------------------------------

--- a/docs/articles/qiita/20260412-ai-score-abc-first.md
+++ b/docs/articles/qiita/20260412-ai-score-abc-first.md
@@ -1,12 +1,7 @@
 # 掲載先情報
 
 - 掲載先: Qiita
-- 公開記事タイトル: `生成AI に譜面対応させたくて、まず ABC 記譜法に寄っていった話`
 - URL: https://qiita.com/igapyon/items/8444b5f50d63207002c0
-- スクリーンショット挿入: Qiita に直接アップロード方式 / 未確認
-
-## Qiita 掲載用属性情報
-
 - タイトル: `生成AI に譜面対応させたくて、まず ABC 記譜法に寄っていった話`
 - タグ: `生成AI`, `ABC`, `楽譜`, `MusicXML`, `MIDI`
 
@@ -221,6 +216,11 @@ miku-abc-player のスクショ
   - https://github.com/igapyon/mikuscore-skills
 
 ソースコードは GitHub で公開しています。
+
+## 関連情報リンク
+
+- Note: `[mikuscore-skills] 生成AI に譜面対応させたくて、まず ABC 記譜法に寄っていった話`
+  - https://note.com/toshikiigaa/n/n5362ea076328
 
 ## `ABC` 記譜法
 


### PR DESCRIPTION
## 概要

記事ドキュメントのメタ情報と関連情報を整理します。

## 変更内容

- `docs/articles/note/20260412-ai-score-abc-first.md`
  - 掲載先情報のタイトル表記を `[mikuscore]` から `[mikuscore-skills]` に修正

- `docs/articles/qiita/20260412-ai-score-abc-first.md`
  - 掲載先情報から `公開記事タイトル` と `スクリーンショット挿入` の記述を削除
  - `## Qiita 掲載用属性情報` 見出しを削除
  - 末尾付近に `## 関連情報リンク` を追加
  - Note 記事へのリンク情報を追加

## 補足

- 変更対象は記事ドキュメント 2 ファイルです