### PR TITLE
mikuscore の説明を変換ツール中心に整理し、README・開発文書・UI文言を整合させる

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,253 +2,162 @@
 
 ![mikuscore OGP image](screenshots/mikuscore-ogp.png)
 
-## Language Policy
-- English text is the normative source unless explicitly noted otherwise.
-- Japanese sections are abridged translations for readability.
-- Exception: for undecided points or in-progress notes, Japanese-only entries MAY be used temporarily.
+mikuscore is a MusicXML-first score converter for people who need to move score data between formats.  
+It treats MusicXML as the central interchange format and helps bridge notation tools, file formats, and AI-oriented workflows.
 
-## English
-mikuscore is a browser-based **score format converter** centered on MusicXML.
-It is delivered as a **single-file web app** (`mikuscore.html`) and runs offline.
+It is distributed as a single-file web app (`mikuscore.html`) and is designed to run offline in a browser.
 
-### Screenshots
+## What mikuscore is for
+
+mikuscore is a practical tool for:
+
+- moving score data from one format to another
+- normalizing score data around MusicXML
+- bridging notation software, exchange files, and AI-friendly handoff workflows
+
+## What mikuscore is not
+
+- not a full score engraving editor
+- not a replacement for MuseScore or other dedicated notation editors
+- not a promise of lossless conversion between every format pair
+
+If you want to edit notation in depth, use a notation editor such as MuseScore.  
+mikuscore is for converting, inspecting, and handing score data off.
+
+## Core idea
+
+- MusicXML-first conversion pipeline
+- preserve existing MusicXML as much as possible
+- keep conversion losses visible through diagnostics and metadata
+- stay lightweight and portable
+
+## Supported formats
+
+- MusicXML (`.musicxml`, `.xml`, `.mxl`)
+- MuseScore (`.mscx`, `.mscz`)
+- MIDI (`.mid`, `.midi`)
+- VSQX (`.vsqx`)
+- ABC (`.abc`)
+- MEI (`.mei`, experimental)
+- LilyPond (`.ly`, experimental)
+
+## Typical use cases
+
+- convert ABC, MIDI, or MuseScore data into MusicXML for downstream editing or archival
+- export MusicXML into another format for a tool or workflow that does not speak MusicXML directly
+- inspect conversion diagnostics instead of silently losing information
+- use ABC as a practical handoff format in generative-AI workflows while keeping MusicXML as the canonical score structure
+
+## Related projects
+
+- `mikuscore-skills`
+  - agent skills for embedding `mikuscore` into generative-AI workflows and making `mikuscore` score-conversion features easier to use from generative AI
+  - https://github.com/igapyon/mikuscore-skills
+- `miku-abc-player`
+  - a companion web app that makes an ABC-limited subset of `mikuscore` easier to use
+  - https://github.com/igapyon/miku-abc-player
+
+## Quick start
+
+### Web app
+
+- open `mikuscore.html` in a browser
+- load a score file
+- convert and export
+- inspect diagnostics if conversion details matter
+
+### CLI
+
+Current CLI is `convert`-first.
+
+Examples:
+
+- `npm run cli -- convert --from abc --to musicxml --in score.abc --out score.musicxml`
+- `npm run cli -- convert --from musicxml --to abc --in score.musicxml --out score.abc`
+- `npm run cli -- convert --from midi --to musicxml --in score.mid --out score.musicxml`
+- `npm run cli -- convert --from musicxml --to midi --in score.musicxml --out score.mid`
+- `npm run cli -- convert --from musescore --to musicxml --in score.mscx --out score.musicxml`
+- `npm run cli -- convert --from musicxml --to musescore --in score.musicxml --out score.mscx`
+- `npm run cli -- render svg --in score.musicxml --out score.svg`
+
+For CLI and development details, see `docs/DEVELOPMENT.md` and `docs/spec/CLI_STEP1.md`.
+
+## Screenshots
+
 ![mikuscore screenshot 1](screenshots/screen1.png)
 ![mikuscore screenshot 2](screenshots/screen2.png)
 ![mikuscore screenshot 3](screenshots/screen3.png)
 ![mikuscore screenshot 4](screenshots/screen4.png)
 
-### What makes mikuscore different
-- MusicXML-first conversion pipeline
-- Preserve existing MusicXML as much as possible
-- Keep conversion losses visible via diagnostics / metadata
-- No installation required (single HTML, browser only)
+## Documents
 
-### Scope
-- Primary: format conversion and round-trip stability
-- Secondary: lightweight notation editing and preview
-- Not a feature-complete score engraving editor
+User-facing documents:
 
