### PR TITLE
Verovio 初期化待ちと VSQX 診断生成を整理

### DIFF
--- a/bundle/mikuscore.mjs
+++ b/bundle/mikuscore.mjs
@@ -136624,6 +136624,39 @@ var BUNDLED_CLI_MODULES = {
       var _a;
       return (_a = window.verovio) !== null && _a !== void 0 ? _a : null;
     };
+    const isVerovioRuntimeReady = (moduleObj) => {
+      return Boolean(moduleObj.calledRun && typeof moduleObj.cwrap === "function");
+    };
+    const waitForVerovioRuntime = async (moduleObj) => {
+      if (isVerovioRuntimeReady(moduleObj))
+        return;
+      await new Promise((resolve, reject) => {
+        let settled = false;
+        const timeoutId = window.setTimeout(() => {
+          if (settled)
+            return;
+          settled = true;
+          reject(new Error("Timed out while waiting for verovio initialization."));
+        }, VEROVIO_INIT_TIMEOUT_MS);
+        const complete = () => {
+          if (settled)
+            return;
+          settled = true;
+          window.clearTimeout(timeoutId);
+          resolve();
+        };
+        const previous = moduleObj.onRuntimeInitialized;
+        moduleObj.onRuntimeInitialized = () => {
+          if (typeof previous === "function") {
+            previous();
+          }
+          complete();
+        };
+        if (isVerovioRuntimeReady(moduleObj)) {
+          complete();
+        }
+      });
+    };
     const ensureVerovioToolkit = async () => {
       if (verovioToolkit) {
         return verovioToolkit;
@@ -136640,34 +136673,7 @@ var BUNDLED_CLI_MODULES = {
         if (!moduleObj) {
           throw new Error("verovio module was not found.");
         }
-        if (!moduleObj.calledRun || typeof moduleObj.cwrap !== "function") {
-          await new Promise((resolve, reject) => {
-            let settled = false;
-            const timeoutId = window.setTimeout(() => {
-              if (settled)
-                return;
-              settled = true;
-              reject(new Error("Timed out while waiting for verovio initialization."));
-            }, VEROVIO_INIT_TIMEOUT_MS);
-            const complete = () => {
-              if (settled)
-                return;
-              settled = true;
-              window.clearTimeout(timeoutId);
-              resolve();
-            };
-            const previous = moduleObj.onRuntimeInitialized;
-            moduleObj.onRuntimeInitialized = () => {
-              if (typeof previous === "function") {
-                previous();
-              }
-              complete();
-            };
-            if (moduleObj.calledRun && typeof moduleObj.cwrap === "function") {
-              complete();
-            }
-          });
-        }
+        await waitForVerovioRuntime(moduleObj);
         verovioToolkit = new runtime.toolkit();
         return verovioToolkit;
       })().catch((error) => {

--- a/mikuscore.html
+++ b/mikuscore.html
@@ -18563,6 +18563,39 @@ const getVerovioRuntime = () => {
     var _a;
     return (_a = window.verovio) !== null && _a !== void 0 ? _a : null;
 };
+const isVerovioRuntimeReady = (moduleObj) => {
+    return Boolean(moduleObj.calledRun && typeof moduleObj.cwrap === "function");
+};
+const waitForVerovioRuntime = async (moduleObj) => {
+    if (isVerovioRuntimeReady(moduleObj))
+        return;
+    await new Promise((resolve, reject) => {
+        let settled = false;
+        const timeoutId = window.setTimeout(() => {
+            if (settled)
+                return;
+            settled = true;
+            reject(new Error("Timed out while waiting for verovio initialization."));
+        }, VEROVIO_INIT_TIMEOUT_MS);
+        const complete = () => {
+            if (settled)
+                return;
+            settled = true;
+            window.clearTimeout(timeoutId);
+            resolve();
+        };
+        const previous = moduleObj.onRuntimeInitialized;
+        moduleObj.onRuntimeInitialized = () => {
+            if (typeof previous === "function") {
+                previous();
+            }
+            complete();
+        };
+        if (isVerovioRuntimeReady(moduleObj)) {
+            complete();
+        }
+    });
+};
 const ensureVerovioToolkit = async () => {
     if (verovioToolkit) {
         return verovioToolkit;
@@ -18579,34 +18612,7 @@ const ensureVerovioToolkit = async () => {
         if (!moduleObj) {
             throw new Error("verovio module was not found.");
         }
-        if (!moduleObj.calledRun || typeof moduleObj.cwrap !== "function") {
-            await new Promise((resolve, reject) => {
-                let settled = false;
-                const timeoutId = window.setTimeout(() => {
-                    if (settled)
-                        return;
-                    settled = true;
-                    reject(new Error("Timed out while waiting for verovio initialization."));
-                }, VEROVIO_INIT_TIMEOUT_MS);
-                const complete = () => {
-                    if (settled)
-                        return;
-                    settled = true;
-                    window.clearTimeout(timeoutId);
-                    resolve();
-                };
-                const previous = moduleObj.onRuntimeInitialized;
-                moduleObj.onRuntimeInitialized = () => {
-                    if (typeof previous === "function") {
-                        previous();
-                    }
-                    complete();
-                };
-                if (moduleObj.calledRun && typeof moduleObj.cwrap === "function") {
-                    complete();
-                }
-            });
-        }
+        await waitForVerovioRuntime(moduleObj);
         verovioToolkit = new runtime.toolkit();
         return verovioToolkit;
     })()
@@ -21344,10 +21350,26 @@ const bridge = () => {
         return null;
     return (_a = window.UtaFormatix3TsPlusMikuscore) !== null && _a !== void 0 ? _a : null;
 };
+const isBlankText = (value) => {
+    return !String(value || "").trim();
+};
 const bridgeUnavailableDiagnostic = () => ({
     code: VSQX_BRIDGE_UNAVAILABLE,
     message: MSG_BRIDGE_UNAVAILABLE,
 });
+const diagnostic = (code, message) => ({ code, message });
+const vsqxExportErrorMessage = (error) => {
+    return error instanceof Error ? error.message : MSG_EXPORT_FAILED;
+};
+const vsqxConvertEmptyResultDiagnostic = () => {
+    return diagnostic(VSQX_CONVERT_EMPTY_RESULT, MSG_CONVERT_EMPTY_RESULT);
+};
+const vsqxExportEmptyResultDiagnostic = () => {
+    return diagnostic(VSQX_EXPORT_EMPTY_RESULT, MSG_EXPORT_EMPTY_RESULT);
+};
+const vsqxExportFailedDiagnostic = (error) => {
+    return diagnostic(VSQX_EXPORT_FAILED, vsqxExportErrorMessage(error));
+};
 const failedVsqxToMusicXmlResult = (diagnostics, warnings = []) => ({
     ok: false,
     xml: "",
@@ -21359,7 +21381,6 @@ const failedMusicXmlToVsqxResult = (diagnostic) => ({
     vsqx: "",
     diagnostic,
 });
-const diagnostic = (code, message) => ({ code, message });
 const issueLevel = (issue) => {
     return String(issue.level || "").toLowerCase();
 };
@@ -21416,11 +21437,11 @@ const convertVsqxToMusicXml = (vsqxText, options) => {
     const report = runtime.convertVsqxToMusicXmlWithReport(vsqxText, options);
     const { diagnostics, warnings } = collectVsqxConversionIssues(reportIssues(report));
     const xml = String((report === null || report === void 0 ? void 0 : report.musicXml) || "");
-    if (!xml.trim()) {
+    if (isBlankText(xml)) {
         const fallbackDiagnostics = diagnostics.length
             ? diagnostics
             : [
-                diagnostic(VSQX_CONVERT_EMPTY_RESULT, MSG_CONVERT_EMPTY_RESULT),
+                vsqxConvertEmptyResultDiagnostic(),
             ];
         return failedVsqxToMusicXmlResult(fallbackDiagnostics, warnings);
     }
@@ -21439,13 +21460,13 @@ const convertMusicXmlToVsqx = (musicXmlText, options) => {
     }
     try {
         const vsqx = runtime.convertMusicXmlToVsqx(musicXmlText, options);
-        if (!String(vsqx || "").trim()) {
-            return failedMusicXmlToVsqxResult(diagnostic(VSQX_EXPORT_EMPTY_RESULT, MSG_EXPORT_EMPTY_RESULT));
+        if (isBlankText(vsqx)) {
+            return failedMusicXmlToVsqxResult(vsqxExportEmptyResultDiagnostic());
         }
         return { ok: true, vsqx };
     }
     catch (error) {
-        return failedMusicXmlToVsqxResult(diagnostic(VSQX_EXPORT_FAILED, error instanceof Error ? error.message : MSG_EXPORT_FAILED));
+        return failedMusicXmlToVsqxResult(vsqxExportFailedDiagnostic(error));
     }
 };
 exports.convertMusicXmlToVsqx = convertMusicXmlToVsqx;

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -8239,6 +8239,39 @@ const getVerovioRuntime = () => {
     var _a;
     return (_a = window.verovio) !== null && _a !== void 0 ? _a : null;
 };
+const isVerovioRuntimeReady = (moduleObj) => {
+    return Boolean(moduleObj.calledRun && typeof moduleObj.cwrap === "function");
+};
+const waitForVerovioRuntime = async (moduleObj) => {
+    if (isVerovioRuntimeReady(moduleObj))
+        return;
+    await new Promise((resolve, reject) => {
+        let settled = false;
+        const timeoutId = window.setTimeout(() => {
+            if (settled)
+                return;
+            settled = true;
+            reject(new Error("Timed out while waiting for verovio initialization."));
+        }, VEROVIO_INIT_TIMEOUT_MS);
+        const complete = () => {
+            if (settled)
+                return;
+            settled = true;
+            window.clearTimeout(timeoutId);
+            resolve();
+        };
+        const previous = moduleObj.onRuntimeInitialized;
+        moduleObj.onRuntimeInitialized = () => {
+            if (typeof previous === "function") {
+                previous();
+            }
+            complete();
+        };
+        if (isVerovioRuntimeReady(moduleObj)) {
+            complete();
+        }
+    });
+};
 const ensureVerovioToolkit = async () => {
     if (verovioToolkit) {
         return verovioToolkit;
@@ -8255,34 +8288,7 @@ const ensureVerovioToolkit = async () => {
         if (!moduleObj) {
             throw new Error("verovio module was not found.");
         }
-        if (!moduleObj.calledRun || typeof moduleObj.cwrap !== "function") {
-            await new Promise((resolve, reject) => {
-                let settled = false;
-                const timeoutId = window.setTimeout(() => {
-                    if (settled)
-                        return;
-                    settled = true;
-                    reject(new Error("Timed out while waiting for verovio initialization."));
-                }, VEROVIO_INIT_TIMEOUT_MS);
-                const complete = () => {
-                    if (settled)
-                        return;
-                    settled = true;
-                    window.clearTimeout(timeoutId);
-                    resolve();
-                };
-                const previous = moduleObj.onRuntimeInitialized;
-                moduleObj.onRuntimeInitialized = () => {
-                    if (typeof previous === "function") {
-                        previous();
-                    }
-                    complete();
-                };
-                if (moduleObj.calledRun && typeof moduleObj.cwrap === "function") {
-                    complete();
-                }
-            });
-        }
+        await waitForVerovioRuntime(moduleObj);
         verovioToolkit = new runtime.toolkit();
         return verovioToolkit;
     })()
@@ -11020,10 +11026,26 @@ const bridge = () => {
         return null;
     return (_a = window.UtaFormatix3TsPlusMikuscore) !== null && _a !== void 0 ? _a : null;
 };
+const isBlankText = (value) => {
+    return !String(value || "").trim();
+};
 const bridgeUnavailableDiagnostic = () => ({
     code: VSQX_BRIDGE_UNAVAILABLE,
     message: MSG_BRIDGE_UNAVAILABLE,
 });
+const diagnostic = (code, message) => ({ code, message });
+const vsqxExportErrorMessage = (error) => {
+    return error instanceof Error ? error.message : MSG_EXPORT_FAILED;
+};
+const vsqxConvertEmptyResultDiagnostic = () => {
+    return diagnostic(VSQX_CONVERT_EMPTY_RESULT, MSG_CONVERT_EMPTY_RESULT);
+};
+const vsqxExportEmptyResultDiagnostic = () => {
+    return diagnostic(VSQX_EXPORT_EMPTY_RESULT, MSG_EXPORT_EMPTY_RESULT);
+};
+const vsqxExportFailedDiagnostic = (error) => {
+    return diagnostic(VSQX_EXPORT_FAILED, vsqxExportErrorMessage(error));
+};
 const failedVsqxToMusicXmlResult = (diagnostics, warnings = []) => ({
     ok: false,
     xml: "",
@@ -11035,7 +11057,6 @@ const failedMusicXmlToVsqxResult = (diagnostic) => ({
     vsqx: "",
     diagnostic,
 });
-const diagnostic = (code, message) => ({ code, message });
 const issueLevel = (issue) => {
     return String(issue.level || "").toLowerCase();
 };
@@ -11092,11 +11113,11 @@ const convertVsqxToMusicXml = (vsqxText, options) => {
     const report = runtime.convertVsqxToMusicXmlWithReport(vsqxText, options);
     const { diagnostics, warnings } = collectVsqxConversionIssues(reportIssues(report));
     const xml = String((report === null || report === void 0 ? void 0 : report.musicXml) || "");
-    if (!xml.trim()) {
+    if (isBlankText(xml)) {
         const fallbackDiagnostics = diagnostics.length
             ? diagnostics
             : [
-                diagnostic(VSQX_CONVERT_EMPTY_RESULT, MSG_CONVERT_EMPTY_RESULT),
+                vsqxConvertEmptyResultDiagnostic(),
             ];
         return failedVsqxToMusicXmlResult(fallbackDiagnostics, warnings);
     }
@@ -11115,13 +11136,13 @@ const convertMusicXmlToVsqx = (musicXmlText, options) => {
     }
     try {
         const vsqx = runtime.convertMusicXmlToVsqx(musicXmlText, options);
-        if (!String(vsqx || "").trim()) {
-            return failedMusicXmlToVsqxResult(diagnostic(VSQX_EXPORT_EMPTY_RESULT, MSG_EXPORT_EMPTY_RESULT));
+        if (isBlankText(vsqx)) {
+            return failedMusicXmlToVsqxResult(vsqxExportEmptyResultDiagnostic());
         }
         return { ok: true, vsqx };
     }
     catch (error) {
-        return failedMusicXmlToVsqxResult(diagnostic(VSQX_EXPORT_FAILED, error instanceof Error ? error.message : MSG_EXPORT_FAILED));
+        return failedMusicXmlToVsqxResult(vsqxExportFailedDiagnostic(error));
     }
 };
 exports.convertMusicXmlToVsqx = convertMusicXmlToVsqx;

--- a/src/ts/verovio-out.ts
+++ b/src/ts/verovio-out.ts
@@ -107,6 +107,42 @@ const getVerovioRuntime = (): VerovioRuntime | null => {
   return (window as unknown as { verovio?: VerovioRuntime }).verovio ?? null;
 };
 
+const isVerovioRuntimeReady = (moduleObj: NonNullable<VerovioRuntime["module"]>): boolean => {
+  return Boolean(moduleObj.calledRun && typeof moduleObj.cwrap === "function");
+};
+
+const waitForVerovioRuntime = async (moduleObj: NonNullable<VerovioRuntime["module"]>): Promise<void> => {
+  if (isVerovioRuntimeReady(moduleObj)) return;
+
+  await new Promise<void>((resolve, reject) => {
+    let settled = false;
+    const timeoutId = window.setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      reject(new Error("Timed out while waiting for verovio initialization."));
+    }, VEROVIO_INIT_TIMEOUT_MS);
+
+    const complete = () => {
+      if (settled) return;
+      settled = true;
+      window.clearTimeout(timeoutId);
+      resolve();
+    };
+
+    const previous = moduleObj.onRuntimeInitialized;
+    moduleObj.onRuntimeInitialized = () => {
+      if (typeof previous === "function") {
+        previous();
+      }
+      complete();
+    };
+
+    if (isVerovioRuntimeReady(moduleObj)) {
+      complete();
+    }
+  });
+};
+
 const ensureVerovioToolkit = async (): Promise<VerovioToolkitApi | null> => {
   if (verovioToolkit) {
     return verovioToolkit;
@@ -125,35 +161,7 @@ const ensureVerovioToolkit = async (): Promise<VerovioToolkitApi | null> => {
       throw new Error("verovio module was not found.");
     }
 
-    if (!moduleObj.calledRun || typeof moduleObj.cwrap !== "function") {
-      await new Promise<void>((resolve, reject) => {
-        let settled = false;
-        const timeoutId = window.setTimeout(() => {
-          if (settled) return;
-          settled = true;
-          reject(new Error("Timed out while waiting for verovio initialization."));
-        }, VEROVIO_INIT_TIMEOUT_MS);
-
-        const complete = () => {
-          if (settled) return;
-          settled = true;
-          window.clearTimeout(timeoutId);
-          resolve();
-        };
-
-        const previous = moduleObj.onRuntimeInitialized;
-        moduleObj.onRuntimeInitialized = () => {
-          if (typeof previous === "function") {
-            previous();
-          }
-          complete();
-        };
-
-        if (moduleObj.calledRun && typeof moduleObj.cwrap === "function") {
-          complete();
-        }
-      });
-    }
+    await waitForVerovioRuntime(moduleObj);
 
     verovioToolkit = new runtime.toolkit();
     return verovioToolkit;

--- a/src/ts/vsqx-io.ts
+++ b/src/ts/vsqx-io.ts
@@ -80,10 +80,32 @@ const bridge = (): UtaFormatixBridge | null => {
   return window.UtaFormatix3TsPlusMikuscore ?? null;
 };
 
+const isBlankText = (value: unknown): boolean => {
+  return !String(value || "").trim();
+};
+
 const bridgeUnavailableDiagnostic = (): VsqxDiagnostic => ({
   code: VSQX_BRIDGE_UNAVAILABLE,
   message: MSG_BRIDGE_UNAVAILABLE,
 });
+
+const diagnostic = (code: string, message: string): VsqxDiagnostic => ({ code, message });
+
+const vsqxExportErrorMessage = (error: unknown): string => {
+  return error instanceof Error ? error.message : MSG_EXPORT_FAILED;
+};
+
+const vsqxConvertEmptyResultDiagnostic = (): VsqxDiagnostic => {
+  return diagnostic(VSQX_CONVERT_EMPTY_RESULT, MSG_CONVERT_EMPTY_RESULT);
+};
+
+const vsqxExportEmptyResultDiagnostic = (): VsqxDiagnostic => {
+  return diagnostic(VSQX_EXPORT_EMPTY_RESULT, MSG_EXPORT_EMPTY_RESULT);
+};
+
+const vsqxExportFailedDiagnostic = (error: unknown): VsqxDiagnostic => {
+  return diagnostic(VSQX_EXPORT_FAILED, vsqxExportErrorMessage(error));
+};
 
 const failedVsqxToMusicXmlResult = (
   diagnostics: VsqxDiagnostic[],
@@ -100,8 +122,6 @@ const failedMusicXmlToVsqxResult = (diagnostic: VsqxDiagnostic): MusicXmlToVsqxR
   vsqx: "",
   diagnostic,
 });
-
-const diagnostic = (code: string, message: string): VsqxDiagnostic => ({ code, message });
 
 const issueLevel = (issue: VsqxIssue): string => {
   return String(issue.level || "").toLowerCase();
@@ -176,11 +196,11 @@ export const convertVsqxToMusicXml = (
   const { diagnostics, warnings } = collectVsqxConversionIssues(reportIssues(report));
 
   const xml = String(report?.musicXml || "");
-  if (!xml.trim()) {
+  if (isBlankText(xml)) {
     const fallbackDiagnostics = diagnostics.length
       ? diagnostics
       : [
-          diagnostic(VSQX_CONVERT_EMPTY_RESULT, MSG_CONVERT_EMPTY_RESULT),
+          vsqxConvertEmptyResultDiagnostic(),
         ];
     return failedVsqxToMusicXmlResult(fallbackDiagnostics, warnings);
   }
@@ -204,21 +224,11 @@ export const convertMusicXmlToVsqx = (
 
   try {
     const vsqx = runtime.convertMusicXmlToVsqx(musicXmlText, options);
-    if (!String(vsqx || "").trim()) {
-      return failedMusicXmlToVsqxResult(
-        diagnostic(
-          VSQX_EXPORT_EMPTY_RESULT,
-          MSG_EXPORT_EMPTY_RESULT
-        )
-      );
+    if (isBlankText(vsqx)) {
+      return failedMusicXmlToVsqxResult(vsqxExportEmptyResultDiagnostic());
     }
     return { ok: true, vsqx };
   } catch (error) {
-    return failedMusicXmlToVsqxResult(
-      diagnostic(
-        VSQX_EXPORT_FAILED,
-        error instanceof Error ? error.message : MSG_EXPORT_FAILED
-      )
-    );
+    return failedMusicXmlToVsqxResult(vsqxExportFailedDiagnostic(error));
   }
 };

--- a/tests/unit/vsqx-io.spec.ts
+++ b/tests/unit/vsqx-io.spec.ts
@@ -150,4 +150,21 @@ describe("vsqx-io bridge diagnostics", () => {
       },
     });
   });
+
+  it("uses a stable fallback diagnostic when VSQX export throws a non-Error value", () => {
+    installVsqxExportBridge(() => {
+      throw "bad export";
+    });
+
+    const result = convertMusicXmlToVsqx("<score-partwise/>");
+
+    expect(result).toEqual({
+      ok: false,
+      vsqx: "",
+      diagnostic: {
+        code: "VSQX_EXPORT_FAILED",
+        message: "MusicXML to VSQX conversion failed.",
+      },
+    });
+  });
 });


### PR DESCRIPTION
## 概要

Verovio toolkit 初期化処理と VSQX 変換時の診断生成処理を整理しました。あわせて、VSQX export が `Error` 以外の値を throw した場合の fallback diagnostic をテストで固定しています。

## 変更内容

- `src/ts/verovio-out.ts` で Verovio runtime の ready 判定を `isVerovioRuntimeReady()` に切り出し
- `src/ts/verovio-out.ts` で Verovio runtime 初期化待ち処理を `waitForVerovioRuntime()` に分離
- `src/ts/vsqx-io.ts` で空文字判定を `isBlankText()` に共通化
- `src/ts/vsqx-io.ts` で VSQX の固定 diagnostic 生成を helper 化
- `src/ts/vsqx-io.ts` で VSQX export failure の fallback message 生成を整理
- `tests/unit/vsqx-io.spec.ts` に、VSQX export が非 `Error` 値を throw した場合の fallback diagnostic テストを追加
- `mikuscore.html`、`src/js/main.js`、`bundle/mikuscore.mjs` を更新

## 動作確認

- `npm run typecheck`
- `npx vitest run tests/unit/vsqx-io.spec.ts`
- `npx vitest run tests/unit/mikuscore-cli.spec.ts -t "renders SVG"`
- `npm run build`