### PR TITLE
CLI を `convert` / `render` / `state` 軸へ拡張し、`state` 初期コマンドと診断基盤を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ mikuscore is for converting, inspecting, and handing score data off.
 
 ### CLI
 
-Current CLI is `convert`-first.
+Current CLI centers on `convert`, `render`, and an initial `state` family.
 
 For `musicxml` and `musescore`, plain-text `stdin` / `stdout` paths are handled as UTF-8 text, while `.mxl` / `.mscz` compression stays on file-path I/O.
 
@@ -84,6 +84,12 @@ Examples:
 - `npm run cli -- convert --from musescore --to musicxml --in score.mscz --out score.mxl`
 - `npm run cli -- convert --from musicxml --to musescore --in score.musicxml --out score.mscz`
 - `npm run cli -- render svg --in score.musicxml --out score.svg`
+- `npm run cli -- render svg --from abc --in score.abc --out score.svg`
+- `npm run cli -- state summarize --in score.musicxml`
+- `npm run cli -- state inspect-measure --measure 1 --in score.musicxml`
+- `npm run cli -- state validate-command --in score.musicxml --command-file command.json`
+- `npm run cli -- state apply-command --in score.musicxml --command-file command.json --out score.next.musicxml`
+- `npm run cli -- state diff --before score.before.musicxml --after score.after.musicxml`
 
 For CLI and development details, see `docs/DEVELOPMENT.md` and `docs/spec/CLI_STEP1.md`.
 

--- a/TODO.md
+++ b/TODO.md
@@ -91,6 +91,107 @@
   - Cover file input, `stdin`, `--out`, and representative failure cases.
   - Keep `stdout` for payload and `stderr` for diagnostics only.
 
+- [ ] Record a future-facing CLI design note for AI-mediated workflows.
+  - Motivation:
+    - `mikuproject` shows that a CLI can be designed simultaneously for human operators, Agent Skills, and the downstream generative-AI interaction layer
+    - the valuable lesson is not only "add AI commands", but "design the CLI contract so each layer can use it safely"
+  - Preserve these candidate principles for future `mikuscore` discussion:
+    - keep human-readable command naming and composable stdio behavior
+    - keep the main artifact on `stdout` and diagnostics on `stderr`
+    - support machine-readable diagnostics when the caller is an agent or another tool
+    - prefer bounded export / validate / apply-style phases over direct opaque mutation
+    - design payload units that are small enough for AI handoff, not only for human CLI use
+  - Likely document homes:
+    - `docs/future/CLI_ROADMAP.md`
+    - `docs/future/AI_JSON_INTERFACE.md`
+
+- [ ] Rebuild CLI taxonomy around `convert` / `render` / `state` while compatibility cost is still low.
+  - Rationale:
+    - current real-world CLI usage appears low enough that command-surface reconstruction is still feasible
+    - `mikuproject` suggests that clearer top-level responsibility split can scale well
+    - `mikuscore` should keep `convert --from ... --to ...` inside `convert`, rather than multiplying fixed pair commands
+  - Intended role split:
+    - `convert`: interchange with external formats
+    - `render`: derived outputs such as SVG, including user-facing one-shot flows like `ABC -> SVG` even if implemented internally as `ABC -> MusicXML -> SVG`
+    - `state`: canonical `MusicXML` inspection, validation, patch-style mutation, and other light edit-oriented workflows
+  - First specification questions:
+    - whether `state summarize` / `state validate` / `state diff` / `state apply-patch` should be the initial reserved names
+    - whether `render` should accept non-MusicXML user input and absorb internal conversion stages
+    - how `--diagnostics text|json` should be shared consistently across all three families
+  - Concrete next slices:
+    - write a first-cut CLI taxonomy spec under `docs/spec/`
+    - define help-text shape for top-level `convert` / `render` / `state`
+    - decide migration wording from the current `convert`-first CLI to the rebuilt taxonomy
+
+- [ ] Add a user-facing one-shot `ABC -> SVG` CLI flow without breaking the internal `MusicXML`-first pipeline.
+  - Intended shape:
+    - external UX should allow a direct score-rendering path for ABC input
+    - internal flow should still remain `ABC -> MusicXML -> SVG`
+  - Specification questions:
+    - whether this belongs under `render svg` with `--from abc`
+    - whether `render` should accept only selected non-MusicXML inputs or remain narrow
+    - how diagnostics should describe both the conversion and render stages when one-shot mode is used
+
+- [ ] Improve CLI failure handling so uncaught runtime errors stop leaking as raw JavaScript failures.
+  - Goal:
+    - turn current unhandled exception behavior into stable CLI-facing usage/processing failures
+  - First slices:
+    - define exit-code policy for usage error vs processing error
+    - ensure stderr messages are human-readable by default
+    - ensure `--diagnostics json` can still describe failure cases structurally
+
+- [ ] Define a first-cut CLI diagnostics contract modeled after the successful direction proven in `mikuproject`.
+  - Scope:
+    - `convert`
+    - `render`
+    - future `state`
+  - First slices:
+    - define the minimum shared JSON fields
+    - decide how warnings vs errors appear in text mode
+    - define whether multi-stage commands such as one-shot `ABC -> SVG` should report stage summaries
+    - decide how much "kept vs dropped" conversion information can be surfaced briefly without becoming noisy
+
+- [ ] Align future `state` CLI naming with the existing core command catalog instead of inventing a second edit model.
+  - Preserve:
+    - existing bounded core commands such as `change_to_pitch`, `change_duration`, `insert_note_after`, `delete_note`, and `split_note`
+  - Prefer:
+    - workflow-phase CLI names like `state inspect-*`, `state validate-command`, `state apply-command`, `state diff`
+    - optional patch envelopes if multiple core commands should be validated/applied together
+  - Avoid:
+    - exposing each core command as its own top-level CLI verb
+    - introducing a whole-measure rewrite contract when a bounded command contract is sufficient
+
+- [ ] Define the `state` first cut around canonical `MusicXML` inspection and bounded mutation.
+  - Candidate initial commands:
+    - `state summarize`
+    - `state inspect-measure`
+    - `state validate-command`
+    - `state apply-command`
+    - `state diff`
+  - First specification questions:
+    - whether first cut should expose single-command apply before patch envelopes
+    - what minimum inspect output is needed to support note-targeted edits reliably
+    - whether tempo-level light edits should enter through the same bounded command path
+
+- [ ] Preserve "small edit" work as `MusicXML`-centered bounded mutation, not as a separate editing product line.
+  - Scope:
+    - pitch change
+    - duration change
+    - note insertion / deletion / split
+    - likely future tempo-level light edits on canonical `MusicXML`
+  - Editorial note:
+    - treat "small edit feature", "`MusicXML`-centered light edit", and "diff-based edit" as the same theme seen from different layers
+
+- [ ] Explicitly keep some user suggestions out of near-term CLI scope.
+  - Defer or omit for now:
+    - batch conversion in CLI itself
+    - lyrics/melody alignment diagnostics
+    - MIDI-expression-specific CLI expansion as a priority over `MusicXML`-centered light edits
+  - Rationale:
+    - batch orchestration can live outside the CLI if single-shot behavior is composable
+    - lyrics diagnostics is interesting but currently too heavy for the current first-cut scope
+    - `mikuscore` should strengthen canonical `MusicXML` editing before expanding MIDI-side tuning controls
+
 ## Facade
 
 - [ ] Keep the non-UI CLI facade small and format-oriented.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -34,7 +34,7 @@ Generated HTML note:
 
 ## CLI Notes
 
-Current CLI uses a `convert`-first command surface.
+Current CLI uses a `convert` / `render` / initial `state` command surface.
 
 Available commands:
 
@@ -45,6 +45,12 @@ Available commands:
 - `mikuscore convert --from musescore --to musicxml`
 - `mikuscore convert --from musicxml --to musescore`
 - `mikuscore render svg`
+- `mikuscore render svg --from abc ...`
+- `mikuscore state summarize`
+- `mikuscore state inspect-measure`
+- `mikuscore state validate-command`
+- `mikuscore state apply-command`
+- `mikuscore state diff`
 
 Input/output contract:
 
@@ -54,6 +60,7 @@ Input/output contract:
 - omitted `--in` reads from `stdin`
 - `--out <file>` writes to file
 - omitted `--out` writes to `stdout`
+- `--out -` writes to `stdout` explicitly
 - text conversions use text input/output
 - MIDI input/output uses binary input/output
 - for file input, `--from musicxml` accepts `.musicxml`, `.xml`, and `.mxl`
@@ -61,12 +68,18 @@ Input/output contract:
 - for file output, `--to musicxml` writes `.mxl` when `--out` ends with `.mxl`
 - for file output, `--to musescore` writes `.mscz` when `--out` ends with `.mscz`
 - `stdin` / `stdout` remain text-only for `musicxml` and `musescore`
+- `render svg` also accepts `--from abc` as a one-shot path while still routing internally through canonical `MusicXML`
+- `state` commands operate on canonical `MusicXML`
+- `--diagnostics text|json` is available across current command families
 - plain-text CLI decode for `musicxml` / `musescore` is kept on UTF-8 `TextDecoder` rather than Node-only `Buffer`, so the same entrypoint can be runtime-compiled in isolated bundle environments
+- usage failures now use a distinct CLI error path from processing failures
 
 Examples:
 
 - `npm run cli -- --help`
 - `npm run cli -- convert --help`
+- `npm run cli -- render --help`
+- `npm run cli -- state --help`
 - `npm run cli -- convert --from abc --to musicxml --in score.abc --out score.musicxml`
 - `npm run cli -- convert --from musicxml --to abc --in score.musicxml --out score.abc`
 - `npm run cli -- convert --from midi --to musicxml --in score.mid --out score.musicxml`
@@ -77,7 +90,22 @@ Examples:
 - `npm run cli -- convert --from musescore --to musicxml --in score.mscz --out score.mxl`
 - `npm run cli -- convert --from musicxml --to musescore --in score.musicxml --out score.mscz`
 - `npm run cli -- render svg --in score.musicxml --out score.svg`
+- `npm run cli -- render svg --from abc --in score.abc --out score.svg`
+- `npm run cli -- state summarize --in score.musicxml`
+- `npm run cli -- state inspect-measure --measure 12 --in score.musicxml`
+- `npm run cli -- state validate-command --in score.musicxml --command-file command.json`
+- `npm run cli -- state apply-command --in score.musicxml --command-file command.json --out score.next.musicxml`
+- `npm run cli -- state diff --before score.before.musicxml --after score.after.musicxml`
 - `cat score.abc | npm run cli -- convert --from abc --to musicxml`
+
+Observed sibling-project direction:
+
+- `mikuproject` CLI grew in a way that intentionally resembles the earlier `mikuscore` CLI surface
+- because of that, similarities are expected and should be read as family resemblance, not accidental convergence
+- `mikuproject` has also evolved beyond the earlier `mikuscore` baseline, and that direction contains many reusable ideas
+- the parts most worth reusing back into `mikuscore` are infrastructure patterns first, not the larger command count itself
+- initial reuse is now present in the current CLI via centralized help output, `CliUsageError` / `CliProcessingError`, explicit `--out -`, optional `--diagnostics text|json`, and the first `state` family entrypoints
+- if `mikuscore` CLI behavior changes in those areas, update `mikuscore-skills` assumptions as well because downstream agent workflows are sensitive to stderr/stdout and exit-code contracts
 
 ## Documentation Map
 
@@ -113,6 +141,12 @@ Specification docs:
 - `docs/spec/MIDI_IO.md`
 - `docs/spec/ABC_IO.md`
 - `docs/spec/CLI_STEP1.md`
+- `docs/spec/CLI_DIAGNOSTICS_FIRSTCUT.md`
+- `docs/spec/CLI_HELP_FIRSTCUT.md`
+- `docs/spec/CLI_REBUILD_PLAN.md`
+- `docs/spec/CLI_RENDER_FIRSTCUT.md`
+- `docs/spec/CLI_TAXONOMY_FIRSTCUT.md`
+- `docs/spec/CLI_STATE_FIRSTCUT.md`
 - `docs/spec/TEST_MATRIX.md`
 
 Future notes:

--- a/docs/future/AI_JSON_INTERFACE.md
+++ b/docs/future/AI_JSON_INTERFACE.md
@@ -29,6 +29,35 @@ Those files should be read as design/archive material unless and until this work
 - Prefer bounded, validation-friendly exchange rather than unconstrained rewrite.
 - Reassess whether JSON is actually better than `ABC` for the target workflow before reviving the interface.
 
