### PR TITLE
ABC エクスポートの初期テンポ解釈を修正し、拍単位付き `Q:` 出力に対応

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -69,6 +69,7 @@
   - Keep compatibility fallbacks on import.
   - Remove any remaining import-side fallback for former custom MuseScore transpose helper tags after related roundtrip/tests are updated.
   - Raise exported `museScore/@version` from `4.0` only after the emitted XML is confirmed to match the expected newer 4.x save-format behavior closely enough (e.g. `4.60`).
+  - Define a clearer general policy for MuseScore files that carry multiple co-located tempo representations (e.g. visible tempo text plus hidden metronome/playback tempo), instead of relying only on the current first-measure/last-candidate heuristic.
 
 - [ ] After the current CLI series settles, prune this file again.
   - Remove items that have become fully implemented.

--- a/mikuscore.html
+++ b/mikuscore.html
@@ -29382,6 +29382,75 @@ const keyFromFifthsMode = (fifths, mode) => {
     }
     return major[idx];
 };
+const fractionToAbcTempoUnit = (fraction) => {
+    const reduced = reduceFraction(fraction.num, fraction.den, { num: 1, den: 4 });
+    return `${reduced.num}/${reduced.den}`;
+};
+const metronomeUnitFractionFromMusicXml = (metronome) => {
+    var _a, _b;
+    if (!metronome)
+        return null;
+    const beatUnit = ((_b = (_a = metronome.querySelector(":scope > beat-unit")) === null || _a === void 0 ? void 0 : _a.textContent) !== null && _b !== void 0 ? _b : "").trim().toLowerCase();
+    const dotCount = metronome.querySelectorAll(":scope > beat-unit-dot").length;
+    const baseByUnit = {
+        whole: { num: 1, den: 1 },
+        half: { num: 1, den: 2 },
+        quarter: { num: 1, den: 4 },
+        eighth: { num: 1, den: 8 },
+        "16th": { num: 1, den: 16 },
+        "32nd": { num: 1, den: 32 },
+        "64th": { num: 1, den: 64 },
+    };
+    const base = baseByUnit[beatUnit];
+    if (!base)
+        return null;
+    let total = reduceFraction(base.num, base.den, base);
+    let add = total;
+    for (let i = 0; i < dotCount; i += 1) {
+        add = divideFractions(add, { num: 2, den: 1 }, add);
+        total = reduceFraction((total.num * add.den) + (add.num * total.den), total.den * add.den, total);
+    }
+    return total;
+};
+const readInitialTempoFromMusicXml = (doc) => {
+    var _a, _b, _c, _d, _e, _f, _g;
+    const firstPart = doc.querySelector("score-partwise > part");
+    const firstMeasure = firstPart === null || firstPart === void 0 ? void 0 : firstPart.querySelector(":scope > measure");
+    if (!firstMeasure)
+        return null;
+    const leadingDirections = Array.from(firstMeasure.children).filter((child) => {
+        const tag = child.tagName.toLowerCase();
+        if (tag === "direction")
+            return true;
+        if (tag === "attributes" || tag === "print" || tag === "sound" || tag === "bookmark")
+            return true;
+        return false;
+    });
+    const candidates = [];
+    for (const child of leadingDirections) {
+        const tag = child.tagName.toLowerCase();
+        if (tag === "direction") {
+            const metronome = child.querySelector(":scope > direction-type > metronome");
+            const soundTempo = Number((_b = (_a = child.querySelector(":scope > sound")) === null || _a === void 0 ? void 0 : _a.getAttribute("tempo")) !== null && _b !== void 0 ? _b : "");
+            const metronomeTempo = Number((_e = (_d = (_c = metronome === null || metronome === void 0 ? void 0 : metronome.querySelector(":scope > per-minute")) === null || _c === void 0 ? void 0 : _c.textContent) === null || _d === void 0 ? void 0 : _d.trim()) !== null && _e !== void 0 ? _e : "");
+            if (Number.isFinite(soundTempo) && soundTempo > 0) {
+                candidates.push({ bpm: soundTempo, unit: null });
+            }
+            if (Number.isFinite(metronomeTempo) && metronomeTempo > 0) {
+                candidates.push({ bpm: metronomeTempo, unit: metronomeUnitFractionFromMusicXml(metronome) });
+            }
+            continue;
+        }
+        if (tag === "sound") {
+            const bpm = Number((_f = child.getAttribute("tempo")) !== null && _f !== void 0 ? _f : "");
+            if (Number.isFinite(bpm) && bpm > 0)
+                candidates.push({ bpm, unit: null });
+        }
+    }
+    if (!candidates.length)
+        return null;
+    return (_g = candidates[candidates.length - 1]) !== null && _g !== void 0 ? _g : null;
+};
 const fifthsFromAbcKey = (raw) => {
     const table = {
         C: 0,
@@ -31841,7 +31910,7 @@ if (typeof window !== "undefined") {
     window.AbcCompatParser = exports.AbcCompatParser;
 }
 const exportMusicXmlDomToAbc = (doc) => {
-    var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p, _q, _r, _s, _t, _u, _v, _w, _x;
+    var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p, _q, _r, _s, _t;
     const title = ((_b = (_a = doc.querySelector("work > work-title")) === null || _a === void 0 ? void 0 : _a.textContent) === null || _b === void 0 ? void 0 : _b.trim()) ||
         ((_d = (_c = doc.querySelector("movement-title")) === null || _c === void 0 ? void 0 : _c.textContent) === null || _d === void 0 ? void 0 : _d.trim()) ||
         "mikuscore";
@@ -31852,17 +31921,22 @@ const exportMusicXmlDomToAbc = (doc) => {
     const fifths = Number(((_m = (_l = firstMeasure === null || firstMeasure === void 0 ? void 0 : firstMeasure.querySelector("attributes > key > fifths")) === null || _l === void 0 ? void 0 : _l.textContent) === null || _m === void 0 ? void 0 : _m.trim()) || "0");
     const mode = ((_p = (_o = firstMeasure === null || firstMeasure === void 0 ? void 0 : firstMeasure.querySelector("attributes > key > mode")) === null || _o === void 0 ? void 0 : _o.textContent) === null || _p === void 0 ? void 0 : _p.trim()) || "major";
     const key = exports.AbcCommon.keyFromFifthsMode(Number.isFinite(fifths) ? fifths : 0, mode);
-    const explicitTempo = Number((_r = (_q = doc.querySelector("sound[tempo]")) === null || _q === void 0 ? void 0 : _q.getAttribute("tempo")) !== null && _r !== void 0 ? _r : "");
-    const metronomeTempo = Number((_u = (_t = (_s = doc.querySelector("direction-type > metronome > per-minute")) === null || _s === void 0 ? void 0 : _s.textContent) === null || _t === void 0 ? void 0 : _t.trim()) !== null && _u !== void 0 ? _u : "");
-    const tempoBpm = Number.isFinite(explicitTempo) && explicitTempo > 0
-        ? explicitTempo
-        : (Number.isFinite(metronomeTempo) && metronomeTempo > 0 ? metronomeTempo : NaN);
+    const initialTempo = readInitialTempoFromMusicXml(doc);
+    const tempoBpm = (_q = initialTempo === null || initialTempo === void 0 ? void 0 : initialTempo.bpm) !== null && _q !== void 0 ? _q : NaN;
+    const abcTempoHeader = (() => {
+        if ((initialTempo === null || initialTempo === void 0 ? void 0 : initialTempo.unit) && Number.isFinite(initialTempo.bpm) && initialTempo.bpm > 0) {
+            return `Q:${fractionToAbcTempoUnit(initialTempo.unit)}=${Math.round(initialTempo.bpm)}`;
+        }
+        if (Number.isFinite(tempoBpm))
+            return `Q:1/4=${Math.round(tempoBpm)}`;
+        return "";
+    })();
     const partNameById = new Map();
     for (const scorePart of Array.from(doc.querySelectorAll("part-list > score-part"))) {
-        const id = (_v = scorePart.getAttribute("id")) !== null && _v !== void 0 ? _v : "";
+        const id = (_r = scorePart.getAttribute("id")) !== null && _r !== void 0 ? _r : "";
         if (!id)
             continue;
-        const name = ((_x = (_w = scorePart.querySelector("part-name")) === null || _w === void 0 ? void 0 : _w.textContent) === null || _x === void 0 ? void 0 : _x.trim()) || id;
+        const name = ((_t = (_s = scorePart.querySelector("part-name")) === null || _s === void 0 ? void 0 : _s.textContent) === null || _t === void 0 ? void 0 : _t.trim()) || id;
         partNameById.set(id, name);
     }
     const unitLength = { num: 1, den: 8 };
@@ -31927,7 +32001,7 @@ const exportMusicXmlDomToAbc = (doc) => {
         composer ? `C:${composer}` : "",
         `M:${meterBeats}/${meterBeatType}`,
         "L:1/8",
-        Number.isFinite(tempoBpm) ? `Q:1/4=${Math.round(tempoBpm)}` : "",
+        abcTempoHeader,
         `K:${key}`,
     ].filter(Boolean);
     const bodyLines = [];

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -21332,6 +21332,75 @@ const keyFromFifthsMode = (fifths, mode) => {
     }
     return major[idx];
 };
+const fractionToAbcTempoUnit = (fraction) => {
+    const reduced = reduceFraction(fraction.num, fraction.den, { num: 1, den: 4 });
+    return `${reduced.num}/${reduced.den}`;
+};
+const metronomeUnitFractionFromMusicXml = (metronome) => {
+    var _a, _b;
+    if (!metronome)
+        return null;
+    const beatUnit = ((_b = (_a = metronome.querySelector(":scope > beat-unit")) === null || _a === void 0 ? void 0 : _a.textContent) !== null && _b !== void 0 ? _b : "").trim().toLowerCase();
+    const dotCount = metronome.querySelectorAll(":scope > beat-unit-dot").length;
+    const baseByUnit = {
+        whole: { num: 1, den: 1 },
+        half: { num: 1, den: 2 },
+        quarter: { num: 1, den: 4 },
+        eighth: { num: 1, den: 8 },
+        "16th": { num: 1, den: 16 },
+        "32nd": { num: 1, den: 32 },
+        "64th": { num: 1, den: 64 },
+    };
+    const base = baseByUnit[beatUnit];
+    if (!base)
+        return null;
+    let total = reduceFraction(base.num, base.den, base);
+    let add = total;
+    for (let i = 0; i < dotCount; i += 1) {
+        add = divideFractions(add, { num: 2, den: 1 }, add);
+        total = reduceFraction((total.num * add.den) + (add.num * total.den), total.den * add.den, total);
+    }
+    return total;
+};
+const readInitialTempoFromMusicXml = (doc) => {
+    var _a, _b, _c, _d, _e, _f, _g;
+    const firstPart = doc.querySelector("score-partwise > part");
+    const firstMeasure = firstPart === null || firstPart === void 0 ? void 0 : firstPart.querySelector(":scope > measure");
+    if (!firstMeasure)
+        return null;
+    const leadingDirections = Array.from(firstMeasure.children).filter((child) => {
+        const tag = child.tagName.toLowerCase();
+        if (tag === "direction")
+            return true;
+        if (tag === "attributes" || tag === "print" || tag === "sound" || tag === "bookmark")
+            return true;
+        return false;
+    });
+    const candidates = [];
+    for (const child of leadingDirections) {
+        const tag = child.tagName.toLowerCase();
+        if (tag === "direction") {
+            const metronome = child.querySelector(":scope > direction-type > metronome");
+            const soundTempo = Number((_b = (_a = child.querySelector(":scope > sound")) === null || _a === void 0 ? void 0 : _a.getAttribute("tempo")) !== null && _b !== void 0 ? _b : "");
+            const metronomeTempo = Number((_e = (_d = (_c = metronome === null || metronome === void 0 ? void 0 : metronome.querySelector(":scope > per-minute")) === null || _c === void 0 ? void 0 : _c.textContent) === null || _d === void 0 ? void 0 : _d.trim()) !== null && _e !== void 0 ? _e : "");
+            if (Number.isFinite(soundTempo) && soundTempo > 0) {
+                candidates.push({ bpm: soundTempo, unit: null });
+            }
+            if (Number.isFinite(metronomeTempo) && metronomeTempo > 0) {
+                candidates.push({ bpm: metronomeTempo, unit: metronomeUnitFractionFromMusicXml(metronome) });
+            }
+            continue;
+        }
+        if (tag === "sound") {
+            const bpm = Number((_f = child.getAttribute("tempo")) !== null && _f !== void 0 ? _f : "");
+            if (Number.isFinite(bpm) && bpm > 0)
+                candidates.push({ bpm, unit: null });
+        }
+    }
+    if (!candidates.length)
+        return null;
+    return (_g = candidates[candidates.length - 1]) !== null && _g !== void 0 ? _g : null;
+};
 const fifthsFromAbcKey = (raw) => {
     const table = {
         C: 0,
@@ -23791,7 +23860,7 @@ if (typeof window !== "undefined") {
     window.AbcCompatParser = exports.AbcCompatParser;
 }
 const exportMusicXmlDomToAbc = (doc) => {
-    var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p, _q, _r, _s, _t, _u, _v, _w, _x;
+    var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p, _q, _r, _s, _t;
     const title = ((_b = (_a = doc.querySelector("work > work-title")) === null || _a === void 0 ? void 0 : _a.textContent) === null || _b === void 0 ? void 0 : _b.trim()) ||
         ((_d = (_c = doc.querySelector("movement-title")) === null || _c === void 0 ? void 0 : _c.textContent) === null || _d === void 0 ? void 0 : _d.trim()) ||
         "mikuscore";
@@ -23802,17 +23871,22 @@ const exportMusicXmlDomToAbc = (doc) => {
     const fifths = Number(((_m = (_l = firstMeasure === null || firstMeasure === void 0 ? void 0 : firstMeasure.querySelector("attributes > key > fifths")) === null || _l === void 0 ? void 0 : _l.textContent) === null || _m === void 0 ? void 0 : _m.trim()) || "0");
     const mode = ((_p = (_o = firstMeasure === null || firstMeasure === void 0 ? void 0 : firstMeasure.querySelector("attributes > key > mode")) === null || _o === void 0 ? void 0 : _o.textContent) === null || _p === void 0 ? void 0 : _p.trim()) || "major";
     const key = exports.AbcCommon.keyFromFifthsMode(Number.isFinite(fifths) ? fifths : 0, mode);
-    const explicitTempo = Number((_r = (_q = doc.querySelector("sound[tempo]")) === null || _q === void 0 ? void 0 : _q.getAttribute("tempo")) !== null && _r !== void 0 ? _r : "");
-    const metronomeTempo = Number((_u = (_t = (_s = doc.querySelector("direction-type > metronome > per-minute")) === null || _s === void 0 ? void 0 : _s.textContent) === null || _t === void 0 ? void 0 : _t.trim()) !== null && _u !== void 0 ? _u : "");
-    const tempoBpm = Number.isFinite(explicitTempo) && explicitTempo > 0
-        ? explicitTempo
-        : (Number.isFinite(metronomeTempo) && metronomeTempo > 0 ? metronomeTempo : NaN);
+    const initialTempo = readInitialTempoFromMusicXml(doc);
+    const tempoBpm = (_q = initialTempo === null || initialTempo === void 0 ? void 0 : initialTempo.bpm) !== null && _q !== void 0 ? _q : NaN;
+    const abcTempoHeader = (() => {
+        if ((initialTempo === null || initialTempo === void 0 ? void 0 : initialTempo.unit) && Number.isFinite(initialTempo.bpm) && initialTempo.bpm > 0) {
+            return `Q:${fractionToAbcTempoUnit(initialTempo.unit)}=${Math.round(initialTempo.bpm)}`;
+        }
+        if (Number.isFinite(tempoBpm))
+            return `Q:1/4=${Math.round(tempoBpm)}`;
+        return "";
+    })();
     const partNameById = new Map();
     for (const scorePart of Array.from(doc.querySelectorAll("part-list > score-part"))) {
-        const id = (_v = scorePart.getAttribute("id")) !== null && _v !== void 0 ? _v : "";
+        const id = (_r = scorePart.getAttribute("id")) !== null && _r !== void 0 ? _r : "";
         if (!id)
             continue;
-        const name = ((_x = (_w = scorePart.querySelector("part-name")) === null || _w === void 0 ? void 0 : _w.textContent) === null || _x === void 0 ? void 0 : _x.trim()) || id;
+        const name = ((_t = (_s = scorePart.querySelector("part-name")) === null || _s === void 0 ? void 0 : _s.textContent) === null || _t === void 0 ? void 0 : _t.trim()) || id;
         partNameById.set(id, name);
     }
     const unitLength = { num: 1, den: 8 };
@@ -23877,7 +23951,7 @@ const exportMusicXmlDomToAbc = (doc) => {
         composer ? `C:${composer}` : "",
         `M:${meterBeats}/${meterBeatType}`,
         "L:1/8",
-        Number.isFinite(tempoBpm) ? `Q:1/4=${Math.round(tempoBpm)}` : "",
+        abcTempoHeader,
         `K:${key}`,
     ].filter(Boolean);
     const bodyLines = [];

--- a/src/ts/abc-io.ts
+++ b/src/ts/abc-io.ts
@@ -159,6 +159,69 @@ const keyFromFifthsMode = (fifths: number, mode: string): string => {
   return major[idx];
 };
 
+const fractionToAbcTempoUnit = (fraction: Fraction): string => {
+  const reduced = reduceFraction(fraction.num, fraction.den, { num: 1, den: 4 });
+  return `${reduced.num}/${reduced.den}`;
+};
+
+const metronomeUnitFractionFromMusicXml = (metronome: Element | null): Fraction | null => {
+  if (!metronome) return null;
+  const beatUnit = (metronome.querySelector(":scope > beat-unit")?.textContent ?? "").trim().toLowerCase();
+  const dotCount = metronome.querySelectorAll(":scope > beat-unit-dot").length;
+  const baseByUnit: Record<string, Fraction> = {
+    whole: { num: 1, den: 1 },
+    half: { num: 1, den: 2 },
+    quarter: { num: 1, den: 4 },
+    eighth: { num: 1, den: 8 },
+    "16th": { num: 1, den: 16 },
+    "32nd": { num: 1, den: 32 },
+    "64th": { num: 1, den: 64 },
+  };
+  const base = baseByUnit[beatUnit];
+  if (!base) return null;
+  let total = reduceFraction(base.num, base.den, base);
+  let add = total;
+  for (let i = 0; i < dotCount; i += 1) {
+    add = divideFractions(add, { num: 2, den: 1 }, add);
+    total = reduceFraction((total.num * add.den) + (add.num * total.den), total.den * add.den, total);
+  }
+  return total;
+};
+
+const readInitialTempoFromMusicXml = (doc: Document): { bpm: number; unit: Fraction | null } | null => {
+  const firstPart = doc.querySelector("score-partwise > part");
+  const firstMeasure = firstPart?.querySelector(":scope > measure");
+  if (!firstMeasure) return null;
+  const leadingDirections = Array.from(firstMeasure.children).filter((child) => {
+    const tag = child.tagName.toLowerCase();
+    if (tag === "direction") return true;
+    if (tag === "attributes" || tag === "print" || tag === "sound" || tag === "bookmark") return true;
+    return false;
+  });
+  const candidates: Array<{ bpm: number; unit: Fraction | null }> = [];
+  for (const child of leadingDirections) {
+    const tag = child.tagName.toLowerCase();
+    if (tag === "direction") {
+      const metronome = child.querySelector(":scope > direction-type > metronome");
+      const soundTempo = Number(child.querySelector(":scope > sound")?.getAttribute("tempo") ?? "");
+      const metronomeTempo = Number(metronome?.querySelector(":scope > per-minute")?.textContent?.trim() ?? "");
+      if (Number.isFinite(soundTempo) && soundTempo > 0) {
+        candidates.push({ bpm: soundTempo, unit: null });
+      }
+      if (Number.isFinite(metronomeTempo) && metronomeTempo > 0) {
+        candidates.push({ bpm: metronomeTempo, unit: metronomeUnitFractionFromMusicXml(metronome) });
+      }
+      continue;
+    }
+    if (tag === "sound") {
+      const bpm = Number(child.getAttribute("tempo") ?? "");
+      if (Number.isFinite(bpm) && bpm > 0) candidates.push({ bpm, unit: null });
+    }
+  }
+  if (!candidates.length) return null;
+  return candidates[candidates.length - 1] ?? null;
+};
+
 const fifthsFromAbcKey = (raw: string): number | null => {
   const table: Record<string, number> = {
     C: 0,
@@ -2830,13 +2893,15 @@ export const exportMusicXmlDomToAbc = (doc: Document): string => {
   const fifths = Number(firstMeasure?.querySelector("attributes > key > fifths")?.textContent?.trim() || "0");
   const mode = firstMeasure?.querySelector("attributes > key > mode")?.textContent?.trim() || "major";
   const key = AbcCommon.keyFromFifthsMode(Number.isFinite(fifths) ? fifths : 0, mode);
-  const explicitTempo = Number(doc.querySelector("sound[tempo]")?.getAttribute("tempo") ?? "");
-  const metronomeTempo = Number(
-    doc.querySelector("direction-type > metronome > per-minute")?.textContent?.trim() ?? ""
-  );
-  const tempoBpm = Number.isFinite(explicitTempo) && explicitTempo > 0
-    ? explicitTempo
-    : (Number.isFinite(metronomeTempo) && metronomeTempo > 0 ? metronomeTempo : NaN);
+  const initialTempo = readInitialTempoFromMusicXml(doc);
+  const tempoBpm = initialTempo?.bpm ?? NaN;
+  const abcTempoHeader = (() => {
+    if (initialTempo?.unit && Number.isFinite(initialTempo.bpm) && initialTempo.bpm > 0) {
+      return `Q:${fractionToAbcTempoUnit(initialTempo.unit)}=${Math.round(initialTempo.bpm)}`;
+    }
+    if (Number.isFinite(tempoBpm)) return `Q:1/4=${Math.round(tempoBpm)}`;
+    return "";
+  })();
 
   const partNameById = new Map<string, string>();
   for (const scorePart of Array.from(doc.querySelectorAll("part-list > score-part"))) {
@@ -2893,7 +2958,7 @@ export const exportMusicXmlDomToAbc = (doc: Document): string => {
     composer ? `C:${composer}` : "",
     `M:${meterBeats}/${meterBeatType}`,
     "L:1/8",
-    Number.isFinite(tempoBpm) ? `Q:1/4=${Math.round(tempoBpm)}` : "",
+    abcTempoHeader,
     `K:${key}`,
   ].filter(Boolean);
 

--- a/tests/unit/abc-io.spec.ts
+++ b/tests/unit/abc-io.spec.ts
@@ -221,6 +221,83 @@ C3/ D | [CE]3/ G | {/g3/}a2 z2 |`;
     expect(Number(soundTempo)).toBe(220);
   });
 
+  it("MusicXML->ABC exports metronome beat unit into Q header", () => {
+    const xmlWithHalfTempo = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>480</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <direction>
+        <direction-type>
+          <metronome>
+            <beat-unit>half</beat-unit>
+            <per-minute>72</per-minute>
+          </metronome>
+        </direction-type>
+        <sound tempo="144"/>
+      </direction>
+      <note><rest/><duration>1920</duration><voice>1</voice><type>whole</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithHalfTempo);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("Q:1/2=72");
+
+    const roundtripXml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(roundtripXml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const soundTempo = outDoc.querySelector("part > measure > direction > sound")?.getAttribute("tempo");
+    expect(Number(soundTempo)).toBe(144);
+  });
+
+  it("MusicXML->ABC prefers the last leading tempo in measure 1 when multiple tempo directions exist", () => {
+    const xmlWithCompetingTempo = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>480</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <direction>
+        <direction-type><words>Allegretto moderato</words></direction-type>
+        <sound tempo="116"/>
+      </direction>
+      <direction>
+        <sound tempo="90"/>
+      </direction>
+      <note><rest/><duration>1920</duration><voice>1</voice><type>whole</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const srcDoc = parseMusicXmlDocument(xmlWithCompetingTempo);
+    expect(srcDoc).not.toBeNull();
+    if (!srcDoc) return;
+
+    const abc = exportMusicXmlDomToAbc(srcDoc);
+    expect(abc).toContain("Q:1/4=90");
+    expect(abc).not.toContain("Q:1/4=116");
+  });
+
   it("roundtrip of same-staff multi-voice score should not trigger MEASURE_OVERFULL", () => {
     const multiVoiceXml = `<?xml version="1.0" encoding="UTF-8"?>
 <score-partwise version="3.1">


### PR DESCRIPTION
## 概要

ABC 書き出し時の初期テンポ解釈を見直し、MusicXML の `metronome` 情報がある場合は拍単位を反映した `Q:` ヘッダを出力するようにします。 あわせて、曲頭に複数のテンポ指示が並ぶ場合の選択ロジックを修正し、関連テストと TODO を更新します。

## 変更内容

- `src/ts/abc-io.ts`
  - ABC の `Q:` ヘッダ出力で、MusicXML の `metronome > beat-unit` / `per-minute` を使って拍単位付きテンポを出力する処理を追加
  - 初期テンポ取得処理を追加し、最初の part の最初の measure に複数のテンポ指示がある場合は、先頭位置に並ぶ候補のうち最後のテンポを採用するように変更
  - 従来の単純な先頭 `sound[tempo]` 参照から、曲頭テンポを明示的に解釈する実装に変更

- `tests/unit/abc-io.spec.ts`
  - `metronome` の拍単位を ABC の `Q:` ヘッダに反映するテストを追加
  - 曲頭に複数テンポがある場合に、最後の先頭テンポを採用するテストを追加

- `TODO.md`
  - MuseScore 由来の「表示テンポと hidden metronome/playback tempo が同居するケース」の一般ルール整理を TODO として追加

- `src/js/main.js`
- `mikuscore.html`
  - ビルド生成物を更新

## 期待される効果

- 四分音符固定ではないテンポ指定でも、ABC の `Q:` ヘッダに拍単位を反映できる
- 曲頭に複数のテンポ指示がある場合に、意図しないテンポを拾うケースを減らせる
- MuseScore 由来データの ABC 書き出しで、初期テンポの解釈が改善される

## テスト

- `npx vitest run tests/unit/abc-io.spec.ts`

## 補足

- 複数テンポが同居する MuseScore データの一般ルールは、このコミットでは完全には確定していません。`TODO.md` に要整理事項として記載されています。