### PR TITLE
CLI の UTF-8 デコードを `TextDecoder` ベースに変更し、関連ドキュメントを更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ mikuscore is for converting, inspecting, and handing score data off.
 
 Current CLI is `convert`-first.
 
+For `musicxml` and `musescore`, plain-text `stdin` / `stdout` paths are handled as UTF-8 text, while `.mxl` / `.mscz` compression stays on file-path I/O.
+
 Examples:
 
 - `npm run cli -- convert --from abc --to musicxml --in score.abc --out score.musicxml`

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -61,6 +61,7 @@ Input/output contract:
 - for file output, `--to musicxml` writes `.mxl` when `--out` ends with `.mxl`
 - for file output, `--to musescore` writes `.mscz` when `--out` ends with `.mscz`
 - `stdin` / `stdout` remain text-only for `musicxml` and `musescore`
+- plain-text CLI decode for `musicxml` / `musescore` is kept on UTF-8 `TextDecoder` rather than Node-only `Buffer`, so the same entrypoint can be runtime-compiled in isolated bundle environments
 
 Examples:
 

--- a/docs/spec/CLI_STEP1.md
+++ b/docs/spec/CLI_STEP1.md
@@ -194,6 +194,7 @@ Options:
 - warnings, diagnostics, and summary text SHOULD go to `stderr`
 - binary output is out of Step 1 scope
 - compressed `.mxl` / `.mscz` support is limited to file-path I/O; `stdin` / `stdout` remain text-only for `musicxml` and `musescore`
+- plain-text decoding for `musicxml` / `musescore` CLI inputs SHOULD use UTF-8 decoding that is compatible with non-Node runtimes as well as Node-based execution
 
 ## Error Contract
 

--- a/src/ts/cli-api.ts
+++ b/src/ts/cli-api.ts
@@ -64,13 +64,17 @@ const failureResult = (message: string): CliResult => ({
   diagnostics: [message],
 });
 
+const decodeUtf8Text = (bytes: Uint8Array): string => {
+  return new TextDecoder("utf-8").decode(bytes);
+};
+
 export const decodeCliMusicXmlInput = async (inputBytes: Uint8Array, inputPath?: string): Promise<CliResult> => {
   const name = lowerFileName(inputPath);
   try {
     if (name.endsWith(".mxl")) {
       return textResult(await extractMusicXmlTextFromMxl(bytesToArrayBuffer(inputBytes)));
     }
-    return textResult(Buffer.from(inputBytes).toString("utf8"));
+    return textResult(decodeUtf8Text(inputBytes));
   } catch (error) {
     return failureResult(`Failed to read MusicXML input: ${error instanceof Error ? error.message : String(error)}`);
   }
@@ -85,7 +89,7 @@ export const decodeCliMuseScoreInput = async (inputBytes: Uint8Array, inputPath?
         [".mscx"]
       ));
     }
-    return textResult(Buffer.from(inputBytes).toString("utf8"));
+    return textResult(decodeUtf8Text(inputBytes));
   } catch (error) {
     return failureResult(`Failed to read MuseScore input: ${error instanceof Error ? error.message : String(error)}`);
   }


### PR DESCRIPTION
## 概要

CLI の `musicxml` / `musescore` 入力デコードで使っていた `Buffer` 依存を外し、UTF-8 デコードを `TextDecoder` ベースに変更します。あわせて、CLI の入出力契約と UTF-8 テキスト扱いに関する説明をドキュメントへ追記します。

## 変更内容

- `src/ts/cli-api.ts`
  - `decodeUtf8Text` を追加
  - `decodeCliMusicXmlInput` の平文入力デコードを `Buffer.from(...).toString("utf8")` から `TextDecoder("utf-8").decode(...)` に変更
  - `decodeCliMuseScoreInput` の平文入力デコードを `Buffer.from(...).toString("utf8")` から `TextDecoder("utf-8").decode(...)` に変更
- `README.md`
  - `musicxml` / `musescore` の平文 `stdin` / `stdout` は UTF-8 テキストとして扱い、`.mxl` / `.mscz` の圧縮入出力はファイルパス I/O に限定される旨を追記
- `docs/DEVELOPMENT.md`
  - CLI の平文デコードが Node 固有の `Buffer` ではなく UTF-8 `TextDecoder` ベースであることを追記
- `docs/spec/CLI_STEP1.md`
  - `musicxml` / `musescore` の CLI 平文入力デコードは、Node 以外のランタイムとも互換な UTF-8 デコードを使うべきことを追記

## 影響範囲

- CLI の `musicxml` / `musescore` 平文入力デコード
- CLI の仕様説明と開発者向けドキュメント