-### Supported formats
-- MusicXML (`.musicxml` / `.xml` / `.mxl`) (MusicXML 4.0 core baseline)
-- MuseScore (`.mscx` / `.mscz`)
-- MIDI (`.mid` / `.midi`)
-- VSQX (`.vsqx`) (via vendored `utaformatix3-ts-plus`)
-- ABC (`.abc`) (ABC standard 2.2 baseline; some standard features remain partially implemented or unimplemented)
-- MEI (`.mei`) (experimental)
-- LilyPond (`.ly`) (experimental)
+- `docs/FORMAT_COVERAGE.md`
+- `docs/PRODUCT_POSITIONING.md`
+- `docs/CONVERSION_PRINCIPLES.md`
+- `docs/QUALITY.md`
 
-### Build and local development
-- `npm run build`
-- `npm run test:build`
-- `npm run test:integration`
-- `npm run check:all`
-- `npm run clean`
-- `npm run typecheck`
-- `npm run test:unit`
-- `npm run test:property`
-- `npm run test:all`
-- `npm run build:vendor:utaformatix3`
+Contributor and repository workflow:
 
-### CLI
-- Current CLI uses a `convert`-first command surface.
-- Available commands:
-  - `mikuscore convert --from abc --to musicxml`
-  - `mikuscore convert --from musicxml --to abc`
-  - `mikuscore convert --from midi --to musicxml`
-  - `mikuscore convert --from musicxml --to midi`
-  - `mikuscore convert --from musescore --to musicxml`
-  - `mikuscore convert --from musicxml --to musescore`
-  - `mikuscore render svg`
-  - `mikuscore convert --help`
-  - `mikuscore render --help`
-  - `mikuscore --help`
-- Input/output contract:
-  - `--from <format>` selects source format
-  - `--to <format>` selects target format
-  - `--in <file>` reads from file
-  - omitted `--in` reads from `stdin`
-  - `--out <file>` writes to file
-  - omitted `--out` writes to `stdout`
-  - text conversions use text input/output
-  - MIDI input/output uses binary input/output
-  - current MuseScore CLI scope is `.mscx`-style text, not compressed `.mscz`
+- `docs/DEVELOPMENT.md`
+- `CONTRIBUTING.md`
+- `TODO.md`
 
-Examples:
-- `npm run cli -- --help`
-- `npm run cli -- convert --help`
-- `npm run cli -- convert --from abc --to musicxml --in score.abc --out score.musicxml`
-- `npm run cli -- convert --from musicxml --to abc --in score.musicxml --out score.abc`
-- `npm run cli -- convert --from midi --to musicxml --in score.mid --out score.musicxml`
-- `npm run cli -- convert --from musicxml --to midi --in score.musicxml --out score.mid`
-- `npm run cli -- convert --from musescore --to musicxml --in score.mscx --out score.musicxml`
-- `npm run cli -- convert --from musicxml --to musescore --in score.musicxml --out score.mscx`
-- `npm run cli -- render svg --in score.musicxml --out score.svg`
-- `cat score.abc | npm run cli -- convert --from abc --to musicxml`
+Implementation specs:
 
-Practical command split:
-- `npm run build`: faster day-to-day build (`typecheck` + `test:build` + `build:dist`)
-- `build:dist` reuses incremental TypeScript cache and skips unchanged generated sample/prompt sources when possible
-- `npm run test:build`: build-gating unit tests without the heaviest integration-style suites
-- `npm run test:property`: property tests kept outside the day-to-day build gate
-- `npm run test:integration`: heavy integration-style suites (`cffp-series`, `mei-io`, `musescore-io`)
-- `npm run check:all`: full verification (`typecheck` + full `test:all` + `build:dist`)
-
-### Documentation map
-- Contribution and repository policy docs:
-  - `CODE_OF_CONDUCT.md`
-  - `CONTRIBUTING.md`
-  - `CONTRIBUTORS.md`
-  - `THIRD-PARTY-NOTICES.md`
-- Product docs (positioning / policy / coverage / quality):
-  - `docs/PRODUCT_POSITIONING.md`
-  - `docs/CONVERSION_PRINCIPLES.md`
-  - `docs/FORMAT_COVERAGE.md`
-  - `docs/QUALITY.md`
-  - `docs/AI_INTERACTION_POLICY.md`
-- Specification docs (`docs/spec/*`) are normative implementation specs:
-  - `docs/spec/SPEC.md`
-  - `docs/spec/ARCHITECTURE.md`
-  - `docs/spec/DIAGNOSTICS.md`
-  - `docs/spec/LOCAL_WORKFLOW.md`
-  - `docs/spec/BUILD_PROCESS.md`
-  - `docs/spec/MUSESCORE_IO.md`
-  - `docs/spec/MIDI_IO.md`
-  - `docs/spec/ABC_IO.md`
-  - `docs/spec/CLI_STEP1.md`
-  - `docs/spec/TEST_MATRIX.md`
-  - `docs/future/AI_JSON_INTERFACE.md` (deferred future work note for a possible AI-facing JSON interface)
-  - `docs/future/CLI_ROADMAP.md` (future note for CLI Step 2 / Step 3 expansion)
-
-### AI interaction policy (transition phase)
-- Canonical score source remains MusicXML.
-- For generative-AI interaction, full-score handoff and new-score generation are currently centered on ABC.
-- Current generative-AI handoff is centered on ABC.
-- A dedicated AI-facing JSON interface is deferred future work, not part of the current product contract.
-- See `docs/AI_INTERACTION_POLICY.md` for the current policy and `docs/future/AI_JSON_INTERFACE.md` for the deferred JSON note.
-
-Debugging note:
-- For import-side incident analysis, check `docs/spec/MIDI_IO.md` and `docs/spec/ABC_IO.md` sections about `attributes > miscellaneous > miscellaneous-field` (`mks:*` debug fields).
-
----
+- `docs/spec/SPEC.md`
+- `docs/spec/ARCHITECTURE.md`
+- `docs/spec/ABC_IO.md`
+- `docs/spec/MIDI_IO.md`
+- `docs/spec/MUSESCORE_IO.md`
 
 ## 日本語
