### PR TITLE
CLI に `abc -> midi` / `MEI` / `LilyPond` の MusicXML 相互変換を追加し、関連ドキュメント…

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ Examples:
 - `npm run cli -- convert --from musicxml --to abc --in score.musicxml --out score.abc`
 - `npm run cli -- convert --from midi --to musicxml --in score.mid --out score.musicxml`
 - `npm run cli -- convert --from musicxml --to midi --in score.musicxml --out score.mid`
+- `npm run cli -- convert --from mei --to musicxml --in score.mei --out score.musicxml`
+- `npm run cli -- convert --from musicxml --to mei --in score.musicxml --out score.mei`
+- `npm run cli -- convert --from lilypond --to musicxml --in score.ly --out score.musicxml`
+- `npm run cli -- convert --from musicxml --to lilypond --in score.musicxml --out score.ly`
 - `npm run cli -- convert --from musescore --to musicxml --in score.mscx --out score.musicxml`
 - `npm run cli -- convert --from musicxml --to musescore --in score.musicxml --out score.mscx`
 - `npm run cli -- convert --from musicxml --to abc --in score.mxl --out score.abc`

--- a/TODO.md
+++ b/TODO.md
@@ -2,6 +2,13 @@
 
 ## CLI
 
+- [ ] Add a CLI surface sync check whenever `src/ts/cli-api.ts` grows new or newly composable entry points.
+  - Scope:
+    - verify command/help/test coverage stays aligned across `src/ts/cli-api.ts`, `scripts/mikuscore-cli.mjs`, and `tests/unit/mikuscore-cli.spec.ts`
+    - explicitly review newly composable one-shot routes such as `abc -> midi`, not only direct one-function facade additions
+  - Expected follow-up:
+    - add a lightweight maintenance checklist or coverage table so CLI-exposed routes do not get missed during future facade expansion
+
 - [ ] Upstream the remaining downstream compatibility adjustments around `src/ts/cli-api.ts`.
   - Scope:
     - stabilize CLI selector resolution behavior so downstream-specific guard code is no longer needed
@@ -33,6 +40,34 @@
   - Next checks:
     - keep MIDI export options internal for now; do not expose CLI flags yet
     - revisit CLI-level MIDI export options such as profile / metadata toggles only after the current fixed defaults prove insufficient
+
+- [ ] Prepare VSQX CLI support by requesting upstream/integration-side changes to the vendored bridge first.
+  - Current blocker:
+    - current `vsqx` support depends on the vendored `utaformatix3-ts-plus` browser-oriented bridge shape, so the existing CLI cannot call it as a normal non-UI facade
+  - Required external ask:
+    - request a non-browser callable entrypoint or equivalent runtime shape from the integration/upstream side before wiring `musicxml <-> vsqx` into the CLI
+  - Intended follow-up after that lands:
+    - add `mikuscore convert --from vsqx --to musicxml`
+    - add `mikuscore convert --from musicxml --to vsqx`
+    - add matching CLI help and regression tests
+
+- [ ] Add MEI CLI conversion pairs around the existing reusable format I/O.
+  - Target pairs:
+    - `mikuscore convert --from mei --to musicxml`
+    - `mikuscore convert --from musicxml --to mei`
+  - Implementation slices:
+    - extend `src/ts/cli-api.ts` with `mei` facade entries
+    - wire `scripts/mikuscore-cli.mjs` help and convert handlers
+    - add CLI regression tests for stdin/file input, `--out`, and representative failures
+
+- [ ] Add LilyPond CLI conversion pairs around the existing reusable format I/O.
+  - Target pairs:
+    - `mikuscore convert --from lilypond --to musicxml`
+    - `mikuscore convert --from musicxml --to lilypond`
+  - Implementation slices:
+    - extend `src/ts/cli-api.ts` with `lilypond` facade entries
+    - wire `scripts/mikuscore-cli.mjs` help and convert handlers
+    - add CLI regression tests for stdin/file input, `--out`, and representative failures
 
 - [x] Implement Step 3 conversion/render pairs.
   - Current first cut exists for:

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -42,6 +42,10 @@ Available commands:
 - `mikuscore convert --from musicxml --to abc`
 - `mikuscore convert --from midi --to musicxml`
 - `mikuscore convert --from musicxml --to midi`
