### PR TITLE
CLI 再構築を前進し、`state` selector targeting と stage-aware diagnostics を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ Examples:
 - `npm run cli -- state apply-command --in score.musicxml --command-file command.json --out score.next.musicxml`
 - `npm run cli -- state diff --before score.before.musicxml --after score.after.musicxml`
 
+For `state validate-command` / `state apply-command`, command payloads may target notes either by `targetNodeId` / `anchorNodeId` or by `selector` / `anchor_selector` derived from `state inspect-measure`.
+
 For CLI and development details, see `docs/DEVELOPMENT.md` and `docs/spec/CLI_STEP1.md`.
 
 ## Screenshots

--- a/TODO.md
+++ b/TODO.md
@@ -91,7 +91,7 @@
   - Cover file input, `stdin`, `--out`, and representative failure cases.
   - Keep `stdout` for payload and `stderr` for diagnostics only.
 
-- [ ] Record a future-facing CLI design note for AI-mediated workflows.
+- [x] Record a future-facing CLI design note for AI-mediated workflows.
   - Motivation:
     - `mikuproject` shows that a CLI can be designed simultaneously for human operators, Agent Skills, and the downstream generative-AI interaction layer
     - the valuable lesson is not only "add AI commands", but "design the CLI contract so each layer can use it safely"
@@ -105,7 +105,7 @@
     - `docs/future/CLI_ROADMAP.md`
     - `docs/future/AI_JSON_INTERFACE.md`
 
-- [ ] Rebuild CLI taxonomy around `convert` / `render` / `state` while compatibility cost is still low.
+- [x] Rebuild CLI taxonomy around `convert` / `render` / `state` while compatibility cost is still low.
   - Rationale:
     - current real-world CLI usage appears low enough that command-surface reconstruction is still feasible
     - `mikuproject` suggests that clearer top-level responsibility split can scale well
@@ -123,7 +123,7 @@
     - define help-text shape for top-level `convert` / `render` / `state`
     - decide migration wording from the current `convert`-first CLI to the rebuilt taxonomy
 
-- [ ] Add a user-facing one-shot `ABC -> SVG` CLI flow without breaking the internal `MusicXML`-first pipeline.
+- [x] Add a user-facing one-shot `ABC -> SVG` CLI flow without breaking the internal `MusicXML`-first pipeline.
   - Intended shape:
     - external UX should allow a direct score-rendering path for ABC input
     - internal flow should still remain `ABC -> MusicXML -> SVG`
@@ -132,7 +132,7 @@
     - whether `render` should accept only selected non-MusicXML inputs or remain narrow
     - how diagnostics should describe both the conversion and render stages when one-shot mode is used
 
-- [ ] Improve CLI failure handling so uncaught runtime errors stop leaking as raw JavaScript failures.
+- [x] Improve CLI failure handling so uncaught runtime errors stop leaking as raw JavaScript failures.
   - Goal:
     - turn current unhandled exception behavior into stable CLI-facing usage/processing failures
   - First slices:
@@ -140,7 +140,7 @@
     - ensure stderr messages are human-readable by default
     - ensure `--diagnostics json` can still describe failure cases structurally
 
-- [ ] Define a first-cut CLI diagnostics contract modeled after the successful direction proven in `mikuproject`.
+- [x] Define a first-cut CLI diagnostics contract modeled after the successful direction proven in `mikuproject`.
   - Scope:
     - `convert`
     - `render`
@@ -151,7 +151,7 @@
     - define whether multi-stage commands such as one-shot `ABC -> SVG` should report stage summaries
     - decide how much "kept vs dropped" conversion information can be surfaced briefly without becoming noisy
 
-- [ ] Align future `state` CLI naming with the existing core command catalog instead of inventing a second edit model.
+- [x] Align future `state` CLI naming with the existing core command catalog instead of inventing a second edit model.
   - Preserve:
     - existing bounded core commands such as `change_to_pitch`, `change_duration`, `insert_note_after`, `delete_note`, and `split_note`
   - Prefer:
@@ -161,7 +161,7 @@
     - exposing each core command as its own top-level CLI verb
     - introducing a whole-measure rewrite contract when a bounded command contract is sufficient
 
-- [ ] Define the `state` first cut around canonical `MusicXML` inspection and bounded mutation.
+- [x] Define the `state` first cut around canonical `MusicXML` inspection and bounded mutation.
   - Candidate initial commands:
     - `state summarize`
     - `state inspect-measure`
@@ -173,7 +173,7 @@
     - what minimum inspect output is needed to support note-targeted edits reliably
     - whether tempo-level light edits should enter through the same bounded command path
 
-- [ ] Preserve "small edit" work as `MusicXML`-centered bounded mutation, not as a separate editing product line.
+- [x] Preserve "small edit" work as `MusicXML`-centered bounded mutation, not as a separate editing product line.
   - Scope:
     - pitch change
     - duration change
@@ -182,7 +182,7 @@
   - Editorial note:
     - treat "small edit feature", "`MusicXML`-centered light edit", and "diff-based edit" as the same theme seen from different layers
 
-- [ ] Explicitly keep some user suggestions out of near-term CLI scope.
+- [x] Explicitly keep some user suggestions out of near-term CLI scope.
   - Defer or omit for now:
     - batch conversion in CLI itself
     - lyrics/melody alignment diagnostics

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -70,6 +70,7 @@ Input/output contract:
 - `stdin` / `stdout` remain text-only for `musicxml` and `musescore`
 - `render svg` also accepts `--from abc` as a one-shot path while still routing internally through canonical `MusicXML`
 - `state` commands operate on canonical `MusicXML`
