### PR TITLE
mikuソフトウェア設計文書を拡充しMCP/Agent Skills方針を追加

### DIFF
--- a/docs/miku-soft-00-overview-design-v20260427.md
+++ b/docs/miku-soft-00-overview-design-v20260427.md
@@ -1,0 +1,227 @@
+# Miku Software Overview Design v20260427
+
+This memo is the entry point for the shared design documents of the `miku` software series.
+
+The initial versions of the related tools were created by `Mikuku` and Toshiki Iga.
+
+The current contents are based on the main-application design memo, Java application design memo, straight-conversion guide, Agent Skills design memo, and MCP design memo checked on 2026-04-27.
+
+## Design Summary
+
+The `miku` software series can be summarized as follows.
+
+> A family of small, local-first bridge tools that expose domain files and domain data through human-facing Web Apps, scriptable CLI runtimes, agent-facing skill packages, Java runtime artifacts, and MCP protocol adapters while preserving each product's semantic center.
+
+The series is not organized around a single UI, runtime, or protocol. It is organized around a layered product shape.
+
+- Keep each upstream product's semantic center clear
+- Provide human-facing Single-file Web Apps where useful
+- Provide Node.js CLI surfaces as normal main-application surfaces
+- Provide Java 1.8 CLI runtimes through straight conversion as a normal follow-up deliverable
+- Package Agent Skills with instructions, operation maps, references, and executable CLI runtime artifacts
+- Provide MCP servers in Node.js / TypeScript when there is no product-specific reason to avoid them
+- Keep Java versions, Agent Skills, and MCP servers downstream of the upstream product semantics
+- Preserve artifact roles, diagnostics, local execution, and runtime traceability across layers
+
+## Role of This Document
+
+This document is not a replacement for the detailed design documents. It explains how those documents fit together and records the product-family shape that sits above them.
+
+The detailed documents define the behavior and conventions of each layer. This overview explains the order, responsibility split, and intended relationship among those layers.
+
+When a specification is unclear, read this overview as the product-family map, then use the layer-specific document for detailed decisions.
+
+## Document Set
+
+This overview is the entry point for the shared miku software design document set.
+
+The detailed documents are organized by layer and concern.
+
+- `docs/miku-soft-00-overview-design-v*.md`
+  - provides the top-level product-family overview and explains how the design documents relate to each other
+- `docs/miku-soft-10-mainapp-design-v*.md`
+  - describes the main application layer, including the Single-file Web App and Node.js CLI as normal first-class product surfaces
+- `docs/miku-soft-20-javaapp-design-v*.md`
+  - describes Java application versions, especially Java 1.8 CLI/runtime artifacts, packaging, testing, and build integration
+- `docs/miku-soft-30-straight-conversion-v*.md`
+  - describes how TypeScript / Node.js products are converted into Java while preserving upstream traceability and behavior
+- `docs/miku-soft-40-agentskills-design-v*.md`
+  - describes Agent Skills packages, including local instructions, operation maps, references, and bundled CLI runtime artifacts for AI agents
+- `docs/miku-soft-50-mcp-design-v*.md`
+  - describes Node.js / TypeScript MCP server versions that expose product operations to MCP clients through tools, resources, and prompts
+
+## Layered Product Shape
+
+The miku software series can be understood through three facing layers.
+
+1. Human-facing layer
+2. Agent-facing layer
+3. MCP-facing layer
+
+These are facing layers, not independent product semantics. The upstream product owns the semantic center. Downstream runtime, skill, and protocol layers should expose that product meaning without becoming replacement implementations.
+
+## Human-Facing Layer
+
+A miku main application normally has two first-class surfaces: a Single-file Web App for human users and a Node.js CLI for automation, agents, and repeatable local workflows.
+
+The Single-file Web App is the human-facing surface when a product benefits from interactive loading, preview, diagnostics, and download. It is usually created in Node.js / TypeScript, has a Web UI, and runs locally in a browser without requiring server setup.
+
+The Node.js CLI is also a normal main-application surface. It exposes the same product core for scripts, repeatable local workflows, downstream Agent Skills, and later runtime adapters.
+
+Some main applications may be CLI-only when that is the natural product shape. In that case, the product is still a main application if it stands as the primary upstream product, accepts real local input, and produces verifiable artifacts.
+
+The human-facing layer should keep the following properties.
+
+- local-first execution
+- no server requirement for core functionality
+- clear canonical source or semantic base
+- structured outputs that scripts and AI agents can reuse
+- human-reviewable outputs such as HTML, Markdown, SVG, XLSX, XML, or ZIP when useful
+- shared core behavior behind UI, CLI, tests, and downstream adapters where practical
+
+## Java Runtime Layer
+
+A Java 1.8 CLI runtime is treated as a normal follow-up deliverable for miku products, implemented through straight conversion from the TypeScript / Node.js product unless there is a clear reason not to.
+
+The Java runtime should not be a Java-first redesign. Its first responsibility is to preserve upstream semantics, vocabulary, file-boundary traceability, CLI behavior, diagnostics, and artifact roles while making the product easier to run in Java-centered local and build environments.
+
+The Java runtime layer usually emphasizes:
+
+- Java 1.8 source and binary compatibility
+- CLI runtime jar
+- batch execution where it has clear operational value
+- Maven and build-tool integration when useful
+- deterministic artifact generation
+- public core APIs callable from CLI, tests, Maven plugins, and automation
+- distribution artifacts such as executable jars, sources jars, and distribution zips
+
+The TypeScript / Node.js CLI and Java CLI are peer runtime surfaces when both exist. Differences caused by runtime constraints should be documented rather than hidden.
+
+## Straight Conversion Layer
+
+Straight conversion is the bridge from the TypeScript / Node.js upstream product to the Java runtime.
+
+It is not a separate user-facing product layer. It is the reproducible method used to create and maintain Java versions without losing the ability to follow upstream changes.
+
+Straight conversion fixes the following direction.
+
+- Do not start from Java-first redesign
+- Keep upstream file boundaries and vocabulary traceable
+- Keep upstream tests and Java tests mapped
+- Keep the Node.js CLI contract close where a CLI exists
+- Treat Java-side extensions as separate contracts
+- Keep the Web UI out of the Java runtime unless explicitly required
+
+The output of straight conversion is a Java application version that remains understandable as a downstream runtime of the upstream product.
+
+## Agent-Facing Layer
+
+The agent-facing layer packages the product for AI agents.
+
+Agent Skills are not only instruction documents. They are agent-facing packages that combine local instructions, constraints, operation maps, references, and executable CLI runtime artifacts.
+
+The normal first runtime is the TypeScript / Node.js CLI artifact produced by the main application. A Java CLI runtime is also a normal runtime path when the Java version exists. As the target shape, miku Agent Skills should receive runtime artifacts as simple files under the skill package.
+
+Typical runtime artifacts are:
+
+- a single JavaScript CLI file for the Node.js runtime path
+- a single jar for the Java CLI runtime path
+
+Both runtime paths belong to the same skill product. Their presence should not split the skill name, activation rules, workflow vocabulary, artifact roles, or product boundary.
+
+Agent Skills should use upstream public APIs, documented CLI commands, stable global APIs, or bundled runtime artifacts before writing skill-local product logic. If the upstream product does not expose a needed capability, the preferred direction is to add or stabilize that capability upstream, then let the skill call it.
+
+The agent-facing layer should especially preserve:
+
+- explicit activation boundaries
+- product-specific operation maps
+- distinction between canonical source, state, draft, patch, projection, report, and diagnostics artifacts
+- local file workflow discipline
+- hard-error and soft-warning reporting
+- runtime lookup through declared skill-local artifacts before broad repository search
+
+## MCP-Facing Layer
+
+The MCP-facing layer is a normal extension target, not a replacement for Agent Skills.
+
+When there is no product-specific reason to avoid it, a miku product should provide an MCP server for MCP clients. The standard implementation choice for miku MCP servers is Node.js / TypeScript, using the MCP SDK and keeping the server as a thin protocol adapter.
+
+The MCP server exposes product operations through tools, resources, and prompts. It should remain a protocol adapter over the product runtime, not a replacement implementation.
+
+The MCP server may execute the TypeScript / Node.js runtime, the Java runtime, or both as product runtime artifacts. This runtime choice is separate from the MCP server implementation language. When both runtime artifacts are available, the MCP server should treat runtime choice as an execution policy, not as a change in product semantics.
+
+Java should not be treated as a default second MCP server implementation. A Java-side directory in an MCP repository may exist as a placeholder, but it should remain a placeholder unless a concrete future distribution or runtime constraint justifies maintaining a Java MCP server.
+
+The MCP-facing layer should keep the following properties.
+
+- product-prefixed tools with structured input schemas
+- structured tool results and diagnostics
+- resources for reusable state, specifications, reports, generated files, and diagnostics
+- small product-specific prompts when useful
+- local stdio transport as the first implementation target
+- HTTP transport as an additional deployment form with explicit session, storage, authentication, and isolation boundaries
+- shared tool names and result shapes across local and server variants
+
+MCP servers and Agent Skills should stay aligned around upstream product vocabulary, operation maps, artifact roles, and runtime contracts. Neither layer should become the semantic owner of the product.
+
+## Normal Product Flow
+
+The usual product flow for the miku software series is as follows.
+
+1. Create or maintain the TypeScript / Node.js main application.
+2. Provide the Single-file Web App when human-facing UI is useful.
+3. Provide the Node.js CLI as a normal product surface.
+4. Produce a single-file Node.js CLI runtime artifact for downstream use.
+5. Create the Java 1.8 CLI runtime through straight conversion unless there is a clear reason not to.
+6. Package Agent Skills with instructions, operation maps, references, and bundled runtime artifacts.
+7. Provide a Node.js / TypeScript MCP server when there is no product-specific reason to avoid it.
+
+This flow is a default direction, not a reason to blur responsibilities. Each layer must keep the upstream product boundary visible.
+
+## Responsibility Split
+
+The preferred responsibility split is as follows.
+
+- Main application
+  - owns product semantics, canonical source or semantic base, primary conversions, core APIs, Web UI when present, and Node.js CLI
+- Java application
+  - owns Java runtime packaging, Java CLI, Java-side batch or build integration, and Java-side tests while preserving upstream behavior
+- Straight conversion guide
+  - owns the method for creating and maintaining Java versions from TypeScript / Node.js upstreams
+- Agent Skills package
+  - owns agent-facing instructions, activation rules, workflow maps, local file discipline, runtime lookup, and bundled runtime artifact wiring
+- MCP server
+  - owns MCP tools, resources, prompts, transport handling, session or workspace policy, and protocol result formatting
+  - is normally implemented in Node.js / TypeScript; Java runtime artifacts remain runtime inputs, not a default second MCP server
+
+The semantic center should remain with the upstream main application. Runtime, skill, and protocol layers should expose or adapt that center rather than redefining it.
+
+## Shared Artifact Discipline
+
+Across all layers, miku products distinguish artifact roles.
+
+Common roles include:
+
+- canonical source or semantic base
+- internal product state
+- AI-facing projection
+- draft or patch returned by AI
+- primary exchange output
+- human-facing report
+- generated bundle
+- diagnostics and warnings
+- temporary scratch output
+
+These roles should not be collapsed only because the artifacts share a file extension or can all be represented as JSON or files.
+
+For example, a structural workbook `XLSX`, a human-facing `WBS XLSX`, a workbook JSON state file, and a Patch JSON document may all participate in one product workflow, but they are not the same contract.
+
+Keeping artifact roles visible makes UI, CLI, Java runtime, Agent Skills, and MCP server behavior easier to align.
+
+## Summary
+
+The miku software series starts from small local products, usually implemented in TypeScript / Node.js, and then exposes the same product meaning through multiple surfaces.
+
+The main application provides the upstream semantic center and normally exposes both a Single-file Web App and a Node.js CLI. Java versions provide Java 1.8 CLI runtimes through straight conversion. Agent Skills package instructions and executable runtime artifacts for AI agents. MCP servers expose product operations through a standard protocol for MCP clients and are normally implemented in Node.js / TypeScript.
+
+The important point is not to multiply implementations. It is to keep one product meaning usable from human UI, local CLI, Java runtime, agent package, and MCP protocol without losing traceability, diagnostics, or artifact discipline. In particular, a Java runtime artifact does not imply that a Java MCP server should also be implemented.