+## Multi-layer design note
+
+If this area is resumed, the design should not be framed only as "an AI feature".
+
+The stronger lesson from the related `mikuproject` work is that the same contract may need to serve three layers at once:
+
+- human CLI users
+- Agent Skills or other tool-mediated callers
+- downstream generative-AI interaction that sits behind those tool callers
+
+That implies several desirable properties:
+
+- command names and phases should remain understandable to a human operator
+- stdio behavior should remain composable in ordinary shell workflows
+- diagnostics should have a machine-readable form when the caller is an agent or another program
+- AI-facing exchange should prefer bounded projections, validation, and staged apply flows over unconstrained whole-document rewrites
+- handoff units should be small enough for reliable AI interaction, not only convenient for a human at a terminal
+
+For `mikuscore`, one strong candidate is to keep the actual mutation contract close to the existing core command catalog rather than inventing a separate whole-measure rewrite model.
+
+That would mean:
+
+- human-facing CLI phases may still look like `state inspect` / `state validate` / `state apply`
+- but the machine-facing payload inside those phases may compile down to bounded commands such as `change_to_pitch` or `change_duration`
+
+This does not mean `mikuscore` should copy the `mikuproject` AI command tree directly.
+
+It means future AI-facing interface work should be judged partly by how well it serves all three layers together, not only by whether a single AI prompt can produce an output.
+
 ## Re-entry conditions
 
 Revisit this only when there is a concrete implementation need such as:
@@ -36,6 +65,7 @@ Revisit this only when there is a concrete implementation need such as:
 - a stable tool-mediated AI workflow
 - clear bounded edit operations that benefit from a machine-facing contract
 - evidence that the added interface meaningfully improves reliability over the current ABC-centered flow
+- a plausible CLI or tool contract that remains legible for human users while also serving agent-mediated workflows
 
 ## Editorial rule
 

--- a/docs/future/CLI_ROADMAP.md
+++ b/docs/future/CLI_ROADMAP.md
@@ -3,9 +3,21 @@
 ## Status
 
 - Step 1 first cut exists.
+- CLI infrastructure hardening first cut now exists:
+  - centralized help output
+  - usage-error vs processing-error separation
+  - `--out -`
+  - `--diagnostics text|json`
 - Initial Step 2 MIDI pairs now exist as a first cut.
 - Initial Step 3 MuseScore pairs now exist as a first cut, including `.mscz` / `.mxl` file I/O support.
 - Initial `render svg` support now exists as a first cut.
+- Initial one-shot `render svg --from abc` support now exists as a first cut.
+- Initial `state` family first cut now exists:
+  - `state summarize`
+  - `state inspect-measure`
+  - `state validate-command`
+  - `state apply-command`
+  - `state diff`
 - This file tracks likely next-step expansion only.
 - This is a future note, not a current normative contract.
 
@@ -20,9 +32,16 @@ Current implemented Step 1 scope:
 - `mikuscore convert --from musescore --to musicxml`
 - `mikuscore convert --from musicxml --to musescore`
 - `mikuscore render svg`
+- `mikuscore render svg --from abc`
+- `mikuscore state summarize`
+- `mikuscore state inspect-measure`
+- `mikuscore state validate-command`
+- `mikuscore state apply-command`
+- `mikuscore state diff`
 - `mikuscore --help`
 - `mikuscore convert --help`
 - `mikuscore render --help`
+- `mikuscore state --help`
 
 Current Step 1 policy is defined in:
 
@@ -30,12 +49,156 @@ Current Step 1 policy is defined in:
 
 ## Planned Direction
 
-The CLI family is expected to grow along two tracks:
+The current CLI is still `convert`-first, but the next taxonomy candidate is broader:
 
-- convert-oriented commands
-- render-oriented commands
+- `convert`
+- `render`
+- `state`
 
 `MusicXML` remains canonical underneath.
+
+This means:
+
+- `convert` handles interchange with external formats
+- `render` handles derived outputs such as SVG
+- `state` handles canonical `MusicXML` state inspection, validation, patch-style mutation, and other light edit-oriented workflows
+
+This is intentionally closer to the successful `mikuproject` style of separating command responsibility at the top level.
+
+At the same time, `mikuscore` should keep `convert --from ... --to ...` for format-pair scaling, rather than exploding the command surface into one fixed command per format pair.
+
+In other words:
+
+- top-level command taxonomy should become more structured
+- format-pair selection inside `convert` should likely stay option-based
+
+## Shared CLI Pattern
+
+The `mikuproject` CLI command family was developed in a shape that intentionally resembles `mikuscore`.
+
+So the relationship here is not "import a foreign command system into `mikuscore`".
+
+It is closer to:
+
+- `mikuscore` established the early `convert`-first CLI pattern
+- `mikuproject` expanded that style into a larger command tree
+- `mikuproject` later evolved that pattern in ways that are often worth studying back in `mikuscore`
+- `mikuscore` can reuse those infrastructure lessons without changing its product identity
+
+For specification work, `mikuproject` should therefore be treated as an evolved sibling implementation of the same general CLI style.
+
+The important nuance is:
+
+- similarity alone does not mean `mikuscore` should copy the larger command surface
+- but the direction of `mikuproject` evolution is strong evidence for which CLI infrastructure ideas scale well in practice
+
+The most reusable infrastructure lessons are:
+
+- separate usage failures from processing failures, with distinct exit-code policy
+- centralize help text generation instead of scattering inline help branches
+- support `--out -` explicitly as stdout, not only omitted `--out`
+- add optional structured diagnostics such as `--diagnostics text|json`
+- validate stdin/file input combinations consistently before command execution
+- keep the main artifact on `stdout` and diagnostics on `stderr`, including machine-readable diagnostics when requested
+
+For `mikuscore`, these are more urgent than broadening the command family again.
+
+In other words, the next CLI step is likely infrastructure hardening before major surface expansion.
+
+## Near-Term Candidate
+
+The earlier CLI infrastructure pass has now landed as a first cut.
+
+The next strongest near-term candidate is to deepen the current `state` family and tighten documentation/current-contract alignment around the now-implemented `convert` / `render` / `state` surface.
+
+Likely next slices are:
+
+- improve current-facing docs to reflect implemented behavior more directly
+- decide whether `state inspect-measure` target identity should stay session-scoped `nodeId` based
+- deepen `state diff` beyond the current shallow summary if clearer user value emerges
+- decide when or whether to introduce patch envelopes after the single-command path has proven itself
+
+## Candidate Top-Level Taxonomy
+
+If the CLI is rebuilt while compatibility cost is still low, the strongest current candidate is:
+
+- `mikuscore convert ...`
+- `mikuscore render ...`
+- `mikuscore state ...`
+
+Suggested role split:
+
+- `convert`
+  - external interchange only
+  - example: `mikuscore convert --from abc --to musicxml`
+- `render`
+  - derived artifact generation
+  - example: `mikuscore render svg --in score.musicxml`
+  - a user-facing one-shot `ABC -> SVG` flow may still be offered here even if it internally routes through `ABC -> MusicXML -> SVG`
+- `state`
+  - canonical `MusicXML` inspection and mutation
+  - future examples: `state summarize`, `state validate`, `state diff`, `state apply-patch`
+
+This shape matches several goals at once:
+
+- preserve `MusicXML` as the canonical state
+- avoid multiplying fixed format-pair commands
+- give small edit features and diff-based workflows a natural home
+- align better with human CLI use, Agent Skills, and future tool-mediated AI workflows
+
+The current first-cut specification notes for this direction are:
+
+- `docs/spec/CLI_TAXONOMY_FIRSTCUT.md`
+- `docs/spec/CLI_RENDER_FIRSTCUT.md`
+- `docs/spec/CLI_STATE_FIRSTCUT.md`
+- `docs/spec/CLI_DIAGNOSTICS_FIRSTCUT.md`
+- `docs/spec/CLI_HELP_FIRSTCUT.md`
+- `docs/spec/CLI_REBUILD_PLAN.md`
+
+## State Family And Core Command Alignment
+
+`mikuscore` already has an internal command model for bounded score edits:
+
+- `change_to_pitch`
+- `change_duration`
+- `insert_note_after`
+- `delete_note`
+- `split_note`
+
+So the CLI should not invent a second unrelated edit model.
+
+At the same time, those command names do not need to become top-level CLI verbs.
+
+The more coherent direction is:
+
+- keep top-level CLI responsibility split as `convert` / `render` / `state`
+- let `state` expose phase-oriented commands such as inspect, validate, diff, and apply
+- let payloads inside those `state` commands carry the existing core command names
+
+In practice, that suggests a shape such as:
+
+- `mikuscore state summarize`
+- `mikuscore state inspect-measure`
+- `mikuscore state validate-command`
+- `mikuscore state apply-command`
+- `mikuscore state diff`
+
+or, if batching several core commands together becomes useful:
+
+- `mikuscore state validate-patch`
+- `mikuscore state apply-patch`
+
+with payloads that contain one or more existing core commands.
+
+This keeps the command-line taxonomy consistent with the rest of the CLI while preserving the already-designed internal edit semantics.
+
+In other words:
+
+- the CLI surface should be organized around workflow phases
+- the payload schema should reuse the current core command catalog
+- `mikuscore` should avoid creating separate top-level verbs like `mikuscore change-to-pitch ...`
+
+That separation is important because it keeps human-facing command discovery manageable while still giving agents and other tools a precise mutation contract.
 
 ## Step 2 Candidate Scope
 

--- a/docs/spec/CLI_DIAGNOSTICS_FIRSTCUT.md
+++ b/docs/spec/CLI_DIAGNOSTICS_FIRSTCUT.md
@@ -1,0 +1,220 @@
+# CLI Diagnostics First Cut
+
+## Purpose
+
+This document defines the first candidate shared diagnostics contract for the future `mikuscore` CLI.
+
+Scope note:
+
+- this is a first-cut CLI diagnostics note
+- this is distinct from the core diagnostics catalog in `docs/spec/DIAGNOSTICS.md`
+- this document focuses on CLI-facing error/warning/result reporting
+
+## Positioning
+
+The CLI diagnostics contract should work across:
+
+- `convert`
+- `render`
+- `state`
+
+It should also serve multiple callers:
+
+- human command-line users
+- shell/script callers
+- Agent Skills and other tool-mediated callers
+
+## Main Stream Rule
+
+Across all CLI families:
+
+- the primary artifact MUST go to `stdout`
+- diagnostics MUST go to `stderr`
+
+Examples:
+
+- converted `MusicXML` goes to `stdout`
+- rendered `SVG` goes to `stdout`
+- state summary JSON goes to `stdout`
+- warnings/errors/status summaries go to `stderr`
+
+This rule remains important even for multi-stage commands.
+
+## Diagnostics Modes
+
+The strongest current candidate is:
+
+- `--diagnostics text`
+- `--diagnostics json`
+
+Default:
+
+- text
+
+Intended use:
+
+- text: human-facing CLI use
+- json: machine-facing CLI use
+
+## Text Diagnostics
+
+Text diagnostics SHOULD:
+
+- stay short and readable
+- preserve the current shell expectation that stderr contains concise warnings/errors
+- avoid leaking raw JavaScript stack traces as the normal failure surface
+
+Text diagnostics MAY include:
+
+- warnings
+- primary failure message
+- short stage summary when a command spans multiple internal stages
+
+## JSON Diagnostics
+
+JSON diagnostics SHOULD provide a stable minimum shape across top-level families.
+
+The strongest current candidate minimum fields are:
+
+```json
+{
+  "ok": true,
+  "diagnostics_version": 1,
+  "command": "render svg",
+  "context": "render svg",
+  "status": "success",
+  "exit_code": 0,
+  "warning_count": 0,
+  "error_count": 0,
+  "io": {
+    "inputs": [],
+    "output": { "mode": "stdout" }
+  },
+  "warnings": [],
+  "errors": []
+}
+```
+
+Field intent:
+
+- `ok`
+  - overall success/failure boolean
+- `diagnostics_version`
+  - version marker for the CLI diagnostics contract
+- `command`
+  - compact command identity
+- `context`
+  - command context string; may equal `command` in first cut
+- `status`
+  - candidate values such as `success`, `warning`, `error`
+- `exit_code`
+  - actual CLI exit code
+- `warning_count`
+  - number of warnings
+- `error_count`
+  - number of errors
+- `io`
+  - summary of input/output locations
+- `warnings`
+  - warning list
+- `errors`
+  - error list
+
+## Error Classification
+
+The CLI SHOULD distinguish at least:
+
+- usage error
+- processing error
+
+Candidate JSON fields for failure cases:
+
+- `error_type`
+  - `usage_error` or `processing_error`
+- `error_code`
+  - stable CLI-facing code when available
+- `error_details`
+  - optional machine-facing structured details
+
+This distinction helps:
+
+- human debugging
+- shell automation
+- Agent Skills retry/repair logic
+
+## Relationship To Core Diagnostics
+
+Core diagnostics such as:
+
+- `MEASURE_OVERFULL`
+- `MVP_UNSUPPORTED_NON_EDITABLE_VOICE`
+- `MVP_INVALID_COMMAND_PAYLOAD`
+
+remain authoritative for bounded edit semantics.
+
+The CLI diagnostics contract should wrap those diagnostics rather than replace them.
+
+That means:
+
+- CLI diagnostics describe command execution, I/O context, and exit semantics
+- core diagnostics describe music-edit validity and execution outcomes inside the bounded command layer
+
+## Multi-stage Commands
+
+Some future CLI commands may cross multiple internal stages.
+
+Example:
+
+- `render svg --from abc`
+  - read input
+  - convert `ABC -> MusicXML`
+  - render `MusicXML -> SVG`
+
+First-cut rule:
+
+- the primary artifact MUST still be only the final output
+- diagnostics MAY summarize stages briefly in text mode
+- JSON diagnostics SHOULD be able to expose stage-aware context when useful
+
+Candidate optional JSON extension fields:
+
+- `stages`
+- `output_kind`
+- `detected_input_kind`
+
+These are optional first-cut extensions, not yet required minimum fields.
+
+## "Kept vs Dropped" Direction
+
+One important future diagnostics goal is to make `mikuscore` more trustworthy as a converter by making conversion loss easier to notice.
+
+First-cut direction:
+
+- diagnostics SHOULD eventually be able to summarize important warnings in short human-facing form
+- diagnostics SHOULD avoid pretending to provide a complete musicological diff when they do not
+- the first cut may remain conservative and surface only stable, bounded warnings
+
+## Exit-code Direction
+
+The strongest current candidate policy is:
+
+- `0` for success, including success-with-warnings
+- non-zero for failure
+- usage failures and processing failures SHOULD be distinguishable by code path and, ideally, by exit-code policy
+
+The exact exit-code split may be finalized later, but the category split should be designed early.
+
+## First-cut Non-Goals
+
+This diagnostics note does not yet require:
+
+- exhaustive stage-by-stage trace output
+- a complete diff of every preserved vs dropped notation feature
+- parity with every diagnostics shape used in sibling projects
+- broad AI-specific diagnostics fields beyond what helps generic tool callers
+
+## Relationship To Current Docs
+
+- `docs/spec/DIAGNOSTICS.md` remains the core diagnostics catalog
+- this file defines the strongest current candidate shared CLI diagnostics contract
+- current implemented CLI behavior remains defined by `docs/spec/CLI_STEP1.md`