+- `state validate-command` / `state apply-command` accept command payloads that target notes either by `targetNodeId` / `anchorNodeId` or by `selector` / `anchor_selector`
 - `--diagnostics text|json` is available across current command families
 - plain-text CLI decode for `musicxml` / `musescore` is kept on UTF-8 `TextDecoder` rather than Node-only `Buffer`, so the same entrypoint can be runtime-compiled in isolated bundle environments
 - usage failures now use a distinct CLI error path from processing failures
@@ -96,6 +97,7 @@ Examples:
 - `npm run cli -- state validate-command --in score.musicxml --command-file command.json`
 - `npm run cli -- state apply-command --in score.musicxml --command-file command.json --out score.next.musicxml`
 - `npm run cli -- state diff --before score.before.musicxml --after score.after.musicxml`
+- `state inspect-measure` output can be fed back into `state validate-command` / `state apply-command` via `selector` / `anchor_selector` payload fields
 - `cat score.abc | npm run cli -- convert --from abc --to musicxml`
 
 Observed sibling-project direction:

--- a/docs/spec/CLI_DIAGNOSTICS_FIRSTCUT.md
+++ b/docs/spec/CLI_DIAGNOSTICS_FIRSTCUT.md
@@ -184,6 +184,10 @@ Candidate optional JSON extension fields:
 
 These are optional first-cut extensions, not yet required minimum fields.
 
+Current first-cut implementation note:
+
+- one-shot `render svg --from abc` now emits `stages` in JSON diagnostics so tool callers can see the internal `ABC -> MusicXML -> SVG` path without changing the primary artifact contract
+
 ## "Kept vs Dropped" Direction
 
 One important future diagnostics goal is to make `mikuscore` more trustworthy as a converter by making conversion loss easier to notice.

--- a/docs/spec/CLI_HELP_FIRSTCUT.md
+++ b/docs/spec/CLI_HELP_FIRSTCUT.md
@@ -129,6 +129,10 @@ Examples:
   mikuscore state validate-command --in score.musicxml --command-file command.json
   mikuscore state apply-command --in score.musicxml --command-file command.json --out score.next.musicxml
   mikuscore state diff --before score.before.musicxml --after score.after.musicxml
