### PR TITLE
CLI 互換対応を upstream に取り込み、landing page 文言と ZIP/selector 回帰テストを更新

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,6 +2,13 @@
 
 ## CLI
 
+- [ ] Upstream the remaining downstream compatibility adjustments around `src/ts/cli-api.ts`.
+  - Scope:
+    - stabilize CLI selector resolution behavior so downstream-specific guard code is no longer needed
+    - remove `Array.prototype.flatMap` usage from indexed measure-note building so the current `ES2018`-based isolated bundle path remains compatible
+  - Expected follow-up:
+    - add focused regression coverage for selector resolution edge cases
+
 - [x] Document `convert`-first CLI naming consistently in all current-facing docs.
   - Recheck `README.md`, `docs/spec/CLI_STEP1.md`, and future notes after the command surface stabilizes.
   - Keep `import/export` as internal facade wording only, not CLI wording.
@@ -24,7 +31,8 @@
     - `mikuscore convert --from midi --to musicxml`
     - `mikuscore convert --from musicxml --to midi`
   - Next checks:
-    - decide whether CLI needs MIDI export options such as profile / metadata toggles
+    - keep MIDI export options internal for now; do not expose CLI flags yet
+    - revisit CLI-level MIDI export options such as profile / metadata toggles only after the current fixed defaults prove insufficient
 
 - [x] Implement Step 3 conversion/render pairs.
   - Current first cut exists for:
@@ -207,6 +215,12 @@
   - Do not move conversion facade code into `core/` without a concrete need.
 
 ## Build
+
+- [ ] Keep landing page CLI wording aligned with the current `convert` / `render` / `state` command split.
+  - Current source of truth:
+    - `index-src.html`
+    - generated `index.html`
+  - Remove stale `convert-first` wording from current-facing landing-page copy.
 
 - [ ] Shorten and stabilize `npm run build:full`.
   - Current observation:

--- a/index-src.html
+++ b/index-src.html
@@ -140,7 +140,7 @@
       </ul>
       <p><strong>Supported formats:</strong> MusicXML (`.musicxml` / `.xml` / `.mxl`), MuseScore (`.mscx` / `.mscz`), MIDI (`.mid` / `.midi`), VSQX (`.vsqx`), ABC (`.abc`), MEI (`.mei`, experimental), LilyPond (`.ly`, experimental).</p>
       <p>
-        A convert-first CLI is also available for scripted workflows. Related projects include
+        A CLI is also available for scripted workflows, centered on `convert`, `render`, and `state`. Related projects include
         mikuscore-skills, which embeds mikuscore into generative-AI workflows,
         and miku-abc-player, which makes an ABC-limited subset of mikuscore easier to use.
       </p>
@@ -174,7 +174,7 @@
       </ul>
       <p><strong>対応フォーマット:</strong> MusicXML（`.musicxml` / `.xml` / `.mxl`）、MuseScore（`.mscx` / `.mscz`）、MIDI（`.mid` / `.midi`）、VSQX（`.vsqx`）、ABC（`.abc`）、MEI（`.mei`、実験的対応）、LilyPond（`.ly`、実験的対応）。</p>
       <p>
-        スクリプト利用向けには convert-first の CLI もあります。関連プロダクトとして、
+        スクリプト利用向けには `convert` / `render` / `state` を中心にした CLI もあります。関連プロダクトとして、
         mikuscore-skills は mikuscore を生成 AI ワークフローに組み込むための agent skills、
         miku-abc-player は mikuscore の機能を ABC に限定して使いやすくした companion web app です。
       </p>

--- a/index.html
+++ b/index.html
@@ -125,7 +125,7 @@
 <body>
   <main class="card">
     <h1>mikuscore</h1>
-    <p class="sub">Updated: 2026-04-17</p>
+    <p class="sub">Updated: 2026-04-18</p>
     <section class="lang-block" aria-label="English">
       <h2>English</h2>
       <p>
@@ -140,7 +140,7 @@
       </ul>
       <p><strong>Supported formats:</strong> MusicXML (`.musicxml` / `.xml` / `.mxl`), MuseScore (`.mscx` / `.mscz`), MIDI (`.mid` / `.midi`), VSQX (`.vsqx`), ABC (`.abc`), MEI (`.mei`, experimental), LilyPond (`.ly`, experimental).</p>
       <p>
