### PR TITLE
MusicXML からの MuseScore エクスポートで `concertKey` / `transposeKey` を出力して 4.…

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -65,6 +65,10 @@
      */
     ```
 
+- [ ] Make MuseScore export fully 4.0+-native where compatibility fallback is not required.
+  - Keep compatibility fallbacks on import.
+  - Remove custom MuseScore transpose helper tags such as `mksTransposeDiatonic` / `mksTransposeChromatic` from export once related roundtrip/tests are updated.
+
 - [ ] After the current CLI series settles, prune this file again.
   - Remove items that have become fully implemented.
   - Keep only active backlog and intentionally retained long-term notes.

--- a/mikuscore.html
+++ b/mikuscore.html
@@ -19685,6 +19685,25 @@ const readMuseKeyFifths = (node, options = { transposingPart: false }) => {
         return null;
     return Math.max(-7, Math.min(7, Math.round(resolved)));
 };
+const normalizeKeyFifthsToMuseRange = (fifths) => {
+    if (!Number.isFinite(fifths))
+        return 0;
+    let normalized = Math.round(fifths);
+    while (normalized > 7)
+        normalized -= 12;
+    while (normalized < -7)
+        normalized += 12;
+    return normalized;
+};
+const resolveMuseExportKeySigXml = (writtenFifths, transpose) => {
+    const normalizedWritten = normalizeKeyFifthsToMuseRange(writtenFifths);
+    const chromatic = Number.isFinite(transpose === null || transpose === void 0 ? void 0 : transpose.chromatic) ? Math.round(Number(transpose === null || transpose === void 0 ? void 0 : transpose.chromatic)) : null;
+    if (chromatic === null) {
+        return `<KeySig><accidental>${normalizedWritten}</accidental><concertKey>${normalizedWritten}</concertKey></KeySig>`;
+    }
+    const concertKey = normalizeKeyFifthsToMuseRange(normalizedWritten + (7 * chromatic));
+    return `<KeySig><accidental>${normalizedWritten}</accidental><concertKey>${concertKey}</concertKey><transposeKey>${normalizedWritten}</transposeKey></KeySig>`;
+};
 const buildTransposeXml = (transpose) => {
     if (!transpose)
         return "";
@@ -22265,7 +22284,7 @@ const exportMusicXmlDomToMuseScore = (doc, options = {}) => {
                             voiceXml += `<TimeSig>${cutSubtypeXml}<sigN>${effectiveMeasureBeats}</sigN><sigD>${effectiveMeasureBeatType}</sigD></TimeSig>`;
                         }
                         if (shouldWriteKey) {
-                            voiceXml += `<KeySig><accidental>${measureFifths}</accidental></KeySig>`;
+                            voiceXml += resolveMuseExportKeySigXml(measureFifths, partTranspose);
                         }
                         if (needsDoubleBarlineAtMeasureStart) {
                             voiceXml += `<BarLine><subtype>double</subtype></BarLine>`;

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -11635,6 +11635,25 @@ const readMuseKeyFifths = (node, options = { transposingPart: false }) => {
         return null;
     return Math.max(-7, Math.min(7, Math.round(resolved)));
 };
+const normalizeKeyFifthsToMuseRange = (fifths) => {
+    if (!Number.isFinite(fifths))
+        return 0;
+    let normalized = Math.round(fifths);
+    while (normalized > 7)
+        normalized -= 12;
+    while (normalized < -7)
+        normalized += 12;
+    return normalized;
+};
+const resolveMuseExportKeySigXml = (writtenFifths, transpose) => {
+    const normalizedWritten = normalizeKeyFifthsToMuseRange(writtenFifths);
+    const chromatic = Number.isFinite(transpose === null || transpose === void 0 ? void 0 : transpose.chromatic) ? Math.round(Number(transpose === null || transpose === void 0 ? void 0 : transpose.chromatic)) : null;
+    if (chromatic === null) {
+        return `<KeySig><accidental>${normalizedWritten}</accidental><concertKey>${normalizedWritten}</concertKey></KeySig>`;
+    }
+    const concertKey = normalizeKeyFifthsToMuseRange(normalizedWritten + (7 * chromatic));
+    return `<KeySig><accidental>${normalizedWritten}</accidental><concertKey>${concertKey}</concertKey><transposeKey>${normalizedWritten}</transposeKey></KeySig>`;
+};
 const buildTransposeXml = (transpose) => {
     if (!transpose)
         return "";
@@ -14215,7 +14234,7 @@ const exportMusicXmlDomToMuseScore = (doc, options = {}) => {
                             voiceXml += `<TimeSig>${cutSubtypeXml}<sigN>${effectiveMeasureBeats}</sigN><sigD>${effectiveMeasureBeatType}</sigD></TimeSig>`;
                         }
                         if (shouldWriteKey) {
-                            voiceXml += `<KeySig><accidental>${measureFifths}</accidental></KeySig>`;
+                            voiceXml += resolveMuseExportKeySigXml(measureFifths, partTranspose);
                         }
                         if (needsDoubleBarlineAtMeasureStart) {
                             voiceXml += `<BarLine><subtype>double</subtype></BarLine>`;

--- a/src/ts/musescore-io.ts
+++ b/src/ts/musescore-io.ts
@@ -664,6 +664,24 @@ const readMuseKeyFifths = (
   return Math.max(-7, Math.min(7, Math.round(resolved)));
 };
 
+const normalizeKeyFifthsToMuseRange = (fifths: number): number => {
+  if (!Number.isFinite(fifths)) return 0;
+  let normalized = Math.round(fifths);
+  while (normalized > 7) normalized -= 12;
+  while (normalized < -7) normalized += 12;
+  return normalized;
+};
+
+const resolveMuseExportKeySigXml = (writtenFifths: number, transpose: { diatonic?: number; chromatic?: number } | null): string => {
+  const normalizedWritten = normalizeKeyFifthsToMuseRange(writtenFifths);
+  const chromatic = Number.isFinite(transpose?.chromatic) ? Math.round(Number(transpose?.chromatic)) : null;
+  if (chromatic === null) {
+    return `<KeySig><accidental>${normalizedWritten}</accidental><concertKey>${normalizedWritten}</concertKey></KeySig>`;
+  }
+  const concertKey = normalizeKeyFifthsToMuseRange(normalizedWritten + (7 * chromatic));
+  return `<KeySig><accidental>${normalizedWritten}</accidental><concertKey>${concertKey}</concertKey><transposeKey>${normalizedWritten}</transposeKey></KeySig>`;
+};
+
 const buildTransposeXml = (transpose: { diatonic?: number; chromatic?: number } | null): string => {
   if (!transpose) return "";
   const diatonic = Number.isFinite(transpose.diatonic) ? Math.round(Number(transpose.diatonic)) : null;
@@ -3387,7 +3405,7 @@ export const exportMusicXmlDomToMuseScore = (doc: Document, options: MuseScoreEx
               voiceXml += `<TimeSig>${cutSubtypeXml}<sigN>${effectiveMeasureBeats}</sigN><sigD>${effectiveMeasureBeatType}</sigD></TimeSig>`;
             }
             if (shouldWriteKey) {
-              voiceXml += `<KeySig><accidental>${measureFifths}</accidental></KeySig>`;
+              voiceXml += resolveMuseExportKeySigXml(measureFifths, partTranspose);
             }
             if (needsDoubleBarlineAtMeasureStart) {
               voiceXml += `<BarLine><subtype>double</subtype></BarLine>`;

--- a/tests/unit/musescore-io.spec.ts
+++ b/tests/unit/musescore-io.spec.ts
@@ -798,7 +798,7 @@ describe("musescore-io", () => {
     expect(mscx).toContain("<museScore");
     expect(mscx).toContain("<Staff id=\"1\">");
     expect(mscx).toContain("<TimeSig><sigN>3</sigN><sigD>4</sigD></TimeSig>");
-    expect(mscx).toContain("<KeySig><accidental>1</accidental></KeySig>");
+    expect(mscx).toContain("<KeySig><accidental>1</accidental><concertKey>1</concertKey></KeySig>");
     expect(mscx).toContain("<Tempo><tempo>2.000000</tempo></Tempo>");
     expect(mscx).toContain("<Dynamic><subtype>mf</subtype></Dynamic>");
     expect(mscx).toContain("<endRepeat/>");
@@ -2861,6 +2861,7 @@ describe("musescore-io", () => {
     const mscx = exportMusicXmlDomToMuseScore(sourceDoc);
     expect(mscx).toContain("<transposeDiatonic>-2</transposeDiatonic>");
     expect(mscx).toContain("<transposeChromatic>-3</transposeChromatic>");
+    expect(mscx).toContain("<KeySig><accidental>0</accidental><concertKey>3</concertKey><transposeKey>0</transposeKey></KeySig>");
 
     const roundtrip = convertMuseScoreToMusicXml(mscx, { sourceMetadata: false, debugMetadata: false });
     const outDoc = parseMusicXmlDocument(roundtrip);


### PR DESCRIPTION
…0+ 寄りにする

## 概要

MusicXML から MuseScore へのエクスポート時の `KeySig` 出力を見直し、`accidental` に加えて `concertKey` を出力するようにします。 また、移調情報を持つパートでは `transposeKey` も併記し、MuseScore 4.0+ の key signature 表現に寄せます。

## 変更内容

- `src/ts/musescore-io.ts`
  - MuseScore export 用の key signature 組み立て処理を追加
  - `KeySig` 出力を `accidental` 単独から、`concertKey` / `transposeKey` を含む形に変更
  - 移調情報を持たない場合は `accidental` と `concertKey` を出力
  - 移調情報を持つ場合は `accidental` と `concertKey` と `transposeKey` を出力

- `tests/unit/musescore-io.spec.ts`
  - 基本的な MusicXML -> MuseScore エクスポートで `concertKey` を含むことを確認する期待値に更新
  - 移調楽器の roundtrip テストで、`transposeDiatonic` / `transposeChromatic` に加えて `KeySig` に `concertKey` / `transposeKey` が出ることを確認する期待値を追加

- `TODO.md`
  - MuseScore export を 4.0+ ネイティブ寄りに寄せる方針を追記
  - import 側の互換フォールバックは維持しつつ、export 側の独自 transpose helper tag を将来的に整理する TODO を追加

- `src/js/main.js`
- `mikuscore.html`
  - ビルド生成物を更新

## 期待される効果

- MuseScore export の `KeySig` が `accidental` 単独よりも 4.0+ の表現に近づく
- 移調楽器のエクスポートで、written key と concert key の区別が `KeySig` 上でも明示される
- MusicXML -> MuseScore -> MusicXML の transpose roundtrip 確認を強化できる

## テスト

- 変更対象の unit test 更新あり
- 実行コマンド: `npx vitest run tests/unit/musescore-io.spec.ts`

## 補足

- import 側の互換フォールバックを削除する変更ではありません。
- `mksTransposeDiatonic` / `mksTransposeChromatic` の整理は、このコミットでは未対応です。`TODO.md` に記載されています。