+
+Notes:
+  Command payloads may target notes either by targetNodeId/anchorNodeId
+  or by selector/anchor_selector values derived from state inspect-measure.
 ```
 
 ## Help Tone

--- a/docs/spec/CLI_STATE_FIRSTCUT.md
+++ b/docs/spec/CLI_STATE_FIRSTCUT.md
@@ -143,6 +143,7 @@ Behavior:
 - MUST NOT invent a separate whole-measure rewrite contract
 - MUST return success or failure with diagnostics
 - MUST keep mutation semantics aligned with `docs/spec/COMMAND_CATALOG.md`
+- current CLI implementation may also accept selector-style targeting hints and resolve them to bounded core node ids before dispatch
 
 Candidate command payloads include:
 
@@ -169,6 +170,7 @@ Behavior:
 - MUST emit the next canonical `MusicXML` state on success
 - MUST fail atomically when command execution fails
 - MUST preserve the existing save/serialization policy defined in core specs
+- current CLI implementation may also accept selector-style targeting hints and resolve them to bounded core node ids before dispatch
 
 ### 5. `state diff`
 
@@ -185,7 +187,7 @@ Behavior:
 
 - SHOULD produce a compact difference summary rather than a raw textual XML diff
 - SHOULD focus on user-relevant score changes when practical
-- MAY remain intentionally shallow in first cut if a deeper music-aware diff is not yet stable
+- first cut may stay compact, but should still try to surface changed measure hints when they are cheap to derive
 
 ## Relationship To Core Command Catalog
 

--- a/index.html
+++ b/index.html
@@ -125,7 +125,7 @@
 <body>
   <main class="card">
     <h1>mikuscore</h1>
-    <p class="sub">Updated: 2026-04-16</p>
+    <p class="sub">Updated: 2026-04-17</p>
     <section class="lang-block" aria-label="English">
       <h2>English</h2>
       <p>

--- a/scripts/mikuscore-cli.mjs
+++ b/scripts/mikuscore-cli.mjs
@@ -121,6 +121,10 @@ const HELP_TEXT = {
     "  apply-command   Apply one bounded command and emit the next canonical MusicXML state",
     "  diff   Emit a compact JSON summary of differences between two canonical MusicXML states",
     "",
+    "Command payload note:",
+    "  state validate-command/apply-command accept core command JSON.",
+    "  Targeting may use targetNodeId/anchorNodeId directly or selector/anchor_selector from inspect-measure output.",
+    "",
     "Options:",
     "  --diagnostics text|json  Select diagnostics format",
     "  --help                   Show help",
@@ -273,12 +277,7 @@ async function runCommand(command, options, api) {
     }
 
     if (from === "musicxml" && to === "abc") {
-      const inputBytes = await readBinaryInput(options.in);
-      const decoded = await api.fileIO.musicxml.decodeInput(inputBytes, options.in);
-      if (!decoded.ok || typeof decoded.output !== "string") {
-        throw new CliCommandFailure(decoded, "Failed to read MusicXML input.");
-      }
-      const inputText = decoded.output;
+      const inputText = await readMusicXmlInputText(options.in, api);
       const result = api.abc.exportFromMusicXml(inputText);
       if (!result.ok) {
         throw new CliCommandFailure(result, "MusicXML to ABC conversion failed.");
@@ -296,12 +295,7 @@ async function runCommand(command, options, api) {
     }
 
     if (from === "musicxml" && to === "midi") {
-      const inputBytes = await readBinaryInput(options.in);
-      const decoded = await api.fileIO.musicxml.decodeInput(inputBytes, options.in);
-      if (!decoded.ok || typeof decoded.output !== "string") {
-        throw new CliCommandFailure(decoded, "Failed to read MusicXML input.");
-      }
-      const inputText = decoded.output;
+      const inputText = await readMusicXmlInputText(options.in, api);
       const result = api.midi.exportFromMusicXml(inputText);
       if (!result.ok) {
         throw new CliCommandFailure(result, "MusicXML to MIDI conversion failed.");
@@ -323,12 +317,7 @@ async function runCommand(command, options, api) {
     }
 
     if (from === "musicxml" && to === "musescore") {
-      const inputBytes = await readBinaryInput(options.in);
-      const decoded = await api.fileIO.musicxml.decodeInput(inputBytes, options.in);
-      if (!decoded.ok || typeof decoded.output !== "string") {
-        throw new CliCommandFailure(decoded, "Failed to read MusicXML input.");
-      }
-      const inputText = decoded.output;
+      const inputText = await readMusicXmlInputText(options.in, api);
       const result = api.musescore.exportFromMusicXml(inputText);
       if (!result.ok) {
         throw new CliCommandFailure(result, "MusicXML to MuseScore conversion failed.");
@@ -359,6 +348,20 @@ async function runCommand(command, options, api) {
         ...rendered,
         warnings: [...imported.warnings, ...rendered.warnings],
         diagnostics: [...imported.diagnostics, ...rendered.diagnostics],
+        stages: [
+          {
+            name: "abc_to_musicxml",
+            status: imported.diagnostics.length > 0 ? "warning" : "success",
+            warning_count: imported.warnings.length,
+            error_count: imported.diagnostics.length,
+          },
+          {
+            name: "musicxml_to_svg",
+            status: rendered.diagnostics.length > 0 ? "warning" : "success",
+            warning_count: rendered.warnings.length,
+            error_count: rendered.diagnostics.length,
+          },
+        ],
       };
     }
 
@@ -368,12 +371,7 @@ async function runCommand(command, options, api) {
       });
     }
 
-    const inputBytes = await readBinaryInput(options.in);
-    const decoded = await api.fileIO.musicxml.decodeInput(inputBytes, options.in);
-    if (!decoded.ok || typeof decoded.output !== "string") {
-      throw new CliCommandFailure(decoded, "Failed to read MusicXML input.");
-    }
-    const inputText = decoded.output;
+    const inputText = await readMusicXmlInputText(options.in, api);
     const result = await api.render.svgFromMusicXml(inputText);
     if (!result.ok) {
       throw new CliCommandFailure(result, "SVG render failed.");
@@ -382,16 +380,12 @@ async function runCommand(command, options, api) {
   }
 
   if (isCommand(command, ["state", "summarize"])) {
-    const inputBytes = await readBinaryInput(options.in);
-    const decoded = await api.fileIO.musicxml.decodeInput(inputBytes, options.in);
-    if (!decoded.ok || typeof decoded.output !== "string") {
-      throw new CliCommandFailure(decoded, "Failed to read MusicXML input.");
-    }
-    const result = api.state.summarizeFromMusicXml(decoded.output);
-    if (!result.ok) {
-      throw new CliCommandFailure(result, "Failed to summarize MusicXML state.");
-    }
-    return result;
+    return runStateMusicXmlCommand(
+      options.in,
+      api,
+      (inputText) => api.state.summarizeFromMusicXml(inputText),
+      "Failed to summarize MusicXML state."
+    );
   }
 
   if (isCommand(command, ["state", "inspect-measure"])) {
@@ -399,44 +393,32 @@ async function runCommand(command, options, api) {
     if (!measure) {
       throw new CliUsageError("state inspect-measure requires --measure <number>.", "missing_measure_option");
     }
-    const inputBytes = await readBinaryInput(options.in);
-    const decoded = await api.fileIO.musicxml.decodeInput(inputBytes, options.in);
-    if (!decoded.ok || typeof decoded.output !== "string") {
-      throw new CliCommandFailure(decoded, "Failed to read MusicXML input.");
-    }
-    const result = api.state.inspectMeasureFromMusicXml(decoded.output, measure);
-    if (!result.ok) {
-      throw new CliCommandFailure(result, "Failed to inspect MusicXML measure.");
-    }
-    return result;
+    return runStateMusicXmlCommand(
+      options.in,
+      api,
+      (inputText) => api.state.inspectMeasureFromMusicXml(inputText, measure),
+      "Failed to inspect MusicXML measure."
+    );
   }
 
   if (isCommand(command, ["state", "validate-command"])) {
-    const inputBytes = await readBinaryInput(options.in);
-    const decoded = await api.fileIO.musicxml.decodeInput(inputBytes, options.in);
-    if (!decoded.ok || typeof decoded.output !== "string") {
-      throw new CliCommandFailure(decoded, "Failed to read MusicXML input.");
-    }
     const commandPayload = await readCommandPayload(options);
-    const result = api.state.validateCommandFromMusicXml(decoded.output, commandPayload);
-    if (!result.ok) {
-      throw new CliCommandFailure(result, "Failed to validate MusicXML command.");
-    }
-    return result;
+    return runStateMusicXmlCommand(
+      options.in,
+      api,
+      (inputText) => api.state.validateCommandFromMusicXml(inputText, commandPayload),
+      "Failed to validate MusicXML command."
+    );
   }
 
   if (isCommand(command, ["state", "apply-command"])) {
-    const inputBytes = await readBinaryInput(options.in);
-    const decoded = await api.fileIO.musicxml.decodeInput(inputBytes, options.in);
-    if (!decoded.ok || typeof decoded.output !== "string") {
-      throw new CliCommandFailure(decoded, "Failed to read MusicXML input.");
-    }
     const commandPayload = await readCommandPayload(options);
-    const result = api.state.applyCommandFromMusicXml(decoded.output, commandPayload);
-    if (!result.ok) {
-      throw new CliCommandFailure(result, "Failed to apply MusicXML command.");
-    }
-    return result;
+    return runStateMusicXmlCommand(
+      options.in,
+      api,
+      (inputText) => api.state.applyCommandFromMusicXml(inputText, commandPayload),
+      "Failed to apply MusicXML command."
+    );
   }
 
   if (isCommand(command, ["state", "diff"])) {
@@ -461,6 +443,24 @@ async function runCommand(command, options, api) {
   }
 
   throw new CliUsageError(`Unsupported command: ${command.join(" ")}`, "unsupported_command");
+}
+
+async function readMusicXmlInputText(inputPath, api) {
+  const inputBytes = await readBinaryInput(inputPath);
+  const decoded = await api.fileIO.musicxml.decodeInput(inputBytes, inputPath);
+  if (!decoded.ok || typeof decoded.output !== "string") {
+    throw new CliCommandFailure(decoded, "Failed to read MusicXML input.");
+  }
+  return decoded.output;
+}
+
+async function runStateMusicXmlCommand(inputPath, api, run, fallbackMessage) {
+  const inputText = await readMusicXmlInputText(inputPath, api);
+  const result = await run(inputText);
+  if (!result.ok) {
+    throw new CliCommandFailure(result, fallbackMessage);
+  }
+  return result;
 }
 
 async function encodeOutputForTarget(result, outPath, api, to) {
@@ -558,7 +558,7 @@ function buildSuccessDiagnostics(command, options, result) {
   const warnings = Array.isArray(result.warnings) ? result.warnings : [];
   const errors = Array.isArray(result.diagnostics) ? result.diagnostics : [];
   const status = errors.length > 0 ? "error" : warnings.length > 0 ? "warning" : "success";
-  return {
+  const diagnostics = {
     ok: result.ok && errors.length === 0,
     diagnostics_version: DIAGNOSTICS_VERSION,
     command: command.join(" "),
@@ -571,6 +571,10 @@ function buildSuccessDiagnostics(command, options, result) {
     warnings,
     errors,
   };
+  if (Array.isArray(result.stages) && result.stages.length > 0) {
+    diagnostics.stages = result.stages;
+  }
+  return diagnostics;
 }
 
 function buildErrorDiagnostics(argv, error, exitCode) {

--- a/src/ts/cli-api.ts
+++ b/src/ts/cli-api.ts
@@ -71,6 +71,170 @@ const decodeUtf8Text = (bytes: Uint8Array): string => {
   return new TextDecoder("utf-8").decode(bytes);
 };
 
+type MeasureNoteSelector = {
+  part_id?: string | null;
+  measure_number?: string | null;
+  measure_note_index?: number | null;
+  voice?: string | null;
+  voice_note_index?: number | null;
+};
+
+type IndexedMeasureNote = {
+  nodeId: string;
+  selector: {
+    part_id: string | null;
+    measure_number: string;
+    measure_note_index: number;
+    voice: string | null;
+    voice_note_index: number;
+  };
+};
+
+type CliCommandNormalizationResult =
+  | {
+    ok: true;
+    command: CoreCommand;
+  }
+  | {
+    ok: false;
+    message: string;
+  };
+
+const buildIndexedMeasureNotes = (xmlText: string): IndexedMeasureNote[] => {
+  const doc = parseCoreXml(xmlText);
+  const nodeToId = new WeakMap();
+  const idToNode = new Map();
+  let sequence = 0;
+  reindexNodeIds(doc, nodeToId, idToNode, () => {
+    sequence += 1;
+    return `n${sequence}`;
+  });
+
+  return Array.from(doc.querySelectorAll("score-partwise > part > measure")).flatMap((measure) => {
+    const part = measure.parentElement;
+    const partId = part?.getAttribute("id")?.trim() ?? null;
+    const measureNumber = measure.getAttribute("number")?.trim() ?? "";
+    const voiceNoteCounts = new Map<string, number>();
+    return Array.from(measure.querySelectorAll(":scope > note")).flatMap((note, noteIndex) => {
+      const nodeId = nodeToId.get(note);
+      if (!nodeId) return [];
+      const voice = getVoiceText(note);
+      const voiceKey = voice ?? "__none__";
+      const nextVoiceNoteIndex = (voiceNoteCounts.get(voiceKey) ?? 0) + 1;
+      voiceNoteCounts.set(voiceKey, nextVoiceNoteIndex);
+      return [{
+        nodeId,
+        selector: {
+          part_id: partId,
+          measure_number: measureNumber,
+          measure_note_index: noteIndex + 1,
+          voice,
+          voice_note_index: nextVoiceNoteIndex,
+        },
+      }];
+    });
+  });
+};
+
+const resolveMeasureNoteSelector = (
+  selector: MeasureNoteSelector | undefined,
+  indexedNotes: IndexedMeasureNote[],
+  selectorName: string
+): { ok: true; nodeId: string; voice?: string | null } | { ok: false; message: string } => {
+  if (!selector || typeof selector !== "object") {
+    return {
+      ok: false,
+      message: `${selectorName} must be an object when provided.`,
+    };
+  }
+
+  const normalized = {
+    part_id: selector.part_id == null ? undefined : String(selector.part_id),
+    measure_number: selector.measure_number == null ? undefined : String(selector.measure_number),
+    measure_note_index: Number.isInteger(selector.measure_note_index) ? Number(selector.measure_note_index) : undefined,
+    voice: selector.voice == null ? undefined : String(selector.voice),
+    voice_note_index: Number.isInteger(selector.voice_note_index) ? Number(selector.voice_note_index) : undefined,
+  };
+
+  const activeKeys = Object.entries(normalized).filter(([, value]) => value !== undefined);
+  if (activeKeys.length === 0) {
+    return {
+      ok: false,
+      message: `${selectorName} must include at least one selector field.`,
+    };
+  }
+
+  const matches = indexedNotes.filter((note) => {
+    return activeKeys.every(([key, value]) => note.selector[key as keyof typeof note.selector] === value);
+  });
+
+  if (matches.length === 0) {
+    return {
+      ok: false,
+      message: `${selectorName} did not match any note in the current MusicXML state.`,
+    };
+  }
+
+  if (matches.length > 1) {
+    return {
+      ok: false,
+      message: `${selectorName} matched multiple notes; add more selector fields to disambiguate.`,
+    };
+  }
+
+  return {
+    ok: true,
+    nodeId: matches[0].nodeId,
+    voice: matches[0].selector.voice,
+  };
+};
+
+const normalizeCliCommandSelectors = (xmlText: string, command: CoreCommand): CliCommandNormalizationResult => {
+  const commandObject = command as Record<string, unknown>;
+  const indexedNotes = buildIndexedMeasureNotes(xmlText);
+  const nextCommand = { ...commandObject };
+
+  if ("selector" in nextCommand && !("targetNodeId" in nextCommand)) {
+    const resolved = resolveMeasureNoteSelector(nextCommand.selector as MeasureNoteSelector | undefined, indexedNotes, "selector");
+    if (!resolved.ok) {
+      return {
+        ok: false,
+        message: `Failed to resolve CLI command selector: ${resolved.message}`,
+      };
+    }
+    nextCommand.targetNodeId = resolved.nodeId;
+    if (!("voice" in nextCommand) && resolved.voice != null) {
+      nextCommand.voice = resolved.voice;
+    }
+  }
+
+  if ("anchor_selector" in nextCommand && !("anchorNodeId" in nextCommand)) {
+    const resolved = resolveMeasureNoteSelector(
+      nextCommand.anchor_selector as MeasureNoteSelector | undefined,
+      indexedNotes,
+      "anchor_selector"
+    );
+    if (!resolved.ok) {
+      return {
+        ok: false,
+        message: `Failed to resolve CLI command selector: ${resolved.message}`,
+      };
+    }
+    nextCommand.anchorNodeId = resolved.nodeId;
+    if (!("voice" in nextCommand) && resolved.voice != null) {
+      nextCommand.voice = resolved.voice;
+    }
+  }
+
+  delete nextCommand.selector;
+  delete nextCommand.anchor_selector;
+
+  return {
+    ok: true,
+    command: nextCommand as CoreCommand,
+  };
+};
+
 export const decodeCliMusicXmlInput = async (inputBytes: Uint8Array, inputPath?: string): Promise<CliResult> => {
   const name = lowerFileName(inputPath);
   try {
@@ -382,9 +546,11 @@ export const summarizeMusicXmlState = (xmlText: string): CliResult => {
 
 export const validateMusicXmlCommand = (xmlText: string, command: CoreCommand): CliResult => {
   try {
+    const normalized = normalizeCliCommandSelectors(xmlText, command);
+    if (!normalized.ok) return failureResult(normalized.message);
     const core = new ScoreCore();
     core.load(xmlText);
-    const result = core.dispatch(command);
+    const result = core.dispatch(normalized.command);
     return {
       ok: true,
       output: `${JSON.stringify(
@@ -414,9 +580,11 @@ export const validateMusicXmlCommand = (xmlText: string, command: CoreCommand): 
 
 export const applyMusicXmlCommand = (xmlText: string, command: CoreCommand): CliResult => {
   try {
+    const normalized = normalizeCliCommandSelectors(xmlText, command);
+    if (!normalized.ok) return failureResult(normalized.message);
     const core = new ScoreCore();
     core.load(xmlText);
-    const result = core.dispatch(command);
+    const result = core.dispatch(normalized.command);
     if (!result.ok) {
       return {
         ok: true,
@@ -463,43 +631,36 @@ export const applyMusicXmlCommand = (xmlText: string, command: CoreCommand): Cli
 
 export const inspectMusicXmlMeasure = (xmlText: string, measureNumber: string): CliResult => {
   try {
+    const indexedNotes = buildIndexedMeasureNotes(xmlText);
     const doc = parseCoreXml(xmlText);
-    const nodeToId = new WeakMap();
-    const idToNode = new Map();
-    let sequence = 0;
-    reindexNodeIds(doc, nodeToId, idToNode, () => {
-      sequence += 1;
-      return `n${sequence}`;
-    });
-
-    const measures = Array.from(doc.querySelectorAll("score-partwise > part > measure"))
+    const matchingMeasures = Array.from(doc.querySelectorAll("score-partwise > part > measure"))
       .filter((measure) => (measure.getAttribute("number")?.trim() ?? "") === measureNumber);
 
     const summary = {
       kind: "musicxml_measure_inspection",
       measure_number: measureNumber,
-      measures: measures.map((measure) => {
+      measures: matchingMeasures.map((measure) => {
         const part = measure.parentElement;
         const partId = part?.getAttribute("id")?.trim() ?? null;
-        const voiceNoteCounts = new Map<string, number>();
         const notes = Array.from(measure.querySelectorAll(":scope > note")).map((note, noteIndex) => {
-          const nodeId = nodeToId.get(note) ?? null;
+          const indexed = indexedNotes.find((item) =>
+            item.selector.part_id === partId &&
+            item.selector.measure_number === measureNumber &&
+            item.selector.measure_note_index === noteIndex + 1
+          );
           const voice = getVoiceText(note);
           const step = note.querySelector(":scope > pitch > step")?.textContent?.trim() ?? null;
           const octaveText = note.querySelector(":scope > pitch > octave")?.textContent?.trim() ?? null;
           const alterText = note.querySelector(":scope > pitch > alter")?.textContent?.trim() ?? null;
           const alter = alterText === null ? null : Number(alterText);
-          const voiceKey = voice ?? "__none__";
-          const nextVoiceNoteIndex = (voiceNoteCounts.get(voiceKey) ?? 0) + 1;
-          voiceNoteCounts.set(voiceKey, nextVoiceNoteIndex);
           return {
-            node_id: nodeId,
-            selector: {
+            node_id: indexed?.nodeId ?? null,
+            selector: indexed?.selector ?? {
               part_id: partId,
               measure_number: measureNumber,
               measure_note_index: noteIndex + 1,
               voice,
-              voice_note_index: nextVoiceNoteIndex,
+              voice_note_index: null,
             },
             voice,
             duration: getDurationValue(note),
@@ -558,22 +719,81 @@ const buildMusicXmlStateSummaryObject = (doc: Document) => {
   };
 };
 
+const buildMeasureDiffSignatures = (doc: Document) => {
+  return Array.from(doc.querySelectorAll("score-partwise > part > measure")).map((measure) => {
+    const partId = measure.parentElement?.getAttribute("id")?.trim() ?? null;
+    const measureNumber = measure.getAttribute("number")?.trim() ?? "";
+    const noteSummary = Array.from(measure.querySelectorAll(":scope > note")).map((note) => {
+      const voice = getVoiceText(note);
+      const duration = getDurationValue(note);
+      const isRest = note.querySelector(":scope > rest") !== null;
+      const step = note.querySelector(":scope > pitch > step")?.textContent?.trim() ?? null;
+      const octave = note.querySelector(":scope > pitch > octave")?.textContent?.trim() ?? null;
+      const alter = note.querySelector(":scope > pitch > alter")?.textContent?.trim() ?? null;
+      return {
+        voice,
+        duration,
+        is_rest: isRest,
+        pitch: isRest || !step || !octave
+          ? null
+          : {
+            step,
+            alter: alter == null ? null : Number(alter),
+            octave: Number(octave),
+          },
+      };
+    });
+    return {
+      part_id: partId,
+      measure_number: measureNumber,
+      note_count: noteSummary.length,
+      signature: JSON.stringify(noteSummary),
+    };
+  });
+};
+
 export const diffMusicXmlState = (beforeXml: string, afterXml: string): CliResult => {
   try {
     const beforeDoc = parseCoreXml(beforeXml);
     const afterDoc = parseCoreXml(afterXml);
     const beforeSummary = buildMusicXmlStateSummaryObject(beforeDoc);
     const afterSummary = buildMusicXmlStateSummaryObject(afterDoc);
+    const beforeMeasures = buildMeasureDiffSignatures(beforeDoc);
+    const afterMeasures = buildMeasureDiffSignatures(afterDoc);
 
     const changedFields = Object.keys(beforeSummary).filter((key) => {
       return JSON.stringify(beforeSummary[key as keyof typeof beforeSummary]) !==
         JSON.stringify(afterSummary[key as keyof typeof afterSummary]);
     });
 
+    const beforeMeasureMap = new Map(beforeMeasures.map((item) => [`${item.part_id ?? ""}:${item.measure_number}`, item]));
+    const afterMeasureMap = new Map(afterMeasures.map((item) => [`${item.part_id ?? ""}:${item.measure_number}`, item]));
+    const changedMeasureKeys = Array.from(new Set([...beforeMeasureMap.keys(), ...afterMeasureMap.keys()])).filter((key) => {
+      const beforeItem = beforeMeasureMap.get(key);
+      const afterItem = afterMeasureMap.get(key);
+      if (!beforeItem || !afterItem) return true;
+      return beforeItem.signature !== afterItem.signature;
+    });
+
     const diff = {
       kind: "musicxml_state_diff",
-      changed: changedFields.length > 0,
+      changed: changedFields.length > 0 || changedMeasureKeys.length > 0,
       changed_fields: changedFields,
+      changed_measure_numbers: changedMeasureKeys
+        .map((key) => afterMeasureMap.get(key) ?? beforeMeasureMap.get(key))
+        .filter((item): item is NonNullable<typeof item> => item != null)
+        .map((item) => item.measure_number),
+      changed_measures: changedMeasureKeys
+        .map((key) => {
+          const beforeItem = beforeMeasureMap.get(key);
+          const afterItem = afterMeasureMap.get(key);
+          return {
+            part_id: afterItem?.part_id ?? beforeItem?.part_id ?? null,
+            measure_number: afterItem?.measure_number ?? beforeItem?.measure_number ?? "",
+            before_note_count: beforeItem?.note_count ?? 0,
+            after_note_count: afterItem?.note_count ?? 0,
+          };
+        }),
       before: beforeSummary,
       after: afterSummary,
     };

--- a/tests/unit/mikuscore-cli.spec.ts
+++ b/tests/unit/mikuscore-cli.spec.ts
@@ -56,6 +56,7 @@ describe("mikuscore cli", () => {
     expect(stateHelp.stdout).toContain("validate-command");
     expect(stateHelp.stdout).toContain("apply-command");
     expect(stateHelp.stdout).toContain("diff");
+    expect(stateHelp.stdout).toContain("selector/anchor_selector");
     expect(stateHelp.stderr).toBe("");
   }, 10000);
 
@@ -194,6 +195,35 @@ describe("mikuscore cli", () => {
     expect(validation.affected_measure_numbers).toEqual(["1"]);
   });
 
+  it("validates one bounded MusicXML command via selector", () => {
+    const result = runCli(
+      [
+        "state",
+        "validate-command",
+        "--command",
+        JSON.stringify({
+          type: "change_to_pitch",
+          selector: {
+            part_id: "P1",
+            measure_number: "1",
+            measure_note_index: 1,
+            voice: "1",
+          },
+          pitch: { step: "G", octave: 4 },
+        }),
+      ],
+      {
+        input: validEditableMusicXml("Validate selector command"),
+      }
+    );
+
+    expect(result.status).toBe(0);
+    const validation = JSON.parse(result.stdout);
+    expect(validation.kind).toBe("musicxml_command_validation");
+    expect(validation.ok).toBe(true);
+    expect(validation.changed_node_ids).toEqual(["n1"]);
+  });
+
   it("inspects one measure for edit targeting", () => {
     const result = runCli(["state", "inspect-measure", "--measure", "1"], {
       input: validEditableMusicXml("Inspect measure"),
@@ -240,6 +270,64 @@ describe("mikuscore cli", () => {
     expect(result.stdout).toContain("<octave>4</octave>");
   });
 
+  it("applies one bounded MusicXML command via selector", () => {
+    const result = runCli(
+      [
+        "state",
+        "apply-command",
+        "--command",
+        JSON.stringify({
+          type: "change_to_pitch",
+          selector: {
+            part_id: "P1",
+            measure_number: "1",
+            measure_note_index: 1,
+            voice: "1",
+          },
+          pitch: { step: "A", octave: 4 },
+        }),
+      ],
+      {
+        input: validEditableMusicXml("Apply selector command"),
+      }
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("<step>A</step>");
+    expect(result.stdout).toContain("<octave>4</octave>");
+  });
+
+  it("applies insert_note_after via anchor_selector", () => {
+    const result = runCli(
+      [
+        "state",
+        "apply-command",
+        "--command",
+        JSON.stringify({
+          type: "insert_note_after",
+          anchor_selector: {
+            part_id: "P1",
+            measure_number: "1",
+            measure_note_index: 1,
+            voice: "1",
+          },
+          note: {
+            duration: 1,
+            pitch: { step: "A", octave: 4 },
+          },
+        }),
+      ],
+      {
+        input: validInsertableMusicXml("Apply anchor selector command"),
+      }
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("<step>A</step>");
+    expect(result.stdout).toContain("<step>D</step>");
+    expect(result.stdout.match(/<note>/g)?.length).toBe(4);
+  });
+
   it("diffs two canonical MusicXML states", () => {
     const beforePath = writeTempFile("before.musicxml", validEditableMusicXml("Before title"));
     const afterPath = writeTempFile("after.musicxml", validEditableMusicXml("After title").replace("<step>C</step>", "<step>G</step>"));
@@ -251,6 +339,15 @@ describe("mikuscore cli", () => {
     expect(diff.kind).toBe("musicxml_state_diff");
     expect(diff.changed).toBe(true);
     expect(diff.changed_fields).toContain("title");
+    expect(diff.changed_measure_numbers).toEqual(["1"]);
+    expect(diff.changed_measures).toEqual([
+      {
+        part_id: "P1",
+        measure_number: "1",
+        before_note_count: 4,
+        after_note_count: 4,
+      },
+    ]);
     expect(diff.before.title).toBe("Before title");
     expect(diff.after.title).toBe("After title");
   });
@@ -270,6 +367,32 @@ describe("mikuscore cli", () => {
     expect(diagnostics.exit_code).toBe(0);
     expect(diagnostics.output?.mode).toBeUndefined();
     expect(diagnostics.io.output).toEqual({ mode: "stdout" });
+    expect(diagnostics.stages).toBeUndefined();
+  });
+
+  it("writes stage-aware diagnostics for one-shot render json output", () => {
+    const inputPath = writeTempFile("score.abc", "X:1\nT:Stage diagnostics\nM:4/4\nL:1/4\nK:C\nC D E F|\n");
+    const result = runCli(["render", "svg", "--from", "abc", "--in", inputPath, "--diagnostics", "json"]);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("<svg");
+    const diagnostics = JSON.parse(result.stderr);
+    expect(diagnostics.ok).toBe(true);
+    expect(diagnostics.command).toBe("render svg");
+    expect(diagnostics.stages).toEqual([
+      {
+        name: "abc_to_musicxml",
+        status: "success",
+        warning_count: 0,
+        error_count: 0,
+      },
+      {
+        name: "musicxml_to_svg",
+        status: "success",
+        warning_count: 0,
+        error_count: 0,
+      },
+    ]);
   });
 
   it("writes structured usage diagnostics for usage failures when requested", () => {
@@ -303,6 +426,25 @@ describe("mikuscore cli", () => {
     const missingCommandPayload = runCli(["state", "validate-command"], {
       input: validEditableMusicXml("Missing command"),
     });
+    const unresolvedSelector = runCli(
+      [
+        "state",
+        "validate-command",
+        "--command",
+        JSON.stringify({
+          type: "change_to_pitch",
+          selector: {
+            part_id: "P1",
+            measure_number: "99",
+            measure_note_index: 1,
+          },
+          pitch: { step: "G", octave: 4 },
+        }),
+      ],
+      {
+        input: validEditableMusicXml("Bad selector"),
+      }
+    );
     const missingMeasureOption = runCli(["state", "inspect-measure"], {
       input: validEditableMusicXml("Missing measure"),
     });
@@ -322,6 +464,8 @@ describe("mikuscore cli", () => {
     expect(unsupportedRenderSource.stderr).toContain("Unsupported render source");
     expect(missingCommandPayload.status).toBe(2);
     expect(missingCommandPayload.stderr).toContain("requires exactly one of --command");
+    expect(unresolvedSelector.status).toBe(1);
+    expect(unresolvedSelector.stderr).toContain("Failed to resolve CLI command selector");
     expect(missingMeasureOption.status).toBe(2);
     expect(missingMeasureOption.stderr).toContain("requires --measure");
     expect(missingDiffInputs.status).toBe(2);
@@ -402,6 +546,29 @@ function validEditableMusicXml(title: string) {
    <note><pitch><step>D</step><octave>4</octave></pitch><duration>1</duration><voice>1</voice><type>quarter</type></note>
    <note><pitch><step>E</step><octave>4</octave></pitch><duration>1</duration><voice>1</voice><type>quarter</type></note>
    <note><pitch><step>F</step><octave>4</octave></pitch><duration>1</duration><voice>1</voice><type>quarter</type></note>
+  </measure>
+ </part>
+</score-partwise>`;
+}
+
+function validInsertableMusicXml(title: string) {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+ <work><work-title>${title}</work-title></work>
+ <part-list>
+  <score-part id="P1"><part-name>Music</part-name></score-part>
+ </part-list>
+ <part id="P1">
+  <measure number="1">
+   <attributes>
+    <divisions>1</divisions>
+    <key><fifths>0</fifths></key>
+    <time><beats>4</beats><beat-type>4</beat-type></time>
+    <clef><sign>G</sign><line>2</line></clef>
+   </attributes>
+   <note><pitch><step>C</step><octave>4</octave></pitch><duration>1</duration><voice>1</voice><type>quarter</type></note>
+   <note><pitch><step>D</step><octave>4</octave></pitch><duration>1</duration><voice>1</voice><type>quarter</type></note>
+   <note><pitch><step>E</step><octave>4</octave></pitch><duration>1</duration><voice>1</voice><type>quarter</type></note>
   </measure>
  </part>
 </score-partwise>`;


### PR DESCRIPTION
## 概要

CLI 再構築の続きを進め、`state` 系コマンドの targeting を強化しました。
あわせて、one-shot `render svg --from abc` の JSON diagnostics に stage 情報を追加し、CLI help / spec / README / development note を現在の実装に合わせて更新しています。

## 変更内容

### `state` 系コマンドの targeting 強化

`src/ts/cli-api.ts` で、`state validate-command` / `state apply-command` の command payload が以下の両方を受けられるようになりました。

- `targetNodeId` / `anchorNodeId` の直接指定
- `state inspect-measure` 出力に基づく `selector` / `anchor_selector`

これにより、`inspect-measure` の結果をそのまま次の bounded edit workflow へつなぎやすくしています。

### `state inspect-measure` / `state diff` の実用性向上

`src/ts/cli-api.ts` で以下を強化しました。

- `state inspect-measure`
  - hybrid targeting hint を返す方向を維持
- `state diff`
  - `changed_measure_numbers`
  - `changed_measures`

を返すようにし、raw XML diff ではなく workflow-friendly な差分 summary を少し深めました。

### one-shot render の stage-aware diagnostics

`scripts/mikuscore-cli.mjs` で、`render svg --from abc --diagnostics json` 実行時に `stages` を返すようにしました。

現状の stage は以下です。

- `abc_to_musicxml`
- `musicxml_to_svg`

primary artifact は従来どおり `stdout` の SVG のままにしつつ、`stderr` の JSON diagnostics だけを強化しています。

### CLI 実装の整理

`scripts/mikuscore-cli.mjs` では、`MusicXML` 入力の読み込みや `state` 実行の重複を helper 化して整理しています。

- `readMusicXmlInputText(...)`
- `runStateMusicXmlCommand(...)`

### ドキュメント更新

以下を current behavior に合わせて更新しました。

- `README.md`
- `docs/DEVELOPMENT.md`
- `docs/spec/CLI_DIAGNOSTICS_FIRSTCUT.md`
- `docs/spec/CLI_HELP_FIRSTCUT.md`
- `docs/spec/CLI_STATE_FIRSTCUT.md`
- `TODO.md`

主に反映した内容は以下です。

- `state` payload が `selector` / `anchor_selector` を受けられること
- one-shot render の JSON diagnostics が `stages` を返すこと
- CLI 再構築系列の TODO 実態反映

## テスト

`tests/unit/mikuscore-cli.spec.ts` を拡張し、以下を追加・更新しました。

- `state validate-command` の selector targeting
- `state apply-command` の selector targeting
- `insert_note_after` の `anchor_selector` targeting
- `state diff` の measure-level summary
- one-shot render の stage-aware diagnostics
- `state --help` の payload note

## 補足

- `index.html` の更新日は `2026-04-17` に更新されています
- `推測:` このコミットは CLI 再構築の first cut をさらに実運用しやすくするための refinement と位置づけられます