--- a/docs/spec/CLI_HELP_FIRSTCUT.md
+++ b/docs/spec/CLI_HELP_FIRSTCUT.md
@@ -1,0 +1,164 @@
+# CLI Help First Cut
+
+## Purpose
+
+This document defines the first candidate help-text surface for the future `mikuscore` CLI.
+
+Scope note:
+
+- this is a first-cut help and discoverability note
+- it does not lock the exact final wording
+- it is intended to keep the rebuilt CLI understandable to human operators
+
+## Positioning
+
+The future CLI is expected to be organized around:
+
+- `convert`
+- `render`
+- `state`
+
+The help surface should reflect that split directly.
+
+The goal is:
+
+- clear top-level discovery for humans
+- stable enough wording for docs and examples
+- no need to understand internal canonical routing before basic use
+
+## Top-level Help Direction
+
+The strongest current candidate top-level help shape is:
+
+```text
+Usage:
+  mikuscore convert --from <format> --to <format> [--in <file>|-] [--out <file>|-] [--diagnostics text|json]
+  mikuscore render svg [--from <format>] [--in <file>|-] [--out <file>|-] [--diagnostics text|json]
+  mikuscore state summarize [--in <file>|-] [--diagnostics text|json]
+  mikuscore state inspect-measure --measure <number> [--in <file>|-] [--diagnostics text|json]
+  mikuscore state validate-command [--in <file>|-] [--command <json>|--command-file <file>] [--diagnostics text|json]
+  mikuscore state apply-command [--in <file>|-] [--command <json>|--command-file <file>] [--out <file>|-] [--diagnostics text|json]
+  mikuscore state diff --before <file> --after <file> [--diagnostics text|json]
+  mikuscore <command> --help
+  mikuscore --help
+
+Commands:
+  convert   Convert score data between external formats
+  render    Generate derived outputs such as SVG
+  state     Inspect, validate, diff, and mutate canonical MusicXML state
+```
+
+## Design Rules For Help Text
+
+Top-level help SHOULD:
+
+- expose the three top-level families directly
+- show one strong example for each family
+- reveal `--diagnostics text|json` early because it affects both humans and tool callers
+- make `stdin` / `stdout` behavior visible
+
+Top-level help SHOULD NOT:
+
+- list every future command possibility
+- expose internal implementation detail such as forced intermediate `MusicXML` routing
+- turn into a long command catalog dump
+
+## `convert --help` Direction
+
+The strongest current candidate command help shape is:
+
+```text
+Usage:
+  mikuscore convert --from <format> --to <format> [--in <file>|-] [--out <file>|-] [--diagnostics text|json]
+  mikuscore convert --help
+
+Description:
+  Convert score data between supported external formats.
+
+Examples:
+  mikuscore convert --from abc --to musicxml --in score.abc --out score.musicxml
+  mikuscore convert --from musicxml --to abc --in score.musicxml --out score.abc
+
+Notes:
+  MusicXML remains canonical internally.
+  Main output goes to stdout unless --out is used.
+  Diagnostics go to stderr.
+```
+
+## `render --help` Direction
+
+The strongest current candidate command help shape is:
+
+```text
+Usage:
+  mikuscore render svg [--from <format>] [--in <file>|-] [--out <file>|-] [--diagnostics text|json]
+  mikuscore render --help
+
+Description:
+  Generate derived outputs such as SVG from canonical score state.
+
+Examples:
+  mikuscore render svg --in score.musicxml --out score.svg
+  mikuscore render svg --from abc --in score.abc --out score.svg
+
+Notes:
+  A one-shot ABC -> SVG path may internally route through MusicXML.
+  Main output goes to stdout unless --out is used.
+  Diagnostics go to stderr.
+```
+
+## `state --help` Direction
+
+The strongest current candidate command help shape is:
+
+```text
+Usage:
+  mikuscore state summarize [--in <file>|-] [--diagnostics text|json]
+  mikuscore state inspect-measure --measure <number> [--in <file>|-] [--diagnostics text|json]
+  mikuscore state validate-command [--in <file>|-] [--command <json>|--command-file <file>] [--diagnostics text|json]
+  mikuscore state apply-command [--in <file>|-] [--command <json>|--command-file <file>] [--out <file>|-] [--diagnostics text|json]
+  mikuscore state diff --before <file> --after <file> [--diagnostics text|json]
+  mikuscore state --help
+
+Description:
+  Inspect, validate, compare, and mutate canonical MusicXML state.
+
+Examples:
+  mikuscore state summarize --in score.musicxml
+  mikuscore state inspect-measure --measure 12 --in score.musicxml
+  mikuscore state validate-command --in score.musicxml --command-file command.json
+  mikuscore state apply-command --in score.musicxml --command-file command.json --out score.next.musicxml
+  mikuscore state diff --before score.before.musicxml --after score.after.musicxml
+```
+
+## Help Tone
+
+Help text SHOULD:
+
+- be compact
+- be explicit
+- favor example-driven understanding
+- name the top-level family responsibility in plain terms
+
+Help text SHOULD NOT:
+
+- assume the user already knows the internal data model
+- over-explain architectural background inside the help output itself
+- mix human-readable examples with large schema dumps
+
+## Relationship To Diagnostics
+
+Because diagnostics are now part of the CLI direction, help text SHOULD make this visible early.
+
+At minimum:
+
+- `--diagnostics text|json` SHOULD appear in usage lines where supported
+- help SHOULD reinforce that the main artifact goes to `stdout` and diagnostics go to `stderr`
+
+## Relationship To Current Docs
+
+- `docs/spec/CLI_TAXONOMY_FIRSTCUT.md` defines the top-level future split
+- `docs/spec/CLI_RENDER_FIRSTCUT.md` defines the current render first cut
+- `docs/spec/CLI_STATE_FIRSTCUT.md` defines the current state first cut
+- this file defines the strongest current candidate help-text surface for those command families
+- current implemented CLI behavior remains defined by `docs/spec/CLI_STEP1.md`

--- a/docs/spec/CLI_REBUILD_PLAN.md
+++ b/docs/spec/CLI_REBUILD_PLAN.md
@@ -1,0 +1,186 @@
+# CLI Rebuild Plan
+
+## Purpose
+
+This document defines the first implementation-oriented plan for rebuilding the `mikuscore` CLI around the future taxonomy.
+
+Scope note:
+
+- this is a planning and sequencing document
+- it does not replace the current implemented CLI contract
+- it exists to connect the future CLI specs to an execution order
+
+## Target Shape
+
+The current strongest future target is:
+
+- `convert`
+- `render`
+- `state`
+
+with shared CLI diagnostics and clearer help output.
+
+The goal of this plan is not to deliver everything at once.
+
+It is to move from the current `convert`-first CLI to the new shape in bounded slices.
+
+## Guiding Constraints
+
+- keep `MusicXML` canonical throughout
+- avoid introducing a second edit model
+- preserve composable CLI behavior: primary artifact on `stdout`, diagnostics on `stderr`
+- reduce raw runtime exception leakage early
+- sequence implementation so each slice produces usable value on its own
+
+## Recommended Implementation Order
+
+### Phase 1. CLI Infrastructure Hardening
+
+Primary goal:
+
+- improve the current CLI shell behavior before broadening the visible command surface
+
+Work items:
+
+- introduce centralized help output
+- introduce usage-error vs processing-error separation
+- add `--out -`
+- add `--diagnostics text|json`
+- define first-cut JSON diagnostics shape
+
+Why first:
+
+- this immediately improves failure UX
+- later `render` and `state` work both depend on the same CLI contract quality
+
+Related specs:
+
+- `docs/spec/CLI_DIAGNOSTICS_FIRSTCUT.md`
+- `docs/spec/CLI_HELP_FIRSTCUT.md`
+
+### Phase 2. Render One-shot Improvement
+
+Primary goal:
+
+- expose a user-facing direct `ABC -> SVG` path while keeping the internal `MusicXML`-first pipeline
+
+Work items:
+
+- extend `render svg` input policy
+- decide exact `--from` behavior for `render`
+- ensure diagnostics can describe multi-stage render flows
+
+Why second:
+
+- this is high visible user value
+- it reuses Phase 1 diagnostics and help work
+- it does not yet require full `state` mutation machinery
+
+Related specs:
+
+- `docs/spec/CLI_RENDER_FIRSTCUT.md`
+- `docs/spec/CLI_DIAGNOSTICS_FIRSTCUT.md`
+- `docs/spec/CLI_HELP_FIRSTCUT.md`
+
+### Phase 3. Reserve And Introduce `state`
+
+Primary goal:
+
+- add the first `state` family entrypoints for canonical `MusicXML` workflows
+
+Strongest current initial scope:
+
+- `state summarize`
+- `state validate-command`
+- `state apply-command`
+
+Deferred until later in the same family if needed:
+
+- `state inspect-measure`
+- `state diff`
+- patch envelopes
+
+Why this order:
+
+- `summarize` gives a low-risk first `state` surface
+- `validate-command` and `apply-command` align directly with the existing core command catalog
+- inspect/diff can be added after the first mutation path is proven
+
+Related specs:
+
+- `docs/spec/CLI_STATE_FIRSTCUT.md`
+- `docs/spec/COMMAND_CATALOG.md`
+- `docs/spec/DIAGNOSTICS.md`
+
+### Phase 4. Refine State Inspection And Diff
+
+Primary goal:
+
+- make bounded edit workflows easier to drive for humans and tools
+
+Work items:
+
+- `state inspect-measure`
+- `state diff`
+- possible command/target selector refinement
+
+Why later:
+
+- these commands are useful, but they depend on decisions made in early `state` mutation work
+
+### Phase 5. Revisit Patch Envelopes
+
+Primary goal:
+
+- decide whether `validate-patch` / `apply-patch` are needed after single-command workflows exist
+
+Why last:
+
+- first cut can prove the bounded mutation model without immediately committing to batch/patched mutation envelopes
+
+## Recommended First-code Slice
+
+If implementation starts now, the strongest initial code slice is:
+
+1. centralize current help handling
+2. add error classification
+3. add `--diagnostics text|json`
+4. add `--out -`
+5. keep current `convert` / `render` behavior otherwise stable
+
+This lets the current CLI improve materially without yet forcing the whole taxonomy rebuild in one patch.
+
+## Migration Direction
+
+Because current CLI usage is believed to be low, the project can tolerate a more direct rebuild than a high-adoption CLI could.
+
+Still, migration should stay legible.
+
+Recommended stance:
+
+- keep migration messaging explicit in help/docs
+- prefer one deliberate command-surface revision over long-lived half-compatible hybrids
+- keep current specs and future specs both visible until the rebuild lands
+
+## Deferred Items
+
+The following remain intentionally out of the near-term rebuild plan:
+
+- batch conversion as a built-in CLI feature
+- lyrics/melody alignment diagnostics
+- a broad AI-specific command family
+- large MIDI-expression tuning surfaces ahead of canonical `MusicXML` state work
+
+## Relationship To Other Specs
+
+- `docs/spec/CLI_TAXONOMY_FIRSTCUT.md`
+  - top-level future shape
+- `docs/spec/CLI_RENDER_FIRSTCUT.md`
+  - future `render` family
+- `docs/spec/CLI_STATE_FIRSTCUT.md`
+  - future `state` family
+- `docs/spec/CLI_DIAGNOSTICS_FIRSTCUT.md`
+  - shared CLI diagnostics contract
+- `docs/spec/CLI_HELP_FIRSTCUT.md`
+  - human-facing help surface
+- current implemented CLI behavior remains defined by `docs/spec/CLI_STEP1.md`