-mikuscore は、MusicXML を中核に据えた **譜面フォーマット変換ソフト** です。  
-配布形態は **単一 HTML**（`mikuscore.html`）で、ブラウザのみでオフライン動作します。
 
-### スクリーンショット
-![mikuscore スクリーンショット 1](screenshots/screen1.png)
-![mikuscore スクリーンショット 2](screenshots/screen2.png)
-![mikuscore スクリーンショット 3](screenshots/screen3.png)
-![mikuscore スクリーンショット 4](screenshots/screen4.png)
+mikuscore は、譜面データを別形式へ持ち替えたい人のための、MusicXML-first な譜面変換ツールです。  
+MusicXML を変換の中心に置き、譜面ソフト、交換用ファイル、生成 AI 向けワークフローの橋渡しを行います。
 
-### mikuscore の特徴
-- MusicXML-first の変換パイプライン
-- 既存 MusicXML を極力壊さない
-- 変換で生じた欠落を診断情報・メタデータで追跡可能
-- インストール不要（単一 HTML、ブラウザのみ）
+配布形態は単一 HTML (`mikuscore.html`) で、ブラウザでオフライン動作します。
 
-### スコープ
-- 主機能: フォーマット変換と round-trip 安定性
-- 副機能: 軽量な譜面編集とプレビュー
-- 多機能な浄書エディタの代替を目指すものではない
+### 用途
+
+- 複数の譜面フォーマット間の変換
+- MusicXML を基準にした譜面データ整理
+- 他ソフトや AI ワークフローへの受け渡し
+
+### これは何ではないか
+
+- 多機能な浄書エディタではありません
+- MuseScore などの本格的な譜面編集ソフトの代替ではありません
+- すべての形式間で完全な無損失変換を保証するものではありません
+
+譜面をしっかり編集したい場合は、MuseScore などの既存エディタの利用を推奨します。  
+mikuscore は、変換・確認・受け渡しのためのツールです。
 
 ### 対応フォーマット
-- MusicXML（`.musicxml` / `.xml` / `.mxl`）（MusicXML 4.0 基準フォーマット）
-- MuseScore（`.mscx` / `.mscz`）
-- MIDI（`.mid` / `.midi`）
-- VSQX（`.vsqx`）（同梱 `utaformatix3-ts-plus` 経由）
-- ABC（`.abc`）（ABC standard 2.2 ベース。一部の標準機能は未実装または部分対応）
-- MEI（`.mei`）（実験的対応）
-- LilyPond（`.ly`）（実験的対応）
 
-### ビルドとローカル開発
-- `npm run build`
-- `npm run test:build`
-- `npm run test:integration`
-- `npm run check:all`
-- `npm run clean`
-- `npm run typecheck`
-- `npm run test:unit`
-- `npm run test:property`
-- `npm run test:all`
-- `npm run build:vendor:utaformatix3`
+- MusicXML（`.musicxml`, `.xml`, `.mxl`）
+- MuseScore（`.mscx`, `.mscz`）
+- MIDI（`.mid`, `.midi`）
+- VSQX（`.vsqx`）
+- ABC（`.abc`）
+- MEI（`.mei`、実験的）
+- LilyPond（`.ly`、実験的）
 