--- a/docs/miku-soft-20-javaapp-design-v20260426.md
+++ b/docs/miku-soft-20-javaapp-design-v20260426.md
@@ -1,4 +1,4 @@
-# Miku Software Java Application Design v20260425
+# Miku Software Java Application Design v20260426
 
 This memo organizes design characteristics commonly expected for Java application versions in the `miku` software series.
 
@@ -302,9 +302,12 @@ Java applications package local runtime use explicitly.
 
 The default runtime artifact is a single executable fat jar.
 
+The normal Maven package should also attach a sources jar, such as `<artifactId>-<version>-sources.jar`. The sources jar is a traceability and publication artifact, not the executable runtime artifact.
+
 When a distribution zip is useful, it should contain the minimal runtime-user-facing items such as:
 
 - runtime jar
+- sources jar when publishing or downstream traceability needs it
 - `README.md`
 - `LICENSE`
 - CLI or runtime docs where useful
@@ -316,6 +319,7 @@ The basic naming direction is:
 - Maven `groupId`: `jp.igapyon`
 - Maven `artifactId`: product-derived artifact name
 - jar name: `<artifactId>-<version>.jar`
+- sources jar name: `<artifactId>-<version>-sources.jar`
 - distribution zip name: `<artifactId>-dist-<version>.zip` or a similarly traceable form
 
 Runtime artifacts should not depend on source-tree-relative paths. If runtime markdown, prompt specs, or templates are needed inside the jar, copy them to classpath resources and read them through `getResourceAsStream` or an equivalent jar-safe mechanism.
@@ -842,9 +846,10 @@ The repository currently uses a single Maven project.
 The expected runtime artifacts are:
 
 - `target/mikuproject.jar`
+- `target/mikuproject-sources.jar`
 - `target/mikuproject-dist.zip`
 
-The distribution zip contains the runtime jar and minimal runtime-facing documentation such as `README.md`, `LICENSE`, and CLI documentation.
+The distribution zip contains the runtime jar, sources jar, and minimal runtime-facing documentation such as `README.md`, `LICENSE`, and CLI documentation.
 
 This single-module shape should remain acceptable while there is no Maven plugin deliverable. If a Maven plugin is added later, the repository should be reconsidered as a multi-module Maven reactor so that plugin code remains a thin adapter over the runtime / core API rather than a second implementation.
 