--- a/docs/spec/CLI_RENDER_FIRSTCUT.md
+++ b/docs/spec/CLI_RENDER_FIRSTCUT.md
@@ -1,0 +1,157 @@
+# CLI Render First Cut
+
+## Purpose
+
+This document defines the first candidate `render` command family for the future `mikuscore` CLI.
+
+Scope note:
+
+- this is a first-cut render workflow spec
+- this is not yet the current implemented CLI contract
+- it focuses on SVG-oriented rendering because that is the strongest current user-facing render need
+
+## Positioning
+
+The `render` family exists to generate derived artifacts from canonical score state.
+
+For the current first cut, the primary target is:
+
+- `svg`
+
+`render` is not the same as external format interchange.
+
+That means:
+
+- `convert` is still the home for interchange such as `ABC <-> MusicXML`
+- `render` is the home for user-facing outputs such as score SVG
+
+## First-cut Command Shape
+
+The strongest current candidate shape is:
+
+- `mikuscore render svg [--from <format>] [--in <file>] [--out <file>]`
+
+Examples:
+
+- `mikuscore render svg --in score.musicxml`
+- `mikuscore render svg --from abc --in score.abc`
+
+## Render Target
+
+### `render svg`
+
+Purpose:
+
+- emit score SVG for visual inspection or lightweight score sharing
+
+Output:
+
+- SVG text to `stdout` or `--out <file>`
+
+Diagnostics:
+
+- diagnostics MUST go to `stderr`
+- `--diagnostics text|json` SHOULD be supported in the same style as other top-level command families
+
+## Input Policy
+
+### Canonical Direction
+
+Internally, rendering SHOULD continue to treat `MusicXML` as canonical.
+
+That means the internal pipeline for a direct ABC render MAY be:
+
+```text
+ABC -> MusicXML -> SVG
+```
+
+without exposing intermediate `MusicXML` to the user unless requested elsewhere.
+
+### User-facing One-shot Direction
+
+The current strongest product direction is:
+
+- `render svg` SHOULD allow at least a direct `ABC -> SVG` path
+
+Rationale:
+
+- many users care about "turn this ABC into visible notation" rather than about explicitly seeing the intermediate canonical form
+- the internal `MusicXML`-first architecture can remain intact while the CLI becomes more purpose-oriented
+
+### First-cut Accepted Inputs
+
+Strongest current candidate:
+
+- default or explicit `--from musicxml`
+- optional `--from abc` for one-shot rendering
+
+Open question for later:
+
+- whether first cut should accept additional non-`MusicXML` render inputs such as `midi` or `musescore`, or whether those should stay outside render until the direct value is clearer
+
+## Shared I/O Direction
+
+Input:
+
+- `--in <file>` reads from file
+- omitted `--in` reads from `stdin`
+- `--in -` MAY be used as explicit stdin
+
+Output:
+
+- `--out <file>` writes the rendered artifact to file
+- omitted `--out` writes to `stdout`
+- `--out -` SHOULD be treated as explicit stdout
+
+## Stage-awareness
+
+One-shot render commands may cross more than one internal stage.
+
+Example:
+
+```text
+render svg --from abc
+```
+
+may internally involve:
+
+1. decode/read input
+2. convert `ABC -> MusicXML`
+3. render `MusicXML -> SVG`
+
+First-cut rule:
+
+- the main artifact MUST still be only the final SVG
+- diagnostics MAY mention stage boundaries briefly
+- machine-readable diagnostics SHOULD be able to represent that the command crossed multiple internal stages
+
+## Relationship To `convert`
+
+The future CLI SHOULD avoid forcing users to manually spell every internal step when the end goal is obvious.
+
+So this is acceptable:
+
+- user asks for score SVG from ABC
+- CLI internally converts through canonical `MusicXML`
+
+This does not weaken the canonical architecture.
+
+It simply means:
+
+- internal canonical flow remains `MusicXML`
+- external user-facing CLI may be more task-oriented than the internal pipeline
+
+## First-cut Non-Goals
+
+The first render cut does not yet require:
+
+- many render targets beyond SVG
+- broad render-option surfaces such as layout tuning, page geometry, or engraving controls
+- every supported input format to become a direct render source
+- a separate batch render mode inside the CLI itself
+
+## Relationship To Current Docs
+
+- `docs/spec/CLI_TAXONOMY_FIRSTCUT.md` defines the top-level future CLI split
+- this file defines the strongest current candidate first cut inside `render`
+- current implemented CLI behavior remains defined by `docs/spec/CLI_STEP1.md`

--- a/docs/spec/CLI_STATE_FIRSTCUT.md
+++ b/docs/spec/CLI_STATE_FIRSTCUT.md
@@ -1,0 +1,246 @@
+# CLI State First Cut
+
+## Purpose
+
+This document defines the first candidate `state` command family for the future `mikuscore` CLI.
+
+Scope note:
+
+- this is a first-cut state workflow spec
+- current CLI implementation now covers most of this first cut, though payload details may still evolve
+- detailed payload schemas may be refined later
+
+## Positioning
+
+The `state` family exists to operate on canonical `MusicXML` state.
+
+It is intended for workflows that are not just format interchange and not just derived rendering.
+
+Typical use cases include:
+
+- inspect the current score state briefly
+- inspect a specific measure before making a bounded edit
+- validate one bounded command before applying it
+- apply one bounded command and write the next `MusicXML` state
+- compare two `MusicXML` states
+
+`state` MUST NOT introduce a second canonical score model.
+
+## Relationship To Other Top-level Families
+
+- `convert`
+  - handles interchange with external formats
+- `render`
+  - handles derived artifacts such as SVG
+- `state`
+  - handles canonical `MusicXML` inspection, validation, diff, and bounded mutation
+
+This means a flow such as:
+
+```text
+ABC -> MusicXML -> inspect/validate/apply -> SVG
+```
+
+may cross multiple top-level families, but `state` itself remains centered on canonical `MusicXML`.
+
+## First-cut Command Set
+
+The strongest current candidate first cut is:
+
+- `mikuscore state summarize`
+- `mikuscore state inspect-measure`
+- `mikuscore state validate-command`
+- `mikuscore state apply-command`
+- `mikuscore state diff`
+
+If patch envelopes become necessary later, likely additions are:
+
+- `mikuscore state validate-patch`
+- `mikuscore state apply-patch`
+
+## Shared I/O Direction
+
+Input:
+
+- `state` commands SHOULD accept canonical `MusicXML` from `--in <file>` or `stdin`
+- commands that compare two states MAY use paired options such as `--before` and `--after`
+
+Output:
+
+- the primary artifact MUST go to `stdout` unless `--out <file>` is used
+- diagnostics MUST go to `stderr`
+- `--out -` SHOULD be treated as explicit stdout
+
+Diagnostics:
+
+- first-cut direction is `--diagnostics text|json`
+- text is the default human-facing mode
+- json is the machine-facing mode for Agent Skills and other tool callers
+
+## Command Semantics
+
+### 1. `state summarize`
+
+Purpose:
+
+- provide a compact summary of canonical `MusicXML` state
+
+Intended output shape:
+
+- machine-readable summary
+- enough information to confirm that the score loaded as expected
+- not a full serialization of the whole score
+
+Candidate summary fields:
+
+- part count
+- measure count
+- available measure numbers
+- available voices or lanes when cheaply derivable
+- title / metadata when available
+
+### 2. `state inspect-measure`
+
+Purpose:
+
+- inspect one target measure before a bounded edit
+
+Input:
+
+- canonical `MusicXML`
+- a target selector such as measure number
+
+Intended output shape:
+
+- compact measure-focused view
+- enough information to identify note targets for later bounded commands
+
+First-cut design rule:
+
+- inspect output SHOULD be smaller and easier to reason about than raw full-document `MusicXML`
+- inspect output SHOULD still preserve enough identity information to target a later mutation reliably
+
+Current first-cut direction:
+
+- inspect output currently returns a hybrid targeting hint
+- session-scoped `node_id` is preserved for direct command payload use
+- selector metadata such as part, measure, and note position is also returned to make workflows easier to explain and debug
+
+### 3. `state validate-command`
+
+Purpose:
+
+- validate one bounded mutation command against the current canonical `MusicXML` state without mutating output state
+
+Input:
+
+- canonical `MusicXML`
+- one machine-facing bounded command payload
+
+Behavior:
+
+- MUST reuse the existing core command catalog semantics
+- MUST NOT invent a separate whole-measure rewrite contract
+- MUST return success or failure with diagnostics
+- MUST keep mutation semantics aligned with `docs/spec/COMMAND_CATALOG.md`
+
+Candidate command payloads include:
+
+- `change_to_pitch`
+- `change_duration`
+- `insert_note_after`
+- `delete_note`
+- `split_note`
+
+### 4. `state apply-command`
+
+Purpose:
+
+- apply one bounded mutation command to canonical `MusicXML` state and emit the next canonical `MusicXML`
+
+Input:
+
+- canonical `MusicXML`
+- one machine-facing bounded command payload
+
+Behavior:
+
+- MUST reuse the same validation and command semantics as `state validate-command`
+- MUST emit the next canonical `MusicXML` state on success
+- MUST fail atomically when command execution fails
+- MUST preserve the existing save/serialization policy defined in core specs
+
+### 5. `state diff`
+
+Purpose:
+
+- compare two canonical `MusicXML` states in a bounded, workflow-friendly way
+
+Input:
+
+- `--before`
+- `--after`
+
+Behavior:
+
+- SHOULD produce a compact difference summary rather than a raw textual XML diff
+- SHOULD focus on user-relevant score changes when practical
+- MAY remain intentionally shallow in first cut if a deeper music-aware diff is not yet stable
+
+## Relationship To Core Command Catalog
+
+`state` SHOULD expose workflow phases, not one top-level CLI verb per mutation primitive.
+
+Preferred split:
+
+- CLI surface:
+  - `state summarize`
+  - `state inspect-measure`
+  - `state validate-command`
+  - `state apply-command`
+  - `state diff`
+- payload layer:
+  - `change_to_pitch`
+  - `change_duration`
+  - `insert_note_after`
+  - `delete_note`
+  - `split_note`
+
+This preserves the current bounded edit semantics without making CLI command discovery noisy.
+
+## Small-edit Direction
+
+The first-cut `state` family is the natural home for the current "small edit" theme.
+
+That theme includes:
+
+- pitch change
+- duration change
+- note insertion
+- note deletion
+- note split
+- likely future canonical-`MusicXML` light edits such as tempo-level changes
+
+This means:
+
+- "small edit feature"
+- "`MusicXML`-centered light edit"
+- "diff-based edit"
+
+should be treated as the same direction seen from different layers.
+
+## First-cut Non-Goals
+
+The first `state` family does not yet require:
+
+- patch envelopes containing many commands
+- a broad AI-only command tree
+- whole-measure rewrite as the primary mutation contract
+- lyrics/melody alignment diagnostics
+- batch orchestration inside the CLI itself
+
+## Relationship To Current Docs
+
+- `docs/spec/CLI_TAXONOMY_FIRSTCUT.md` defines the top-level future CLI split
+- this file defines the strongest current candidate first cut inside `state`
+- current implemented CLI behavior remains defined by `docs/spec/CLI_STEP1.md`

--- a/docs/spec/CLI_STEP1.md
+++ b/docs/spec/CLI_STEP1.md
@@ -7,8 +7,14 @@ This document defines the first-cut CLI scope for `mikuscore`.
 Scope note:
 
 - This file defines only the initial CLI contract.
+- Current implementation has already grown beyond this initial contract.
 - It does not define future AI JSON or patch-based workflows.
 - It does not replace the canonical MusicXML-centered architecture.
+
+For current repository-facing behavior, also see:
+
+- `README.md`
+- `docs/DEVELOPMENT.md`
 
 ## Positioning
 
@@ -238,3 +244,11 @@ If the CLI grows later, it SHOULD still preserve the same principles:
 - narrowly scoped command families
 
 Any later expansion beyond `ABC` SHOULD be justified by concrete workflow need, not by symmetry with another project.
+
+Current future-facing first-cut notes are tracked separately in:
+
+- `docs/spec/CLI_TAXONOMY_FIRSTCUT.md`
+- `docs/spec/CLI_RENDER_FIRSTCUT.md`
+- `docs/spec/CLI_STATE_FIRSTCUT.md`
+- `docs/spec/CLI_DIAGNOSTICS_FIRSTCUT.md`
+- `docs/spec/CLI_HELP_FIRSTCUT.md`