-### CLI
-- 現在の CLI は `convert` 中心のコマンド体系です。
-- 利用可能コマンド:
-  - `mikuscore convert --from abc --to musicxml`
-  - `mikuscore convert --from musicxml --to abc`
-  - `mikuscore convert --from midi --to musicxml`
-  - `mikuscore convert --from musicxml --to midi`
-  - `mikuscore convert --from musescore --to musicxml`
-  - `mikuscore convert --from musicxml --to musescore`
-  - `mikuscore render svg`
-  - `mikuscore convert --help`
-  - `mikuscore render --help`
-  - `mikuscore --help`
-- 入出力契約:
-  - `--from <format>` で入力形式を指定
-  - `--to <format>` で出力形式を指定
-  - `--in <file>` でファイル入力
-  - `--in` 省略時は `stdin`
-  - `--out <file>` でファイル出力
-  - `--out` 省略時は `stdout`
-  - text 変換は text 入出力
-  - MIDI 入出力は binary 入出力
-  - 現在の MuseScore CLI は `.mscx` 相当の text を対象とし、圧縮 `.mscz` はまだ対象外
+### 関連プロジェクト
 
-例:
-- `npm run cli -- --help`
-- `npm run cli -- convert --help`
-- `npm run cli -- convert --from abc --to musicxml --in score.abc --out score.musicxml`
-- `npm run cli -- convert --from musicxml --to abc --in score.musicxml --out score.abc`
-- `npm run cli -- convert --from midi --to musicxml --in score.mid --out score.musicxml`
-- `npm run cli -- convert --from musicxml --to midi --in score.musicxml --out score.mid`
-- `npm run cli -- convert --from musescore --to musicxml --in score.mscx --out score.musicxml`
-- `npm run cli -- convert --from musicxml --to musescore --in score.musicxml --out score.mscx`
-- `npm run cli -- render svg --in score.musicxml --out score.svg`
-- `cat score.abc | npm run cli -- convert --from abc --to musicxml`
+- `mikuscore-skills`
+  - `mikuscore` を生成 AI に組み込み、生成 AI から `mikuscore` の譜面変換機能を利用しやすくするための agent skills
+  - https://github.com/igapyon/mikuscore-skills
+- `miku-abc-player`
+  - `mikuscore` の機能を ABC に限定して使いやすくした companion web app
+  - https://github.com/igapyon/miku-abc-player
 
-実用的なコマンド分割:
-- `npm run build`: 日常用の比較的速いビルド（`typecheck` + `test:build` + `build:dist`）
-- `build:dist` は incremental な TypeScript キャッシュを再利用し、未変更の生成 sample / prompt 同期を可能な範囲で省略
-- `npm run test:build`: ビルドゲート用 unit テスト（最重量の統合寄り suite は除外）
-- `npm run test:property`: property テスト（日常 build gate の外に維持）
-- `npm run test:integration`: 重い統合寄り suite（`cffp-series`, `mei-io`, `musescore-io`）
-- `npm run check:all`: フル検証（`typecheck` + full `test:all` + `build:dist`）
+### はじめかた
 
-### ドキュメントマップ
-- コントリビューションとリポジトリ運用文書:
-  - `CODE_OF_CONDUCT.md`
-  - `CONTRIBUTING.md`
-  - `CONTRIBUTORS.md`
-  - `THIRD-PARTY-NOTICES.md`
-- プロダクト文書（位置づけ / 方針 / 対応範囲 / 品質方針）:
-  - `docs/PRODUCT_POSITIONING.md`
-  - `docs/CONVERSION_PRINCIPLES.md`
-  - `docs/FORMAT_COVERAGE.md`
-  - `docs/QUALITY.md`
-  - `docs/AI_INTERACTION_POLICY.md`
-- 仕様文書（`docs/spec/*`）は実装規範:
-  - `docs/spec/SPEC.md`
-  - `docs/spec/ARCHITECTURE.md`
-  - `docs/spec/DIAGNOSTICS.md`
-  - `docs/spec/LOCAL_WORKFLOW.md`
-  - `docs/spec/BUILD_PROCESS.md`
-  - `docs/spec/MUSESCORE_IO.md`
-  - `docs/spec/MIDI_IO.md`
-  - `docs/spec/ABC_IO.md`
-  - `docs/spec/CLI_STEP1.md`
-  - `docs/spec/TEST_MATRIX.md`
-  - `docs/future/AI_JSON_INTERFACE.md`（生成AI向け JSON インタフェースの将来検討メモ）
-  - `docs/future/CLI_ROADMAP.md`（CLI の STEP2 / STEP3 拡張メモ）
+- `mikuscore.html` をブラウザで開く
+- 譜面ファイルを読み込む
+- 変換して書き出す
+- 必要なら診断情報を確認する
 