--- a/docs/miku-soft-40-agentskills-design-v20260425.md
+++ b/docs/miku-soft-40-agentskills-design-v20260425.md
@@ -1,0 +1,713 @@
+# Miku Software Agent Skills Design v20260425
+
+This memo organizes design characteristics commonly expected for Agent Skills versions in the `miku` software series.
+
+The initial versions of the related tools were created by `Mikuku` and Toshiki Iga.
+
+The current contents are based on current Agent Skills examples, the main-application design memo, the Java application design memo, and the straight-conversion guide checked on 2026-04-25.
+
+## Design Summary
+
+The Agent Skills versions in the `miku` software series can be summarized as follows.
+
+> Agent-facing local workflow packages that make miku main applications easier for AI agents to call, while preserving upstream semantics, structured artifacts, diagnostics, and human-reviewable handoff points.
+
+What characterizes Agent Skills versions is not a new product separate from the upstream application. It is a repeated set of constraints.
+
+- Keep the semantic center of the upstream main application
+- Make AI-agent workflows explicit and repeatable
+- Prefer structured input / output over screen operation or loose prose
+- Keep intermediate artifacts inspectable when needed
+- Use upstream public APIs, CLI, or bundled runtime artifacts rather than duplicating product logic
+- Treat the skill as a thin orchestration and guidance layer
+- Distinguish conversation state from canonical source and primary product artifacts
+- Package the skill so it can be installed and used locally
+
+## Role of This Document
+
+This document is not a detailed specification for one skill repository. Repository-specific behavior should be checked in each `SKILL.md`, README, and product-specific documents.
+
+Use the shared design documents together as follows.
+
+- `docs/miku-soft-10-mainapp-design-v20260425.md`
+  - describes the upstream product design and semantic center
+- `docs/miku-soft-20-javaapp-design-v20260425.md`
+  - describes Java runtime versions when they exist
+- `docs/miku-soft-30-straight-conversion-v20260425.md`
+  - describes how Java versions are created from upstream main applications
+- `docs/miku-soft-40-agentskills-design-v20260425.md`
+  - describes how Agent Skills versions should expose miku workflows to AI agents
+
+This document separates the following levels.
+
+- **Cross-cutting principles**: design policies that should generally be kept for Agent Skills versions.
+- **Recommended conventions**: repository, packaging, state, and documentation shapes that make maintenance easier.
+- **Observed tendencies**: design habits visible in current Agent Skills repositories.
+- **Product-specific notes**: design decisions for specific skill products, recorded as concrete examples.
+
+When a specification is unclear, first check whether the decision preserves upstream meaning and improves agent-operable structured workflow. Agent convenience is important, but it should not hide unsupported behavior, discard diagnostics, or make the skill drift into a different product.
+
+## Scope
+
+The series whose names start with `miku` includes several related product types.
+
+Main applications:
+
+- `miku-abc-player`
+- `miku-docx2md`
+- `miku-indexgen`
+- `miku-unicode-guard`
+- `miku-xlsx2md`
+- `mikuproject`
+- `mikuscore`
+
+Java application versions:
+
+- `miku-indexgen-java`
+- `mikuproject-java`
+- `miku-xlsx2md-java`
+
+Agent Skills versions:
+
+- `mikuproject-skills`
+- `mikuscore-skills`
+
+Projects with the `-skills` suffix are positioned as Agent Skills versions that make the original products easier for AI agents to use.
+
+This document focuses on Agent Skills versions. It does not define the Web UI conventions for upstream main applications, and it does not define the Java packaging conventions for Java application versions.
+
+## Shared Direction
+
+Agent Skills versions continue the shared direction of the miku series: small local bridge tools that convert, extract, inspect, normalize, or export domain files and domain data.
+
+The Agent Skills version emphasizes the parts that fit AI-agent operation particularly well.
+
+- explicit activation and usage instructions
+- structured JSON, Markdown, XML, XLSX, SVG, ZIP, or similar artifacts
+- local import / validate / export operations
+- agent-readable diagnostics and summaries
+- small projections instead of unnecessarily large state handoff
+- patch / apply / diff workflows where existing data is revised
+- bundled Java CLI and Node.js CLI paths where practical
+- repeatable file-based operation
+- skill bundles that can be installed into an agent environment
+
+An Agent Skills version should not become a generic planner, generic converter, or autonomous replacement for the upstream application. Its value is that an AI agent can use the upstream miku product correctly with less guesswork.
+
+## Relationship to Main Applications
+
+Agent Skills versions are downstream of miku main applications.
+
+The upstream main application owns the product semantics, canonical source, core conversions, output policy, and limitations. The skill owns agent-facing activation, workflow guidance, runtime discovery, state handoff, and packaging.
+
+The preferred relationship is as follows.
+
+- upstream main application provides core APIs, CLI, bundled runtime, or stable artifacts
+- Agent Skill calls those upstream surfaces
+- Agent Skill explains when to use which operation
+- Agent Skill keeps intermediate JSON and file artifacts organized
+- Agent Skill reports diagnostics, warnings, and hard errors in an agent-readable form
+- Agent Skill does not reimplement core conversion behavior unless no upstream surface exists
+
+If an upstream capability is missing, the preferred order is to request or implement the capability on the upstream side, expose it as a stable upstream API, and then let the skill call it. Agent Skills should not silently add upstream product capabilities on the skill side. Skill-local workaround code should be treated as temporary or product-specific, not as the new semantic center.
+
+## Role of Agent Skills
+
+In this document, an Agent Skill means a `miku` repository with a `-skills` suffix that packages one or more skills for agent environments.
+
+An Agent Skill is primarily an agent-facing workflow adapter. It usually exposes one or more of the following.
+
+- `SKILL.md` activation and operating instructions
+- references for detailed workflows and examples
+- local scripts for import / export / validation / report generation
+- bundled upstream runtime artifacts or install-time runtime dependency
+- test coverage for skill behavior and smoke paths
+- distributable skill bundle or bundle zip
+
+The Agent Skill is not primarily the browser UI and is not primarily a Java port. It can use Node.js, Java, or another runtime if that is the natural way to call the upstream product, but the skill layer itself should remain thin.
+
+The center of an Agent Skill is reliable orchestration: determine when the skill applies, call the upstream runtime, validate or transform structured documents, preserve useful state, emit artifacts, and tell the agent what to do next without hiding important constraints.
+
+## Cross-Cutting Principles
+
+miku Agent Skills emphasize the following cross-cutting principles.
+
+1. Preserve the semantic center and product boundary of the upstream main application.
+2. Treat the skill as an agent workflow adapter, not as a replacement implementation.
+3. Use structured artifacts and diagnostics instead of screen-driven or prose-only operation.
+4. Keep skill activation explicit enough to avoid accidental takeover of generic tasks.
+5. Prefer local runtime execution and file artifacts over server-dependent workflows.
+6. Distinguish canonical source, conversation state, primary output, reports, and temporary handoff data.
+7. Use small projections, patches, validation, and diffs for AI-assisted edits where practical.
+8. Make installation, bundling, smoke testing, and upstream synchronization explainable.
+
+### Basic Philosophy of Agent Skills
+
+Agent Skills versions emphasize the following philosophy.
+
+- Run product operations locally when practical
+- Keep the upstream product meaning recognizable
+- Use the upstream API or CLI before writing skill-local conversion logic
+- Make AI-facing operations explicit
+- Keep intermediate JSON internal when direct internal execution is possible
+- Expose handoff artifacts when a human or upper-layer agent needs to inspect or reuse them
+- Preserve diagnostics and warnings as part of the result
+- Keep state and generated files easy to save, compare, and rerun
+- Make skill activation narrow enough that generic user requests are not captured accidentally
+- Keep `SKILL.md` concise and place detailed workflow material in references or docs
+
+The value of an Agent Skills version is not that it can answer a domain question conversationally in a generic way. It is that it can safely drive a specific miku workflow through structured operations that are faithful to the upstream product.
+
+### Common Principles for Agent Skills
+
+Agent Skills use the following principles as defaults.
+
+- Place one or more skills under `skills/`
+- Put each skill's primary instructions in `skills/<skill-name>/SKILL.md`
+- Keep the skill name close to the upstream product name when the product identity matters
+- Require explicit product naming for skills that would otherwise overlap with generic tasks
+- Keep detailed references under the skill directory or repository `docs/`
+- Use Node.js when calling a Node.js upstream runtime directly is the simplest path
+- Bundle both Java CLI and Node.js CLI paths as the standard future direction for miku Agent Skills
+- Treat the Java CLI runtime artifact as a single jar
+- Treat the Node.js CLI runtime artifact as a single JavaScript file
+- Use bundled upstream runtime artifacts when local, reproducible execution and bundling need them
+- Prefer upstream public APIs, stable global APIs, or documented CLI commands
+- Package distributable bundles with scripts that can be tested
+- Keep repository-level README user-facing and developer details under `docs/`
+- Use `workplace/` for local scratch data, upstream checks, generated outputs, and verification files
+
+These are defaults for the miku Agent Skills series. Individual products may add product-specific conventions, but should not change these foundations casually.
+
+### Activation Boundary Principles
+
+Agent Skills must be careful about when they activate.
+
+Many miku domains overlap with ordinary conversation. A request mentioning planning, schedules, tabular files, score files, music, Markdown, SVG, XML, or reports should not automatically mean that a product-specific skill must take over.
+
+The preferred activation rule is explicit opt-in.
+
+Typical activation criteria include the following.
+
+- the user explicitly names the upstream product or skill
+- the user requests a documented product-specific workflow
+- the recent conversation is already inside an explicitly activated workflow
+
+Without an explicit trigger, the agent should answer normally or ask a brief clarifying question if using the skill would materially change the result.
+
+Activation instructions should be written in `SKILL.md` because they are part of the skill contract, not just documentation.
+Product-specific trigger words and exceptions should be recorded in each product's `SKILL.md` or product-specific notes.
+
+### Core Runtime Principles
+
+Agent Skills should use declared runtime artifacts before broad repository exploration.
+
+The preferred order is as follows.
+
+1. Read the active skill's `SKILL.md`
+2. Check the bundled runtime artifacts declared by the skill
+3. Use upstream public APIs, stable globals, or documented CLI/runtime flows
+4. Use skill-local helpers only when they are the intended adapter layer
+5. Search broadly for alternatives only when the declared runtime path is missing or unusable
+
+This keeps agent behavior predictable. It also prevents the skill from accidentally using stale generated files, unrelated scripts, or partial local experiments.
+
+Runtime artifact lookup should be simple and fixed. Place the single jar and single JavaScript CLI file under the skill directory, such as `skills/<skill-name>/runtime/`, and let the skill use those declared paths.
+
+Do not create a separate skill product line only because an additional runtime path exists. When both Java CLI and Node.js CLI runtimes are available, treat them as runtime artifacts of the same normal `-skills` package. The skill name, activation rules, workflow vocabulary, artifact roles, and product boundary should remain tied to the upstream main application, not to the runtime implementation.
+
+When both Java CLI and Node.js CLI runtime artifacts are bundled, the skill may prefer the Java CLI first for local execution. A single jar is easy to locate, smoke-test, and run in automation environments. If the Java CLI artifact is missing, cannot be invoked, or does not support the requested operation, the skill may fall back to the Node.js CLI runtime.
+
+This runtime preference is an execution policy, not a semantic priority. The upstream main application remains the semantic center. Runtime differences should be reported as capability or compatibility diagnostics.
+
+### AI-Facing Spec Retrieval Principles
+
+Agent Skills should not rely on broad file search to find prompt or spec documents.
+
+When an upstream product provides AI-facing prompts, JSON specs, schemas, workflow instructions, or similar documents, those documents should be retrievable through a stable upstream API or CLI contract.
+
+The skill may bundle or reference those documents, but the preferred runtime path is as follows.
+
+- Call an upstream API such as `getAiSpec()` or `getAiSpecText()`
+- Call a documented CLI command such as `<product> ai spec`
+- Receive `id`, `version`, `text`, diagnostics, and related metadata as structured data where practical
+
+This keeps prompt and spec retrieval stable across repository layout changes. It also prevents skills from depending on source-tree paths, generated file names, or broad search behavior.
+
+### Thin Adapter Principles
+
+Agent Skills keep product logic in the upstream application as much as possible.
+
+The skill layer may contain:
+
+- activation rules
+- workflow instructions
+- operation selection
+- input kind detection
+- file naming conventions
+- runtime path discovery
+- small adapters around upstream API calls
+- result formatting for the agent
+- bundle-building scripts
+- smoke tests
+
+The skill layer should not contain:
+
+- a parallel implementation of upstream conversion
+- hidden product semantics that the upstream does not know
+- broad UI replacement logic
+- model-specific prompting logic that makes the skill unusable with another agent
+- server credentials or provider-specific calling code unless the repository explicitly owns that integration
+
+When skill-local code becomes large, first ask whether the upstream main application should expose a smaller public API.
+
+### State and Artifact Principles
+
+Agent Skills distinguish several kinds of data.
+
+- canonical source or semantic base owned by the upstream product
+- conversation state used by the skill or agent
+- AI-facing projection or draft document
+- patch or edit document returned by AI
+- primary product output
+- report or presentation output
+- diagnostics and warnings
+- temporary files and local scratch outputs
+
+These roles should not be collapsed only because they are all represented as JSON or files.
+
+For individual products, the conversation state may differ from the upstream semantic base. That does not make the conversation state the canonical semantic center of the product.
+
+Similarly, two artifacts may share an extension while having different roles, such as structural exchange data and human-facing reports. Ambiguous filenames and ambiguous operation names should be avoided when identical extensions represent different artifact roles.
+
+### AI Workflow Principles
+
+Agent Skills should prefer structured AI workflows.
+
+Representative operations include:
+
+- provide a JSON spec or schema-like guide
+- accept a draft document
+- validate document kind and required fields
+- import draft into product state
+- export a small overview or detail projection
+- accept a patch document
+- validate patch references and impact radius
+- apply patch to a base state
+- return change summary, diagnostics, and updated state
+- export human-facing reports
+
+When revising existing state, prefer small projections and patches over full-state replacement where the upstream product supports them.
+
+This has several advantages.
+
+- AI context stays smaller
+- returned changes are easier to validate
+- references to existing IDs can be checked
+- diffs are easier for humans to review
+- accidental unrelated edits are less likely
+
+Visible handoff is useful when the user or an upper-layer agent needs to inspect or pass data. However, when the skill can safely execute import / apply / export internally, it should not stop merely by printing intermediate JSON.
+
+### Handoff and Agent-Internal Principles
+
+Agent Skills may support both handoff-style and agent-internal workflows.
+
+Handoff-style workflow:
+
+- skill returns spec, projection, workbook, or prompt material visibly
+- user or upper-layer agent passes that material to another AI turn or tool
+- useful for inspection, debugging, interoperability, and early MVPs
+
+Agent-internal workflow:
+
+- skill keeps intermediate JSON internal when possible
+- agent calls the next operation directly
+- visible output focuses on result, diagnostics, artifacts, and next useful choices
+- useful when the agent environment supports tool execution and state handling
+
+Both styles are allowed. The default for mature flows should move toward agent-internal execution when it is safer and less noisy. Handoff should remain available when it improves reviewability or when the environment cannot chain operations internally.
+
+### Error and Diagnostic Principles
+
+Agent Skills distinguish hard errors from soft errors.
+
+Hard errors include:
+
+- unsupported or ambiguous document kind
+- missing required base state for patch application
+- syntactically invalid structured input
+- missing upstream runtime
+- failed import / export that prevents a valid result
+
+Soft errors include:
+
+- upstream warnings
+- partial import where the upstream says processing can continue
+- ignored unknown fields or columns
+- fallback output formatting
+- report simplifications
+
+On hard error, the skill should stop the operation and report what is needed to continue. On soft error, the skill may continue and report warnings concisely with enough structure for the agent or user to understand the risk.
+
+Diagnostics should preserve upstream messages and locations where practical. Skill-side wording should not hide upstream limitations.
+
+### File and Workplace Principles
+
+Agent Skills often produce state and report artifacts.
+
+Generated files should be placed in predictable product-specific directories rather than scattered through the repository root.
+
+Recommended local shape:
+
+```text
+<product>/
+  state/
+  output/ or report/
+  tmp/
+```
+
+Recommended usage:
+
+- `state/` for conversation state, draft JSON, patch JSON, workbook JSON, and similar reusable state files
+- `output/` for final deliverables when the product is naturally conversion / rendering oriented
+- `report/` for human-facing reports such as spreadsheets, Markdown, SVG, diagram text, and ZIP
+- `tmp/` for short-lived local work
+
+When multiple artifacts come from one run, use a common timestamp or run prefix so they can be grouped.
+
+The repository-level `workplace/` directory remains local scratch space for development, upstream checks, generated outputs, and verification files. It should not become a source directory or a hidden place for checked-in fixtures.
+
+### Upstream Runtime Artifact Principles
+
+Agent Skills repositories should move toward receiving upstream main applications as runtime artifacts rather than as full upstream source trees.
+
+The TOBE target shape is as follows.
+
+- receive a single jar for the Java CLI path
+- receive a single JavaScript file for the Node.js CLI path
+- do not edit upstream source inside the skill repository
+- document the artifact update procedure
+- verify the received artifacts through skill smoke tests and API / CLI contract checks
+
+Current repositories may not yet have this shape. During transition, it is acceptable for a skill repository to keep a vendored upstream source tree or a broader runtime copy when that is how the current skill works. However, this is a current-state allowance, not the target design.
+
+Near-term maintenance should move those repositories toward the target shape: replace source-tree dependency with received single-jar and single-JavaScript runtime artifacts under the skill directory.
+
+### Packaging and Distribution Principles
+
+Agent Skills should be installable as local skill packages.
+
+Packaging should include the files needed for the agent to read instructions and run intended local workflows.
+
+As the TOBE target shape, miku Agent Skills should bundle both Java CLI and Node.js CLI paths when the corresponding upstream runtime exists or can be produced. The Java path should be represented by a single jar, and the Node.js path should be represented by a single JavaScript CLI file.
+
+Current repositories may temporarily use broader vendored runtime contents or source-tree-derived packaging. This is allowed only as a transition state. New packaging work should move toward single-runtime-artifact handling.
+
+The purpose of bundling both paths is not to make the skill layer heavier. It is to let an agent choose the runtime that best fits the local environment while keeping each runtime artifact simple, explicit, and reproducible.
+
+Typical bundle contents:
+
+- `SKILL.md`
+- references needed by the skill
+- skill-local scripts
+- single jar Java CLI runtime when provided
+- single-file JavaScript CLI runtime when provided
+- upstream runtime artifacts, preferably single jar and single JavaScript CLI file
+- package metadata when needed
+- license files and notices as appropriate
+
+Packaging should exclude development-only noise.
+
+Examples:
+
+- local scratch files
+- `workplace/` contents
+- temporary reports
+- test output
+- unrelated upstream development files if not needed at runtime
+
+Bundle-building scripts should be deterministic enough that changes are reviewable. A zipped bundle should be created by a documented command such as `npm run build:bundle` or `npm run build:bundle:zip`.
+
+### Testing Principles
+
+Agent Skills use tests to preserve activation behavior, runtime wiring, structured I/O, and packaging.
+
+Test coverage should include:
+
+- skill smoke tests
+- upstream runtime availability checks
+- runtime selection checks, including Java CLI available, Java CLI unavailable with Node.js fallback, unsupported Java CLI operation with Node.js fallback, and all runtimes missing as a hard error
+- representative import / export operations
+- draft / patch / validate / apply operations where applicable
+- diagnostics and hard-error behavior
+- bundle creation
+- important file naming and artifact paths
+
+As miku Agent Skills move toward receiving upstream runtime artifacts as a single jar and a single JavaScript CLI file, the TOBE target shape is that the upstream source tree and upstream source test suite are not bundled and cannot be executed in the skill repository.
+
+The main responsibility of the skill repository is to verify that the bundled runtime artifacts exist, can be invoked from the skill layer, expose the expected API / CLI contracts, and support the intended agent workflows.
+
+When a failure points into the upstream product itself, fix and verify it in the upstream repository first, then receive updated single-jar or single-JavaScript runtime artifacts in the skill repository.
+
+### Documentation Principles
+
+Agent Skills keep README, `SKILL.md`, references, and docs roles separate.
+
+`README.md` is the user-facing entry point. It should explain:
+
+- what the skill package does
+- how to install or build it
+- how to start using the main skill
+- representative operations
+- runtime requirements
+- where developer documents live
+
+`SKILL.md` is the agent-facing operating contract. It should explain:
+
+- when the skill activates
+- what the skill is allowed to do
+- the most important workflow rules
+- runtime lookup discipline
+- hard boundaries and common mistakes
+- where detailed references are located
+
+Detailed references may include:
+
+- workflow examples
+- input / output formats
+- runtime API notes
+- file import / export notes
+- report export notes
+- installation notes
+- development notes
+
+Do not make `SKILL.md` carry every product detail. It should be compact enough for an agent to read at activation time.
+
+## Recommended Conventions
+
+### Repository Shape
+
+A typical Agent Skills repository has the following shape.
+
+```text
+repository root
+  README.md
+  LICENSE
+  package.json
+  docs/
+  scripts/
+  skills/
+    <skill-name>/
+      SKILL.md
+      references/
+      runtime/
+        <product>.jar
+        <product>.mjs
+  tests/
+  workplace/.gitkeep
+```
+
+In the TOBE target shape, runtime artifacts should be placed under each skill directory. Do not design new normal operation around root-level runtime artifacts, vendored source trees, or multiple competing runtime lookup paths. Current repositories that still use a vendored runtime tree should document that as a transition state and keep the lookup path explicit.
+
+For example, `mikuproject-skills` should move toward this shape when both runtime paths are available.
+
+```text
+skills/
+  mikuproject/
+    SKILL.md
+    references/
+    runtime/
+      mikuproject.jar
+      mikuproject.mjs
+```
+
+The Java jar and Node.js CLI file are peer runtime artifacts. Their presence should not change the skill name or split the workflow vocabulary into runtime-specific skill products.
+
+`vendor/` directories are transition-only locations for repositories that still depend on copied upstream source trees or broader runtime trees. New normal operation should not add new runtime lookup through `vendor/`. As upstream Java and Node.js CLI artifacts become available as single files, repositories should move those artifacts into `skills/<skill-name>/runtime/` and remove the vendored runtime tree.
+
+### Skill Naming Conventions
+
+Skill names should usually match the upstream product name.
+
+Examples:
+
+- `mikuproject`
+- `mikuscore`
+
+Use a more specific name only when the skill intentionally exposes a narrow subset and the product name alone would be misleading.
+
+Avoid generic names such as `planner`, `score`, `xlsx`, or `markdown` for product-specific miku skills. Generic names make accidental activation more likely and weaken the relationship to the upstream product.
+
+### Operation Naming Conventions
+
+Operation names should expose artifact roles, not just file extensions.
+
+Good operation names:
+
+- `draft`
+- `patch`
+- `state`
+- `<format>-import`
+- `<format>-export`
+- `<state-format>-export`
+- `<report-kind>-export`
+- `<bundle-kind>-export`
+
+Avoid ambiguous names when the same extension has multiple meanings.
+
+For example, if two outputs both use `XLSX` but one is structural exchange data and the other is a human-facing report, use names that distinguish those roles.
+
+### Runtime API Conventions
+
+Agent Skills should call stable upstream surfaces.
+
+Preferred surfaces:
+
+- exported Node.js modules
+- documented CLI commands
+- stable global APIs intentionally exposed by bundled single-file or browser-derived runtime
+- Java CLI or Maven plugin when a Java version is the intended local runtime
+
+The skill should not depend on UI DOM state, browser click sequences, or private generated internals when a public API exists.
+
+If a stable upstream API is not available, document the dependency clearly and consider adding the needed API upstream.
+
+### Result Reporting Conventions
+
+Skill responses should be concise but structured.
+
+A useful result usually includes:
+
+- operation performed
+- success or failure
+- key artifact paths or artifact names
+- warning count and short warning summary
+- important diagnostics
+- next state identifier or file path when relevant
+
+Do not dump large JSON or generated artifacts into the conversation unless the user asked for the body or visible handoff is the intended workflow. Prefer file artifacts or concise summaries when the environment supports them.
+
+### Bundle Script Conventions
+
+Bundle scripts should be explicit.
+
+Bundle scripts are packaging and verification commands for the skill package. In the TOBE target shape, they should not assume that TypeScript source, Java source, or the full upstream source tree is present in the skill repository.
+
+The normal inputs are the skill files and the received runtime artifacts:
+
+- single jar Java CLI runtime
+- single JavaScript CLI runtime
+- `SKILL.md`
+- references and small skill-local scripts
+
+Common commands:
+
+```bash
+npm test
+npm run build:bundle
+npm run build:bundle:zip
+```
+
+`npm test` should verify the skill layer and the bundled runtime artifact contracts. `build:bundle` and `build:bundle:zip` should assemble those files into installable skill artifacts. In the TOBE target shape, they should not compile upstream TypeScript or Java source as part of normal skill packaging.
+
+If a current repository still compiles or copies broader upstream runtime contents as part of packaging, that can be tolerated during transition, but it should be treated as a migration item toward single jar and single JavaScript runtime artifacts.
+
+The build script should fail when required runtime files are missing. It should not silently create a skill bundle that cannot run the documented workflow.
+
+## Product-Specific Notes
+
+### Notes Specific to `mikuproject-skills`
+
+`mikuproject-skills` centers on WBS drafting, revision, import / export, and report generation through `mikuproject`.
+
+Important design points:
+
+- skill name is `mikuproject`
+- explicit triggers include `mikuproject`, `miku project`, and documented synonyms
+- activation is explicit and should not trigger from generic planning words alone
+- current MVP keeps `spec`, `draft`, `patch`, and `workbook` in one skill
+- conversation-boundary state is primarily `mikuproject_workbook_json`
+- upstream semantic base remains MS Project XML and `ProjectModel`
+- new WBS creation uses `project_draft_view`
+- existing WBS revision uses local projections and `Patch JSON`
+- file import / export is separate from AI draft / patch workflow
+- structural workbook `XLSX` and report `WBS XLSX` must be named as different artifact roles
+- report outputs such as `WBS XLSX`, `SVG`, `Markdown`, `Mermaid`, and ZIP are derived outputs
+- AI JSON spec retrieval is exposed through upstream core API functions and the `mikuproject ai spec` CLI path, so the skill should prefer those contracts over file search
+- declared `mikuproject` runtime artifacts are checked before broad repository exploration
+- the upstream Node.js CLI runtime artifact is produced by `mikuproject` as a single `bundle/mikuproject.mjs` file and should be received by `mikuproject-skills` as `skills/mikuproject/runtime/mikuproject.mjs`
+- the upstream Java CLI runtime artifact is produced by `mikuproject-java` as `target/mikuproject.jar` and should be received by `mikuproject-skills` as `skills/mikuproject/runtime/mikuproject.jar`
+
+This skill does not aim to replace the `mikuproject` browser UI. Its center is structured AI-agent operation over the upstream product's core APIs and artifacts.
+
+### Notes Specific to `mikuscore-skills`
+
+`mikuscore-skills` should follow the same relationship to `mikuscore`.
+
+Expected design points:
+
+- skill name is `mikuscore`
+- explicit triggers should name `mikuscore` or a documented `mikuscore` score workflow
+- activation is explicit and should not trigger from generic music theory, generic MIDI editing, ordinary notation discussion, or format names alone
+- preserve `mikuscore` product boundaries as a score conversion and AI handoff tool
+- keep `MusicXML` as the canonical score source and explanation axis across format pairs
+- use `ABC` for current generative-AI full-score handoff and new-score generation
+- state the documented `ABC` baseline as `ABC standard 2.2`, while noting that some standard features remain partial or unimplemented
+- distinguish notation source, AI-facing representation, rendered output, final deliverables, and temporary handoff data
+- operation categories include `convert`, `render`, `diagnostics`, `format-guidance`, `ai-handoff`, and `workflow`
+- prefer the vendored upstream CLI or documented runtime flow before broad repository exploration or generic converter logic
+- in the development repository, check `vendor/mikuscore` first; in an installed bundle, check the skill-local `skills/mikuscore/vendor/mikuscore` runtime before treating the runtime as missing
+- current documented conversion / render routes include `ABC <-> MusicXML`, `ABC -> MIDI`, `MIDI -> MusicXML`, `MusicXML <-> MEI`, `MusicXML <-> LilyPond`, `MusicXML <-> MuseScore`, `MusicXML -> SVG`, and `ABC -> MusicXML -> SVG`
+- keep `MEI`, `LilyPond`, and other experimental paths explicitly marked as experimental when explaining them
+- place default generated files under a workspace-local `mikuscore/` tree: `state/` for handoff or canonical artifacts, `output/` for final deliverables, and `tmp/` for temporary intermediates
+- avoid presenting the skill as a full notation editor
+- make unsupported notation, fallback, and conversion loss visible as diagnostics
+
+The current `mikuscore-skills` repository may still bundle a vendored `mikuscore` runtime tree, including runtime dependencies, as its practical runtime source. That is acceptable as the current state when documented in README, `SKILL.md`, references, and smoke tests. The longer-term shared target remains single runtime artifact handling when upstream provides suitable JavaScript and Java CLI artifacts.
+
+The details should be fixed in the `mikuscore-skills` repository's own `SKILL.md`, README, references, and docs.
+
+## Maintenance Principles
+
+Agent Skills maintenance focuses on keeping the skill aligned with upstream product behavior and agent runtime expectations.
+
+Important maintenance questions:
+
+- Does the skill still activate only for intended requests?
+- Does the declared runtime path still exist in development and bundled installs?
+- Did upstream API names, document kinds, or diagnostics change?
+- Do smoke tests cover the main workflows users actually ask for?
+- Does bundling include all required files and exclude local scratch data?
+- Are artifact names still unambiguous?
+- Are README, `SKILL.md`, references, and tests still synchronized?
+
+When updating upstream, separate the work into:
+
+- upstream sync
+- skill adapter changes
+- docs updates
+- bundle verification
+- smoke test results
+
+This separation makes it easier to tell whether a change came from upstream behavior, skill orchestration, packaging, or documentation.
+
+## Minimal Checklist for a New Agent Skills Repository
+
+Before treating a new `-skills` repository as usable, confirm at least the following.
+
+- Upstream product and semantic center are named
+- Skill name and activation rule are fixed
+- Product boundary and non-goals are written in `SKILL.md`
+- Runtime lookup order is documented
+- Upstream API / CLI / runtime surface is identified
+- Main operations are named by artifact role
+- Conversation state format is chosen, if state is needed
+- Hard errors and soft errors are separated
+- Generated file placement is decided
+- Bundle command exists
+- Smoke test command exists
+- README links to developer docs
+- `workplace/` is present or local scratch policy is otherwise documented
+
+This checklist is intentionally small. The purpose is to prevent an Agent Skill from becoming an unclear collection of prompts and scripts before its relationship to the upstream product is stable.

