### PR TITLE
docs: downstream 追従確認の運用メモと workflow 導線を追加

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,7 @@ See `CODE_OF_CONDUCT.md` for collaboration and behavior expectations in project 
 - `src/js/main.js` is generated from TypeScript and is committed. If you change `src/ts/`, regenerate `src/js/main.js` as part of the same change when needed.
 - Application logic should normally be edited in `src/ts/` and `core/`.
 - Tests live under `tests/`.
+- `mikuscore` changes can require downstream follow-up in `mikuscore-skills` and `miku-abc-player`, which basically track `devel`. Keep that impact visible when a change affects shared behavior, contract, generated assets, or handoff assumptions.
 - Vendored or externally sourced files should be treated carefully:
   - `src/js/verovio.js`
   - `src/js/midi-writer.js`
@@ -59,6 +60,7 @@ In practice, not every change needs every command. A smaller change may only nee
 - Explain what changed and why.
 - Mention any user-visible behavior change.
 - Mention any spec, README, or TODO updates that are part of the change.
+- If downstream follow-up is expected, mention that `mikuscore-skills` and/or `miku-abc-player` may need updates from `devel`.
 - If a change is intentionally partial, deferred, or scoped down, say so explicitly.
 - If fixtures, samples, or local-only data were used for verification, explain that briefly.
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ Practical command split:
   - `docs/spec/SPEC.md`
   - `docs/spec/ARCHITECTURE.md`
   - `docs/spec/DIAGNOSTICS.md`
+  - `docs/spec/LOCAL_WORKFLOW.md`
+  - `docs/spec/BUILD_PROCESS.md`
   - `docs/spec/MUSESCORE_IO.md`
   - `docs/spec/MIDI_IO.md`
   - `docs/spec/ABC_IO.md`
@@ -231,6 +233,8 @@ mikuscore は、MusicXML を中核に据えた **譜面フォーマット変換�
   - `docs/spec/SPEC.md`
   - `docs/spec/ARCHITECTURE.md`
   - `docs/spec/DIAGNOSTICS.md`
+  - `docs/spec/LOCAL_WORKFLOW.md`
+  - `docs/spec/BUILD_PROCESS.md`
   - `docs/spec/MUSESCORE_IO.md`
   - `docs/spec/MIDI_IO.md`
   - `docs/spec/ABC_IO.md`

--- a/docs/spec/LOCAL_WORKFLOW.md
+++ b/docs/spec/LOCAL_WORKFLOW.md
@@ -43,11 +43,13 @@
 3. fixture・テスト更新（必要時）
 4. `npm run check:all` 実行
 5. 差分確認
+6. downstream 影響確認
 
 補足:
 
 - 回帰不具合は、可能な限り最小 fixture を `tests/fixtures/` に固定する。
 - 一時的な検証ファイルは恒久管理しない（調査完了後に除去する）。
+- `mikuscore` の更新が shared behavior、format contract、生成物、AI handoff 前提に影響する場合は、`devel` を連携先とする downstream の `mikuscore-skills` および `miku-abc-player` 側でも追従作業が発生しうることを意識する。
 
 ## 4. 品質ゲート方針
 


### PR DESCRIPTION
## 概要

`mikuscore` の更新時に、`devel` と連携している downstream 側で追従作業が発生しうることを、開発フローとコントリビューション文書から気づけるようにするためのドキュメント更新です。

## 変更内容

- `CONTRIBUTING.md`
  - `mikuscore` の変更が `mikuscore-skills` / `miku-abc-player` に影響しうることを Development Notes に追記
  - PR 記載事項として、必要に応じて downstream 側の `devel` 追従に触れることを追記
- `docs/spec/LOCAL_WORKFLOW.md`
  - 日常フローに `downstream 影響確認` を追加
  - shared behavior / format contract / 生成物 / AI handoff 前提に影響する変更では、downstream 側の追従作業発生可能性を意識する旨を追記
- `README.md`
  - documentation map に `docs/spec/LOCAL_WORKFLOW.md` と `docs/spec/BUILD_PROCESS.md` を追加
  - 運用文書への到達性を改善

## 目的

- `mikuscore` 側の変更時に、downstream 側の確認や追従が必要になる可能性を見落としにくくする
- 既存の downstream 側手順そのものではなく、こちら側での気づきと記載漏れ防止を強化する

## 影響

- ドキュメントのみの変更
- 実装変更なし

## テスト

- ドキュメント更新のみ