-### 生成AI 連携方針（過渡期）
-- 正本は引き続き MusicXML です。
-- 生成AI とのやり取りでは、全体の受け渡しと新規譜面生成は現在 ABC を中心にします。
-- 現在の生成AI 連携は ABC を中心にします。
-- 生成AI向けの専用 JSON インタフェースは将来検討事項であり、現行プロダクト契約には含めません。
-- 運用方針は `docs/AI_INTERACTION_POLICY.md`、将来検討メモは `docs/future/AI_JSON_INTERFACE.md` を参照してください。
-
-デバッグメモ:
-- インポート時の事象解析は `docs/spec/MIDI_IO.md` と `docs/spec/ABC_IO.md` の `attributes > miscellaneous > miscellaneous-field`（`mks:*` デバッグ項目）を参照してください。
+CLI や開発向け情報は `docs/DEVELOPMENT.md` を参照してください。

--- a/docs/AI_INTERACTION_POLICY.md
+++ b/docs/AI_INTERACTION_POLICY.md
@@ -13,6 +13,7 @@ It complements:
 - Full-score handoff to a generative model uses `ABC`.
 - New score generation by a generative model uses `ABC`.
 - A dedicated AI-facing JSON patch/projection interface is not part of the current product contract.
+- AI interaction is one bridge use case for mikuscore, not the sole or primary product identity.
 
 ## Why this policy is simpler now
 
@@ -22,7 +23,8 @@ It complements:
 - practical readability for generative models
 - a smaller current-scope contract
 
-For the current product shape, `ABC` is the only documented AI-facing interchange layer.
+For the current product shape, `ABC` is the documented AI-facing interchange layer.
+This sits inside the broader product role of moving score data between tools and formats while keeping MusicXML canonical.
 
 ## Current constraint
 

--- a/docs/CONVERSION_PRINCIPLES.md
+++ b/docs/CONVERSION_PRINCIPLES.md
@@ -27,5 +27,6 @@
 
 ## Scope Note
 
-These principles define behavior goals for conversion and lightweight editing.
+These principles define behavior goals for conversion, inspection, and handoff workflows.
+They do not define mikuscore as a general-purpose notation editor.
 Detailed normative rules remain in `docs/spec/*`.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,0 +1,127 @@