--- a/docs/miku-soft-50-mcp-design-v20260427.md
+++ b/docs/miku-soft-50-mcp-design-v20260427.md
@@ -1,0 +1,735 @@
+# Miku Software MCP Design v20260427
+
+This memo organizes design characteristics commonly expected for MCP server versions in the `miku` software series.
+
+The initial versions of the related tools were created by `Mikuku` and Toshiki Iga.
+
+The current contents are based on the miku main-application design memo, Java application design memo, straight-conversion guide, Agent Skills design memo, and the MCP concepts checked on 2026-04-27.
+
+## Design Summary
+
+The MCP server versions in the `miku` software series can be summarized as follows.
+
+> Protocol adapters that expose miku product operations to MCP clients as tools, resources, and prompts, while preserving upstream semantics, local-first workflows, structured artifacts, diagnostics, and runtime traceability.
+
+What characterizes MCP server versions is not a new product separate from the upstream application. It is a repeated set of constraints.
+
+- Keep the semantic center of the upstream main application
+- Expose product operations through stable MCP tools
+- Expose reusable state, specifications, reports, and generated files through MCP resources
+- Expose a small number of product-specific prompts when useful
+- Keep local stdio execution as the first implementation target
+- Allow HTTP server deployment as a later transport and hosting variant
+- Use Node.js / TypeScript as the standard MCP server implementation choice
+- Use upstream public APIs, CLI, or bundled runtime artifacts rather than duplicating product logic
+- Treat the MCP server as a thin protocol adapter
+- Keep local and server deployments aligned around the same tool contracts
+- Preserve diagnostics, warnings, and artifact roles in structured results
+
+For the current `mikuproject-mcp` repository, this means the MCP server is
+implemented in Node.js / TypeScript. Runtime artifacts live under `runtime/`;
+`packages/java/` is a placeholder only, not a second MCP server implementation
+target.
+
+## Role of This Document
+
+This document is not a detailed specification for one MCP repository. Repository-specific behavior should be checked in each MCP server README, package metadata, tool schema, and product-specific documents.
+
+Use the shared design documents together as follows.
+
+- `docs/miku-soft-10-mainapp-design-v20260425.md`
+  - describes the upstream product design and semantic center
+- `docs/miku-soft-40-agentskills-design-v20260425.md`
+  - describes how Agent Skills versions expose miku workflows to AI agents
+- `docs/miku-soft-50-mcp-design-v20260427.md`
+  - describes how MCP server versions should expose miku workflows to MCP clients
+
+This document separates the following levels.
+
+- **Cross-cutting principles**: design policies that should generally be kept for MCP server versions.
+- **Recommended conventions**: transport, tool, resource, state, runtime, and packaging shapes that make maintenance easier.
+- **Observed tendencies**: design habits visible in current miku repositories and MCP usage.
+- **Product-specific notes**: design decisions for specific MCP products, recorded as concrete examples.
+
+When a specification is unclear, first check whether the decision preserves upstream meaning and keeps the MCP surface stable for clients. For products with a documented CLI, look first to the CLI command tree as the source of truth before inventing MCP method names or operation groups. MCP convenience is important, but it should not hide unsupported behavior, discard diagnostics, or make local and server deployments drift into different products.
+
+## MCP Specification Authority
+
+This document defines the miku-series design stance for MCP server products. It does not replace the external MCP protocol specification.
+
+When implementing an MCP server in a miku-series repository, follow MCP-related authorities in the following order.
+
+1. The official specification published at `modelcontextprotocol.io`
+2. The types and schemas provided by the official MCP SDKs
+3. Changes accepted through MCP governance and Specification Enhancement Proposals
+4. Optional compatibility notes for individual MCP clients such as Claude Desktop, Claude Code, IDE clients, or other host applications
+
+The official MCP specification is the primary contract. Client-specific behavior is optional compatibility material, not a source of product semantics and not a reason to change the core protocol shape.
+
+When supporting a specific client, implement the support as a compatibility layer or documented operational note. Do not let client-specific behavior redefine tool names, input schemas, result schemas, resource URI roles, artifact roles, or error categories. If a client requires a workaround, keep the official MCP contract intact and document the workaround as client compatibility behavior.
+
+The preferred order is:
+
+1. Implement the official MCP contract.
+2. Verify behavior with official SDK types and schemas.
+3. Add client compatibility checks where useful.
+4. Document any client-specific behavior separately from the protocol contract.
+
+## Scope
+
+The series whose names start with `miku` includes several related product types.
+
+Main applications:
+
+- `miku-abc-player`
+- `miku-docx2md`
+- `miku-indexgen`
+- `miku-unicode-guard`
+- `miku-xlsx2md`
+- `mikuproject`
+- `mikuscore`
+
+Agent Skills versions:
+
+- `mikuproject-skills`
+- `mikuscore-skills`
+
+MCP server versions:
+
+- `mikuproject-mcp`
+
+Projects with the `-mcp` suffix are positioned as MCP server adapters for original suffixless tools or their runtime artifacts.
+
+For `mikuproject-mcp`, the server implementation is Node.js / TypeScript.
+`packages/java/` is intentionally only a placeholder.
+
+This document focuses on MCP server versions. It does not define the Web UI conventions for upstream main applications, Java packaging conventions for Java application versions, or skill packaging conventions for Agent Skills repositories.
+
+## Shared Direction
+
+MCP server versions continue the shared direction of the miku series: small local bridge tools that convert, extract, inspect, normalize, or export domain files and domain data.
+
+The MCP version emphasizes the parts that fit MCP operation particularly well.
+
+- model-callable tools
+- application-readable resources
+- user-selectable prompts where useful
+- structured JSON input and output schemas
+- local import / validate / export operations
+- resource links for generated artifacts
+- diagnostics and warnings as structured results
+- repeatable file-based operation
+- stdio local server execution
+- optional HTTP server deployment when remote access is required
+
+An MCP version should not become a generic planner, generic converter, hosted replacement application, or independent semantic implementation. Its value is that MCP clients can use the upstream miku product correctly through stable tool and resource contracts.
+
+## Relationship to Main Applications
+
+MCP server versions are downstream of miku main applications.
+
+The upstream main application owns the product semantics, canonical source, core conversions, output policy, and limitations. The MCP server owns protocol exposure, tool schema, resource naming, transport handling, runtime discovery, and result formatting.
+
+The preferred relationship is as follows.
+
+- upstream main application provides core APIs, CLI, bundled runtime, or stable artifacts
+- MCP server calls those upstream surfaces
+- MCP server exposes product operations as tools
+- MCP server exposes reusable state and artifacts as resources
+- MCP server may expose product-specific workflow prompts
+- MCP server returns diagnostics, warnings, hard errors, and generated artifact links in a structured form
+- MCP server does not reimplement core conversion behavior unless no upstream surface exists
+
+If an upstream capability is missing, the preferred order is to request or implement the capability on the upstream side, expose it as a stable upstream API, and then let the MCP server call it. MCP servers should not silently add upstream product capabilities on the MCP side. MCP-local workaround code should be treated as temporary or product-specific, not as the new semantic center.
+
+## Relationship to Agent Skills
+
+Agent Skills and MCP servers are closely related, but they are not the same layer.
+
+Agent Skills are instruction and workflow packages for agents. They explain when to activate a product-specific workflow, which runtime artifacts to use, how to manage intermediate files, and how to avoid confusing artifact roles.
+
+MCP servers are protocol adapters. They expose callable tools, readable resources, and optional prompts to MCP clients.
+
+The preferred relationship is as follows.
+
+- Agent Skills may continue to guide agents that can read `SKILL.md` and run local commands directly
+- MCP servers should serve clients that prefer a standard tool/resource/prompt protocol
+- both should call the same upstream runtime artifacts or public APIs when possible
+- both should use the same product vocabulary and artifact roles
+- neither should become the semantic owner of the product
+
+For a product such as `mikuproject`, an Agent Skills repository may include a local MCP server, or a separate `mikuproject-mcp` repository may provide one. In either case, the MCP contract should stay aligned with the Agent Skills operation map and upstream CLI contracts.
+
+## Role of MCP Servers
+
+In this document, an MCP server means a `miku` repository or package with an MCP server entrypoint that provides product operations through MCP.
+
+An MCP server usually exposes one or more of the following.
+
+- stdio server entrypoint for local MCP clients
+- HTTP server entrypoint for hosted or remote MCP clients
+- tool definitions with JSON input schemas
+- structured tool results and optional output schemas
+- resource definitions for state, specifications, reports, and generated files
+- resource templates for session or workspace-scoped artifacts
+- prompt definitions for product-specific workflows
+- runtime adapters for bundled CLI artifacts or public APIs
+- smoke tests for protocol startup and core tool calls
+
+The MCP server is not primarily the browser UI, not primarily a runtime port, and not primarily an Agent Skill. For miku MCP repositories, Node.js / TypeScript is the normal MCP server implementation choice. The server can call bundled or configured runtime artifacts if that is the natural way to execute the upstream product, but the MCP layer itself should remain thin.
+
+The center of an MCP server is reliable protocol adaptation: receive a typed tool call, validate arguments, call the upstream runtime, preserve useful state, expose resulting artifacts as resources, and return diagnostics without hiding important constraints.
+
+## Cross-Cutting Principles
+
+miku MCP servers emphasize the following cross-cutting principles.
+
+1. Preserve the semantic center and product boundary of the upstream main application.
+2. Treat MCP as a protocol adapter, not as a replacement implementation.
+3. Keep MCP tool contracts stable across local stdio and HTTP server deployments.
+4. Prefer local stdio execution as the first implementation target.
+5. Add HTTP server deployment only with explicit session, storage, authentication, and isolation boundaries.
+6. Use structured input schemas, structured results, diagnostics, and resource links instead of loose prose.
+7. Distinguish canonical source, conversation state, MCP resources, primary output, reports, and temporary files.
+8. Make runtime selection, artifact storage, smoke testing, and upstream synchronization explainable.
+
+### Basic Philosophy of MCP Servers
+
+MCP server versions emphasize the following philosophy.
+
+- Run product operations locally when practical
+- Keep the upstream product meaning recognizable
+- Use upstream API or CLI before writing MCP-local conversion logic
+- Expose only product-specific operations that are useful to MCP clients
+- Keep tool names stable, explicit, and product-prefixed
+- Derive tool names from the upstream CLI command tree when a documented CLI
+  exists
+- Keep intermediate JSON internal when direct tool composition is possible
+- Return generated files as resources or resource links when practical
+- Preserve diagnostics and warnings as part of the result
+- Keep state and generated files easy to save, compare, and rerun
+- Keep local and hosted deployments aligned around the same tool contracts
+
+The value of an MCP server version is not that it can answer a domain question conversationally in a generic way. It is that MCP clients can safely call specific miku workflows through structured operations that are faithful to the upstream product.
+
+### Common Principles for MCP Servers
+
+MCP servers use the following principles as defaults.
+
+- Use a `-mcp` suffix when the MCP server is a separate repository or package
+- Keep the product name in tool names
+- When a documented CLI exists, derive MCP tool names from the canonical CLI
+  command tree
+- Use stdio transport as the first local implementation
+- Treat HTTP transport as an additional deployment form, not a separate product contract
+- Use Node.js / TypeScript as the standard implementation choice for the MCP server
+- Prefer a single Node.js / TypeScript MCP server unless a concrete product constraint justifies another server implementation
+- Prefer bundled or configured runtime artifacts when local, reproducible execution needs them
+- Prefer upstream public APIs, stable global APIs, or documented CLI commands
+- Keep tool schemas and result schemas under version control
+- Keep repository-level README user-facing and developer details under `docs/`
+- Use `workplace/` or a configured workspace root for local scratch data, uploaded files, generated outputs, and verification files
+
+These are defaults for the miku MCP series. Individual products may add product-specific conventions, but should not change these foundations casually.
+
+## Transport Principles
+
+MCP is a protocol, not a synonym for an HTTP server.
+
+The first transport for miku MCP servers should usually be local stdio.
+
+Local stdio is appropriate when:
+
+- the user runs an MCP client on the same machine
+- the product reads and writes local files
+- the upstream runtime is available as a local executable artifact or CLI command
+- the workflow benefits from local-first processing and simple installation
+
+HTTP transport is appropriate when:
+
+- multiple clients need remote access
+- the server owns session storage
+- files are uploaded to a controlled workspace
+- authentication, quota, and audit requirements are explicit
+- the deployment environment can isolate user workspaces safely
+
+Local stdio and HTTP deployments should share the same tool names and core input/output contracts. Differences should be limited to transport, file reference handling, session identity, storage, and authentication.
+
+## Local Stdio Server Principles
+
+The local stdio server is the preferred MVP shape.
+
+It should:
+
+- start as a local process launched by the MCP client
+- communicate over standard input and standard output
+- avoid requiring a network listener
+- discover bundled or configured runtime artifacts
+- call upstream CLI or APIs with explicit file paths
+- confine file reads and writes to declared workspace roots where practical
+- return generated file references as resources or resource links
+
+The local stdio server should not behave like a long-running public web service. It is a local adapter process whose authority comes from the user and the MCP client configuration.
+
+## HTTP Server Principles
+
+The HTTP server is a deployment variant, not the initial semantic center.
+
+An HTTP MCP server must define the following before it is treated as production-ready.
+
+- authentication and authorization model
+- session identity
+- workspace isolation
+- uploaded file lifecycle
+- generated artifact lifecycle
+- maximum input and output sizes
+- cleanup policy
+- audit or trace policy when needed
+- runtime sandboxing or equivalent execution boundary
+- user-visible confirmation policy for destructive operations when the client supports it
+
+HTTP deployment should not expose arbitrary local filesystem paths from the host. It should prefer session-scoped resource URIs, upload identifiers, or controlled workspace-relative paths.
+
+## Tool Design Principles
+
+MCP tools are the main execution surface.
+
+Tool names should be product-prefixed and stable.
+
+When a product has a documented CLI, first treat the CLI command tree as the
+source of truth. MCP method names should be derived from that tree before any
+MCP-specific shortening, grouping, or convenience naming is considered.
+
+For products with a documented CLI, MCP tool names should preserve the CLI
+command tree. Use this form:
+
+```text
+<product>.<cli command tokens joined by "_">
+```
+
+Omit only the runtime launcher, such as `node mikuproject.mjs` or
+another runtime command. Convert hyphenated CLI tokens to snake_case.
+
+The CLI command group is part of the operation name. Do not shorten
+`ai detect-kind` to `detect_kind`, `ai validate-patch` to `validate_patch`, or
+`state apply-patch` to `apply_patch` in the MCP surface. Shorter names hide the
+upstream command structure and make MCP, CLI diagnostics, tests, and Agent
+Skills documentation harder to compare.
+
+Examples:
+
+- `mikuproject.ai_spec`
+- `mikuproject.ai_detect_kind`
+- `mikuproject.state_from_draft`
+- `mikuproject.ai_export_project_overview`
+- `mikuproject.ai_export_task_edit`
+- `mikuproject.ai_export_phase_detail`
+- `mikuproject.ai_validate_patch`
+- `mikuproject.state_apply_patch`
+- `mikuproject.state_diff`
+- `mikuproject.export_workbook_json`
+- `mikuproject.report_mermaid`
+
+Tool input should use JSON Schema. Tool results should return structured content when practical. For compatibility with clients that primarily display text, structured results may also be serialized into a text content block.
+
+Tools should prefer explicit argument names over positional behavior. Large input and output should be passed by file path, resource URI, upload ID, or resource link instead of being forced into chat-visible text.
+
+## Resource Design Principles
+
+MCP resources should expose reusable state and artifacts.
+
+Typical resources include:
+
+- AI-facing specifications
+- current workbook state
+- saved workbook states
+- imported canonical source files
+- generated report files
+- diagnostics logs
+- operation summaries
+
+Resource URIs should distinguish artifact roles.
+
+Examples:
+
+- `mikuproject://spec/ai-json`
+- `mikuproject://state/current`
+- `mikuproject://state/{name}`
+- `mikuproject://report/{name}`
+- `mikuproject://diagnostics/{operationId}`
+
+When a resource maps to a real local file, the server may return a `file://` resource link only when the client is expected to access that file directly. Otherwise, a product-specific URI should be preferred so that the server remains the controlled access point.
+
+## Prompt Design Principles
+
+MCP prompts should be small and product-specific.
+
+Prompts are useful when a client wants user-selectable workflow templates. They should not become the primary location for product semantics.
+
+Typical prompts include:
+
+- create a new product-specific draft from user requirements
+- revise an existing state using a small projection and patch
+- review a product artifact using documented diagnostics
+
+For products that already expose AI-facing specifications through upstream APIs or CLI commands, the MCP server should expose that specification as a tool or resource. Prompt text can reference the specification, but should not duplicate a large schema if the upstream product already provides a stable retrieval path.
+
+## Runtime Principles
+
+MCP servers should use declared runtime artifacts before broad repository exploration.
+
+The preferred order is as follows.
+
+1. Check the MCP server configuration
+2. Check bundled runtime artifacts declared by the package under `runtime/`
+3. Use upstream public APIs, stable globals, or documented CLI/runtime flows
+4. Use MCP-local helpers only when they are the intended adapter layer
+5. Search broadly for alternatives only when the declared runtime path is missing or unusable
+
+When multiple runtime artifacts are available, runtime selection is an execution
+policy, not a semantic priority. The upstream main application remains the
+semantic center. Runtime differences should be reported as capability or
+compatibility diagnostics.
+
+When an MCP repository bundles upstream runtime artifacts, `runtime/` is the preferred repository directory. The name reflects that these files are execution artifacts used by the MCP adapter, not general vendored source material. Use `vendor/` only when a repository intentionally vendors third-party source or dependency material.
+
+Recommended runtime artifact layout:
+
+```text
+runtime/
+  product-runtime/
+    runnable-artifact
+    source-traceability-artifact
+```
+
+`runtime/` is the installed runtime surface for the MCP adapter. It should
+contain runnable artifacts and, when available, paired source traceability
+artifacts. The MCP server executes only runnable artifacts, but source
+traceability artifacts can keep runtime bundles auditable without requiring the
+full upstream source checkout.
+
+The exact filenames may differ by product, but the artifact role should remain clear in directory names, package metadata, and diagnostics.
+
+## State and Artifact Principles
+
+MCP servers distinguish several kinds of data.
+
+- canonical source or semantic base owned by the upstream product
+- MCP server session state
+- AI-facing projection or draft document
+- patch or edit document returned by AI
+- primary product output
+- report or presentation output
+- diagnostics and warnings
+- temporary files and local scratch outputs
+
+These roles should not be collapsed only because they are all represented as JSON or files.
+
+For local stdio deployment, file paths can be a practical state boundary. For HTTP deployment, session-scoped resource URIs or upload identifiers are usually safer than arbitrary host paths.
+
+For products such as `mikuproject`, `mikuproject_workbook_json` may be the practical MCP state handoff format, while `MS Project XML` remains the product's semantic base. The MCP server should make that distinction visible in naming, docs, and tool descriptions.
+
+## Local and Server Variant Principles
+
+A separate MCP product may support both local and server deployments.
+
+The recommended split is:
+
+- core tool definitions
+- core input and result schemas
+- runtime adapter interface
+- local stdio entrypoint
+- HTTP entrypoint
+- storage adapter
+- session adapter
+
+Local and server variants should not create different operation vocabularies. They should share the same core tool names and result shapes.
+
+Variant-specific differences should be limited to:
+
+- transport
+- file reference representation
+- workspace and session scope
+- authentication
+- storage persistence
+- artifact lifetime
+- runtime isolation
+
+If a capability is not safe or practical in one deployment form, the server should report an explicit capability or policy error rather than silently changing behavior.
+
+## Implementation Language Principles
+
+MCP is a protocol, not a language-specific product shape. A miku MCP server may be implemented in TypeScript, Java, or another language when that language is appropriate for the repository and runtime environment.
+
+For miku MCP repositories, Node.js / TypeScript is the standard choice because
+it gives a direct path to local stdio MCP servers, official SDK alignment, JSON
+Schema handling, package metadata, and smoke testing.
+
+Do not add a second MCP server implementation unless a concrete product,
+distribution, or runtime constraint requires it. If that happens, decide the
+language-specific porting rules at that time, using the checked-in MCP contract
+as the stable boundary.
+
+## Recommended Repository Layout
+
+When a miku MCP repository uses a Node.js / TypeScript implementation and keeps room for possible future implementation variants, use a repository layout that separates the shared MCP contract from language-specific server code and runtime artifacts.
+
+Recommended layout:
+
+```text
+mikuproject-mcp/
+  docs/
+  contract/
+    tools/
+    results/
+    resources/
+    errors/
+  packages/
+    node/
+      src/
+      test/
+    java/
+      .gitkeep
+  runtime/
+    product-runtime/
+  workplace/
+```
+
+The intended responsibilities are:
+
+- `contract/`
+  - owns shared MCP tool names, input schemas, result shapes, resource URI conventions, prompt names, artifact roles, diagnostics, and error categories
+- `packages/node/`
+  - owns the Node.js / TypeScript MCP server implementation
+  - is usually the first implementation and initial reference implementation
+- `packages/java/`
+  - placeholder only
+- `runtime/`
+  - stores configured or bundled upstream execution artifacts used by the MCP adapters
+- `workplace/`
+  - stores local scratch files, generated outputs, and optional upstream checkouts
+
+The shared MCP contract should not live only as implicit TypeScript code. Keep the contract explicit enough that the MCP surface remains clear even if implementation choices change later.
+
+## Runtime Capability Boundary Principles
+
+When multiple upstream runtime paths exist, the core MCP contract should be limited to operations that are available across the supported runtime paths needed for the product's normal fallback policy.
+
+Runtime-specific operations may be added later as optional, capability-gated extensions, but they should be clearly separated from the core MCP contract. Such operations should:
+
+- be documented as optional extensions
+- report unavailable capability clearly when the selected runtime does not support them
+- avoid changing core tool names, schemas, result shapes, resource URI conventions, artifact roles, or error categories
+- avoid becoming required for the normal local stdio MVP workflow
+
+## Error Handling Principles
+
+MCP servers should separate the following.
+
+- invalid tool arguments
+- unsupported document kind
+- missing base state
+- upstream runtime failure
+- upstream validation error
+- upstream warning
+- file access or storage policy error
+- transport or session error
+
+Hard errors should make the tool call fail in a way the MCP client can surface clearly.
+
+Soft errors and upstream warnings should be returned in structured results when the operation can still produce a meaningful artifact. They should not be discarded only because the requested output file was generated.
+
+## Security and Trust Principles
+
+MCP servers expose executable operations to AI clients, so security boundaries must be explicit.
+
+Local stdio servers should:
+
+- avoid reading arbitrary files unless the user or client provides them explicitly
+- avoid writing outside configured workspace or output roots when practical
+- avoid accepting shell fragments or raw command lines from tool arguments
+- call upstream runtimes through fixed argument arrays, not string-built shell commands
+- report generated paths clearly
+
+HTTP servers should additionally:
+
+- authenticate clients or users
+- isolate sessions
+- restrict file access to controlled storage
+- enforce upload and output size limits
+- clean up temporary artifacts
+- prevent cross-user resource access
+- treat uploaded files as untrusted input
+
+MCP tool descriptions and annotations are not a substitute for server-side validation.
+
+## Product Boundary Principles
+
+MCP servers must preserve the product boundary of the upstream miku tool.
+
+Examples:
+
+- `mikuproject-mcp` exposes WBS import, draft, patch, state, and report operations; it is not a full project-management server.
+- `mikuscore-mcp` would expose score conversion, inspection, and handoff operations; it would not become a full notation editor.
+- `miku-xlsx2md-mcp` would expose workbook-to-Markdown extraction and diagnostics; it would not become a general spreadsheet automation server.
+
+If the MCP server starts needing broad domain features that the upstream application does not own, treat that as a product design issue rather than hiding it in MCP tool code.
+
+## Recommended MVP Shape
+
+For a first miku MCP server, use this shape.
+
+- local stdio transport
+- product-prefixed tools
+- JSON Schema input definitions
+- structured tool results
+- resource links for generated artifacts
+- bundled or configured runtime artifact lookup
+- smoke test for server startup
+- smoke test for one read-only tool
+- smoke test for one state-changing tool with temporary files
+
+For `mikuproject-mcp`, the MVP tools should be close to the Agent Skills MVP operation set.
+
+- `mikuproject.ai_spec`
+- `mikuproject.ai_detect_kind`
+- `mikuproject.state_from_draft`
+- `mikuproject.ai_export_project_overview`
+- `mikuproject.ai_export_task_edit`
+- `mikuproject.ai_export_phase_detail`
+- `mikuproject.ai_validate_patch`
+- `mikuproject.state_apply_patch`
+- `mikuproject.state_diff`
+- `mikuproject.state_summarize`
+- `mikuproject.export_workbook_json`
+
+File import/export and report generation can be added after the core state workflow is stable.
+
+## Out of Scope for the First Version
+
+The first version should not include:
+
+- broad hosted multi-tenant operation
+- custom user management
+- external AI model invocation
+- API key management for model providers
+- a browser UI replacement
+- full domain editing outside upstream-supported operations
+- automatic workflow planning beyond exposed tools and prompts
+- broad filesystem browsing
+- parallel implementation of upstream conversion logic
+
+These may become useful later, but they should not be allowed to blur the initial MCP contract.
+
+## Product-Specific Note: mikuproject-mcp
+
+`mikuproject-mcp` should expose `mikuproject` operations to MCP clients.
+
+The semantic center remains upstream `mikuproject`. The practical MCP state handoff format may be `mikuproject_workbook_json`. `MS Project XML` remains the semantic base and compatibility format for the product.
+
+`mikuproject-mcp` may be developed as an independent repository and product, rather than as a subdirectory of `mikuproject-skills`.
+
+This independence means that `mikuproject-mcp` owns its MCP-specific entrypoints, schemas, transport handling, and adapter code. It does not mean that `mikuproject-mcp` owns the product semantics of `mikuproject`.
+
+The preferred repository relationship is as follows.
+
+- `mikuproject`
+  - owns the upstream product semantics
+  - owns the canonical domain behavior, conversion policy, report policy, and AI-facing product contracts
+- `mikuproject-skills`
+  - provides the Agent Skills workflow design reference
+  - records operation maps, state-handling rules, file workflow rules, and agent-facing boundaries
+- `mikuproject-mcp`
+  - owns the MCP server entrypoints
+  - owns tool, resource, and prompt definitions
+  - owns MCP input and output schemas
+  - owns local stdio transport and optional HTTP transport
+  - owns session, workspace, storage, and runtime adapter policy for MCP deployments
+
+For development, `mikuproject-mcp` may use local upstream checkouts under `workplace/upstream/`.
+
+When cloning upstream repositories for local reference, clone them into the prescribed `workplace/upstream/` directory. Do not clone upstream repositories into the repository root, `runtime/`, `packages/`, or `contract/`.
+
+Recommended layout:
+
+```text
+mikuproject-mcp/
+  contract/
+    tools/
+    results/
+    resources/
+    errors/
+  packages/
+    node/
+    java/
+  runtime/
+    product-runtime/
+  workplace/
+    upstream/
+      mikuproject/
+      mikuproject-skills/
+```
+
+`contract/` is the shared MCP contract. `packages/node/` is the TypeScript implementation and reference implementation. `packages/java/` is a placeholder only.
+
+Files under `runtime/` are the configured or bundled execution artifacts used by the MCP server. Checkouts under `workplace/upstream/` are reference material and local development inputs. They should normally remain outside Git tracking except for placeholder files needed to keep the workspace directory shape.
+
+Use the following clone destinations:
+
+```text
+workplace/upstream/mikuproject/
+workplace/upstream/mikuproject-skills/
+```
+
+The upstream checkouts should be used to inspect and synchronize the following.
+
+- upstream `mikuproject` CLI contracts and AI-facing specifications
+- upstream `mikuproject` product behavior and artifact roles
+- `mikuproject-skills` operation map and workflow boundary rules
+- runtime artifact generation and smoke-test expectations
+
+The MCP repository may copy, bundle, or download runtime artifacts into `runtime/` according to its own packaging policy, but it should not treat `workplace/upstream/` itself as the installed runtime surface.
+
+The clean responsibility split is:
+
+```text
+mikuproject
+  -> upstream semantic owner
+
+mikuproject-skills
+  -> Agent Skills workflow design reference
+
+mikuproject-mcp
+  -> MCP protocol adapter
+```
+
+The first implementation should borrow heavily from `mikuproject-skills` design material, especially:
+
+- operation names and operation grouping
+- `mikuproject_workbook_json` as the practical state boundary
+- distinction between structural workbook `XLSX` and `WBS XLSX` report output
+- distinction between draft, patch, projection, workbook, report, and diagnostics artifacts
+- default local output discipline for state, report, and temporary files
+
+The first implementation should prefer local stdio transport. It should call
+runtime artifacts through fixed runtime adapter code. It should keep the tool
+names aligned with the existing `mikuproject-skills` operation map and upstream
+CLI correspondence.
+
+The CLI command tree is the naming source for MCP tools:
+
+- `ai spec` becomes `mikuproject.ai_spec`
+- `ai detect-kind` becomes `mikuproject.ai_detect_kind`
+- `state from-draft` becomes `mikuproject.state_from_draft`
+- `ai validate-patch` becomes `mikuproject.ai_validate_patch`
+- `state apply-patch` becomes `mikuproject.state_apply_patch`
+
+For `mikuproject-mcp`, the MCP server implementation is TypeScript. The
+TypeScript version establishes the MCP contract for tools, schemas, result
+shapes, resources, diagnostics, and local workspace behavior.
+
+`packages/java/` remains a placeholder only. Do not predesign another MCP server
+implementation in the current Node server documentation. If a concrete future
+requirement appears, handle that implementation design at that time.
+
+If `mikuproject-mcp` later adds an HTTP server, it should keep the same core tool names. The HTTP server should add session-scoped resources, upload handling, authentication, storage policy, and artifact lifecycle management rather than changing the product operation vocabulary.