--- a/docs/spec/CLI_TAXONOMY_FIRSTCUT.md
+++ b/docs/spec/CLI_TAXONOMY_FIRSTCUT.md
@@ -1,0 +1,156 @@
+# CLI Taxonomy First Cut
+
+## Purpose
+
+This document records the next candidate CLI taxonomy for `mikuscore`.
+
+Scope note:
+
+- this is a first-cut taxonomy and workflow note
+- this is not yet the current implemented CLI contract
+- detailed command payloads and diagnostics schemas may be defined later in separate specs
+
+## Positioning
+
+The current CLI is still centered on `convert --from ... --to ...`.
+
+The strongest next candidate is to organize the CLI around three top-level families:
+
+- `convert`
+- `render`
+- `state`
+
+This keeps `MusicXML` canonical while making command responsibilities clearer.
+
+## Top-level Families
+
+### 1. `convert`
+
+Purpose:
+
+- interchange between external score formats
+
+Examples:
+
+- `mikuscore convert --from abc --to musicxml`
+- `mikuscore convert --from musicxml --to abc`
+- `mikuscore convert --from midi --to musicxml`
+
+Rules:
+
+- `convert` SHOULD keep format-pair selection option-based via `--from` / `--to`
+- `convert` SHOULD NOT expand into one fixed command per format pair
+- `convert` SHOULD focus on interchange rather than canonical-state mutation
+
+### 2. `render`
+
+Purpose:
+
+- generate derived artifacts such as SVG
+
+Examples:
+
+- `mikuscore render svg --in score.musicxml`
+- future one-shot example: `mikuscore render svg --from abc --in score.abc`
+
+Rules:
+
+- `render` SHOULD remain output-oriented
+- internal canonical flow MAY still route through `MusicXML`
+- a user-facing one-shot `ABC -> SVG` path is allowed even if the internal pipeline is `ABC -> MusicXML -> SVG`
+
+### 3. `state`
+
+Purpose:
+
+- inspect, validate, compare, and mutate canonical `MusicXML` state
+
+Candidate first-cut examples:
+
+- `mikuscore state summarize`
+- `mikuscore state inspect-measure`
+- `mikuscore state validate-command`
+- `mikuscore state apply-command`
+- `mikuscore state diff`
+
+Rules:
+
+- `state` SHOULD be the natural home for bounded edit-oriented workflows
+- `state` SHOULD treat `MusicXML` as canonical state, not introduce a second canonical score model
+- `state` SHOULD support both human CLI use and tool-mediated callers
+
+## Why This Taxonomy
+
+This split aims to satisfy several constraints at once:
+
+- preserve `MusicXML` as canonical
+- keep format-pair growth manageable
+- make user intent clearer at the top level
+- give small edit workflows and diff-based mutation a natural home
+- align better with Agent Skills and future tool-mediated AI workflows
+
+## Relationship To Existing Core Commands
+
+`mikuscore` already has a bounded internal command model:
+
+- `change_to_pitch`
+- `change_duration`
+- `insert_note_after`
+- `delete_note`
+- `split_note`
+
+Those command names describe mutation semantics well, but they do not need to become top-level CLI verbs.
+
+Preferred direction:
+
+- top-level CLI stays phase-oriented: `state inspect`, `state validate`, `state apply`, `state diff`
+- machine-facing payloads inside those `state` commands SHOULD reuse the existing core command catalog
+
+This means `mikuscore` SHOULD avoid a surface such as:
+
+- `mikuscore change-to-pitch ...`
+- `mikuscore change-duration ...`
+
+and instead prefer workflow-oriented commands with bounded command payloads.
+
+## Render Input Policy
+
+One open first-cut question is how much non-`MusicXML` input `render` should accept directly.
+
+Current strongest direction:
+
+- user-facing CLI SHOULD allow at least a direct `ABC -> SVG` path
+- internal implementation SHOULD still route through canonical `MusicXML`
+
+This preserves the internal architecture while reducing user-visible friction.
+
+## Diagnostics Direction
+
+All three top-level families SHOULD converge on a shared diagnostics style.
+
+First-cut direction:
+
+- main artifact on `stdout`
+- diagnostics on `stderr`
+- human-readable text by default
+- optional machine-readable form via `--diagnostics text|json`
+
+This direction is especially important for:
+
+- one-shot render flows that cross multiple internal stages
+- `state` validation/apply workflows
+- Agent Skills and other tool-mediated callers
+
+## First-cut Non-Goals
+
+This taxonomy note does not yet require:
+
+- batch conversion inside the CLI itself
+- lyrics/melody alignment diagnostics
+- a broad AI-specific command family
+- a top-level command per internal edit primitive
+
+## Relationship To Current Docs
+
+- current implemented CLI behavior remains defined by `docs/spec/CLI_STEP1.md`
+- this file defines the most plausible next taxonomy after the current first cut

--- a/scripts/mikuscore-cli.mjs
+++ b/scripts/mikuscore-cli.mjs
@@ -9,127 +9,194 @@ import { loadCliApi } from "./lib/load-cli-api.mjs";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const repoRoot = path.resolve(__dirname, "..");
+const DIAGNOSTICS_VERSION = 1;
 