+- `mikuscore convert --from mei --to musicxml`
+- `mikuscore convert --from musicxml --to mei`
+- `mikuscore convert --from lilypond --to musicxml`
+- `mikuscore convert --from musicxml --to lilypond`
 - `mikuscore convert --from musescore --to musicxml`
 - `mikuscore convert --from musicxml --to musescore`
 - `mikuscore render svg`
@@ -85,6 +89,10 @@ Examples:
 - `npm run cli -- convert --from musicxml --to abc --in score.musicxml --out score.abc`
 - `npm run cli -- convert --from midi --to musicxml --in score.mid --out score.musicxml`
 - `npm run cli -- convert --from musicxml --to midi --in score.musicxml --out score.mid`
+- `npm run cli -- convert --from mei --to musicxml --in score.mei --out score.musicxml`
+- `npm run cli -- convert --from musicxml --to mei --in score.musicxml --out score.mei`
+- `npm run cli -- convert --from lilypond --to musicxml --in score.ly --out score.musicxml`
+- `npm run cli -- convert --from musicxml --to lilypond --in score.musicxml --out score.ly`
 - `npm run cli -- convert --from musescore --to musicxml --in score.mscx --out score.musicxml`
 - `npm run cli -- convert --from musicxml --to musescore --in score.musicxml --out score.mscx`
 - `npm run cli -- convert --from musicxml --to abc --in score.mxl --out score.abc`

--- a/docs/future/CLI_ROADMAP.md
+++ b/docs/future/CLI_ROADMAP.md
@@ -29,6 +29,10 @@ Current implemented Step 1 scope:
 - `mikuscore convert --from musicxml --to abc`
 - `mikuscore convert --from midi --to musicxml`
 - `mikuscore convert --from musicxml --to midi`
+- `mikuscore convert --from mei --to musicxml`
+- `mikuscore convert --from musicxml --to mei`
+- `mikuscore convert --from lilypond --to musicxml`
+- `mikuscore convert --from musicxml --to lilypond`
 - `mikuscore convert --from musescore --to musicxml`
 - `mikuscore convert --from musicxml --to musescore`
 - `mikuscore render svg`