### PR DESCRIPTION
## 概要

mikuソフトウェアシリーズの設計文書を拡充し、全体概要、Agent Skills、MCPに関する設計メモを追加しました。あわせて、Javaアプリケーション設計メモを `v20260426` に更新しています。

## 変更内容

- `docs/miku-soft-00-overview-design-v20260427.md` を追加
  - mikuソフトウェアシリーズ全体の設計概要を整理
  - Human-facing layer、Java Runtime Layer、Straight Conversion Layer、Agent-facing layer、MCP-facing layer の関係を記述
  - 通常のプロダクトフロー、責務分担、成果物ロールの扱いを整理

- `docs/miku-soft-20-javaapp-design-v20260425.md` を削除し、`docs/miku-soft-20-javaapp-design-v20260426.md` を追加
  - Javaアプリケーション設計メモを版更新
  - sources jar の扱いを追記
  - `mikuproject-java` の想定成果物として sources jar と distribution zip への同梱を明記

- `docs/miku-soft-40-agentskills-design-v20260425.md` を追加
  - Agent Skills の役割、スコープ、Main Application との関係を整理
  - 推奨構成、保守方針、Agent Skills リポジトリ作成時の最小チェックリストを追加

- `docs/miku-soft-50-mcp-design-v20260427.md` を追加
  - miku MCPサーバーの設計方針を整理
  - tools / resources / prompts、stdio / HTTP、runtime、artifact、error handling、security、MVP範囲を記述
  - `mikuproject-mcp` 向けのプロダクト固有メモを追加

## 補足

この変更はドキュメント追加・更新が中心です。既存の実装コード変更は含まれていません。