-        A convert-first CLI is also available for scripted workflows. Related projects include
+        A CLI is also available for scripted workflows, centered on `convert`, `render`, and `state`. Related projects include
         mikuscore-skills, which embeds mikuscore into generative-AI workflows,
         and miku-abc-player, which makes an ABC-limited subset of mikuscore easier to use.
       </p>
@@ -174,7 +174,7 @@
       </ul>
       <p><strong>対応フォーマット:</strong> MusicXML（`.musicxml` / `.xml` / `.mxl`）、MuseScore（`.mscx` / `.mscz`）、MIDI（`.mid` / `.midi`）、VSQX（`.vsqx`）、ABC（`.abc`）、MEI（`.mei`、実験的対応）、LilyPond（`.ly`、実験的対応）。</p>
       <p>
-        スクリプト利用向けには convert-first の CLI もあります。関連プロダクトとして、
+        スクリプト利用向けには `convert` / `render` / `state` を中心にした CLI もあります。関連プロダクトとして、
         mikuscore-skills は mikuscore を生成 AI ワークフローに組み込むための agent skills、
         miku-abc-player は mikuscore の機能を ABC に限定して使いやすくした companion web app です。
       </p>

--- a/src/ts/cli-api.ts
+++ b/src/ts/cli-api.ts
@@ -110,19 +110,20 @@ const buildIndexedMeasureNotes = (xmlText: string): IndexedMeasureNote[] => {
     return `n${sequence}`;
   });
 