+# Development Notes
+
+This page collects repository-facing notes that are useful for contributors and local development, but too detailed for the root `README.md`.
+
+## Build And Verification
+
+- `npm run build`
+- `npm run build:full`
+- `npm run test:build`
+- `npm run test:build:full`
+- `npm run test:slow`
+- `npm run test:integration`
+- `npm run check:all`
+- `npm run clean`
+- `npm run typecheck`
+- `npm run test:unit`
+- `npm run test:property`
+- `npm run test:all`
+- `npm run build:vendor:utaformatix3`
+
+Practical command split:
+
+- `npm run build`: faster day-to-day build (`typecheck` + `test:build` + `build:dist`)
+- `npm run build:full`: fuller build path (`typecheck` + `test:build:full` + `build:dist`)
+- `npm run test:slow`: heavy suites currently split out of the day-to-day build path
+- `npm run test:integration`: heavy integration-style suites (`cffp-series`, `mei-io`, `musescore-io`)
+- `npm run check:all`: full verification (`typecheck` + full `test:all` + `build:dist`)
+
+## CLI Notes
+
+Current CLI uses a `convert`-first command surface.
+
+Available commands:
+
+- `mikuscore convert --from abc --to musicxml`
+- `mikuscore convert --from musicxml --to abc`
+- `mikuscore convert --from midi --to musicxml`
+- `mikuscore convert --from musicxml --to midi`
+- `mikuscore convert --from musescore --to musicxml`
+- `mikuscore convert --from musicxml --to musescore`
+- `mikuscore render svg`
+
+Input/output contract:
+
+- `--from <format>` selects source format
+- `--to <format>` selects target format
+- `--in <file>` reads from file
+- omitted `--in` reads from `stdin`
+- `--out <file>` writes to file
+- omitted `--out` writes to `stdout`
+- text conversions use text input/output
+- MIDI input/output uses binary input/output
+- current MuseScore CLI scope is `.mscx`-style text, not compressed `.mscz`
+
+Examples:
+
+- `npm run cli -- --help`
+- `npm run cli -- convert --help`
+- `npm run cli -- convert --from abc --to musicxml --in score.abc --out score.musicxml`
+- `npm run cli -- convert --from musicxml --to abc --in score.musicxml --out score.abc`
+- `npm run cli -- convert --from midi --to musicxml --in score.mid --out score.musicxml`
+- `npm run cli -- convert --from musicxml --to midi --in score.musicxml --out score.mid`
+- `npm run cli -- convert --from musescore --to musicxml --in score.mscx --out score.musicxml`
+- `npm run cli -- convert --from musicxml --to musescore --in score.musicxml --out score.mscx`
+- `npm run cli -- render svg --in score.musicxml --out score.svg`
+- `cat score.abc | npm run cli -- convert --from abc --to musicxml`
+
+## Documentation Map
+
+Contribution and repository policy docs:
+
+- `CODE_OF_CONDUCT.md`
+- `CONTRIBUTING.md`
+- `CONTRIBUTORS.md`
+- `THIRD-PARTY-NOTICES.md`
+
+Product docs:
+
+- `docs/PRODUCT_POSITIONING.md`
+- `docs/CONVERSION_PRINCIPLES.md`
+- `docs/FORMAT_COVERAGE.md`
+- `docs/QUALITY.md`
+- `docs/AI_INTERACTION_POLICY.md`
+
+Related-project note:
+
+- `mikuscore-skills` and `miku-abc-player` embed `mikuscore` as an upstream dependency
+- when `mikuscore` changes in a way that affects behavior, contracts, generated assets, or handoff assumptions, remember that those downstream projects may need to pull the updated upstream
+- keep this follow-up visible in PRs and development notes when the change is likely to affect downstream consumers
+
+Specification docs:
+
+- `docs/spec/SPEC.md`
+- `docs/spec/ARCHITECTURE.md`
+- `docs/spec/DIAGNOSTICS.md`
+- `docs/spec/LOCAL_WORKFLOW.md`
+- `docs/spec/BUILD_PROCESS.md`
+- `docs/spec/MUSESCORE_IO.md`
+- `docs/spec/MIDI_IO.md`
+- `docs/spec/ABC_IO.md`
+- `docs/spec/CLI_STEP1.md`
+- `docs/spec/TEST_MATRIX.md`
+
+Future notes:
+
+- `docs/future/AI_JSON_INTERFACE.md`
+- `docs/future/CLI_ROADMAP.md`
+
+## AI Interaction Policy
+
+- Canonical score source remains MusicXML.
+- For generative-AI interaction, full-score handoff and new-score generation are currently centered on ABC.
+- A dedicated AI-facing JSON interface is deferred future work, not part of the current product contract.
+
+See:
+
+- `docs/AI_INTERACTION_POLICY.md`
+- `docs/future/AI_JSON_INTERFACE.md`
+
+## Debugging Note
+
+For import-side incident analysis, check:
+
+- `docs/spec/MIDI_IO.md`
+- `docs/spec/ABC_IO.md`
+
+Especially the sections about `attributes > miscellaneous > miscellaneous-field` (`mks:*` debug fields).

--- a/docs/FORMAT_COVERAGE.md
+++ b/docs/FORMAT_COVERAGE.md
@@ -5,6 +5,7 @@
 - Priority order: MusicXML fidelity > conversion breadth.
 - "Supported" means available in product flows, not full notation parity.
 - Supported formats may still change behavior as compatibility and parity work progress.
+- mikuscore is a converter, not a promise of lossless editing parity across all formats.
 
 ## Current Coverage
 
@@ -23,6 +24,7 @@
 - Some notation semantics are format-specific and cannot be preserved 1:1.
 - Enharmonic spelling, articulation detail, repeat semantics, and layout constructs can differ by source format.
 - When exact preservation is not possible, diagnostics and metadata should provide traceability.
+- For notation editing beyond conversion-oriented inspection, use a dedicated notation editor.
 - Quick playback in mikuscore is a lightweight feature and may not work reliably on large scores (long duration, many parts, dense events).
 - For reliable playback of large scores, export MIDI and use an external MIDI-capable playback app.
 

--- a/docs/PRODUCT_POSITIONING.md
+++ b/docs/PRODUCT_POSITIONING.md
@@ -2,14 +2,15 @@
 
 ## Summary
 
-mikuscore is a MusicXML-centered score format converter.
-It is not positioned as a full-featured notation editor.
+mikuscore is a MusicXML-first score converter for moving score data between formats.
+It is not positioned as a score editor, and it does not try to replace dedicated notation editors such as MuseScore.
 
 ## Target Use Cases
 