-const TOP_LEVEL_HELP = `Usage:
-  mikuscore convert --from abc --to musicxml [--in <file>] [--out <file>]
-  mikuscore convert --from musicxml --to abc [--in <file>] [--out <file>]
-  mikuscore convert --from midi --to musicxml [--in <file>] [--out <file>]
-  mikuscore convert --from musicxml --to midi [--in <file>] [--out <file>]
-  mikuscore convert --from musescore --to musicxml [--in <file>] [--out <file>]
-  mikuscore convert --from musicxml --to musescore [--in <file>] [--out <file>]
-  mikuscore render svg [--in <file>] [--out <file>]
-  mikuscore render --help
-  mikuscore convert --help
-  mikuscore --help
+const HELP_TEXT = {
+  top: [
+    "Usage:",
+    "  mikuscore convert --from abc --to musicxml [--in <file>|-] [--out <file>|-] [--diagnostics text|json]",
+    "  mikuscore convert --from musicxml --to abc [--in <file>|-] [--out <file>|-] [--diagnostics text|json]",
+    "  mikuscore convert --from midi --to musicxml [--in <file>|-] [--out <file>|-] [--diagnostics text|json]",
+    "  mikuscore convert --from musicxml --to midi [--in <file>|-] [--out <file>|-] [--diagnostics text|json]",
+    "  mikuscore convert --from musescore --to musicxml [--in <file>|-] [--out <file>|-] [--diagnostics text|json]",
+    "  mikuscore convert --from musicxml --to musescore [--in <file>|-] [--out <file>|-] [--diagnostics text|json]",
+    "  mikuscore render svg [--in <file>|-] [--out <file>|-] [--diagnostics text|json]",
+    "  mikuscore state summarize [--in <file>|-] [--diagnostics text|json]",
+    "  mikuscore state inspect-measure --measure <number> [--in <file>|-] [--diagnostics text|json]",
+    "  mikuscore state validate-command [--in <file>|-] [--command <json>|--command-file <file>|-] [--diagnostics text|json]",
+    "  mikuscore state apply-command [--in <file>|-] [--command <json>|--command-file <file>|-] [--out <file>|-] [--diagnostics text|json]",
+    "  mikuscore state diff --before <file> --after <file> [--diagnostics text|json]",
+    "  mikuscore render --help",
+    "  mikuscore state --help",
+    "  mikuscore convert --help",
+    "  mikuscore --help",
+    "",
+    "Commands:",
+    "  convert   Convert score text between supported formats",
+    "  render    Render derived outputs such as SVG",
+    "  state     Inspect canonical MusicXML state",
+    "",
+    "Options:",
+    "  --from <format>          Source format",
+    "  --to <format>            Target format",
+    "  --in <file>|-            Read input from file or stdin",
+    "  --out <file>|-           Write output to file or stdout",
+    "  --diagnostics text|json  Select diagnostics format",
+    "  --help                   Show help",
+  ].join("\n"),
+  convert: [
+    "Usage:",
+    "  mikuscore convert --from abc --to musicxml [--in <file>|-] [--out <file>|-] [--diagnostics text|json]",
+    "  mikuscore convert --from musicxml --to abc [--in <file>|-] [--out <file>|-] [--diagnostics text|json]",
+    "  mikuscore convert --help",
+    "",
+    "Description:",
+    "  Convert score text between supported formats.",
+    "",
+    "Supported pairs:",
+    "  --from abc --to musicxml",
+    "  --from musicxml --to abc",
+    "  --from midi --to musicxml",
+    "  --from musicxml --to midi",
+    "  --from musescore --to musicxml",
+    "  --from musicxml --to musescore",
+    "",
+    "Input:",
+    "  --in <file>|-  Read source text or bytes from file or stdin",
+    "  stdin          Used when --in is omitted",
+    "  file paths     musicxml accepts .musicxml / .xml / .mxl; musescore accepts .mscx / .mscz",
+    "",
+    "Output:",
+    "  --out <file>|-  Write converted text or bytes to file or stdout",
+    "  stdout          Used when --out is omitted",
+    "  file paths      --to musicxml writes .mxl when --out ends with .mxl; --to musescore writes .mscz when --out ends with .mscz",
+    "",
+    "Options:",
+    "  --from <format>          Source format",
+    "  --to <format>            Target format",
+    "  --diagnostics text|json  Select diagnostics format",
+    "  --help                   Show help",
+  ].join("\n"),
+  render: [
+    "Usage:",
+    "  mikuscore render svg [--from <format>] [--in <file>|-] [--out <file>|-] [--diagnostics text|json]",
+    "  mikuscore render --help",
+    "",
+    "Description:",
+    "  Render derived outputs from canonical MusicXML input or supported one-shot source formats.",
+    "",
+    "Available targets:",
+    "  svg",
+    "",
+    "Input:",
+    "  --from <format>  Source format for render input (default: musicxml)",
+    "  --in <file>|-    Read render input from file or stdin",
+    "  stdin            Used when --in is omitted",
+    "",
+    "Output:",
+    "  --out <file>|-  Write rendered output to file or stdout",
+    "  stdout          Used when --out is omitted",
+    "",
+    "Options:",
+    "  --from <format>          Source format",
+    "  --diagnostics text|json  Select diagnostics format",
+    "  --help                   Show help",
+  ].join("\n"),
+  state: [
+    "Usage:",
+    "  mikuscore state summarize [--in <file>|-] [--diagnostics text|json]",
+    "  mikuscore state inspect-measure --measure <number> [--in <file>|-] [--diagnostics text|json]",
+    "  mikuscore state validate-command [--in <file>|-] [--command <json>|--command-file <file>|-] [--diagnostics text|json]",
+    "  mikuscore state apply-command [--in <file>|-] [--command <json>|--command-file <file>|-] [--out <file>|-] [--diagnostics text|json]",
+    "  mikuscore state diff --before <file> --after <file> [--diagnostics text|json]",
+    "  mikuscore state --help",
+    "",
+    "Description:",
+    "  Inspect canonical MusicXML state.",
+    "",
+    "Available commands:",
+    "  summarize   Emit a compact JSON summary of canonical MusicXML state",
+    "  inspect-measure   Emit a compact JSON view of one measure for edit targeting",
+    "  validate-command   Validate one bounded command against canonical MusicXML state",
+    "  apply-command   Apply one bounded command and emit the next canonical MusicXML state",
+    "  diff   Emit a compact JSON summary of differences between two canonical MusicXML states",
+    "",
+    "Options:",
+    "  --diagnostics text|json  Select diagnostics format",
+    "  --help                   Show help",
+  ].join("\n"),
+};
 
-Commands:
-  convert   Convert score text between supported formats
-  render    Render derived outputs such as SVG
+class CliUsageError extends Error {
+  constructor(message, code = "usage_error", details = undefined) {
+    super(message);
+    this.name = "CliUsageError";
+    this.code = code;
+    this.details = details;
+  }
+}
 
-Options:
-  --from <format>  Source format
-  --to <format>    Target format
-  --in <file>   Read input from file instead of stdin
-  --out <file>  Write output to file instead of stdout
-  --help        Show help
-`;
-
-const CONVERT_HELP = `Usage:
-  mikuscore convert --from abc --to musicxml [--in <file>] [--out <file>]
-  mikuscore convert --from musicxml --to abc [--in <file>] [--out <file>]
-  mikuscore convert --help
-
-Description:
-  Convert score text between supported formats.
-
-Supported pairs:
-  --from abc --to musicxml
-  --from musicxml --to abc
-  --from midi --to musicxml
-  --from musicxml --to midi
-  --from musescore --to musicxml
-  --from musicxml --to musescore
-
-Input:
-  --in <file>  Read source text from file
-  stdin        Used when --in is omitted
-  file paths    musicxml accepts .musicxml / .xml / .mxl; musescore accepts .mscx / .mscz
-
-Output:
-  --out <file>  Write converted text to file
-  stdout        Used when --out is omitted
-  file paths    --to musicxml writes .mxl when --out ends with .mxl; --to musescore writes .mscz when --out ends with .mscz
-
-Options:
-  --from <format>  Source format
-  --to <format>    Target format
-  --help        Show help
-`;
-
-const RENDER_HELP = `Usage:
-  mikuscore render svg [--in <file>] [--out <file>]
-  mikuscore render --help
-
-Description:
-  Render derived outputs from canonical MusicXML input.
-
-Available targets:
-  svg
-
-Input:
-  --in <file>  Read MusicXML text from file
-  stdin        Used when --in is omitted
-
-Output:
-  --out <file>  Write rendered output to file
-  stdout        Used when --out is omitted
-
-Options:
-  --help        Show help
-`;
+class CliProcessingError extends Error {
+  constructor(message, code = "processing_error", details = undefined) {
+    super(message);
+    this.name = "CliProcessingError";
+    this.code = code;
+    this.details = details;
+  }
+}
 
 class CliCommandFailure extends Error {
   constructor(result, fallbackMessage) {
     super(result.diagnostics[0] || fallbackMessage);
+    this.name = "CliCommandFailure";
     this.result = result;
   }
 }
 
 main().catch((error) => {
-  if (error instanceof CliCommandFailure) {
+  const rawArgv = process.argv.slice(2);
+  const diagnosticsFormat = detectRequestedDiagnosticsFormat(rawArgv);
+  const exitCode = error instanceof CliUsageError ? 2 : 1;
+  if (diagnosticsFormat === "json") {
+    process.stderr.write(`${JSON.stringify(buildErrorDiagnostics(rawArgv, error, exitCode), null, 2)}\n`);
+  } else if (error instanceof CliCommandFailure) {
     writeMessages(process.stderr, error.result.warnings, error.result.diagnostics);
     if (!error.result.diagnostics.length && error.message) {
       process.stderr.write(`${error.message}\n`);
     }
-    process.exitCode = 1;
-    return;
+  } else {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
   }
-  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
-  process.exitCode = 1;
+  process.exit(exitCode);
 });
 
 async function main() {
   const { command, options } = parseArgs(process.argv.slice(2));
 
   if (command.length === 0 || (options.help && !options.helpCommand)) {
-    process.stdout.write(TOP_LEVEL_HELP);
+    writeHelp(process.stdout, "top");
     return;
   }
 
   if (isCommand(command, ["convert"]) && options.helpCommand) {
-    process.stdout.write(CONVERT_HELP);
+    writeHelp(process.stdout, "convert");
     return;
   }
 
   if (isCommand(command, ["render"]) && options.helpCommand) {
-    process.stdout.write(RENDER_HELP);
+    writeHelp(process.stdout, "render");
+    return;
+  }
+
+  if (isCommand(command, ["state"]) && options.helpCommand) {
+    writeHelp(process.stdout, "state");
     return;
   }
 
   const loaded = loadCliApi({ rootDir: repoRoot });
   try {
     const result = await runCommand(command, options, loaded.api);
-    writeMessages(process.stderr, result.warnings, result.diagnostics);
+    writeDiagnostics(process.stderr, buildSuccessDiagnostics(command, options, result), options.diagnostics);
     writeOutput(result.output, options.out);
   } finally {
     loaded.dispose();
@@ -153,9 +220,24 @@ function parseArgs(argv) {
       continue;
     }
 
+    if (key === "diagnostics") {
+      const diagnosticsValue = argv[index + 1];
+      if (!diagnosticsValue || diagnosticsValue.startsWith("--")) {
+        throw new CliUsageError(`Option ${token} requires a value.`, "missing_option_value", { option: token });
+      }
+      if (diagnosticsValue !== "text" && diagnosticsValue !== "json") {
+        throw new CliUsageError("--diagnostics must be either text or json.", "invalid_diagnostics_option", {
+          option: "--diagnostics",
+        });
+      }
+      options.diagnostics = diagnosticsValue;
+      index += 1;
+      continue;
+    }
+
     const value = argv[index + 1];
     if (value === undefined || value.startsWith("--")) {
-      throw new Error(`Option ${token} requires a value.`);
+      throw new CliUsageError(`Option ${token} requires a value.`, "missing_option_value", { option: token });
     }
     options[key] = value;
     index += 1;
@@ -178,7 +260,7 @@ async function runCommand(command, options, api) {
     const to = String(options.to || "").trim().toLowerCase();
 
     if (!from || !to) {
-      throw new Error("convert requires both --from <format> and --to <format>.");
+      throw new CliUsageError("convert requires both --from <format> and --to <format>.", "missing_from_to");
     }
 
     if (from === "abc" && to === "musicxml") {
@@ -254,10 +336,38 @@ async function runCommand(command, options, api) {
       return options.out ? await encodeOutputForTarget(result, options.out, api, to) : result;
     }
 
-    throw new Error(`Unsupported conversion pair: --from ${from} --to ${to}`);
+    throw new CliUsageError(`Unsupported conversion pair: --from ${from} --to ${to}`, "unsupported_conversion_pair", {
+      from,
+      to,
+    });
   }
 
   if (isCommand(command, ["render", "svg"])) {
+    const from = String(options.from || "musicxml").trim().toLowerCase();
+
+    if (from === "abc") {
+      const inputText = await readTextInput(options.in);
+      const imported = api.abc.importToMusicXml(inputText);
+      if (!imported.ok || typeof imported.output !== "string") {
+        throw new CliCommandFailure(imported, "ABC to MusicXML conversion failed.");
+      }
+      const rendered = await api.render.svgFromMusicXml(imported.output);
+      if (!rendered.ok) {
+        throw new CliCommandFailure(rendered, "SVG render failed.");
+      }
+      return {
+        ...rendered,
+        warnings: [...imported.warnings, ...rendered.warnings],
+        diagnostics: [...imported.diagnostics, ...rendered.diagnostics],
+      };
+    }
+
+    if (from !== "musicxml") {
+      throw new CliUsageError(`Unsupported render source: --from ${from}`, "unsupported_render_source", {
+        from,
+      });
+    }
+
     const inputBytes = await readBinaryInput(options.in);
     const decoded = await api.fileIO.musicxml.decodeInput(inputBytes, options.in);
     if (!decoded.ok || typeof decoded.output !== "string") {
@@ -271,7 +381,86 @@ async function runCommand(command, options, api) {
     return result;
   }
 
-  throw new Error(`Unsupported command: ${command.join(" ")}`);
+  if (isCommand(command, ["state", "summarize"])) {
+    const inputBytes = await readBinaryInput(options.in);
+    const decoded = await api.fileIO.musicxml.decodeInput(inputBytes, options.in);
+    if (!decoded.ok || typeof decoded.output !== "string") {
+      throw new CliCommandFailure(decoded, "Failed to read MusicXML input.");
+    }
+    const result = api.state.summarizeFromMusicXml(decoded.output);
+    if (!result.ok) {
+      throw new CliCommandFailure(result, "Failed to summarize MusicXML state.");
+    }
+    return result;
+  }
+
+  if (isCommand(command, ["state", "inspect-measure"])) {
+    const measure = String(options.measure || "").trim();
+    if (!measure) {
+      throw new CliUsageError("state inspect-measure requires --measure <number>.", "missing_measure_option");
+    }
+    const inputBytes = await readBinaryInput(options.in);
+    const decoded = await api.fileIO.musicxml.decodeInput(inputBytes, options.in);
+    if (!decoded.ok || typeof decoded.output !== "string") {
+      throw new CliCommandFailure(decoded, "Failed to read MusicXML input.");
+    }
+    const result = api.state.inspectMeasureFromMusicXml(decoded.output, measure);
+    if (!result.ok) {
+      throw new CliCommandFailure(result, "Failed to inspect MusicXML measure.");
+    }
+    return result;
+  }
+
+  if (isCommand(command, ["state", "validate-command"])) {
+    const inputBytes = await readBinaryInput(options.in);
+    const decoded = await api.fileIO.musicxml.decodeInput(inputBytes, options.in);
+    if (!decoded.ok || typeof decoded.output !== "string") {
+      throw new CliCommandFailure(decoded, "Failed to read MusicXML input.");
+    }
+    const commandPayload = await readCommandPayload(options);
+    const result = api.state.validateCommandFromMusicXml(decoded.output, commandPayload);
+    if (!result.ok) {
+      throw new CliCommandFailure(result, "Failed to validate MusicXML command.");
+    }
+    return result;
+  }
+
+  if (isCommand(command, ["state", "apply-command"])) {
+    const inputBytes = await readBinaryInput(options.in);
+    const decoded = await api.fileIO.musicxml.decodeInput(inputBytes, options.in);
+    if (!decoded.ok || typeof decoded.output !== "string") {
+      throw new CliCommandFailure(decoded, "Failed to read MusicXML input.");
+    }
+    const commandPayload = await readCommandPayload(options);
+    const result = api.state.applyCommandFromMusicXml(decoded.output, commandPayload);
+    if (!result.ok) {
+      throw new CliCommandFailure(result, "Failed to apply MusicXML command.");
+    }
+    return result;
+  }
+
+  if (isCommand(command, ["state", "diff"])) {
+    if (!options.before || !options.after) {
+      throw new CliUsageError("state diff requires both --before <file> and --after <file>.", "missing_diff_inputs");
+    }
+    const beforeBytes = await readBinaryInput(options.before);
+    const afterBytes = await readBinaryInput(options.after);
+    const beforeDecoded = await api.fileIO.musicxml.decodeInput(beforeBytes, options.before);
+    const afterDecoded = await api.fileIO.musicxml.decodeInput(afterBytes, options.after);
+    if (!beforeDecoded.ok || typeof beforeDecoded.output !== "string") {
+      throw new CliCommandFailure(beforeDecoded, "Failed to read before MusicXML input.");
+    }
+    if (!afterDecoded.ok || typeof afterDecoded.output !== "string") {
+      throw new CliCommandFailure(afterDecoded, "Failed to read after MusicXML input.");
+    }
+    const result = api.state.diffMusicXmlState(beforeDecoded.output, afterDecoded.output);
+    if (!result.ok) {
+      throw new CliCommandFailure(result, "Failed to diff MusicXML state.");
+    }
+    return result;
+  }
+
+  throw new CliUsageError(`Unsupported command: ${command.join(" ")}`, "unsupported_command");
 }
 
 async function encodeOutputForTarget(result, outPath, api, to) {
@@ -291,7 +480,7 @@ async function readTextInput(inputPath) {
 }
 
 async function readBinaryInput(inputPath) {
-  if (inputPath) {
+  if (inputPath && inputPath !== "-") {
     return fs.readFileSync(path.resolve(inputPath));
   }
 
@@ -300,7 +489,7 @@ async function readBinaryInput(inputPath) {
     chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
   }
   if (chunks.length === 0) {
-    throw new Error("Input is required. Use --in <file> or pipe text via stdin.");
+    throw new CliUsageError("Input is required. Use --in <file> or pipe text via stdin.", "missing_input");
   }
   return Buffer.concat(chunks);
 }
@@ -314,11 +503,150 @@ function writeMessages(stream, warnings = [], diagnostics = []) {
   }
 }
 
+function writeDiagnostics(stream, diagnostics, diagnosticsFormat = "text") {
+  if (diagnosticsFormat === "json") {
+    stream.write(`${JSON.stringify(diagnostics, null, 2)}\n`);
+    return;
+  }
+  writeMessages(stream, diagnostics.warnings, diagnostics.errors);
+}
+
 function writeOutput(output, outPath) {
   const payload = typeof output === "string" ? output : Buffer.from(output);
-  if (outPath) {
+  if (outPath && outPath !== "-") {
     fs.writeFileSync(path.resolve(outPath), payload);
     return;
   }
   process.stdout.write(payload);
+}
+
+async function readCommandPayload(options) {
+  const hasInline = typeof options.command === "string";
+  const hasFile = typeof options["command-file"] === "string";
+  if (hasInline === hasFile) {
+    throw new CliUsageError(
+      "state validate-command requires exactly one of --command <json> or --command-file <file>.",
+      "missing_command_payload"
+    );
+  }
+
+  const jsonText = hasInline ? options.command : await readTextInput(options["command-file"]);
+  try {
+    return JSON.parse(jsonText);
+  } catch (error) {
+    throw new CliUsageError(
+      `Command payload must be valid JSON: ${error instanceof Error ? error.message : String(error)}`,
+      "invalid_command_json"
+    );
+  }
+}
+
+function writeHelp(stream, topic) {
+  stream.write(`${HELP_TEXT[topic]}\n`);
+}
+
+function detectRequestedDiagnosticsFormat(argv) {
+  for (let index = 0; index < argv.length; index += 1) {
+    if (argv[index] === "--diagnostics" && argv[index + 1] === "json") {
+      return "json";
+    }
+  }
+  return "text";
+}
+
+function buildSuccessDiagnostics(command, options, result) {
+  const warnings = Array.isArray(result.warnings) ? result.warnings : [];
+  const errors = Array.isArray(result.diagnostics) ? result.diagnostics : [];
+  const status = errors.length > 0 ? "error" : warnings.length > 0 ? "warning" : "success";
+  return {
+    ok: result.ok && errors.length === 0,
+    diagnostics_version: DIAGNOSTICS_VERSION,
+    command: command.join(" "),
+    context: command.join(" "),
+    status,
+    exit_code: status === "error" ? 1 : 0,
+    warning_count: warnings.length,
+    error_count: errors.length,
+    io: buildIoDiagnostics(options),
+    warnings,
+    errors,
+  };
+}
+
+function buildErrorDiagnostics(argv, error, exitCode) {
+  const command = summarizeCommandFromArgv(argv);
+  const message = error instanceof Error ? error.message : String(error);
+  return {
+    ok: false,
+    diagnostics_version: DIAGNOSTICS_VERSION,
+    command,
+    context: command,
+    status: "error",
+    exit_code: exitCode,
+    warning_count: 0,
+    error_count: 1,
+    io: buildIoDiagnosticsFromArgv(argv),
+    error_type: error instanceof CliUsageError ? "usage_error" : "processing_error",
+    error_code: typeof error?.code === "string" ? error.code : "processing_error",
+    error_details: error?.details,
+    warnings: [],
+    errors: [message],
+  };
+}
+
+function summarizeCommandFromArgv(argv) {
+  const command = [];
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (!token.startsWith("--")) {
+      command.push(token);
+      continue;
+    }
+    if (token !== "--help") {
+      index += 1;
+    }
+  }
+  return command.join(" ") || "cli";
+}
+
+function buildIoDiagnostics(options) {
+  return {
+    inputs: buildInputListFromOptions(options),
+    output: buildOutputFromValue(options.out),
+  };
+}
+
+function buildIoDiagnosticsFromArgv(argv) {
+  const options = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (!token.startsWith("--")) continue;
+    const key = token.slice(2);
+    if (key === "help") continue;
+    options[key] = argv[index + 1];
+    index += 1;
+  }
+  return buildIoDiagnostics(options);
+}
+
+function buildInputListFromOptions(options) {
+  const inputs = [];
+  if ("in" in options) {
+    inputs.push(buildInputDescriptor("--in", options.in));
+  }
+  return inputs.length > 0 ? inputs : [{ option: "--in", mode: "stdin" }];
+}
+
+function buildInputDescriptor(option, value) {
+  if (value === "-" || value === undefined) {
+    return { option, mode: "stdin" };
+  }
+  return { option, mode: "file", path: value };
+}
+
+function buildOutputFromValue(value) {
+  if (value === "-" || value === undefined) {
+    return { mode: "stdout" };
+  }
+  return { mode: "file", path: value };
 }

--- a/src/ts/cli-api.ts
+++ b/src/ts/cli-api.ts
@@ -26,6 +26,9 @@ import {
   makeMsczBytes,
   makeMxlBytes,
 } from "./zip-io";
+import { ScoreCore } from "../../core/ScoreCore";
+import type { CoreCommand } from "../../core/interfaces";
+import { getDurationValue, getVoiceText, parseXml as parseCoreXml, reindexNodeIds } from "../../core/xmlUtils";
 
 export type CliResult =
   | {
@@ -324,6 +327,272 @@ export const renderMusicXmlToSvg = async (xmlText: string): Promise<CliResult> =
   }
 };
 
+export const summarizeMusicXmlState = (xmlText: string): CliResult => {
+  const doc = parseMusicXmlDocument(xmlText);
+  if (!doc) {
+    return {
+      ok: false,
+      warnings: [],
+      diagnostics: ["Failed to parse MusicXML: input is not a valid MusicXML document."],
+    };
+  }
+
+  try {
+    const parts = Array.from(doc.querySelectorAll("score-partwise > part"));
+    const measures = Array.from(doc.querySelectorAll("score-partwise > part > measure"));
+    const measureNumbers = Array.from(
+      new Set(
+        measures
+          .map((measure) => measure.getAttribute("number")?.trim() ?? "")
+          .filter((value) => value.length > 0)
+      )
+    );
+    const voices = Array.from(
+      new Set(
+        Array.from(doc.querySelectorAll("score-partwise > part > measure > note > voice"))
+          .map((voice) => voice.textContent?.trim() ?? "")
+          .filter((value) => value.length > 0)
+      )
+    );
+    const summary = {
+      kind: "musicxml_state_summary",
+      title:
+        doc.querySelector("score-partwise > work > work-title")?.textContent?.trim() ??
+        doc.querySelector("score-partwise > movement-title")?.textContent?.trim() ??
+        null,
+      part_count: parts.length,
+      measure_count: measures.length,
+      measure_numbers: measureNumbers,
+      voices,
+    };
+    return {
+      ok: true,
+      output: `${JSON.stringify(summary, null, 2)}\n`,
+      warnings: [],
+      diagnostics: [],
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      warnings: [],
+      diagnostics: [`Failed to summarize MusicXML state: ${error instanceof Error ? error.message : String(error)}`],
+    };
+  }
+};
+
+export const validateMusicXmlCommand = (xmlText: string, command: CoreCommand): CliResult => {
+  try {
+    const core = new ScoreCore();
+    core.load(xmlText);
+    const result = core.dispatch(command);
+    return {
+      ok: true,
+      output: `${JSON.stringify(
+        {
+          kind: "musicxml_command_validation",
+          ok: result.ok,
+          dirty_changed: result.dirtyChanged,
+          changed_node_ids: result.changedNodeIds,
+          affected_measure_numbers: result.affectedMeasureNumbers,
+          warnings: result.warnings,
+          diagnostics: result.diagnostics,
+        },
+        null,
+        2
+      )}\n`,
+      warnings: [],
+      diagnostics: [],
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      warnings: [],
+      diagnostics: [`Failed to validate MusicXML command: ${error instanceof Error ? error.message : String(error)}`],
+    };
+  }
+};
+
+export const applyMusicXmlCommand = (xmlText: string, command: CoreCommand): CliResult => {
+  try {
+    const core = new ScoreCore();
+    core.load(xmlText);
+    const result = core.dispatch(command);
+    if (!result.ok) {
+      return {
+        ok: true,
+        output: `${JSON.stringify(
+          {
+            kind: "musicxml_command_apply",
+            ok: false,
+            changed_node_ids: result.changedNodeIds,
+            affected_measure_numbers: result.affectedMeasureNumbers,
+            warnings: result.warnings,
+            diagnostics: result.diagnostics,
+          },
+          null,
+          2
+        )}\n`,
+        warnings: [],
+        diagnostics: [],
+      };
+    }
+
+    const saved = core.save();
+    if (!saved.ok) {
+      return {
+        ok: false,
+        warnings: [],
+        diagnostics: saved.diagnostics.map((item) => item.message),
+      };
+    }
+
+    return {
+      ok: true,
+      output: saved.xml,
+      warnings: result.warnings.map((item) => item.message),
+      diagnostics: [],
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      warnings: [],
+      diagnostics: [`Failed to apply MusicXML command: ${error instanceof Error ? error.message : String(error)}`],
+    };
+  }
+};
+
+export const inspectMusicXmlMeasure = (xmlText: string, measureNumber: string): CliResult => {
+  try {
+    const doc = parseCoreXml(xmlText);
+    const nodeToId = new WeakMap();
+    const idToNode = new Map();
+    let sequence = 0;
+    reindexNodeIds(doc, nodeToId, idToNode, () => {
+      sequence += 1;
+      return `n${sequence}`;
+    });
+
+    const measures = Array.from(doc.querySelectorAll("score-partwise > part > measure"))
+      .filter((measure) => (measure.getAttribute("number")?.trim() ?? "") === measureNumber);
+
+    const summary = {
+      kind: "musicxml_measure_inspection",
+      measure_number: measureNumber,
+      measures: measures.map((measure) => {
+        const part = measure.parentElement;
+        const partId = part?.getAttribute("id")?.trim() ?? null;
+        const voiceNoteCounts = new Map<string, number>();
+        const notes = Array.from(measure.querySelectorAll(":scope > note")).map((note, noteIndex) => {
+          const nodeId = nodeToId.get(note) ?? null;
+          const voice = getVoiceText(note);
+          const step = note.querySelector(":scope > pitch > step")?.textContent?.trim() ?? null;
+          const octaveText = note.querySelector(":scope > pitch > octave")?.textContent?.trim() ?? null;
+          const alterText = note.querySelector(":scope > pitch > alter")?.textContent?.trim() ?? null;
+          const alter = alterText === null ? null : Number(alterText);
+          const voiceKey = voice ?? "__none__";
+          const nextVoiceNoteIndex = (voiceNoteCounts.get(voiceKey) ?? 0) + 1;
+          voiceNoteCounts.set(voiceKey, nextVoiceNoteIndex);
+          return {
+            node_id: nodeId,
+            selector: {
+              part_id: partId,
+              measure_number: measureNumber,
+              measure_note_index: noteIndex + 1,
+              voice,
+              voice_note_index: nextVoiceNoteIndex,
+            },
+            voice,
+            duration: getDurationValue(note),
+            is_rest: note.querySelector(":scope > rest") !== null,
+            pitch: step && octaveText
+              ? {
+                step,
+                alter: Number.isFinite(alter) ? alter : null,
+                octave: Number(octaveText),
+              }
+              : null,
+          };
+        });
+        return {
+          part_id: partId,
+          note_count: notes.length,
+          notes,
+        };
+      }),
+    };
+
+    return {
+      ok: true,
+      output: `${JSON.stringify(summary, null, 2)}\n`,
+      warnings: [],
+      diagnostics: [],
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      warnings: [],
+      diagnostics: [`Failed to inspect MusicXML measure: ${error instanceof Error ? error.message : String(error)}`],
+    };
+  }
+};
+
+const buildMusicXmlStateSummaryObject = (doc: Document) => {
+  const parts = Array.from(doc.querySelectorAll("score-partwise > part"));
+  const measures = Array.from(doc.querySelectorAll("score-partwise > part > measure"));
+  const notes = Array.from(doc.querySelectorAll("score-partwise > part > measure > note"));
+  return {
+    title:
+      doc.querySelector("score-partwise > work > work-title")?.textContent?.trim() ??
+      doc.querySelector("score-partwise > movement-title")?.textContent?.trim() ??
+      null,
+    part_count: parts.length,
+    measure_count: measures.length,
+    note_count: notes.length,
+    measure_numbers: Array.from(
+      new Set(
+        measures
+          .map((measure) => measure.getAttribute("number")?.trim() ?? "")
+          .filter((value) => value.length > 0)
+      )
+    ),
+  };
+};
+
+export const diffMusicXmlState = (beforeXml: string, afterXml: string): CliResult => {
+  try {
+    const beforeDoc = parseCoreXml(beforeXml);
+    const afterDoc = parseCoreXml(afterXml);
+    const beforeSummary = buildMusicXmlStateSummaryObject(beforeDoc);
+    const afterSummary = buildMusicXmlStateSummaryObject(afterDoc);
+
+    const changedFields = Object.keys(beforeSummary).filter((key) => {
+      return JSON.stringify(beforeSummary[key as keyof typeof beforeSummary]) !==
+        JSON.stringify(afterSummary[key as keyof typeof afterSummary]);
+    });
+
+    const diff = {
+      kind: "musicxml_state_diff",
+      changed: changedFields.length > 0,
+      changed_fields: changedFields,
+      before: beforeSummary,
+      after: afterSummary,
+    };
+
+    return {
+      ok: true,
+      output: `${JSON.stringify(diff, null, 2)}\n`,
+      warnings: [],
+      diagnostics: [],
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      warnings: [],
+      diagnostics: [`Failed to diff MusicXML state: ${error instanceof Error ? error.message : String(error)}`],
+    };
+  }
+};
+
 export const cliApi = {
   abc: {
     importToMusicXml: importAbcToMusicXml,
@@ -349,5 +618,12 @@ export const cliApi = {
   },
   render: {
     svgFromMusicXml: renderMusicXmlToSvg,
+  },
+  state: {
+    summarizeFromMusicXml: summarizeMusicXmlState,
+    inspectMeasureFromMusicXml: inspectMusicXmlMeasure,
+    validateCommandFromMusicXml: validateMusicXmlCommand,
+    applyCommandFromMusicXml: applyMusicXmlCommand,
+    diffMusicXmlState,
   },
 };

--- a/tests/unit/mikuscore-cli.spec.ts
+++ b/tests/unit/mikuscore-cli.spec.ts
@@ -30,12 +30,14 @@ describe("mikuscore cli", () => {
     const topLevel = runCli(["--help"]);
     const convertHelp = runCli(["convert", "--help"]);
     const renderHelp = runCli(["render", "--help"]);
+    const stateHelp = runCli(["state", "--help"]);
 
     expect(topLevel.status).toBe(0);
     expect(topLevel.stdout).toContain("mikuscore convert --from abc --to musicxml");
     expect(topLevel.stdout).toContain("mikuscore convert --from midi --to musicxml");
     expect(topLevel.stdout).toContain("mikuscore convert --from musescore --to musicxml");
     expect(topLevel.stdout).toContain("mikuscore render svg");
+    expect(topLevel.stdout).toContain("mikuscore state summarize");
     expect(topLevel.stderr).toBe("");
 
     expect(convertHelp.status).toBe(0);
@@ -43,8 +45,18 @@ describe("mikuscore cli", () => {
     expect(convertHelp.stderr).toBe("");
 
     expect(renderHelp.status).toBe(0);
-    expect(renderHelp.stdout).toContain("Render derived outputs from canonical MusicXML input");
+    expect(renderHelp.stdout).toContain("supported one-shot source formats");
+    expect(renderHelp.stdout).toContain("--from <format>");
     expect(renderHelp.stderr).toBe("");
+
+    expect(stateHelp.status).toBe(0);
+    expect(stateHelp.stdout).toContain("Inspect canonical MusicXML state");
+    expect(stateHelp.stdout).toContain("summarize");
+    expect(stateHelp.stdout).toContain("inspect-measure");
+    expect(stateHelp.stdout).toContain("validate-command");
+    expect(stateHelp.stdout).toContain("apply-command");
+    expect(stateHelp.stdout).toContain("diff");
+    expect(stateHelp.stderr).toBe("");
   }, 10000);
 
   it("converts stdin to stdout for a supported pair", () => {
@@ -65,6 +77,15 @@ describe("mikuscore cli", () => {
     expect(result.status).toBe(0);
     expect(result.stdout).toBe("");
     expect(readFileSync(outPath, "utf8")).toContain("<score-partwise");
+  });
+
+  it("treats --out - as explicit stdout", () => {
+    const inputPath = writeTempFile("score.abc", "X:1\nT:Stdout dash\nM:4/4\nL:1/4\nK:C\nC D E F|\n");
+
+    const result = runCli(["convert", "--from", "abc", "--to", "musicxml", "--in", inputPath, "--out", "-"]);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("<work-title>Stdout dash</work-title>");
   });
 
   it("reads .mxl input files for musicxml source", () => {
@@ -123,6 +144,147 @@ describe("mikuscore cli", () => {
     expect(result.stdout).toContain("<svg");
   });
 
+  it("renders SVG directly from ABC input", () => {
+    const inputPath = writeTempFile("score.abc", "X:1\nT:Render ABC\nM:4/4\nL:1/4\nK:C\nC D E F|\n");
+
+    const result = runCli(["render", "svg", "--from", "abc", "--in", inputPath]);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("<svg");
+  });
+
+  it("summarizes canonical MusicXML state", () => {
+    const result = runCli(["state", "summarize"], {
+      input: validMusicXml("State summary"),
+    });
+
+    expect(result.status).toBe(0);
+    const summary = JSON.parse(result.stdout);
+    expect(summary.kind).toBe("musicxml_state_summary");
+    expect(summary.title).toBe("State summary");
+    expect(summary.part_count).toBe(1);
+    expect(summary.measure_count).toBe(1);
+    expect(summary.measure_numbers).toEqual(["1"]);
+    expect(summary.voices).toEqual([]);
+  });
+
+  it("validates one bounded MusicXML command", () => {
+    const result = runCli(
+      [
+        "state",
+        "validate-command",
+        "--command",
+        JSON.stringify({
+          type: "change_to_pitch",
+          targetNodeId: "n1",
+          voice: "1",
+          pitch: { step: "G", octave: 4 },
+        }),
+      ],
+      {
+        input: validEditableMusicXml("Validate command"),
+      }
+    );
+
+    expect(result.status).toBe(0);
+    const validation = JSON.parse(result.stdout);
+    expect(validation.kind).toBe("musicxml_command_validation");
+    expect(validation.ok).toBe(true);
+    expect(validation.changed_node_ids).toEqual(["n1"]);
+    expect(validation.affected_measure_numbers).toEqual(["1"]);
+  });
+
+  it("inspects one measure for edit targeting", () => {
+    const result = runCli(["state", "inspect-measure", "--measure", "1"], {
+      input: validEditableMusicXml("Inspect measure"),
+    });
+
+    expect(result.status).toBe(0);
+    const inspected = JSON.parse(result.stdout);
+    expect(inspected.kind).toBe("musicxml_measure_inspection");
+    expect(inspected.measure_number).toBe("1");
+    expect(inspected.measures).toHaveLength(1);
+    expect(inspected.measures[0].part_id).toBe("P1");
+    expect(inspected.measures[0].note_count).toBe(4);
+    expect(inspected.measures[0].notes[0].node_id).toBe("n1");
+    expect(inspected.measures[0].notes[0].selector).toEqual({
+      part_id: "P1",
+      measure_number: "1",
+      measure_note_index: 1,
+      voice: "1",
+      voice_note_index: 1,
+    });
+    expect(inspected.measures[0].notes[0].pitch.step).toBe("C");
+  });
+
+  it("applies one bounded MusicXML command", () => {
+    const result = runCli(
+      [
+        "state",
+        "apply-command",
+        "--command",
+        JSON.stringify({
+          type: "change_to_pitch",
+          targetNodeId: "n1",
+          voice: "1",
+          pitch: { step: "G", octave: 4 },
+        }),
+      ],
+      {
+        input: validEditableMusicXml("Apply command"),
+      }
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("<step>G</step>");
+    expect(result.stdout).toContain("<octave>4</octave>");
+  });
+
+  it("diffs two canonical MusicXML states", () => {
+    const beforePath = writeTempFile("before.musicxml", validEditableMusicXml("Before title"));
+    const afterPath = writeTempFile("after.musicxml", validEditableMusicXml("After title").replace("<step>C</step>", "<step>G</step>"));
+
+    const result = runCli(["state", "diff", "--before", beforePath, "--after", afterPath]);
+
+    expect(result.status).toBe(0);
+    const diff = JSON.parse(result.stdout);
+    expect(diff.kind).toBe("musicxml_state_diff");
+    expect(diff.changed).toBe(true);
+    expect(diff.changed_fields).toContain("title");
+    expect(diff.before.title).toBe("Before title");
+    expect(diff.after.title).toBe("After title");
+  });
+
+  it("writes structured diagnostics as json when requested", () => {
+    const result = runCli(["render", "svg", "--diagnostics", "json"], {
+      input: validMusicXml("SVG diagnostics"),
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("<svg");
+    const diagnostics = JSON.parse(result.stderr);
+    expect(diagnostics.ok).toBe(true);
+    expect(diagnostics.diagnostics_version).toBe(1);
+    expect(diagnostics.command).toBe("render svg");
+    expect(diagnostics.status).toBe("success");
+    expect(diagnostics.exit_code).toBe(0);
+    expect(diagnostics.output?.mode).toBeUndefined();
+    expect(diagnostics.io.output).toEqual({ mode: "stdout" });
+  });
+
+  it("writes structured usage diagnostics for usage failures when requested", () => {
+    const result = runCli(["convert", "--from", "abc", "--diagnostics", "json"], {
+      input: "X:1\nT:Bad\nM:4/4\nL:1/4\nK:C\nC D E F|\n",
+    });
+
+    expect(result.status).toBe(2);
+    const diagnostics = JSON.parse(result.stderr);
+    expect(diagnostics.ok).toBe(false);
+    expect(diagnostics.error_type).toBe("usage_error");
+    expect(diagnostics.error_code).toBe("missing_from_to");
+    expect(diagnostics.exit_code).toBe(2);
+  });
+
   it("reports expected CLI failures", () => {
     const missingInput = runCli(["convert", "--from", "abc", "--to", "musicxml"]);
     const inputPath = writeTempFile("invalid.abc", "");
@@ -135,17 +297,35 @@ describe("mikuscore cli", () => {
     const missingFromTo = runCli(["convert", "--from", "abc"], {
       input: "X:1\nT:Bad\nM:4/4\nL:1/4\nK:C\nC D E F|\n",
     });
+    const unsupportedRenderSource = runCli(["render", "svg", "--from", "midi"], {
+      input: "unused",
+    });
+    const missingCommandPayload = runCli(["state", "validate-command"], {
+      input: validEditableMusicXml("Missing command"),
+    });
+    const missingMeasureOption = runCli(["state", "inspect-measure"], {
+      input: validEditableMusicXml("Missing measure"),
+    });
+    const missingDiffInputs = runCli(["state", "diff"]);
 
-    expect(missingInput.status).toBe(1);
+    expect(missingInput.status).toBe(2);
     expect(missingInput.stderr).toContain("Input is required");
     expect(invalidAbc.status).toBe(1);
     expect(invalidAbc.stderr).toContain("Failed to parse ABC");
     expect(invalidMusicXml.status).toBe(1);
     expect(invalidMusicXml.stderr).toContain("Failed to parse MusicXML");
-    expect(unsupportedPair.status).toBe(1);
+    expect(unsupportedPair.status).toBe(2);
     expect(unsupportedPair.stderr).toContain("Unsupported conversion pair");
-    expect(missingFromTo.status).toBe(1);
+    expect(missingFromTo.status).toBe(2);
     expect(missingFromTo.stderr).toContain("convert requires both --from <format> and --to <format>");
+    expect(unsupportedRenderSource.status).toBe(2);
+    expect(unsupportedRenderSource.stderr).toContain("Unsupported render source");
+    expect(missingCommandPayload.status).toBe(2);
+    expect(missingCommandPayload.stderr).toContain("requires exactly one of --command");
+    expect(missingMeasureOption.status).toBe(2);
+    expect(missingMeasureOption.stderr).toContain("requires --measure");
+    expect(missingDiffInputs.status).toBe(2);
+    expect(missingDiffInputs.stderr).toContain("requires both --before");
   }, 15000);
 });
 
@@ -198,6 +378,30 @@ function validMusicXml(title: string) {
    <note><pitch><step>D</step><octave>4</octave></pitch><duration>1</duration><type>quarter</type></note>
    <note><pitch><step>E</step><octave>4</octave></pitch><duration>1</duration><type>quarter</type></note>
    <note><pitch><step>F</step><octave>4</octave></pitch><duration>1</duration><type>quarter</type></note>
+  </measure>
+ </part>
+</score-partwise>`;
+}
+
+function validEditableMusicXml(title: string) {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+ <work><work-title>${title}</work-title></work>
+ <part-list>
+  <score-part id="P1"><part-name>Music</part-name></score-part>
+ </part-list>
+ <part id="P1">
+  <measure number="1">
+   <attributes>
+    <divisions>1</divisions>
+    <key><fifths>0</fifths></key>
+    <time><beats>4</beats><beat-type>4</beat-type></time>
+    <clef><sign>G</sign><line>2</line></clef>
+   </attributes>
+   <note><pitch><step>C</step><octave>4</octave></pitch><duration>1</duration><voice>1</voice><type>quarter</type></note>
+   <note><pitch><step>D</step><octave>4</octave></pitch><duration>1</duration><voice>1</voice><type>quarter</type></note>
+   <note><pitch><step>E</step><octave>4</octave></pitch><duration>1</duration><voice>1</voice><type>quarter</type></note>
+   <note><pitch><step>F</step><octave>4</octave></pitch><duration>1</duration><voice>1</voice><type>quarter</type></note>
   </measure>
  </part>
 </score-partwise>`;


### PR DESCRIPTION
## 概要

`mikuscore` の CLI を `convert` 中心の構成から、`convert` / `render` / `state` を意識した構成へ広げます。 あわせて、CLI の help・エラーハンドリング・diagnostics の基盤を整理し、`state` 系の初期コマンドを追加します。

## 変更内容

### CLI 基盤の改善

- help 出力を一元化
- `CliUsageError` / `CliProcessingError` を導入
- `--diagnostics text|json` を追加
- `--out -` を明示的な `stdout` として扱うよう変更
- usage error と processing error の扱いを分離
- JSON diagnostics の first cut を追加

### `render` の拡張

- `render svg` に `--from abc` を追加
- 外向きには one-shot な `ABC -> SVG` を提供しつつ、内部は `ABC -> MusicXML -> SVG` の流れを維持

### `state` 初期コマンドの追加

- `state summarize`
- `state inspect-measure`
- `state validate-command`
- `state apply-command`
- `state diff`

### CLI API の拡張

`src/ts/cli-api.ts` に以下を追加し、CLI から canonical `MusicXML` の inspection / validation / mutation / diff を扱えるようにしました。

- `summarizeMusicXmlState(...)`
- `inspectMusicXmlMeasure(...)`
- `validateMusicXmlCommand(...)`
- `applyMusicXmlCommand(...)`
- `diffMusicXmlState(...)`

### テスト更新

`tests/unit/mikuscore-cli.spec.ts` を拡張し、以下を含む CLI の振る舞いを検証対象に追加しました。

- top-level / command help
- `--out -`
- `--diagnostics json`
- `render svg --from abc`
- `state` 系各コマンド
- usage failure / unsupported input の扱い

### ドキュメント更新

README / development note / roadmap / future note / spec 群を更新し、今回の CLI 再構築方針と first cut を文書化しました。

追加した主な spec:

- `docs/spec/CLI_TAXONOMY_FIRSTCUT.md`
- `docs/spec/CLI_RENDER_FIRSTCUT.md`
- `docs/spec/CLI_STATE_FIRSTCUT.md`
- `docs/spec/CLI_DIAGNOSTICS_FIRSTCUT.md`
- `docs/spec/CLI_HELP_FIRSTCUT.md`
- `docs/spec/CLI_REBUILD_PLAN.md`

## 意図

- `MusicXML` canonical を維持したまま CLI の責務分離を明確にする
- 人間利用、Agent Skills、将来の生成 AI 連携を見据えた CLI 契約へ寄せる
- raw な JavaScript 例外露出を減らし、CLI としての failure UX を改善する
- 小さい編集機能を `state` 系の bounded mutation workflow として扱える土台を作る

## 補足

- `TODO.md` には、今回の CLI 再構築系列に関する TODO / future direction を追加しています
- patch envelope やより深い `state` workflow は今後の拡張対象です