### PR TITLE
CLI API の selector 正規化まわりに型ガードを追加

### DIFF
--- a/src/ts/cli-api.ts
+++ b/src/ts/cli-api.ts
@@ -100,6 +100,29 @@ type CliCommandNormalizationResult =
     message: string;
   };
 
+type ResolvedMeasureNoteSelectorResult =
+  | {
+    ok: true;
+    nodeId: string;
+    voice?: string | null;
+  }
+  | {
+    ok: false;
+    message: string;
+  };
+
+const isResolvedMeasureNoteSelectorFailure = (
+  result: ResolvedMeasureNoteSelectorResult
+): result is { ok: false; message: string } => {
+  return result.ok === false;
+};
+
+const isCliCommandNormalizationFailure = (
+  result: CliCommandNormalizationResult
+): result is { ok: false; message: string } => {
+  return result.ok === false;
+};
+
 const buildIndexedMeasureNotes = (xmlText: string): IndexedMeasureNote[] => {
   const doc = parseCoreXml(xmlText);
   const nodeToId = new WeakMap();
@@ -142,7 +165,7 @@ const resolveMeasureNoteSelector = (
   selector: MeasureNoteSelector | undefined,
   indexedNotes: IndexedMeasureNote[],
   selectorName: string
-): { ok: true; nodeId: string; voice?: string | null } | { ok: false; message: string } => {
+): ResolvedMeasureNoteSelectorResult => {
   if (!selector || typeof selector !== "object") {
     return {
       ok: false,
@@ -198,7 +221,7 @@ const normalizeCliCommandSelectors = (xmlText: string, command: CoreCommand): Cl
 
   if ("selector" in nextCommand && !("targetNodeId" in nextCommand)) {
     const resolved = resolveMeasureNoteSelector(nextCommand.selector as MeasureNoteSelector | undefined, indexedNotes, "selector");
-    if (!resolved.ok) {
+    if (isResolvedMeasureNoteSelectorFailure(resolved)) {
       return {
         ok: false,
         message: `Failed to resolve CLI command selector: ${resolved.message}`,
@@ -216,7 +239,7 @@ const normalizeCliCommandSelectors = (xmlText: string, command: CoreCommand): Cl
       indexedNotes,
       "anchor_selector"
     );
-    if (!resolved.ok) {
+    if (isResolvedMeasureNoteSelectorFailure(resolved)) {
       return {
         ok: false,
         message: `Failed to resolve CLI command selector: ${resolved.message}`,
@@ -549,7 +572,7 @@ export const summarizeMusicXmlState = (xmlText: string): CliResult => {
 export const validateMusicXmlCommand = (xmlText: string, command: CoreCommand): CliResult => {
   try {
     const normalized = normalizeCliCommandSelectors(xmlText, command);
-    if (!normalized.ok) return failureResult(normalized.message);
+    if (isCliCommandNormalizationFailure(normalized)) return failureResult(normalized.message);
     const core = new ScoreCore();
     core.load(xmlText);
     const result = core.dispatch(normalized.command);
@@ -583,7 +606,7 @@ export const validateMusicXmlCommand = (xmlText: string, command: CoreCommand): 
 export const applyMusicXmlCommand = (xmlText: string, command: CoreCommand): CliResult => {
   try {
     const normalized = normalizeCliCommandSelectors(xmlText, command);
-    if (!normalized.ok) return failureResult(normalized.message);
+    if (isCliCommandNormalizationFailure(normalized)) return failureResult(normalized.message);
     const core = new ScoreCore();
     core.load(xmlText);
     const result = core.dispatch(normalized.command);


### PR DESCRIPTION
## 概要

`src/ts/cli-api.ts` において、CLI command selector の解決結果および command 正規化結果に対する型ガードを追加し、失敗時の `message` 参照を型安全にしました。

## 変更内容

- `resolveMeasureNoteSelector(...)` の戻り値型に `ResolvedMeasureNoteSelectorResult` を追加
- `ResolvedMeasureNoteSelectorResult` 用の型ガード `isResolvedMeasureNoteSelectorFailure(...)` を追加
- `CliCommandNormalizationResult` 用の型ガード `isCliCommandNormalizationFailure(...)` を追加
- `if (!resolved.ok)` を `isResolvedMeasureNoteSelectorFailure(resolved)` に置き換え
- `if (!normalized.ok)` を `isCliCommandNormalizationFailure(normalized)` に置き換え

## 補足

- 変更対象は `src/ts/cli-api.ts` のみです
- 失敗分岐の型絞り込みを明示するための修正です