-- Convert scores between MusicXML and other formats while minimizing notation loss.
-- Keep round-trip behavior stable for practical workflows.
-- Run conversion and verification in restricted/offline environments with a single HTML app.
+- Move score data from one format to another while keeping MusicXML as the semantic center.
+- Normalize score data around MusicXML for downstream editing, exchange, or archival workflows.
+- Bridge notation tools, exchange formats, and AI-oriented handoff flows.
+- Run conversion and verification in restricted or offline environments with a single HTML app.
 
 ## Value Proposition
 
@@ -17,12 +18,14 @@ It is not positioned as a full-featured notation editor.
 - Preservation-first conversion policy.
 - Conversion diagnostics and metadata for traceability.
 - Single-file web app distribution (`mikuscore.html`) with offline runtime.
+- Clear separation of roles: use notation editors for editing, use mikuscore for conversion and handoff.
 
 ## Non-goals
 
 - Competing with feature-rich engraving editors in direct notation editing.
 - Providing full parity for every advanced notation feature in all source formats.
 - Replacing desktop notation authoring workflows end-to-end.
+- Acting as a general-purpose notation editor with deep interactive editing features.
 
 ## Relationship with `docs/spec/*`
 

--- a/docs/spec/SCREEN_SPEC.md
+++ b/docs/spec/SCREEN_SPEC.md
@@ -22,19 +22,19 @@ Scope note:
   - `Export`
 
 ### Brand Tooltip `(i)` (`About mikuscore`)
-- Browser-based local score editor.
-- Preserves existing MusicXML structure while editing.
-- Supports loading MusicXML/ABC, score preview, note editing, playback, and export/download (`MusicXML`/`ABC`/`MIDI`) in one screen.
-- Intentionally small feature set for practical, fast editing, especially on smartphones.
+- Browser-based MusicXML-first score converter.
+- Uses MusicXML as the central interchange format for moving score data between formats.
+- Supports loading score data, previewing structure, checking diagnostics, playback, and export/download in one screen.
+- Intentionally focused on conversion, inspection, and handoff rather than deep notation editing.
 - Smartphone-centered, but usable on PCs as well.
 - Workflow guidance:
   - `1) Choose input and load`
-  - `2) Select from score preview`
-  - `3) Edit notes`
-  - `4) Verify by playback and export/download`
+  - `2) Inspect the score and diagnostics`
+  - `3) Verify by playback if needed`
+  - `4) Export or hand off in another format`
 - Positioning guidance:
-  - Use dedicated notation software for large-scale/complex work.
-  - Use mikuscore for quick input or focused partial tasks.
+  - Use dedicated notation software for large-scale or complex notation editing.
+  - Use mikuscore for conversion-oriented tasks.
 
 ## Tabs / Interaction
 - Clicking a top tab opens the corresponding panel.

--- a/mikuscore-src.html
+++ b/mikuscore-src.html
@@ -26,14 +26,14 @@
           </span>
           <span>mikuscore</span>
           <lht-help-tooltip label="About mikuscore" wide>
-            mikuscore is a browser-based local score editor focused on preserving existing MusicXML structure while editing.
-            It supports loading MusicXML/ABC/MIDI, score preview, note editing, playback, and export/download as MusicXML/ABC/MEI/MIDI in one screen.
+            mikuscore is a browser-based MusicXML-first score converter for moving score data between formats.
+            It uses MusicXML as the central interchange format and helps bridge notation tools, exchange files, and AI-oriented workflows.
+            It supports loading score data, previewing structure, checking diagnostics, and exporting to other formats in one screen.
             MEI support is currently experimental.
-            mikuscore intentionally keeps the feature set small to make score editing practical and fast, especially on smartphones.
+            mikuscore intentionally keeps the feature set focused on conversion, inspection, and handoff rather than deep notation editing.
             It is smartphone-centered, but it can also be used on PCs.
-            Workflow: 1) Choose input and load 2) Select from score preview 3) Edit notes 4) Verify by playback and export/download.
-            After loading, click notes in the score to select targets, then adjust pitch and duration.
-            Use tools like MuseScore for large-scale or complex work, and use mikuscore for quick input or focused partial tasks.
+            Workflow: 1) Choose input and load 2) Inspect the score and diagnostics 3) Verify by playback if needed 4) Export or hand off in another format.
+            Use tools like MuseScore for large-scale or complex notation editing, and use mikuscore for conversion-oriented tasks.
           </lht-help-tooltip>
           <a
             href="https://github.com/igapyon/mikuscore"