--- a/scripts/mikuscore-cli.mjs
+++ b/scripts/mikuscore-cli.mjs
@@ -15,9 +15,14 @@ const HELP_TEXT = {
   top: [
     "Usage:",
     "  mikuscore convert --from abc --to musicxml [--in <file>|-] [--out <file>|-] [--diagnostics text|json]",
+    "  mikuscore convert --from abc --to midi [--in <file>|-] [--out <file>|-] [--diagnostics text|json]",
     "  mikuscore convert --from musicxml --to abc [--in <file>|-] [--out <file>|-] [--diagnostics text|json]",
     "  mikuscore convert --from midi --to musicxml [--in <file>|-] [--out <file>|-] [--diagnostics text|json]",
     "  mikuscore convert --from musicxml --to midi [--in <file>|-] [--out <file>|-] [--diagnostics text|json]",
+    "  mikuscore convert --from mei --to musicxml [--in <file>|-] [--out <file>|-] [--diagnostics text|json]",
+    "  mikuscore convert --from musicxml --to mei [--in <file>|-] [--out <file>|-] [--diagnostics text|json]",
+    "  mikuscore convert --from lilypond --to musicxml [--in <file>|-] [--out <file>|-] [--diagnostics text|json]",
+    "  mikuscore convert --from musicxml --to lilypond [--in <file>|-] [--out <file>|-] [--diagnostics text|json]",
     "  mikuscore convert --from musescore --to musicxml [--in <file>|-] [--out <file>|-] [--diagnostics text|json]",
     "  mikuscore convert --from musicxml --to musescore [--in <file>|-] [--out <file>|-] [--diagnostics text|json]",
     "  mikuscore render svg [--in <file>|-] [--out <file>|-] [--diagnostics text|json]",
@@ -47,7 +52,12 @@ const HELP_TEXT = {
   convert: [
     "Usage:",
     "  mikuscore convert --from abc --to musicxml [--in <file>|-] [--out <file>|-] [--diagnostics text|json]",
+    "  mikuscore convert --from abc --to midi [--in <file>|-] [--out <file>|-] [--diagnostics text|json]",
     "  mikuscore convert --from musicxml --to abc [--in <file>|-] [--out <file>|-] [--diagnostics text|json]",
+    "  mikuscore convert --from mei --to musicxml [--in <file>|-] [--out <file>|-] [--diagnostics text|json]",
+    "  mikuscore convert --from musicxml --to mei [--in <file>|-] [--out <file>|-] [--diagnostics text|json]",
+    "  mikuscore convert --from lilypond --to musicxml [--in <file>|-] [--out <file>|-] [--diagnostics text|json]",
+    "  mikuscore convert --from musicxml --to lilypond [--in <file>|-] [--out <file>|-] [--diagnostics text|json]",
     "  mikuscore convert --help",
     "",
     "Description:",
@@ -55,9 +65,14 @@ const HELP_TEXT = {
     "",
     "Supported pairs:",
     "  --from abc --to musicxml",
+    "  --from abc --to midi",
     "  --from musicxml --to abc",
     "  --from midi --to musicxml",
     "  --from musicxml --to midi",
+    "  --from mei --to musicxml",
+    "  --from musicxml --to mei",
+    "  --from lilypond --to musicxml",
+    "  --from musicxml --to lilypond",
     "  --from musescore --to musicxml",
     "  --from musicxml --to musescore",
     "",
@@ -328,6 +343,8 @@ function buildConvertHandlers(options, api) {
           "ABC to MusicXML conversion failed."
         )
       ),
+    "abc:midi": async () =>
+      runAbcToMidiConvertCommand(options.in, api),
     "musicxml:abc": async () =>
       runMusicXmlExportCommand(
         options.in,
@@ -349,6 +366,36 @@ function buildConvertHandlers(options, api) {
         api,
         (inputText) => api.midi.exportFromMusicXml(inputText),
         "MusicXML to MIDI conversion failed."
+      ),
+    "mei:musicxml": async () =>
+      runEncodedImportCommand(options.in, options.out, api, to, (inputPath) =>
+        runTextImportCommand(
+          inputPath,
+          (inputText) => api.mei.importToMusicXml(inputText),
+          "MEI to MusicXML conversion failed."
+        )
+      ),
+    "musicxml:mei": async () =>
+      runMusicXmlExportCommand(
+        options.in,
+        api,
+        (inputText) => api.mei.exportFromMusicXml(inputText),
+        "MusicXML to MEI conversion failed."
+      ),
+    "lilypond:musicxml": async () =>
+      runEncodedImportCommand(options.in, options.out, api, to, (inputPath) =>
+        runTextImportCommand(
+          inputPath,
+          (inputText) => api.lilypond.importToMusicXml(inputText),
+          "LilyPond to MusicXML conversion failed."
+        )
+      ),
+    "musicxml:lilypond": async () =>
+      runMusicXmlExportCommand(
+        options.in,
+        api,
+        (inputText) => api.lilypond.exportFromMusicXml(inputText),
+        "MusicXML to LilyPond conversion failed."
       ),
     "musescore:musicxml": async () =>
       runEncodedImportCommand(options.in, options.out, api, to, async (inputPath) => {
@@ -522,6 +569,27 @@ async function runAbcToSvgRenderCommand(inputPath, api) {
     stages: [
       buildStageDiagnostics("abc_to_musicxml", imported),
       buildStageDiagnostics("musicxml_to_svg", rendered),
+    ],
+  };
+}
+
+async function runAbcToMidiConvertCommand(inputPath, api) {
+  const inputText = await readTextInput(inputPath);
+  const imported = api.abc.importToMusicXml(inputText);
+  if (!imported.ok || typeof imported.output !== "string") {
+    throw new CliCommandFailure(imported, "ABC to MusicXML conversion failed.");
+  }
+  const exported = api.midi.exportFromMusicXml(imported.output);
+  if (!exported.ok) {
+    throw new CliCommandFailure(exported, "MusicXML to MIDI conversion failed.");
+  }
+  return {
+    ...exported,
+    warnings: [...imported.warnings, ...exported.warnings],
+    diagnostics: [...imported.diagnostics, ...exported.diagnostics],
+    stages: [
+      buildStageDiagnostics("abc_to_musicxml", imported),
+      buildStageDiagnostics("musicxml_to_midi", exported),
     ],
   };
 }

--- a/src/ts/cli-api.ts
+++ b/src/ts/cli-api.ts
@@ -4,6 +4,8 @@
  */
 
 import { convertAbcToMusicXml, exportMusicXmlDomToAbc } from "./abc-io";
+import { convertLilyPondToMusicXml, exportMusicXmlDomToLilyPond } from "./lilypond-io";
+import { convertMeiToMusicXml, exportMusicXmlDomToMei } from "./mei-io";
 import {
   buildMidiBytesForPlayback,
   buildPlaybackEventsFromMusicXmlDoc,
@@ -454,6 +456,92 @@ export const importMuseScoreToMusicXml = (musescoreText: string): CliResult => {
   }
 };
 
+export const importMeiToMusicXml = (meiText: string): CliResult => {
+  try {
+    return {
+      ok: true,
+      output: normalizeImportedMusicXmlText(convertMeiToMusicXml(meiText)),
+      warnings: [],
+      diagnostics: [],
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      warnings: [],
+      diagnostics: [`Failed to parse MEI: ${error instanceof Error ? error.message : String(error)}`],
+    };
+  }
+};
+
+export const exportMusicXmlToMei = (xmlText: string): CliResult => {
+  const doc = parseMusicXmlDocument(xmlText);
+  if (!doc) {
+    return {
+      ok: false,
+      warnings: [],
+      diagnostics: ["Failed to parse MusicXML: input is not a valid MusicXML document."],
+    };
+  }
+
+  try {
+    return {
+      ok: true,
+      output: exportMusicXmlDomToMei(doc),
+      warnings: [],
+      diagnostics: [],
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      warnings: [],
+      diagnostics: [`Failed to export MEI: ${error instanceof Error ? error.message : String(error)}`],
+    };
+  }
+};
+
+export const importLilyPondToMusicXml = (lilypondText: string): CliResult => {
+  try {
+    return {
+      ok: true,
+      output: normalizeImportedMusicXmlText(convertLilyPondToMusicXml(lilypondText)),
+      warnings: [],
+      diagnostics: [],
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      warnings: [],
+      diagnostics: [`Failed to parse LilyPond: ${error instanceof Error ? error.message : String(error)}`],
+    };
+  }
+};
+
+export const exportMusicXmlToLilyPond = (xmlText: string): CliResult => {
+  const doc = parseMusicXmlDocument(xmlText);
+  if (!doc) {
+    return {
+      ok: false,
+      warnings: [],
+      diagnostics: ["Failed to parse MusicXML: input is not a valid MusicXML document."],
+    };
+  }
+
+  try {
+    return {
+      ok: true,
+      output: exportMusicXmlDomToLilyPond(doc),
+      warnings: [],
+      diagnostics: [],
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      warnings: [],
+      diagnostics: [`Failed to export LilyPond: ${error instanceof Error ? error.message : String(error)}`],
+    };
+  }
+};
+
 export const exportMusicXmlToMuseScore = (xmlText: string): CliResult => {
   const doc = parseMusicXmlDocument(xmlText);
   if (!doc) {
@@ -856,6 +944,14 @@ export const cliApi = {
   midi: {
     importToMusicXml: importMidiToMusicXml,
     exportFromMusicXml: exportMusicXmlToMidi,
+  },
+  mei: {
+    importToMusicXml: importMeiToMusicXml,
+    exportFromMusicXml: exportMusicXmlToMei,
+  },
+  lilypond: {
+    importToMusicXml: importLilyPondToMusicXml,
+    exportFromMusicXml: exportMusicXmlToLilyPond,
   },
   musescore: {
     importToMusicXml: importMuseScoreToMusicXml,

--- a/tests/unit/mikuscore-cli.spec.ts
+++ b/tests/unit/mikuscore-cli.spec.ts
@@ -34,7 +34,10 @@ describe("mikuscore cli", () => {
 
     expect(topLevel.status).toBe(0);
     expect(topLevel.stdout).toContain("mikuscore convert --from abc --to musicxml");
+    expect(topLevel.stdout).toContain("mikuscore convert --from abc --to midi");
     expect(topLevel.stdout).toContain("mikuscore convert --from midi --to musicxml");
+    expect(topLevel.stdout).toContain("mikuscore convert --from mei --to musicxml");
+    expect(topLevel.stdout).toContain("mikuscore convert --from lilypond --to musicxml");
     expect(topLevel.stdout).toContain("mikuscore convert --from musescore --to musicxml");
     expect(topLevel.stdout).toContain("mikuscore render svg");
     expect(topLevel.stdout).toContain("mikuscore state summarize");
@@ -67,6 +70,54 @@ describe("mikuscore cli", () => {
 
     expect(result.status).toBe(0);
     expect(result.stdout).toContain("<work-title>STDIN</work-title>");
+  });
+
+  it("converts ABC directly to MIDI", () => {
+    const result = runCli(["convert", "--from", "abc", "--to", "midi"], {
+      input: "X:1\nT:ABC MIDI\nM:4/4\nL:1/4\nK:C\nC D E F|\n",
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout.length).toBeGreaterThan(0);
+  });
+
+  it("converts MEI directly to MusicXML", () => {
+    const result = runCli(["convert", "--from", "mei", "--to", "musicxml"], {
+      input: validMei("MEI import"),
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("<score-partwise");
+    expect(result.stdout).toContain("<work-title>MEI import</work-title>");
+  });
+
+  it("converts MusicXML directly to MEI", () => {
+    const result = runCli(["convert", "--from", "musicxml", "--to", "mei"], {
+      input: validMusicXml("MEI export"),
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("<mei");
+    expect(result.stdout).toContain("<title>MEI export</title>");
+  });
+
+  it("converts LilyPond directly to MusicXML", () => {
+    const result = runCli(["convert", "--from", "lilypond", "--to", "musicxml"], {
+      input: validLilyPond(),
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("<score-partwise");
+  });
+
+  it("converts MusicXML directly to LilyPond", () => {
+    const result = runCli(["convert", "--from", "musicxml", "--to", "lilypond"], {
+      input: validMusicXml("Lily export"),
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("\\version");
+    expect(result.stdout).toContain("\\score");
   });
 
   it("writes output via --out", () => {
@@ -414,7 +465,11 @@ describe("mikuscore cli", () => {
     const invalidAbc = runCli(["convert", "--from", "abc", "--to", "musicxml", "--in", inputPath]);
     const invalidMusicXmlPath = writeTempFile("invalid.musicxml", "<not-xml");
     const invalidMusicXml = runCli(["convert", "--from", "musicxml", "--to", "abc", "--in", invalidMusicXmlPath]);
-    const unsupportedPair = runCli(["convert", "--from", "abc", "--to", "midi"], {
+    const invalidMeiPath = writeTempFile("invalid.mei", "<mei");
+    const invalidMei = runCli(["convert", "--from", "mei", "--to", "musicxml", "--in", invalidMeiPath]);
+    const invalidLilyPath = writeTempFile("invalid.ly", "\\score { }");
+    const invalidLilyPond = runCli(["convert", "--from", "lilypond", "--to", "musicxml", "--in", invalidLilyPath]);
+    const unsupportedPair = runCli(["convert", "--from", "midi", "--to", "abc"], {
       input: "X:1\nT:Bad\nM:4/4\nL:1/4\nK:C\nC D E F|\n",
     });
     const missingFromTo = runCli(["convert", "--from", "abc"], {
@@ -489,6 +544,10 @@ describe("mikuscore cli", () => {
     expect(invalidAbc.stderr).toContain("Failed to parse ABC");
     expect(invalidMusicXml.status).toBe(1);
     expect(invalidMusicXml.stderr).toContain("Failed to parse MusicXML");
+    expect(invalidMei.status).toBe(1);
+    expect(invalidMei.stderr).toContain("Failed to parse MEI");
+    expect(invalidLilyPond.status).toBe(1);
+    expect(invalidLilyPond.stderr).toContain("Failed to parse LilyPond");
     expect(unsupportedPair.status).toBe(2);
     expect(unsupportedPair.stderr).toContain("Unsupported conversion pair");
     expect(missingFromTo.status).toBe(2);
@@ -609,4 +668,49 @@ function validInsertableMusicXml(title: string) {
   </measure>
  </part>
 </score-partwise>`;
+}
+
+function validMei(title: string) {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+ <meiHead>
+  <fileDesc>
+   <titleStmt>
+    <title>${title}</title>
+   </titleStmt>
+  </fileDesc>
+ </meiHead>
+ <music>
+  <body>
+   <mdiv>
+    <score>
+     <scoreDef meter.count="4" meter.unit="4" key.sig="0">
+      <staffGrp>
+       <staffDef n="1" lines="5" clef.shape="G" clef.line="2"/>
+      </staffGrp>
+     </scoreDef>
+     <section>
+      <measure n="1">
+       <staff n="1">
+        <layer n="1">
+         <note pname="c" oct="4" dur="4"/>
+         <note pname="d" oct="4" dur="4"/>
+         <note pname="e" oct="4" dur="4"/>
+         <note pname="f" oct="4" dur="4"/>
+        </layer>
+       </staff>
+      </measure>
+     </section>
+    </score>
+   </mdiv>
+  </body>
+ </music>
+</mei>`;
+}
+
+function validLilyPond() {
+  return `\\version "2.24.0"
+\\score {
+  \\new Staff { c'4 d'4 e'4 f'4 }
+}`;
 }


### PR DESCRIPTION
…と TODO を更新

## 概要

CLI の変換面を拡張し、既存の reusable な変換ロジックを `cli-api` と `mikuscore-cli` に接続しました。あわせて、CLI help・回帰テスト・関連ドキュメント・TODO を更新しています。

## 変更内容

- `abc -> midi` の CLI 変換を追加
- `mei <-> musicxml` の CLI 変換を追加
- `lilypond <-> musicxml` の CLI 変換を追加
- `src/ts/cli-api.ts` に `mei` / `lilypond` の facade を追加
- `scripts/mikuscore-cli.mjs` の help と convert handler を更新
- `tests/unit/mikuscore-cli.spec.ts` に成功ケース・失敗ケースの回帰テストを追加
- `README.md` / `docs/DEVELOPMENT.md` / `docs/future/CLI_ROADMAP.md` の CLI 記述を更新
- `TODO.md` に CLI surface sync、VSQX の外部依存対応、MEI / LilyPond の CLI 対応タスクを追記

## 変更ファイル

- `src/ts/cli-api.ts`
- `scripts/mikuscore-cli.mjs`
- `tests/unit/mikuscore-cli.spec.ts`
- `README.md`
- `docs/DEVELOPMENT.md`
- `docs/future/CLI_ROADMAP.md`
- `TODO.md`

## 補足

- VSQX の CLI 対応はこの変更には含めていません。
- 理由として、`TODO.md` に integration / upstream 側への変更依頼が必要な前提を追記しています。