-  return Array.from(doc.querySelectorAll("score-partwise > part > measure")).flatMap((measure) => {
+  const indexedNotes: IndexedMeasureNote[] = [];
+  for (const measure of Array.from(doc.querySelectorAll("score-partwise > part > measure"))) {
     const part = measure.parentElement;
     const partId = part?.getAttribute("id")?.trim() ?? null;
     const measureNumber = measure.getAttribute("number")?.trim() ?? "";
     const voiceNoteCounts = new Map<string, number>();
-    return Array.from(measure.querySelectorAll(":scope > note")).flatMap((note, noteIndex) => {
+    for (const [noteIndex, note] of Array.from(measure.querySelectorAll(":scope > note")).entries()) {
       const nodeId = nodeToId.get(note);
-      if (!nodeId) return [];
+      if (!nodeId) continue;
       const voice = getVoiceText(note);
       const voiceKey = voice ?? "__none__";
       const nextVoiceNoteIndex = (voiceNoteCounts.get(voiceKey) ?? 0) + 1;
       voiceNoteCounts.set(voiceKey, nextVoiceNoteIndex);
-      return [{
+      indexedNotes.push({
         nodeId,
         selector: {
           part_id: partId,
@@ -131,9 +132,10 @@ const buildIndexedMeasureNotes = (xmlText: string): IndexedMeasureNote[] => {
           voice,
           voice_note_index: nextVoiceNoteIndex,
         },
-      }];
-    });
-  });
+      });
+    }
+  }
+  return indexedNotes;
 };
 
 const resolveMeasureNoteSelector = (

--- a/tests/unit/cli-api.spec.ts
+++ b/tests/unit/cli-api.spec.ts
@@ -154,6 +154,37 @@ describe("cli-api", () => {
     expect(extracted).toContain("<museScore version=\"4.0\">");
     expect(extracted).toContain("\n  <Score>");
   });
+
+  it("roundtrips MusicXML through .mxl helper I/O", async () => {
+    const encoded = await encodeCliMusicXmlOutput(validMusicXml("Roundtrip MXL"), "score.mxl");
+    expect(encoded.ok).toBe(true);
+    if (!encoded.ok || typeof encoded.output === "string") return;
+
+    const decoded = await decodeCliMusicXmlInput(encoded.output, "score.mxl");
+    expect(decoded.ok).toBe(true);
+    if (!decoded.ok || typeof decoded.output !== "string") return;
+    expect(decoded.output).toContain("<work-title>Roundtrip MXL</work-title>");
+  });
+
+  it("roundtrips MusicXML through .mscz helper I/O via MuseScore facade", async () => {
+    const exported = exportMusicXmlToMuseScore(validMusicXml("Roundtrip MSCZ"));
+    expect(exported.ok).toBe(true);
+    if (!exported.ok || typeof exported.output !== "string") return;
+
+    const encoded = await encodeCliMuseScoreOutput(exported.output, "score.mscz");
+    expect(encoded.ok).toBe(true);
+    if (!encoded.ok || typeof encoded.output === "string") return;
+
+    const decoded = await decodeCliMuseScoreInput(encoded.output, "score.mscz");
+    expect(decoded.ok).toBe(true);
+    if (!decoded.ok || typeof decoded.output !== "string") return;
+
+    const imported = importMuseScoreToMusicXml(decoded.output);
+    expect(imported.ok).toBe(true);
+    if (!imported.ok || typeof imported.output !== "string") return;
+    expect(imported.output).toContain("<score-partwise");
+    expect(imported.output).toContain("<work-title>Roundtrip MSCZ</work-title>");
+  });
 });
 
 function buildSimpleMidi() {

--- a/tests/unit/mikuscore-cli.spec.ts
+++ b/tests/unit/mikuscore-cli.spec.ts
@@ -445,6 +445,39 @@ describe("mikuscore cli", () => {
         input: validEditableMusicXml("Bad selector"),
       }
     );
+    const ambiguousSelector = runCli(
+      [
+        "state",
+        "validate-command",
+        "--command",
+        JSON.stringify({
+          type: "change_to_pitch",
+          selector: {
+            part_id: "P1",
+            measure_number: "1",
+          },
+          pitch: { step: "G", octave: 4 },
+        }),
+      ],
+      {
+        input: validEditableMusicXml("Ambiguous selector"),
+      }
+    );
+    const invalidSelectorPayload = runCli(
+      [
+        "state",
+        "validate-command",
+        "--command",
+        JSON.stringify({
+          type: "change_to_pitch",
+          selector: "n1",
+          pitch: { step: "G", octave: 4 },
+        }),
+      ],
+      {
+        input: validEditableMusicXml("Invalid selector payload"),
+      }
+    );
     const missingMeasureOption = runCli(["state", "inspect-measure"], {
       input: validEditableMusicXml("Missing measure"),
     });
@@ -466,6 +499,10 @@ describe("mikuscore cli", () => {
     expect(missingCommandPayload.stderr).toContain("requires exactly one of --command");
     expect(unresolvedSelector.status).toBe(1);
     expect(unresolvedSelector.stderr).toContain("Failed to resolve CLI command selector");
+    expect(ambiguousSelector.status).toBe(1);
+    expect(ambiguousSelector.stderr).toContain("matched multiple notes");
+    expect(invalidSelectorPayload.status).toBe(1);
+    expect(invalidSelectorPayload.stderr).toContain("selector must be an object");
     expect(missingMeasureOption.status).toBe(2);
     expect(missingMeasureOption.stderr).toContain("requires --measure");
     expect(missingDiffInputs.status).toBe(2);


### PR DESCRIPTION
## 概要

CLI 周辺の downstream 互換対応の一部を upstream 側に取り込み、あわせて landing page の CLI 文言と関連テストを更新しています。

## 変更内容

- `src/ts/cli-api.ts`
  - indexed measure-note builder に残っていた `Array.prototype.flatMap` の使用を通常ループに置き換えました。
  - `IndexedMeasureNote[]` の構築方法を整理し、既存の selector 解決処理と組み合わせる形を維持しています。

- `tests/unit/mikuscore-cli.spec.ts`
  - `state validate-command` の失敗系に対する回帰テストを追加しました。
  - 追加した主なケース:
    - selector が複数ノートに一致する場合
    - selector が object ではない不正 payload の場合

- `tests/unit/cli-api.spec.ts`
  - ZIP helper I/O に対する軽量 roundtrip テストを追加しました。
  - 追加した主なケース:
    - `MusicXML -> .mxl -> MusicXML`
    - `MusicXML -> .mscz -> MuseScore text -> MusicXML`

- `index-src.html`
  - landing page に残っていた `convert-first` という表現を、現在の CLI 構成に合わせた文言へ更新しました。
  - 英語・日本語の両方を更新しています。

- `index.html`
  - `index-src.html` の変更を反映した生成物更新です。
  - コミット上では `Updated:` の日付表示も更新されています。

- `TODO.md`
  - `src/ts/cli-api.ts` まわりの upstream 取り込み方針を追記しました。
  - MIDI export option は当面 CLI flag としては公開せず、内部固定のまま扱う方針を追記しました。
  - landing page の CLI 文言を current-facing な構成へ揃える TODO を追記しました。

## 目的

- downstream 側で持っていた CLI 互換対応の一部を upstream 側へ寄せること
- `ES2018` 前提の isolated bundle path と衝突しうる `flatMap` 依存を避けること
- current-facing な CLI 文言を `convert` / `render` / `state` に揃えること
- selector 解決と ZIP helper I/O の回帰検知を強めること