--- a/mikuscore.html
+++ b/mikuscore.html
@@ -1234,14 +1234,14 @@ lht-help-tooltip:not([data-initialized="true"]) * {
           </span>
           <span>mikuscore</span>
           <lht-help-tooltip label="About mikuscore" wide>
-            mikuscore is a browser-based local score editor focused on preserving existing MusicXML structure while editing.
-            It supports loading MusicXML/ABC/MIDI, score preview, note editing, playback, and export/download as MusicXML/ABC/MEI/MIDI in one screen.
+            mikuscore is a browser-based MusicXML-first score converter for moving score data between formats.
+            It uses MusicXML as the central interchange format and helps bridge notation tools, exchange files, and AI-oriented workflows.
+            It supports loading score data, previewing structure, checking diagnostics, and exporting to other formats in one screen.
             MEI support is currently experimental.
-            mikuscore intentionally keeps the feature set small to make score editing practical and fast, especially on smartphones.
+            mikuscore intentionally keeps the feature set focused on conversion, inspection, and handoff rather than deep notation editing.
             It is smartphone-centered, but it can also be used on PCs.
-            Workflow: 1) Choose input and load 2) Select from score preview 3) Edit notes 4) Verify by playback and export/download.
-            After loading, click notes in the score to select targets, then adjust pitch and duration.
-            Use tools like MuseScore for large-scale or complex work, and use mikuscore for quick input or focused partial tasks.
+            Workflow: 1) Choose input and load 2) Inspect the score and diagnostics 3) Verify by playback if needed 4) Export or hand off in another format.
+            Use tools like MuseScore for large-scale or complex notation editing, and use mikuscore for conversion-oriented tasks.
           </lht-help-tooltip>
           <a
             href="https://github.com/igapyon/mikuscore"


### PR DESCRIPTION
## 概要

`mikuscore` の説明を、開発者寄り・軽量エディタ寄りの見え方から、「MusicXML-first な譜面変換ツール」という位置づけに揃える変更です。 このコミットでは、`README.md` を利用者向けに再構成し、開発向け情報を `docs/DEVELOPMENT.md` に分離しています。あわせて、関連ドキュメントと `About mikuscore` の UI 文言も同じ方向に更新されています。

## 変更内容

### 1. `README.md` の再構成

`README.md` は、利用者向けの製品説明に寄せて大きく整理されています。

差分上で確認できる主な内容:
- `mikuscore` を MusicXML-first の score converter として説明
- `What mikuscore is for`
- `What mikuscore is not`
- `Core idea`
- `Supported formats`
- `Typical use cases`
- `Related projects`
- `Quick start`
- `Documents`
- 日本語セクションの再整理

### 2. 開発者向け情報の新設

新規ファイル `docs/DEVELOPMENT.md` が追加されています。

この文書には、差分上で以下の内容が含まれます。
- build / test / verification コマンド一覧
- CLI の開発者向けメモ
- documentation map
- AI interaction policy への導線
- debugging note
- `mikuscore-skills` および `miku-abc-player` が `mikuscore` を upstream dependency として取り込むことに関する注意

### 3. 周辺ドキュメントの位置づけ調整

以下の文書も、README と同じプロダクト像に合わせて更新されています。

- `docs/PRODUCT_POSITIONING.md`
- `docs/FORMAT_COVERAGE.md`
- `docs/CONVERSION_PRINCIPLES.md`
- `docs/AI_INTERACTION_POLICY.md`

差分上で確認できる方向性:
- `mikuscore` は notation editor ではなく変換ツールであることを明確化
- MusicXML-first / conversion / inspection / handoff の役割を強調
- AI は bridge use case の一つであり、製品の唯一の主軸ではないことを明示
- format coverage でも、lossless editing parity を約束するものではないことを補強

### 4. `About mikuscore` UI 文言の更新

`mikuscore-src.html` と生成物 `mikuscore.html` にある `About mikuscore` の tooltip 文言が更新されています。 また、`docs/spec/SCREEN_SPEC.md` の該当説明も同じ内容に合わせて更新されています。

差分上で確認できる変更例:
- `browser-based local score editor` から `browser-based MusicXML-first score converter` へ変更
- workflow を `Inspect the score and diagnostics` / `Export or hand off in another format` に寄せて更新
- MuseScore などの dedicated notation editor を使うべき場面を `notation editing` として明示

## 変更ファイル

- `README.md`
- `docs/DEVELOPMENT.md`
- `docs/PRODUCT_POSITIONING.md`
- `docs/FORMAT_COVERAGE.md`
- `docs/CONVERSION_PRINCIPLES.md`
- `docs/AI_INTERACTION_POLICY.md`
- `docs/spec/SCREEN_SPEC.md`
- `mikuscore-src.html`
- `mikuscore.html`

## 目的

この変更の主目的は以下です。

- `mikuscore` の価値を「MusicXML-first な変換ツール」として読みやすくする
- 利用者向け README と開発者向け文書の役割を分ける
- ドキュメントと UI の説明文を同じプロダクト像に揃える