### PR TITLE
ABC I/O の export helper 分解をさらに進め、grouped `%%score` の characterization…

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -78,6 +78,7 @@
     - `parseForMusicXml(...)` is now much closer to orchestration, with line parsing, layout derivation, body entry dispatch, and post-processing split into helpers
     - pending note-state application and playable-event/body-token dispatch have also been thinned substantially
     - export-side grouped-staff measure rendering, header generation, repeat/ending barline assembly, note serialization, note-level precomputation, measure-note rendering, top-level part rendering, document-shell assembly, and export-context calculation are now also partially helperized
+    - focused characterization coverage now also includes grouped `%%score` multi-measure backup emission and grouped repeat/ending restoration
     - the file is much more segmented than before, but it is still not yet at a split-ready boundary
   - Use the same staged refactoring pattern proven in `src/ts/musicxml-io.ts`:
     - first make responsibility blocks explicit inside the current file
@@ -96,6 +97,10 @@
     - existing export behavior for multi-staff MusicXML parts
   - Goal:
     - make current bounded behavior explicit before reshaping internals
+  - Current status:
+    - inline `[V:...]` switching and bounded `%%score` grouped import are already covered
+    - grouped-staff characterization now also covers multi-measure `<backup>` emission and grouped repeat/ending restoration
+    - further high-value additions would be grouped-staff lyrics and grouped key/meter/tempo changes
 
 - [ ] Refactoring series 2: isolate score-layout parsing from the rest of ABC import.
   - Split out the logic that currently derives:
@@ -132,11 +137,12 @@
   - Keep output stable while reducing the size of the current monolithic emitter.
   - Current status:
     - this has advanced through helper extraction around normalized voice data, part construction, body event rendering, grouped-staff note emission, measure header generation, repeat/ending barline generation, `buildMeasureNotesXml(...)` decomposition, beam/empty-measure note precomputation, top-level measure-note rendering, and top-level part-list / part-body / document / export-context orchestration
+    - per-part state initialization, per-measure misc assembly, note leading-direction grouping, note core subfragments, and note-notations subgroups are also now helperized
     - grouped-staff MusicXML emission and note serialization are much clearer than before, but the exporter is still not fully separated into stable module-sized boundaries
   - Resume here next time:
-    - continue from the remaining seams inside `buildAbcPartBodyXml(...)` and adjacent export helpers in `src/ts/abc-io.ts`
-    - likely next slice is to reduce the remaining per-part/per-measure orchestration closure footprint further, or decide this series is "good enough" and switch effort to characterization coverage
-    - if pausing the refactor, the most valuable immediate follow-up is focused characterization coverage for bounded `%%score` import/export and grouped-staff MusicXML emission
+    - continue from the remaining seams around export helper ordering / section boundaries in `src/ts/abc-io.ts`, or decide this series is "good enough" and switch effort to characterization coverage
+    - if one more refactor slice is desired, the remaining candidates are mostly helper grouping/ordering rather than large logic blocks
+    - if pausing the refactor, the most valuable immediate follow-up is focused characterization coverage for grouped-staff lyrics and grouped key/meter/tempo changes
 
 - [ ] Refactoring series 5: make grouped-staff emission follow the same model as ordinary part emission.
   - Goal:

--- a/mikuscore.html
+++ b/mikuscore.html
@@ -30527,14 +30527,66 @@ const buildAbcRenderedPartMeasureXml = (context) => {
         : buildMeasureNotesXml(notes);
     const repeatStartXml = buildAbcMeasureRepeatStartXml(measureMeta);
     const repeatEndXml = buildAbcMeasureRepeatEndXml(measureMeta);
-    const debugMiscXml = debugMetadata ? buildAbcMeasureDebugMiscXml(notes, measureNo) : "";
-    const diagMiscXml = partIndex === 0 && measureNo === 1
-        ? buildAbcDiagMiscXml((diagnostics !== null && diagnostics !== void 0 ? diagnostics : []).filter((diag) => !diag.voiceId || diag.voiceId === (part.voiceId || "")))
-        : "";
-    const sourceMiscXml = sourceMetadata && partIndex === 0 && measureNo === 1
-        ? buildAbcSourceMiscXml(abcSource)
-        : "";
+    const { debugMiscXml, diagMiscXml, sourceMiscXml } = buildAbcRenderedMeasureMiscXml({
+        part,
+        partIndex,
+        measureNo,
+        notes,
+        debugMetadata,
+        sourceMetadata,
+        diagnostics,
+        abcSource,
+    });
     return buildAbcMeasureXml(measureNo, String((measureMeta === null || measureMeta === void 0 ? void 0 : measureMeta.number) || measureNo), Boolean((measureMeta === null || measureMeta === void 0 ? void 0 : measureMeta.implicit) || inferredImplicitPickup), repeatStartXml, headerXml, tempoDirectionXml, debugMiscXml, diagMiscXml, sourceMiscXml, notesXml, repeatEndXml);
+};
+const buildAbcRenderedMeasureMiscXml = (context) => {
+    const { part, partIndex, measureNo, notes, debugMetadata, sourceMetadata, diagnostics, abcSource, } = context;
+    return {
+        debugMiscXml: debugMetadata ? buildAbcMeasureDebugMiscXml(notes, measureNo) : "",
+        diagMiscXml: partIndex === 0 && measureNo === 1
+            ? buildAbcDiagMiscXml((diagnostics !== null && diagnostics !== void 0 ? diagnostics : []).filter((diag) => !diag.voiceId || diag.voiceId === (part.voiceId || "")))
+            : "",
+        sourceMiscXml: sourceMetadata && partIndex === 0 && measureNo === 1
+            ? buildAbcSourceMiscXml(abcSource)
+            : "",
+    };
+};
+const createInitialAbcPartRenderState = (defaultFifths, beats, beatType, tempoBpm) => ({
+    currentPartFifths: Math.max(-7, Math.min(7, Math.round(defaultFifths))),
+    currentPartMeter: { beats: Math.round(beats), beatType: Math.round(beatType) },
+    currentPartTempo: tempoBpm,
+});
+const buildAbcPartXml = (part, partIndex, measureCount, defaultFifths, beats, beatType, tempoBpm, debugMetadata, sourceMetadata, diagnostics, abcSource, buildMeasureNotesXml) => {
+    const measuresXml = [];
+    let state = createInitialAbcPartRenderState(defaultFifths, beats, beatType, tempoBpm);
+    for (let i = 0; i < measureCount; i += 1) {
+        const measureNo = i + 1;
+        const measureContext = buildAbcPartMeasureRenderContext(part, i, state, beats, beatType);
+        const { notes, measureMeta, hintedFifths, hintedMeter, hintedTempo, nextState, currentMeasureDurationDiv, inferredImplicitPickup, } = measureContext;
+        state = nextState;
+        measuresXml.push(buildAbcRenderedPartMeasureXml({
+            part,
+            partIndex,
+            measureIndex: i,
+            measureNo,
+            notes,
+            measureMeta,
+            hintedFifths,
+            hintedMeter,
+            hintedTempo,
+            currentPartFifths: state.currentPartFifths,
+            currentPartMeter: state.currentPartMeter,
+            currentPartTempo: state.currentPartTempo,
+            currentMeasureDurationDiv,
+            inferredImplicitPickup,
+            debugMetadata,
+            sourceMetadata,
+            diagnostics,
+            abcSource,
+            buildMeasureNotesXml,
+        }));
+    }
+    return `<part id="${xmlEscape(part.partId)}">${measuresXml.join("")}</part>`;
 };
 const buildAbcPartListXml = (resolvedParts) => {
     return resolvedParts
@@ -30554,45 +30606,10 @@ const buildAbcPartListXml = (resolvedParts) => {
 };
 const buildAbcPartBodyXml = (resolvedParts, measureCount, defaultFifths, beats, beatType, tempoBpm, debugMetadata, sourceMetadata, diagnostics, abcSource, buildMeasureNotesXml) => {
     return resolvedParts
-        .map((part, partIndex) => {
-        const measuresXml = [];
-        let state = {
-            currentPartFifths: Math.max(-7, Math.min(7, Math.round(defaultFifths))),
-            currentPartMeter: { beats: Math.round(beats), beatType: Math.round(beatType) },
-            currentPartTempo: tempoBpm,
-        };
-        for (let i = 0; i < measureCount; i += 1) {
-            const measureNo = i + 1;
-            const measureContext = buildAbcPartMeasureRenderContext(part, i, state, beats, beatType);
-            const { notes, measureMeta, hintedFifths, hintedMeter, hintedTempo, nextState, currentMeasureDurationDiv, inferredImplicitPickup, } = measureContext;
-            state = nextState;
-            measuresXml.push(buildAbcRenderedPartMeasureXml({
-                part,
-                partIndex,
-                measureIndex: i,
-                measureNo,
-                notes,
-                measureMeta,
-                hintedFifths,
-                hintedMeter,
-                hintedTempo,
-                currentPartFifths: state.currentPartFifths,
-                currentPartMeter: state.currentPartMeter,
-                currentPartTempo: state.currentPartTempo,
-                currentMeasureDurationDiv,
-                inferredImplicitPickup,
-                debugMetadata,
-                sourceMetadata,
-                diagnostics,
-                abcSource,
-                buildMeasureNotesXml,
-            }));
-        }
-        return `<part id="${xmlEscape(part.partId)}">${measuresXml.join("")}</part>`;
-    })
+        .map((part, partIndex) => buildAbcPartXml(part, partIndex, measureCount, defaultFifths, beats, beatType, tempoBpm, debugMetadata, sourceMetadata, diagnostics, abcSource, buildMeasureNotesXml))
         .join("");
 };
-const buildAbcNoteLeadingDirectionXml = (note) => {
+const buildAbcNoteHarmonyAndWordsDirectionXml = (note) => {
     const chunks = [];
     if (!note.chord && Array.isArray(note.chordSymbols) && note.chordSymbols.length > 0) {
         for (const chordSymbol of note.chordSymbols) {
@@ -30612,6 +30629,10 @@ const buildAbcNoteLeadingDirectionXml = (note) => {
             chunks.push(`<direction><direction-type><words>${xmlEscape(String(annotation))}</words></direction-type></direction>`);
         }
     }
+    return chunks.join("");
+};
+const buildAbcNoteControlDirectionXml = (note) => {
+    const chunks = [];
     if (!note.chord && note.segno)
         chunks.push("<direction><direction-type><segno/></direction-type></direction>");
     if (!note.chord && note.coda)
@@ -30642,6 +30663,55 @@ const buildAbcNoteLeadingDirectionXml = (note) => {
     }
     return chunks.join("");
 };
+const buildAbcNoteLeadingDirectionXml = (note) => {
+    const chunks = [];
+    chunks.push(buildAbcNoteHarmonyAndWordsDirectionXml(note));
+    chunks.push(buildAbcNoteControlDirectionXml(note));
+    return chunks.join("");
+};
+const buildAbcNotePitchOrRestXml = (note) => {
+    if (note.isRest) {
+        return "<rest/>";
+    }
+    const step = /^[A-G]$/.test(String(note.step || "").toUpperCase()) ? String(note.step).toUpperCase() : "C";
+    const octave = Number.isFinite(note.octave) ? Math.max(0, Math.min(9, Math.round(note.octave))) : 4;
+    return [
+        "<pitch>",
+        `<step>${step}</step>`,
+        Number.isFinite(note.alter) && Number(note.alter) !== 0
+            ? `<alter>${Math.round(Number(note.alter))}</alter>`
+            : "",
+        `<octave>${octave}</octave>`,
+        "</pitch>",
+    ].join("");
+};
+const buildAbcNoteLyricXml = (note) => {
+    if (!note.lyricText) {
+        return "";
+    }
+    return `<lyric><syllabic>${xmlEscape(String(note.lyricSyllabic || "single"))}</syllabic><text>${xmlEscape(String(note.lyricText))}</text>${note.lyricExtend ? "<extend/>" : ""}</lyric>`;
+};
+const buildAbcNoteTimeModificationXml = (note) => {
+    if (!(note.timeModification &&
+        Number.isFinite(note.timeModification.actual) &&
+        Number.isFinite(note.timeModification.normal) &&
+        Number(note.timeModification.actual) > 0 &&
+        Number(note.timeModification.normal) > 0)) {
+        return "";
+    }
+    return `<time-modification><actual-notes>${Math.round(Number(note.timeModification.actual))}</actual-notes><normal-notes>${Math.round(Number(note.timeModification.normal))}</normal-notes></time-modification>`;
+};
+const buildAbcNoteAccidentalXml = (note) => {
+    if (!note.accidentalText) {
+        return "";
+    }
+    const accidentalAttrs = [note.accidentalEditorial ? 'editorial="yes"' : "", note.accidentalCautionary ? 'cautionary="yes"' : ""]
+        .filter(Boolean)
+        .join(" ");
+    return accidentalAttrs
+        ? `<accidental ${accidentalAttrs}>${xmlEscape(String(note.accidentalText))}</accidental>`
+        : `<accidental>${xmlEscape(String(note.accidentalText))}</accidental>`;
+};
 const buildAbcNoteCoreXml = (note, noteIndex, staffOverride, beamXmlByNoteIndex) => {
     const chunks = [];
     chunks.push("<note>");
@@ -30649,20 +30719,7 @@ const buildAbcNoteCoreXml = (note, noteIndex, staffOverride, beamXmlByNoteIndex)
         chunks.push("<chord/>");
     if (note.grace)
         chunks.push(note.graceSlash ? '<grace slash="yes"/>' : "<grace/>");
-    if (note.isRest) {
-        chunks.push("<rest/>");
-    }
-    else {
-        const step = /^[A-G]$/.test(String(note.step || "").toUpperCase()) ? String(note.step).toUpperCase() : "C";
-        const octave = Number.isFinite(note.octave) ? Math.max(0, Math.min(9, Math.round(note.octave))) : 4;
-        chunks.push("<pitch>");
-        chunks.push(`<step>${step}</step>`);
-        if (Number.isFinite(note.alter) && Number(note.alter) !== 0) {
-            chunks.push(`<alter>${Math.round(Number(note.alter))}</alter>`);
-        }
-        chunks.push(`<octave>${octave}</octave>`);
-        chunks.push("</pitch>");
-    }
+    chunks.push(buildAbcNotePitchOrRestXml(note));
     if (!note.grace) {
         const duration = Math.max(1, Math.round(Number(note.duration) || 1));
         chunks.push(`<duration>${duration}</duration>`);
@@ -30674,60 +30731,20 @@ const buildAbcNoteCoreXml = (note, noteIndex, staffOverride, beamXmlByNoteIndex)
             : Math.max(1, Math.round(Number(note.staff) || 1));
         chunks.push(`<staff>${staffNumber}</staff>`);
     }
-    if (note.lyricText) {
-        chunks.push(`<lyric><syllabic>${xmlEscape(String(note.lyricSyllabic || "single"))}</syllabic><text>${xmlEscape(String(note.lyricText))}</text>${note.lyricExtend ? "<extend/>" : ""}</lyric>`);
-    }
+    chunks.push(buildAbcNoteLyricXml(note));
     chunks.push(`<type>${normalizeTypeForMusicXml(note.type)}</type>`);
     if (!note.chord && beamXmlByNoteIndex.has(noteIndex))
         chunks.push(String(beamXmlByNoteIndex.get(noteIndex)));
-    if (note.timeModification &&
-        Number.isFinite(note.timeModification.actual) &&
-        Number.isFinite(note.timeModification.normal) &&
-        Number(note.timeModification.actual) > 0 &&
-        Number(note.timeModification.normal) > 0) {
-        chunks.push(`<time-modification><actual-notes>${Math.round(Number(note.timeModification.actual))}</actual-notes><normal-notes>${Math.round(Number(note.timeModification.normal))}</normal-notes></time-modification>`);
-    }
-    if (note.accidentalText) {
-        const accidentalAttrs = [note.accidentalEditorial ? 'editorial="yes"' : "", note.accidentalCautionary ? 'cautionary="yes"' : ""]
-            .filter(Boolean)
-            .join(" ");
-        chunks.push(accidentalAttrs
-            ? `<accidental ${accidentalAttrs}>${xmlEscape(String(note.accidentalText))}</accidental>`
-            : `<accidental>${xmlEscape(String(note.accidentalText))}</accidental>`);
-    }
+    chunks.push(buildAbcNoteTimeModificationXml(note));
+    chunks.push(buildAbcNoteAccidentalXml(note));
     if (note.tieStart)
         chunks.push('<tie type="start"/>');
     if (note.tieStop)
         chunks.push('<tie type="stop"/>');
     return chunks.join("");
 };
-const buildAbcNoteNotationsXml = (note) => {
-    if (!(note.tieStart || note.tieStop || note.slurStart || note.slurStop || note.trill || note.trillLineStop || note.turnType ||
-        note.delayedTurn || note.mordentType || note.tremoloType || note.glissandoStart || note.glissandoStop ||
-        note.slideStart || note.slideStop || note.schleifer || note.shake || note.arpeggiate || note.staccato ||
-        note.staccatissimo || note.accent || note.tenuto || note.stress || note.unstress || note.fermataType ||
-        note.strongAccent || note.breathMark || note.caesura || note.phraseMark || note.upBow || note.downBow ||
-        note.doubleTongue || note.tripleTongue || note.heel || note.toe ||
-        (Array.isArray(note.fingerings) && note.fingerings.length > 0) ||
-        (Array.isArray(note.strings) && note.strings.length > 0) ||
-        (Array.isArray(note.plucks) && note.plucks.length > 0) || note.openString || note.snapPizzicato ||
-        note.harmonic || note.stopped || note.thumbPosition || note.tupletStart || note.tupletStop)) {
-        return "";
-    }
+const buildAbcNoteOrnamentsXml = (note) => {
     const chunks = [];
-    chunks.push("<notations>");
-    if (note.tieStart)
-        chunks.push('<tied type="start"/>');
-    if (note.tieStop)
-        chunks.push('<tied type="stop"/>');
-    if (note.slurStart)
-        chunks.push('<slur type="start"/>');
-    if (note.slurStop)
-        chunks.push('<slur type="stop"/>');
-    if (note.tupletStart)
-        chunks.push('<tuplet type="start"/>');
-    if (note.tupletStop)
-        chunks.push('<tuplet type="stop"/>');
     if (note.trill || note.trillLineStop) {
         const trillParts = [];
         if (note.trill)
@@ -30769,6 +30786,9 @@ const buildAbcNoteNotationsXml = (note) => {
         chunks.push("<ornaments><shake/></ornaments>");
     if (note.arpeggiate)
         chunks.push("<arpeggiate/>");
+    return chunks.join("");
+};
+const buildAbcNoteArticulationsXml = (note) => {
     const articulationParts = [];
     if (note.staccato)
         articulationParts.push("<staccato/>");
@@ -30790,8 +30810,9 @@ const buildAbcNoteNotationsXml = (note) => {
         articulationParts.push("<caesura/>");
     if (note.phraseMark)
         articulationParts.push(`<other-articulation>${xmlEscape(String(note.phraseMark))}</other-articulation>`);
-    if (articulationParts.length > 0)
-        chunks.push(`<articulations>${articulationParts.join("")}</articulations>`);
+    return articulationParts.length > 0 ? `<articulations>${articulationParts.join("")}</articulations>` : "";
+};
+const buildAbcNoteTechnicalXml = (note) => {
     const technicalParts = [];
     if (note.upBow)
         technicalParts.push("<up-bow/>");
@@ -30827,8 +30848,38 @@ const buildAbcNoteNotationsXml = (note) => {
         technicalParts.push("<stopped/>");
     if (note.thumbPosition)
         technicalParts.push("<thumb-position/>");
-    if (technicalParts.length > 0)
-        chunks.push(`<technical>${technicalParts.join("")}</technical>`);
+    return technicalParts.length > 0 ? `<technical>${technicalParts.join("")}</technical>` : "";
+};
+const buildAbcNoteNotationsXml = (note) => {
+    if (!(note.tieStart || note.tieStop || note.slurStart || note.slurStop || note.trill || note.trillLineStop || note.turnType ||
+        note.delayedTurn || note.mordentType || note.tremoloType || note.glissandoStart || note.glissandoStop ||
+        note.slideStart || note.slideStop || note.schleifer || note.shake || note.arpeggiate || note.staccato ||
+        note.staccatissimo || note.accent || note.tenuto || note.stress || note.unstress || note.fermataType ||
+        note.strongAccent || note.breathMark || note.caesura || note.phraseMark || note.upBow || note.downBow ||
+        note.doubleTongue || note.tripleTongue || note.heel || note.toe ||
+        (Array.isArray(note.fingerings) && note.fingerings.length > 0) ||
+        (Array.isArray(note.strings) && note.strings.length > 0) ||
+        (Array.isArray(note.plucks) && note.plucks.length > 0) || note.openString || note.snapPizzicato ||
+        note.harmonic || note.stopped || note.thumbPosition || note.tupletStart || note.tupletStop)) {
+        return "";
+    }
+    const chunks = [];
+    chunks.push("<notations>");
+    if (note.tieStart)
+        chunks.push('<tied type="start"/>');
+    if (note.tieStop)
+        chunks.push('<tied type="stop"/>');
+    if (note.slurStart)
+        chunks.push('<slur type="start"/>');
+    if (note.slurStop)
+        chunks.push('<slur type="stop"/>');
+    if (note.tupletStart)
+        chunks.push('<tuplet type="start"/>');
+    if (note.tupletStop)
+        chunks.push('<tuplet type="stop"/>');
+    chunks.push(buildAbcNoteOrnamentsXml(note));
+    chunks.push(buildAbcNoteArticulationsXml(note));
+    chunks.push(buildAbcNoteTechnicalXml(note));
     if (note.fermataType)
         chunks.push(`<fermata>${note.fermataType === "inverted" ? "inverted" : "normal"}</fermata>`);
     chunks.push("</notations>");
@@ -30895,20 +30946,21 @@ const buildAbcBeamXmlByNoteIndex = (notes, beatDiv) => {
     }
     return out;
 };
+const buildAbcNoteXml = (note, noteIndex, staffOverride, beamXmlByNoteIndex) => {
+    const chunks = [];
+    chunks.push(buildAbcNoteLeadingDirectionXml(note));
+    chunks.push(buildAbcNoteCoreXml(note, noteIndex, staffOverride, beamXmlByNoteIndex));
+    chunks.push(buildAbcNoteNotationsXml(note));
+    chunks.push("</note>");
+    return chunks.join("");
+};
 const buildAbcMeasureNotesXml = (notes, measureDurationDiv, emptyMeasureRestType, beatDiv, staffOverride = null) => {
     if (!notes.length) {
         return buildAbcEmptyMeasureNotesXml(measureDurationDiv, emptyMeasureRestType, staffOverride);
     }
     const beamXmlByNoteIndex = buildAbcBeamXmlByNoteIndex(notes, beatDiv);
     return notes
-        .map((note, noteIndex) => {
-        const chunks = [];
-        chunks.push(buildAbcNoteLeadingDirectionXml(note));
-        chunks.push(buildAbcNoteCoreXml(note, noteIndex, staffOverride, beamXmlByNoteIndex));
-        chunks.push(buildAbcNoteNotationsXml(note));
-        chunks.push("</note>");
-        return chunks.join("");
-    })
+        .map((note, noteIndex) => buildAbcNoteXml(note, noteIndex, staffOverride, beamXmlByNoteIndex))
         .join("");
 };
 const buildAbcParsedPartsFromLayout = (scoreLayout, normalizedVoiceDataById) => {

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -22477,14 +22477,66 @@ const buildAbcRenderedPartMeasureXml = (context) => {
         : buildMeasureNotesXml(notes);
     const repeatStartXml = buildAbcMeasureRepeatStartXml(measureMeta);
     const repeatEndXml = buildAbcMeasureRepeatEndXml(measureMeta);
-    const debugMiscXml = debugMetadata ? buildAbcMeasureDebugMiscXml(notes, measureNo) : "";
-    const diagMiscXml = partIndex === 0 && measureNo === 1
-        ? buildAbcDiagMiscXml((diagnostics !== null && diagnostics !== void 0 ? diagnostics : []).filter((diag) => !diag.voiceId || diag.voiceId === (part.voiceId || "")))
-        : "";
-    const sourceMiscXml = sourceMetadata && partIndex === 0 && measureNo === 1
-        ? buildAbcSourceMiscXml(abcSource)
-        : "";
+    const { debugMiscXml, diagMiscXml, sourceMiscXml } = buildAbcRenderedMeasureMiscXml({
+        part,
+        partIndex,
+        measureNo,
+        notes,
+        debugMetadata,
+        sourceMetadata,
+        diagnostics,
+        abcSource,
+    });
     return buildAbcMeasureXml(measureNo, String((measureMeta === null || measureMeta === void 0 ? void 0 : measureMeta.number) || measureNo), Boolean((measureMeta === null || measureMeta === void 0 ? void 0 : measureMeta.implicit) || inferredImplicitPickup), repeatStartXml, headerXml, tempoDirectionXml, debugMiscXml, diagMiscXml, sourceMiscXml, notesXml, repeatEndXml);
+};
+const buildAbcRenderedMeasureMiscXml = (context) => {
+    const { part, partIndex, measureNo, notes, debugMetadata, sourceMetadata, diagnostics, abcSource, } = context;
+    return {
+        debugMiscXml: debugMetadata ? buildAbcMeasureDebugMiscXml(notes, measureNo) : "",
+        diagMiscXml: partIndex === 0 && measureNo === 1
+            ? buildAbcDiagMiscXml((diagnostics !== null && diagnostics !== void 0 ? diagnostics : []).filter((diag) => !diag.voiceId || diag.voiceId === (part.voiceId || "")))
+            : "",
+        sourceMiscXml: sourceMetadata && partIndex === 0 && measureNo === 1
+            ? buildAbcSourceMiscXml(abcSource)
+            : "",
+    };
+};
+const createInitialAbcPartRenderState = (defaultFifths, beats, beatType, tempoBpm) => ({
+    currentPartFifths: Math.max(-7, Math.min(7, Math.round(defaultFifths))),
+    currentPartMeter: { beats: Math.round(beats), beatType: Math.round(beatType) },
+    currentPartTempo: tempoBpm,
+});
+const buildAbcPartXml = (part, partIndex, measureCount, defaultFifths, beats, beatType, tempoBpm, debugMetadata, sourceMetadata, diagnostics, abcSource, buildMeasureNotesXml) => {
+    const measuresXml = [];
+    let state = createInitialAbcPartRenderState(defaultFifths, beats, beatType, tempoBpm);
+    for (let i = 0; i < measureCount; i += 1) {
+        const measureNo = i + 1;
+        const measureContext = buildAbcPartMeasureRenderContext(part, i, state, beats, beatType);
+        const { notes, measureMeta, hintedFifths, hintedMeter, hintedTempo, nextState, currentMeasureDurationDiv, inferredImplicitPickup, } = measureContext;
+        state = nextState;
+        measuresXml.push(buildAbcRenderedPartMeasureXml({
+            part,
+            partIndex,
+            measureIndex: i,
+            measureNo,
+            notes,
+            measureMeta,
+            hintedFifths,
+            hintedMeter,
+            hintedTempo,
+            currentPartFifths: state.currentPartFifths,
+            currentPartMeter: state.currentPartMeter,
+            currentPartTempo: state.currentPartTempo,
+            currentMeasureDurationDiv,
+            inferredImplicitPickup,
+            debugMetadata,
+            sourceMetadata,
+            diagnostics,
+            abcSource,
+            buildMeasureNotesXml,
+        }));
+    }
+    return `<part id="${xmlEscape(part.partId)}">${measuresXml.join("")}</part>`;
 };
 const buildAbcPartListXml = (resolvedParts) => {
     return resolvedParts
@@ -22504,45 +22556,10 @@ const buildAbcPartListXml = (resolvedParts) => {
 };
 const buildAbcPartBodyXml = (resolvedParts, measureCount, defaultFifths, beats, beatType, tempoBpm, debugMetadata, sourceMetadata, diagnostics, abcSource, buildMeasureNotesXml) => {
     return resolvedParts
-        .map((part, partIndex) => {
-        const measuresXml = [];
-        let state = {
-            currentPartFifths: Math.max(-7, Math.min(7, Math.round(defaultFifths))),
-            currentPartMeter: { beats: Math.round(beats), beatType: Math.round(beatType) },
-            currentPartTempo: tempoBpm,
-        };
-        for (let i = 0; i < measureCount; i += 1) {
-            const measureNo = i + 1;
-            const measureContext = buildAbcPartMeasureRenderContext(part, i, state, beats, beatType);
-            const { notes, measureMeta, hintedFifths, hintedMeter, hintedTempo, nextState, currentMeasureDurationDiv, inferredImplicitPickup, } = measureContext;
-            state = nextState;
-            measuresXml.push(buildAbcRenderedPartMeasureXml({
-                part,
-                partIndex,
-                measureIndex: i,
-                measureNo,
-                notes,
-                measureMeta,
-                hintedFifths,
-                hintedMeter,
-                hintedTempo,
-                currentPartFifths: state.currentPartFifths,
-                currentPartMeter: state.currentPartMeter,
-                currentPartTempo: state.currentPartTempo,
-                currentMeasureDurationDiv,
-                inferredImplicitPickup,
-                debugMetadata,
-                sourceMetadata,
-                diagnostics,
-                abcSource,
-                buildMeasureNotesXml,
-            }));
-        }
-        return `<part id="${xmlEscape(part.partId)}">${measuresXml.join("")}</part>`;
-    })
+        .map((part, partIndex) => buildAbcPartXml(part, partIndex, measureCount, defaultFifths, beats, beatType, tempoBpm, debugMetadata, sourceMetadata, diagnostics, abcSource, buildMeasureNotesXml))
         .join("");
 };
-const buildAbcNoteLeadingDirectionXml = (note) => {
+const buildAbcNoteHarmonyAndWordsDirectionXml = (note) => {
     const chunks = [];
     if (!note.chord && Array.isArray(note.chordSymbols) && note.chordSymbols.length > 0) {
         for (const chordSymbol of note.chordSymbols) {
@@ -22562,6 +22579,10 @@ const buildAbcNoteLeadingDirectionXml = (note) => {
             chunks.push(`<direction><direction-type><words>${xmlEscape(String(annotation))}</words></direction-type></direction>`);
         }
     }
+    return chunks.join("");
+};
+const buildAbcNoteControlDirectionXml = (note) => {
+    const chunks = [];
     if (!note.chord && note.segno)
         chunks.push("<direction><direction-type><segno/></direction-type></direction>");
     if (!note.chord && note.coda)
@@ -22592,6 +22613,55 @@ const buildAbcNoteLeadingDirectionXml = (note) => {
     }
     return chunks.join("");
 };
+const buildAbcNoteLeadingDirectionXml = (note) => {
+    const chunks = [];
+    chunks.push(buildAbcNoteHarmonyAndWordsDirectionXml(note));
+    chunks.push(buildAbcNoteControlDirectionXml(note));
+    return chunks.join("");
+};
+const buildAbcNotePitchOrRestXml = (note) => {
+    if (note.isRest) {
+        return "<rest/>";
+    }
+    const step = /^[A-G]$/.test(String(note.step || "").toUpperCase()) ? String(note.step).toUpperCase() : "C";
+    const octave = Number.isFinite(note.octave) ? Math.max(0, Math.min(9, Math.round(note.octave))) : 4;
+    return [
+        "<pitch>",
+        `<step>${step}</step>`,
+        Number.isFinite(note.alter) && Number(note.alter) !== 0
+            ? `<alter>${Math.round(Number(note.alter))}</alter>`
+            : "",
+        `<octave>${octave}</octave>`,
+        "</pitch>",
+    ].join("");
+};
+const buildAbcNoteLyricXml = (note) => {
+    if (!note.lyricText) {
+        return "";
+    }
+    return `<lyric><syllabic>${xmlEscape(String(note.lyricSyllabic || "single"))}</syllabic><text>${xmlEscape(String(note.lyricText))}</text>${note.lyricExtend ? "<extend/>" : ""}</lyric>`;
+};
+const buildAbcNoteTimeModificationXml = (note) => {
+    if (!(note.timeModification &&
+        Number.isFinite(note.timeModification.actual) &&
+        Number.isFinite(note.timeModification.normal) &&
+        Number(note.timeModification.actual) > 0 &&
+        Number(note.timeModification.normal) > 0)) {
+        return "";
+    }
+    return `<time-modification><actual-notes>${Math.round(Number(note.timeModification.actual))}</actual-notes><normal-notes>${Math.round(Number(note.timeModification.normal))}</normal-notes></time-modification>`;
+};
+const buildAbcNoteAccidentalXml = (note) => {
+    if (!note.accidentalText) {
+        return "";
+    }
+    const accidentalAttrs = [note.accidentalEditorial ? 'editorial="yes"' : "", note.accidentalCautionary ? 'cautionary="yes"' : ""]
+        .filter(Boolean)
+        .join(" ");
+    return accidentalAttrs
+        ? `<accidental ${accidentalAttrs}>${xmlEscape(String(note.accidentalText))}</accidental>`
+        : `<accidental>${xmlEscape(String(note.accidentalText))}</accidental>`;
+};
 const buildAbcNoteCoreXml = (note, noteIndex, staffOverride, beamXmlByNoteIndex) => {
     const chunks = [];
     chunks.push("<note>");
@@ -22599,20 +22669,7 @@ const buildAbcNoteCoreXml = (note, noteIndex, staffOverride, beamXmlByNoteIndex)
         chunks.push("<chord/>");
     if (note.grace)
         chunks.push(note.graceSlash ? '<grace slash="yes"/>' : "<grace/>");
-    if (note.isRest) {
-        chunks.push("<rest/>");
-    }
-    else {
-        const step = /^[A-G]$/.test(String(note.step || "").toUpperCase()) ? String(note.step).toUpperCase() : "C";
-        const octave = Number.isFinite(note.octave) ? Math.max(0, Math.min(9, Math.round(note.octave))) : 4;
-        chunks.push("<pitch>");
-        chunks.push(`<step>${step}</step>`);
-        if (Number.isFinite(note.alter) && Number(note.alter) !== 0) {
-            chunks.push(`<alter>${Math.round(Number(note.alter))}</alter>`);
-        }
-        chunks.push(`<octave>${octave}</octave>`);
-        chunks.push("</pitch>");
-    }
+    chunks.push(buildAbcNotePitchOrRestXml(note));
     if (!note.grace) {
         const duration = Math.max(1, Math.round(Number(note.duration) || 1));
         chunks.push(`<duration>${duration}</duration>`);
@@ -22624,60 +22681,20 @@ const buildAbcNoteCoreXml = (note, noteIndex, staffOverride, beamXmlByNoteIndex)
             : Math.max(1, Math.round(Number(note.staff) || 1));
         chunks.push(`<staff>${staffNumber}</staff>`);
     }
-    if (note.lyricText) {
-        chunks.push(`<lyric><syllabic>${xmlEscape(String(note.lyricSyllabic || "single"))}</syllabic><text>${xmlEscape(String(note.lyricText))}</text>${note.lyricExtend ? "<extend/>" : ""}</lyric>`);
-    }
+    chunks.push(buildAbcNoteLyricXml(note));
     chunks.push(`<type>${normalizeTypeForMusicXml(note.type)}</type>`);
     if (!note.chord && beamXmlByNoteIndex.has(noteIndex))
         chunks.push(String(beamXmlByNoteIndex.get(noteIndex)));
-    if (note.timeModification &&
-        Number.isFinite(note.timeModification.actual) &&
-        Number.isFinite(note.timeModification.normal) &&
-        Number(note.timeModification.actual) > 0 &&
-        Number(note.timeModification.normal) > 0) {
-        chunks.push(`<time-modification><actual-notes>${Math.round(Number(note.timeModification.actual))}</actual-notes><normal-notes>${Math.round(Number(note.timeModification.normal))}</normal-notes></time-modification>`);
-    }
-    if (note.accidentalText) {
-        const accidentalAttrs = [note.accidentalEditorial ? 'editorial="yes"' : "", note.accidentalCautionary ? 'cautionary="yes"' : ""]
-            .filter(Boolean)
-            .join(" ");
-        chunks.push(accidentalAttrs
-            ? `<accidental ${accidentalAttrs}>${xmlEscape(String(note.accidentalText))}</accidental>`
-            : `<accidental>${xmlEscape(String(note.accidentalText))}</accidental>`);
-    }
+    chunks.push(buildAbcNoteTimeModificationXml(note));
+    chunks.push(buildAbcNoteAccidentalXml(note));
     if (note.tieStart)
         chunks.push('<tie type="start"/>');
     if (note.tieStop)
         chunks.push('<tie type="stop"/>');
     return chunks.join("");
 };
-const buildAbcNoteNotationsXml = (note) => {
-    if (!(note.tieStart || note.tieStop || note.slurStart || note.slurStop || note.trill || note.trillLineStop || note.turnType ||
-        note.delayedTurn || note.mordentType || note.tremoloType || note.glissandoStart || note.glissandoStop ||
-        note.slideStart || note.slideStop || note.schleifer || note.shake || note.arpeggiate || note.staccato ||
-        note.staccatissimo || note.accent || note.tenuto || note.stress || note.unstress || note.fermataType ||
-        note.strongAccent || note.breathMark || note.caesura || note.phraseMark || note.upBow || note.downBow ||
-        note.doubleTongue || note.tripleTongue || note.heel || note.toe ||
-        (Array.isArray(note.fingerings) && note.fingerings.length > 0) ||
-        (Array.isArray(note.strings) && note.strings.length > 0) ||
-        (Array.isArray(note.plucks) && note.plucks.length > 0) || note.openString || note.snapPizzicato ||
-        note.harmonic || note.stopped || note.thumbPosition || note.tupletStart || note.tupletStop)) {
-        return "";
-    }
+const buildAbcNoteOrnamentsXml = (note) => {
     const chunks = [];
-    chunks.push("<notations>");
-    if (note.tieStart)
-        chunks.push('<tied type="start"/>');
-    if (note.tieStop)
-        chunks.push('<tied type="stop"/>');
-    if (note.slurStart)
-        chunks.push('<slur type="start"/>');
-    if (note.slurStop)
-        chunks.push('<slur type="stop"/>');
-    if (note.tupletStart)
-        chunks.push('<tuplet type="start"/>');
-    if (note.tupletStop)
-        chunks.push('<tuplet type="stop"/>');
     if (note.trill || note.trillLineStop) {
         const trillParts = [];
         if (note.trill)
@@ -22719,6 +22736,9 @@ const buildAbcNoteNotationsXml = (note) => {
         chunks.push("<ornaments><shake/></ornaments>");
     if (note.arpeggiate)
         chunks.push("<arpeggiate/>");
+    return chunks.join("");
+};
+const buildAbcNoteArticulationsXml = (note) => {
     const articulationParts = [];
     if (note.staccato)
         articulationParts.push("<staccato/>");
@@ -22740,8 +22760,9 @@ const buildAbcNoteNotationsXml = (note) => {
         articulationParts.push("<caesura/>");
     if (note.phraseMark)
         articulationParts.push(`<other-articulation>${xmlEscape(String(note.phraseMark))}</other-articulation>`);
-    if (articulationParts.length > 0)
-        chunks.push(`<articulations>${articulationParts.join("")}</articulations>`);
+    return articulationParts.length > 0 ? `<articulations>${articulationParts.join("")}</articulations>` : "";
+};
+const buildAbcNoteTechnicalXml = (note) => {
     const technicalParts = [];
     if (note.upBow)
         technicalParts.push("<up-bow/>");
@@ -22777,8 +22798,38 @@ const buildAbcNoteNotationsXml = (note) => {
         technicalParts.push("<stopped/>");
     if (note.thumbPosition)
         technicalParts.push("<thumb-position/>");
-    if (technicalParts.length > 0)
-        chunks.push(`<technical>${technicalParts.join("")}</technical>`);
+    return technicalParts.length > 0 ? `<technical>${technicalParts.join("")}</technical>` : "";
+};
+const buildAbcNoteNotationsXml = (note) => {
+    if (!(note.tieStart || note.tieStop || note.slurStart || note.slurStop || note.trill || note.trillLineStop || note.turnType ||
+        note.delayedTurn || note.mordentType || note.tremoloType || note.glissandoStart || note.glissandoStop ||
+        note.slideStart || note.slideStop || note.schleifer || note.shake || note.arpeggiate || note.staccato ||
+        note.staccatissimo || note.accent || note.tenuto || note.stress || note.unstress || note.fermataType ||
+        note.strongAccent || note.breathMark || note.caesura || note.phraseMark || note.upBow || note.downBow ||
+        note.doubleTongue || note.tripleTongue || note.heel || note.toe ||
+        (Array.isArray(note.fingerings) && note.fingerings.length > 0) ||
+        (Array.isArray(note.strings) && note.strings.length > 0) ||
+        (Array.isArray(note.plucks) && note.plucks.length > 0) || note.openString || note.snapPizzicato ||
+        note.harmonic || note.stopped || note.thumbPosition || note.tupletStart || note.tupletStop)) {
+        return "";
+    }
+    const chunks = [];
+    chunks.push("<notations>");
+    if (note.tieStart)
+        chunks.push('<tied type="start"/>');
+    if (note.tieStop)
+        chunks.push('<tied type="stop"/>');
+    if (note.slurStart)
+        chunks.push('<slur type="start"/>');
+    if (note.slurStop)
+        chunks.push('<slur type="stop"/>');
+    if (note.tupletStart)
+        chunks.push('<tuplet type="start"/>');
+    if (note.tupletStop)
+        chunks.push('<tuplet type="stop"/>');
+    chunks.push(buildAbcNoteOrnamentsXml(note));
+    chunks.push(buildAbcNoteArticulationsXml(note));
+    chunks.push(buildAbcNoteTechnicalXml(note));
     if (note.fermataType)
         chunks.push(`<fermata>${note.fermataType === "inverted" ? "inverted" : "normal"}</fermata>`);
     chunks.push("</notations>");
@@ -22845,20 +22896,21 @@ const buildAbcBeamXmlByNoteIndex = (notes, beatDiv) => {
     }
     return out;
 };
+const buildAbcNoteXml = (note, noteIndex, staffOverride, beamXmlByNoteIndex) => {
+    const chunks = [];
+    chunks.push(buildAbcNoteLeadingDirectionXml(note));
+    chunks.push(buildAbcNoteCoreXml(note, noteIndex, staffOverride, beamXmlByNoteIndex));
+    chunks.push(buildAbcNoteNotationsXml(note));
+    chunks.push("</note>");
+    return chunks.join("");
+};
 const buildAbcMeasureNotesXml = (notes, measureDurationDiv, emptyMeasureRestType, beatDiv, staffOverride = null) => {
     if (!notes.length) {
         return buildAbcEmptyMeasureNotesXml(measureDurationDiv, emptyMeasureRestType, staffOverride);
     }
     const beamXmlByNoteIndex = buildAbcBeamXmlByNoteIndex(notes, beatDiv);
     return notes
-        .map((note, noteIndex) => {
-        const chunks = [];
-        chunks.push(buildAbcNoteLeadingDirectionXml(note));
-        chunks.push(buildAbcNoteCoreXml(note, noteIndex, staffOverride, beamXmlByNoteIndex));
-        chunks.push(buildAbcNoteNotationsXml(note));
-        chunks.push("</note>");
-        return chunks.join("");
-    })
+        .map((note, noteIndex) => buildAbcNoteXml(note, noteIndex, staffOverride, beamXmlByNoteIndex))
         .join("");
 };
 const buildAbcParsedPartsFromLayout = (scoreLayout, normalizedVoiceDataById) => {

--- a/src/ts/abc-io.ts
+++ b/src/ts/abc-io.ts
@@ -1412,19 +1412,16 @@ const buildAbcRenderedPartMeasureXml = (
       : buildMeasureNotesXml(notes);
   const repeatStartXml = buildAbcMeasureRepeatStartXml(measureMeta);
   const repeatEndXml = buildAbcMeasureRepeatEndXml(measureMeta);
-  const debugMiscXml = debugMetadata ? buildAbcMeasureDebugMiscXml(notes, measureNo) : "";
-  const diagMiscXml =
-    partIndex === 0 && measureNo === 1
-      ? buildAbcDiagMiscXml(
-          (diagnostics ?? []).filter(
-            (diag) => !diag.voiceId || diag.voiceId === (part.voiceId || "")
-          )
-        )
-      : "";
-  const sourceMiscXml =
-    sourceMetadata && partIndex === 0 && measureNo === 1
-      ? buildAbcSourceMiscXml(abcSource)
-      : "";
+  const { debugMiscXml, diagMiscXml, sourceMiscXml } = buildAbcRenderedMeasureMiscXml({
+    part,
+    partIndex,
+    measureNo,
+    notes,
+    debugMetadata,
+    sourceMetadata,
+    diagnostics,
+    abcSource,
+  });
   return buildAbcMeasureXml(
     measureNo,
     String(measureMeta?.number || measureNo),
@@ -1438,6 +1435,111 @@ const buildAbcRenderedPartMeasureXml = (
     notesXml,
     repeatEndXml
   );
+};
+
+const buildAbcRenderedMeasureMiscXml = (
+  context: Pick<
+    AbcRenderedPartMeasureContext,
+    "part" | "partIndex" | "measureNo" | "notes" | "debugMetadata" | "sourceMetadata" | "diagnostics" | "abcSource"
+  >
+): {
+  debugMiscXml: string;
+  diagMiscXml: string;
+  sourceMiscXml: string;
+} => {
+  const {
+    part,
+    partIndex,
+    measureNo,
+    notes,
+    debugMetadata,
+    sourceMetadata,
+    diagnostics,
+    abcSource,
+  } = context;
+  return {
+    debugMiscXml: debugMetadata ? buildAbcMeasureDebugMiscXml(notes, measureNo) : "",
+    diagMiscXml:
+      partIndex === 0 && measureNo === 1
+        ? buildAbcDiagMiscXml(
+            (diagnostics ?? []).filter(
+              (diag) => !diag.voiceId || diag.voiceId === (part.voiceId || "")
+            )
+          )
+        : "",
+    sourceMiscXml:
+      sourceMetadata && partIndex === 0 && measureNo === 1
+        ? buildAbcSourceMiscXml(abcSource)
+        : "",
+  };
+};
+
+const createInitialAbcPartRenderState = (
+  defaultFifths: number,
+  beats: number,
+  beatType: number,
+  tempoBpm: number | null
+): AbcPartRenderState => ({
+  currentPartFifths: Math.max(-7, Math.min(7, Math.round(defaultFifths))),
+  currentPartMeter: { beats: Math.round(beats), beatType: Math.round(beatType) },
+  currentPartTempo: tempoBpm,
+});
+
+const buildAbcPartXml = (
+  part: AbcParsedPart,
+  partIndex: number,
+  measureCount: number,
+  defaultFifths: number,
+  beats: number,
+  beatType: number,
+  tempoBpm: number | null,
+  debugMetadata: boolean,
+  sourceMetadata: boolean,
+  diagnostics: AbcParsedResult["diagnostics"] | undefined,
+  abcSource: string,
+  buildMeasureNotesXml: (notes: AbcParsedNote[], staffOverride?: number | null) => string
+): string => {
+  const measuresXml: string[] = [];
+  let state = createInitialAbcPartRenderState(defaultFifths, beats, beatType, tempoBpm);
+  for (let i = 0; i < measureCount; i += 1) {
+    const measureNo = i + 1;
+    const measureContext = buildAbcPartMeasureRenderContext(part, i, state, beats, beatType);
+    const {
+      notes,
+      measureMeta,
+      hintedFifths,
+      hintedMeter,
+      hintedTempo,
+      nextState,
+      currentMeasureDurationDiv,
+      inferredImplicitPickup,
+    } = measureContext;
+    state = nextState;
+    measuresXml.push(
+      buildAbcRenderedPartMeasureXml({
+        part,
+        partIndex,
+        measureIndex: i,
+        measureNo,
+        notes,
+        measureMeta,
+        hintedFifths,
+        hintedMeter,
+        hintedTempo,
+        currentPartFifths: state.currentPartFifths,
+        currentPartMeter: state.currentPartMeter,
+        currentPartTempo: state.currentPartTempo,
+        currentMeasureDurationDiv,
+        inferredImplicitPickup,
+        debugMetadata,
+        sourceMetadata,
+        diagnostics,
+        abcSource,
+        buildMeasureNotesXml,
+      })
+    );
+  }
+  return `<part id="${xmlEscape(part.partId)}">${measuresXml.join("")}</part>`;
 };
 
 const buildAbcPartListXml = (resolvedParts: AbcParsedPart[]): string => {
@@ -1471,57 +1573,26 @@ const buildAbcPartBodyXml = (
   buildMeasureNotesXml: (notes: AbcParsedNote[], staffOverride?: number | null) => string
 ): string => {
   return resolvedParts
-    .map((part, partIndex) => {
-      const measuresXml: string[] = [];
-      let state: AbcPartRenderState = {
-        currentPartFifths: Math.max(-7, Math.min(7, Math.round(defaultFifths))),
-        currentPartMeter: { beats: Math.round(beats), beatType: Math.round(beatType) },
-        currentPartTempo: tempoBpm,
-      };
-      for (let i = 0; i < measureCount; i += 1) {
-        const measureNo = i + 1;
-        const measureContext = buildAbcPartMeasureRenderContext(part, i, state, beats, beatType);
-        const {
-          notes,
-          measureMeta,
-          hintedFifths,
-          hintedMeter,
-          hintedTempo,
-          nextState,
-          currentMeasureDurationDiv,
-          inferredImplicitPickup,
-        } = measureContext;
-        state = nextState;
-        measuresXml.push(
-          buildAbcRenderedPartMeasureXml({
-            part,
-            partIndex,
-            measureIndex: i,
-            measureNo,
-            notes,
-            measureMeta,
-            hintedFifths,
-            hintedMeter,
-            hintedTempo,
-            currentPartFifths: state.currentPartFifths,
-            currentPartMeter: state.currentPartMeter,
-            currentPartTempo: state.currentPartTempo,
-            currentMeasureDurationDiv,
-            inferredImplicitPickup,
-            debugMetadata,
-            sourceMetadata,
-            diagnostics,
-            abcSource,
-            buildMeasureNotesXml,
-          })
-        );
-      }
-      return `<part id="${xmlEscape(part.partId)}">${measuresXml.join("")}</part>`;
-    })
+    .map((part, partIndex) =>
+      buildAbcPartXml(
+        part,
+        partIndex,
+        measureCount,
+        defaultFifths,
+        beats,
+        beatType,
+        tempoBpm,
+        debugMetadata,
+        sourceMetadata,
+        diagnostics,
+        abcSource,
+        buildMeasureNotesXml
+      )
+    )
     .join("");
 };
 
-const buildAbcNoteLeadingDirectionXml = (note: AbcParsedNote): string => {
+const buildAbcNoteHarmonyAndWordsDirectionXml = (note: AbcParsedNote): string => {
   const chunks: string[] = [];
   if (!note.chord && Array.isArray(note.chordSymbols) && note.chordSymbols.length > 0) {
     for (const chordSymbol of note.chordSymbols) {
@@ -1539,6 +1610,11 @@ const buildAbcNoteLeadingDirectionXml = (note: AbcParsedNote): string => {
       chunks.push(`<direction><direction-type><words>${xmlEscape(String(annotation))}</words></direction-type></direction>`);
     }
   }
+  return chunks.join("");
+};
+
+const buildAbcNoteControlDirectionXml = (note: AbcParsedNote): string => {
+  const chunks: string[] = [];
   if (!note.chord && note.segno) chunks.push("<direction><direction-type><segno/></direction-type></direction>");
   if (!note.chord && note.coda) chunks.push("<direction><direction-type><coda/></direction-type></direction>");
   if (!note.chord && note.rehearsalMark) {
@@ -1562,6 +1638,64 @@ const buildAbcNoteLeadingDirectionXml = (note: AbcParsedNote): string => {
   return chunks.join("");
 };
 
+const buildAbcNoteLeadingDirectionXml = (note: AbcParsedNote): string => {
+  const chunks: string[] = [];
+  chunks.push(buildAbcNoteHarmonyAndWordsDirectionXml(note));
+  chunks.push(buildAbcNoteControlDirectionXml(note));
+  return chunks.join("");
+};
+
+const buildAbcNotePitchOrRestXml = (note: AbcParsedNote): string => {
+  if (note.isRest) {
+    return "<rest/>";
+  }
+  const step = /^[A-G]$/.test(String(note.step || "").toUpperCase()) ? String(note.step).toUpperCase() : "C";
+  const octave = Number.isFinite(note.octave) ? Math.max(0, Math.min(9, Math.round(note.octave as number))) : 4;
+  return [
+    "<pitch>",
+    `<step>${step}</step>`,
+    Number.isFinite(note.alter as number) && Number(note.alter) !== 0
+      ? `<alter>${Math.round(Number(note.alter))}</alter>`
+      : "",
+    `<octave>${octave}</octave>`,
+    "</pitch>",
+  ].join("");
+};
+
+const buildAbcNoteLyricXml = (note: AbcParsedNote): string => {
+  if (!note.lyricText) {
+    return "";
+  }
+  return `<lyric><syllabic>${xmlEscape(String(note.lyricSyllabic || "single"))}</syllabic><text>${xmlEscape(String(note.lyricText))}</text>${note.lyricExtend ? "<extend/>" : ""}</lyric>`;
+};
+
+const buildAbcNoteTimeModificationXml = (note: AbcParsedNote): string => {
+  if (
+    !(
+      note.timeModification &&
+      Number.isFinite(note.timeModification.actual) &&
+      Number.isFinite(note.timeModification.normal) &&
+      Number(note.timeModification.actual) > 0 &&
+      Number(note.timeModification.normal) > 0
+    )
+  ) {
+    return "";
+  }
+  return `<time-modification><actual-notes>${Math.round(Number(note.timeModification.actual))}</actual-notes><normal-notes>${Math.round(Number(note.timeModification.normal))}</normal-notes></time-modification>`;
+};
+
+const buildAbcNoteAccidentalXml = (note: AbcParsedNote): string => {
+  if (!note.accidentalText) {
+    return "";
+  }
+  const accidentalAttrs = [note.accidentalEditorial ? 'editorial="yes"' : "", note.accidentalCautionary ? 'cautionary="yes"' : ""]
+    .filter(Boolean)
+    .join(" ");
+  return accidentalAttrs
+    ? `<accidental ${accidentalAttrs}>${xmlEscape(String(note.accidentalText))}</accidental>`
+    : `<accidental>${xmlEscape(String(note.accidentalText))}</accidental>`;
+};
+
 const buildAbcNoteCoreXml = (
   note: AbcParsedNote,
   noteIndex: number,
@@ -1572,19 +1706,7 @@ const buildAbcNoteCoreXml = (
   chunks.push("<note>");
   if (note.chord) chunks.push("<chord/>");
   if (note.grace) chunks.push(note.graceSlash ? '<grace slash="yes"/>' : "<grace/>");
-  if (note.isRest) {
-    chunks.push("<rest/>");
-  } else {
-    const step = /^[A-G]$/.test(String(note.step || "").toUpperCase()) ? String(note.step).toUpperCase() : "C";
-    const octave = Number.isFinite(note.octave) ? Math.max(0, Math.min(9, Math.round(note.octave as number))) : 4;
-    chunks.push("<pitch>");
-    chunks.push(`<step>${step}</step>`);
-    if (Number.isFinite(note.alter as number) && Number(note.alter) !== 0) {
-      chunks.push(`<alter>${Math.round(Number(note.alter))}</alter>`);
-    }
-    chunks.push(`<octave>${octave}</octave>`);
-    chunks.push("</pitch>");
-  }
+  chunks.push(buildAbcNotePitchOrRestXml(note));
   if (!note.grace) {
     const duration = Math.max(1, Math.round(Number(note.duration) || 1));
     chunks.push(`<duration>${duration}</duration>`);
@@ -1597,64 +1719,18 @@ const buildAbcNoteCoreXml = (
         : Math.max(1, Math.round(Number(note.staff) || 1));
     chunks.push(`<staff>${staffNumber}</staff>`);
   }
-  if (note.lyricText) {
-    chunks.push(
-      `<lyric><syllabic>${xmlEscape(String(note.lyricSyllabic || "single"))}</syllabic><text>${xmlEscape(String(note.lyricText))}</text>${note.lyricExtend ? "<extend/>" : ""}</lyric>`
-    );
-  }
+  chunks.push(buildAbcNoteLyricXml(note));
   chunks.push(`<type>${normalizeTypeForMusicXml(note.type)}</type>`);
   if (!note.chord && beamXmlByNoteIndex.has(noteIndex)) chunks.push(String(beamXmlByNoteIndex.get(noteIndex)));
-  if (
-    note.timeModification &&
-    Number.isFinite(note.timeModification.actual) &&
-    Number.isFinite(note.timeModification.normal) &&
-    Number(note.timeModification.actual) > 0 &&
-    Number(note.timeModification.normal) > 0
-  ) {
-    chunks.push(
-      `<time-modification><actual-notes>${Math.round(Number(note.timeModification.actual))}</actual-notes><normal-notes>${Math.round(Number(note.timeModification.normal))}</normal-notes></time-modification>`
-    );
-  }
-  if (note.accidentalText) {
-    const accidentalAttrs = [note.accidentalEditorial ? 'editorial="yes"' : "", note.accidentalCautionary ? 'cautionary="yes"' : ""]
-      .filter(Boolean)
-      .join(" ");
-    chunks.push(
-      accidentalAttrs
-        ? `<accidental ${accidentalAttrs}>${xmlEscape(String(note.accidentalText))}</accidental>`
-        : `<accidental>${xmlEscape(String(note.accidentalText))}</accidental>`
-    );
-  }
+  chunks.push(buildAbcNoteTimeModificationXml(note));
+  chunks.push(buildAbcNoteAccidentalXml(note));
   if (note.tieStart) chunks.push('<tie type="start"/>');
   if (note.tieStop) chunks.push('<tie type="stop"/>');
   return chunks.join("");
 };
 
-const buildAbcNoteNotationsXml = (note: AbcParsedNote): string => {
-  if (
-    !(
-      note.tieStart || note.tieStop || note.slurStart || note.slurStop || note.trill || note.trillLineStop || note.turnType ||
-      note.delayedTurn || note.mordentType || note.tremoloType || note.glissandoStart || note.glissandoStop ||
-      note.slideStart || note.slideStop || note.schleifer || note.shake || note.arpeggiate || note.staccato ||
-      note.staccatissimo || note.accent || note.tenuto || note.stress || note.unstress || note.fermataType ||
-      note.strongAccent || note.breathMark || note.caesura || note.phraseMark || note.upBow || note.downBow ||
-      note.doubleTongue || note.tripleTongue || note.heel || note.toe ||
-      (Array.isArray(note.fingerings) && note.fingerings.length > 0) ||
-      (Array.isArray(note.strings) && note.strings.length > 0) ||
-      (Array.isArray(note.plucks) && note.plucks.length > 0) || note.openString || note.snapPizzicato ||
-      note.harmonic || note.stopped || note.thumbPosition || note.tupletStart || note.tupletStop
-    )
-  ) {
-    return "";
-  }
+const buildAbcNoteOrnamentsXml = (note: AbcParsedNote): string => {
   const chunks: string[] = [];
-  chunks.push("<notations>");
-  if (note.tieStart) chunks.push('<tied type="start"/>');
-  if (note.tieStop) chunks.push('<tied type="stop"/>');
-  if (note.slurStart) chunks.push('<slur type="start"/>');
-  if (note.slurStop) chunks.push('<slur type="stop"/>');
-  if (note.tupletStart) chunks.push('<tuplet type="start"/>');
-  if (note.tupletStop) chunks.push('<tuplet type="stop"/>');
   if (note.trill || note.trillLineStop) {
     const trillParts: string[] = [];
     if (note.trill) trillParts.push("<trill-mark/>");
@@ -1686,6 +1762,10 @@ const buildAbcNoteNotationsXml = (note: AbcParsedNote): string => {
   if (note.schleifer) chunks.push("<ornaments><schleifer/></ornaments>");
   if (note.shake) chunks.push("<ornaments><shake/></ornaments>");
   if (note.arpeggiate) chunks.push("<arpeggiate/>");
+  return chunks.join("");
+};
+
+const buildAbcNoteArticulationsXml = (note: AbcParsedNote): string => {
   const articulationParts: string[] = [];
   if (note.staccato) articulationParts.push("<staccato/>");
   if (note.staccatissimo) articulationParts.push("<staccatissimo/>");
@@ -1697,7 +1777,10 @@ const buildAbcNoteNotationsXml = (note: AbcParsedNote): string => {
   if (note.breathMark) articulationParts.push("<breath-mark/>");
   if (note.caesura) articulationParts.push("<caesura/>");
   if (note.phraseMark) articulationParts.push(`<other-articulation>${xmlEscape(String(note.phraseMark))}</other-articulation>`);
-  if (articulationParts.length > 0) chunks.push(`<articulations>${articulationParts.join("")}</articulations>`);
+  return articulationParts.length > 0 ? `<articulations>${articulationParts.join("")}</articulations>` : "";
+};
+
+const buildAbcNoteTechnicalXml = (note: AbcParsedNote): string => {
   const technicalParts: string[] = [];
   if (note.upBow) technicalParts.push("<up-bow/>");
   if (note.downBow) technicalParts.push("<down-bow/>");
@@ -1713,7 +1796,37 @@ const buildAbcNoteNotationsXml = (note: AbcParsedNote): string => {
   if (note.harmonic) technicalParts.push("<harmonic/>");
   if (note.stopped) technicalParts.push("<stopped/>");
   if (note.thumbPosition) technicalParts.push("<thumb-position/>");
-  if (technicalParts.length > 0) chunks.push(`<technical>${technicalParts.join("")}</technical>`);
+  return technicalParts.length > 0 ? `<technical>${technicalParts.join("")}</technical>` : "";
+};
+
+const buildAbcNoteNotationsXml = (note: AbcParsedNote): string => {
+  if (
+    !(
+      note.tieStart || note.tieStop || note.slurStart || note.slurStop || note.trill || note.trillLineStop || note.turnType ||
+      note.delayedTurn || note.mordentType || note.tremoloType || note.glissandoStart || note.glissandoStop ||
+      note.slideStart || note.slideStop || note.schleifer || note.shake || note.arpeggiate || note.staccato ||
+      note.staccatissimo || note.accent || note.tenuto || note.stress || note.unstress || note.fermataType ||
+      note.strongAccent || note.breathMark || note.caesura || note.phraseMark || note.upBow || note.downBow ||
+      note.doubleTongue || note.tripleTongue || note.heel || note.toe ||
+      (Array.isArray(note.fingerings) && note.fingerings.length > 0) ||
+      (Array.isArray(note.strings) && note.strings.length > 0) ||
+      (Array.isArray(note.plucks) && note.plucks.length > 0) || note.openString || note.snapPizzicato ||
+      note.harmonic || note.stopped || note.thumbPosition || note.tupletStart || note.tupletStop
+    )
+  ) {
+    return "";
+  }
+  const chunks: string[] = [];
+  chunks.push("<notations>");
+  if (note.tieStart) chunks.push('<tied type="start"/>');
+  if (note.tieStop) chunks.push('<tied type="stop"/>');
+  if (note.slurStart) chunks.push('<slur type="start"/>');
+  if (note.slurStop) chunks.push('<slur type="stop"/>');
+  if (note.tupletStart) chunks.push('<tuplet type="start"/>');
+  if (note.tupletStop) chunks.push('<tuplet type="stop"/>');
+  chunks.push(buildAbcNoteOrnamentsXml(note));
+  chunks.push(buildAbcNoteArticulationsXml(note));
+  chunks.push(buildAbcNoteTechnicalXml(note));
   if (note.fermataType) chunks.push(`<fermata>${note.fermataType === "inverted" ? "inverted" : "normal"}</fermata>`);
   chunks.push("</notations>");
   return chunks.join("");
@@ -1790,6 +1903,20 @@ const buildAbcBeamXmlByNoteIndex = (
   return out;
 };
 
+const buildAbcNoteXml = (
+  note: AbcParsedNote,
+  noteIndex: number,
+  staffOverride: number | null,
+  beamXmlByNoteIndex: Map<number, string>
+): string => {
+  const chunks: string[] = [];
+  chunks.push(buildAbcNoteLeadingDirectionXml(note));
+  chunks.push(buildAbcNoteCoreXml(note, noteIndex, staffOverride, beamXmlByNoteIndex));
+  chunks.push(buildAbcNoteNotationsXml(note));
+  chunks.push("</note>");
+  return chunks.join("");
+};
+
 const buildAbcMeasureNotesXml = (
   notes: AbcParsedNote[],
   measureDurationDiv: number,
@@ -1802,14 +1929,7 @@ const buildAbcMeasureNotesXml = (
   }
   const beamXmlByNoteIndex = buildAbcBeamXmlByNoteIndex(notes, beatDiv);
   return notes
-    .map((note, noteIndex) => {
-      const chunks: string[] = [];
-      chunks.push(buildAbcNoteLeadingDirectionXml(note));
-      chunks.push(buildAbcNoteCoreXml(note, noteIndex, staffOverride, beamXmlByNoteIndex));
-      chunks.push(buildAbcNoteNotationsXml(note));
-      chunks.push("</note>");
-      return chunks.join("");
-    })
+    .map((note, noteIndex) => buildAbcNoteXml(note, noteIndex, staffOverride, beamXmlByNoteIndex))
     .join("");
 };
 

--- a/tests/unit/abc-io.spec.ts
+++ b/tests/unit/abc-io.spec.ts
@@ -1238,6 +1238,69 @@ V:2 name="Lower" clef=bass
     expect(outDoc.querySelector('miscellaneous-field[name="mks:diag:count"]')).toBeNull();
   });
 
+  it("ABC->MusicXML keeps %%score grouped voices aligned across multiple measures", () => {
+    const abc = `X:1
+T:Grand staff multi-measure from %%score
+M:4/4
+L:1/4
+K:C
+%%score (1 2)
+V:1 name="Upper" clef=treble
+V:2 name="Lower" clef=bass
+[V:1] C D E F | G A B c |
+[V:2] C, D, E, F, | G, A, B, C |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    const measures = Array.from(outDoc.querySelectorAll("part > measure"));
+    expect(measures).toHaveLength(2);
+    expect(Array.from(outDoc.querySelectorAll("part > measure > backup > duration")).map((node) => node.textContent?.trim())).toEqual([
+      "3840",
+      "3840",
+    ]);
+    expect(
+      measures.map((measure) =>
+        Array.from(measure.querySelectorAll(":scope > note > staff")).map((node) => node.textContent?.trim())
+      )
+    ).toEqual([
+      ["1", "1", "1", "1", "2", "2", "2", "2"],
+      ["1", "1", "1", "1", "2", "2", "2", "2"],
+    ]);
+    expect(outDoc.querySelector('miscellaneous-field[name="mks:diag:count"]')).toBeNull();
+  });
+
+  it("ABC->MusicXML restores repeat and ending markers on grouped %%score import", () => {
+    const abc = `X:1
+T:Grand staff alternate endings
+M:4/4
+L:1/4
+K:C
+%%score (1 2)
+V:1 name="Upper" clef=treble
+V:2 name="Lower" clef=bass
+[V:1] |: C D E F |1 G A B c :|2 c B A G |
+[V:2] |: C, D, E, F, |1 G, A, B, C :|2 C B, A, G, |`;
+
+    const xml = convertAbcToMusicXml(abc);
+    const outDoc = parseMusicXmlDocument(xml);
+    expect(outDoc).not.toBeNull();
+    if (!outDoc) return;
+
+    expect(outDoc.querySelectorAll("part")).toHaveLength(1);
+    expect(outDoc.querySelector("part > measure > attributes > staves")?.textContent?.trim()).toBe("2");
+    expect(outDoc.querySelectorAll("part > measure > backup")).toHaveLength(3);
+    expect(outDoc.querySelector('part > measure[number="1"] > barline[location="left"] > repeat')?.getAttribute("direction")).toBe("forward");
+    expect(outDoc.querySelector('part > measure[number="2"] > barline[location="left"] > ending')?.getAttribute("number")).toBe("1");
+    expect(outDoc.querySelector('part > measure[number="2"] > barline[location="right"] > repeat')?.getAttribute("direction")).toBe("backward");
+    expect(outDoc.querySelector('part > measure[number="2"] > barline[location="right"] > ending')?.getAttribute("number")).toBe("1");
+    expect(outDoc.querySelector('part > measure[number="3"] > barline[location="left"] > ending')?.getAttribute("number")).toBe("2");
+    expect(outDoc.querySelector('part > measure[number="3"] > barline[location="right"] > ending')?.getAttribute("number")).toBe("2");
+    expect(outDoc.querySelector('miscellaneous-field[name="mks:diag:count"]')).toBeNull();
+  });
+
   it("ABC->MusicXML applies !editorial! to the next explicit accidental", () => {
     const abc = `X:1
 T:Editorial accidental


### PR DESCRIPTION
… coverage を追加

## 概要

`src/ts/abc-io.ts` の staged refactor をさらに進め、ABC export 側の note / measure / part rendering をより小さい helper に分解した変更です。 あわせて、grouped `%%score` import の複数 measure と repeat / ending 復元を対象にした characterization test を追加しています。

生成物として `src/js/main.js` と `mikuscore.html` も更新されています。

## 変更内容

### 1. ABC export helper の追加分解

`src/ts/abc-io.ts` で、MusicXML emission 側の helper 分解がさらに進んでいます。

差分上で追加されている代表的な helper:
- `buildAbcRenderedMeasureMiscXml(...)`
- `createInitialAbcPartRenderState(...)`
- `buildAbcPartXml(...)`
- `buildAbcNoteXml(...)`
- `buildAbcNoteHarmonyAndWordsDirectionXml(...)`
- `buildAbcNoteControlDirectionXml(...)`
- `buildAbcNotePitchOrRestXml(...)`
- `buildAbcNoteLyricXml(...)`
- `buildAbcNoteTimeModificationXml(...)`
- `buildAbcNoteAccidentalXml(...)`
- `buildAbcNoteOrnamentsXml(...)`
- `buildAbcNoteArticulationsXml(...)`
- `buildAbcNoteTechnicalXml(...)`

これにより、note serialization は少なくとも以下のまとまりが以前より明確になっています。

- leading directions
- note core subfragments
- note notations subgroups
- per-measure misc assembly
- per-part render state / part assembly

### 2. grouped `%%score` の characterization test 追加

`tests/unit/abc-io.spec.ts` に、grouped `%%score` の bounded behavior を凍結するテストが追加されています。

追加された観点:
- grouped voices が複数 measure でも `<backup>` と staff 配置を維持すること
- grouped `%%score` import で repeat / alternate ending が multi-staff part 上に復元されること

### 3. `TODO.md` の現在地更新

`TODO.md` に、ABC refactor と characterization coverage の進捗が反映されています。

反映内容の例:
- grouped `%%score` multi-measure backup emission の coverage 追加
- grouped repeat / ending restoration の coverage 追加
- series 4 の current status 更新
- 次の高価値な coverage 候補を grouped-staff lyrics / grouped key-meter-tempo changes に整理

### 4. 生成物の更新

差分には以下の生成物更新が含まれます。

- `src/js/main.js`
- `mikuscore.html`

## 変更ファイル

- `src/ts/abc-io.ts`
- `tests/unit/abc-io.spec.ts`
- `TODO.md`
- `src/js/main.js`
- `mikuscore.html`

## 目的

この変更の主目的は以下です。

- ABC export 側の helper 境界をさらに明確にする
- grouped `%%score` の bounded behavior を characterization test で明示する
- ABC refactor の current status を `TODO.md` に反映し、次の作業地点を分かりやすくする

## 確認事項

- `typecheck` 実行: 確認済み
- ABC 関連 targeted test 実行: 確認済み
- 実行した targeted test:
  - `tests/unit/abc-io.spec.ts`
  - `tests/unit/abc-inline-voice-switch.spec.ts`
  - `tests/unit/abc-roundtrip-golden.spec.ts`
  - `tests/unit/cli-api.spec.ts`
- 上記 targeted test の結果: `385 passed`