### PR TITLE
ZIP / Verovio / VSQX 周辺の内部処理を整理

### DIFF
--- a/bundle/mikuscore.mjs
+++ b/bundle/mikuscore.mjs
@@ -136139,6 +136139,12 @@ var BUNDLED_CLI_MODULES = {
     const decodeUtf8 = (bytes) => {
       return new TextDecoder("utf-8").decode(bytes);
     };
+    const encodeUtf8 = (text) => {
+      return new TextEncoder().encode(text);
+    };
+    const normalizeZipEntryPathForWrite = (path2) => {
+      return path2.replace(/\\/g, "/").replace(/^\/+/, "");
+    };
     const decodeZipFileName = (bytes, utf8Flag) => {
       if (utf8Flag)
         return decodeUtf8(bytes);
@@ -136242,6 +136248,9 @@ var BUNDLED_CLI_MODULES = {
       }
       throw new Error(`Unsupported ZIP compression method: ${entry.compressionMethod}.`);
     };
+    const extractEntryText = async (archiveBytes, entry) => {
+      return decodeUtf8(await extractEntryBytes(archiveBytes, entry));
+    };
     const findEntryByPath = (entries, path2) => {
       var _a;
       const normalized = normalizeZipPath(path2);
@@ -136335,6 +136344,9 @@ var BUNDLED_CLI_MODULES = {
       const dosDate = (year - 1980 & 127) << 9 | (month & 15) << 5 | day & 31;
       return { dosTime, dosDate };
     };
+    const sumByteLengths = (chunks) => {
+      return chunks.reduce((sum, chunk) => sum + chunk.length, 0);
+    };
     const compressDeflateRaw = async (input) => {
       const CS = globalThis.CompressionStream;
       if (!CS)
@@ -136379,10 +136391,9 @@ var BUNDLED_CLI_MODULES = {
     };
     exports.bytesToArrayBuffer = bytesToArrayBuffer;
     const encodeZipEntries = async (entries, preferCompression) => {
-      const encoder = new TextEncoder();
       const encodedEntries = [];
       for (const entry of entries) {
-        const pathBytes = encoder.encode(entry.path.replace(/\\/g, "/").replace(/^\/+/, ""));
+        const pathBytes = encodeUtf8(normalizeZipEntryPathForWrite(entry.path));
         const uncompressed = entry.bytes;
         let data = uncompressed;
         let method = 0;
@@ -136404,61 +136415,61 @@ var BUNDLED_CLI_MODULES = {
       }
       return encodedEntries;
     };
-    const makeZipBytes = async (entries, preferCompression) => {
-      const localChunks = [];
-      const centralChunks = [];
-      let localOffset = 0;
-      const nowDos = toDosDateTime(/* @__PURE__ */ new Date());
-      const encodedEntries = await encodeZipEntries(entries, preferCompression);
-      for (const entry of encodedEntries) {
-        const { pathBytes, data, crc, method, compressedSize, uncompressedSize } = entry;
-        const localHeader = new Uint8Array(30 + pathBytes.length);
-        writeU32(localHeader, 0, ZIP_LFH_SIG);
-        writeU16(localHeader, 4, 20);
-        writeU16(localHeader, 6, 2048);
-        writeU16(localHeader, 8, method);
-        writeU16(localHeader, 10, nowDos.dosTime);
-        writeU16(localHeader, 12, nowDos.dosDate);
-        writeU32(localHeader, 14, crc);
-        writeU32(localHeader, 18, compressedSize);
-        writeU32(localHeader, 22, uncompressedSize);
-        writeU16(localHeader, 26, pathBytes.length);
-        writeU16(localHeader, 28, 0);
-        localHeader.set(pathBytes, 30);
-        localChunks.push(localHeader, data);
-        const centralHeader = new Uint8Array(46 + pathBytes.length);
-        writeU32(centralHeader, 0, ZIP_CDFH_SIG);
-        writeU16(centralHeader, 4, 20);
-        writeU16(centralHeader, 6, 20);
-        writeU16(centralHeader, 8, 2048);
-        writeU16(centralHeader, 10, method);
-        writeU16(centralHeader, 12, nowDos.dosTime);
-        writeU16(centralHeader, 14, nowDos.dosDate);
-        writeU32(centralHeader, 16, crc);
-        writeU32(centralHeader, 20, compressedSize);
-        writeU32(centralHeader, 24, uncompressedSize);
-        writeU16(centralHeader, 28, pathBytes.length);
-        writeU16(centralHeader, 30, 0);
-        writeU16(centralHeader, 32, 0);
-        writeU16(centralHeader, 34, 0);
-        writeU16(centralHeader, 36, 0);
-        writeU32(centralHeader, 38, 0);
-        writeU32(centralHeader, 42, localOffset);
-        centralHeader.set(pathBytes, 46);
-        centralChunks.push(centralHeader);
-        localOffset += localHeader.length + compressedSize;
-      }
-      const localSize = localChunks.reduce((sum, b) => sum + b.length, 0);
-      const centralSize = centralChunks.reduce((sum, b) => sum + b.length, 0);
+    const buildZipLocalHeader = (entry, nowDos) => {
+      const { pathBytes, crc, method, compressedSize, uncompressedSize } = entry;
+      const localHeader = new Uint8Array(30 + pathBytes.length);
+      writeU32(localHeader, 0, ZIP_LFH_SIG);
+      writeU16(localHeader, 4, 20);
+      writeU16(localHeader, 6, 2048);
+      writeU16(localHeader, 8, method);
+      writeU16(localHeader, 10, nowDos.dosTime);
+      writeU16(localHeader, 12, nowDos.dosDate);
+      writeU32(localHeader, 14, crc);
+      writeU32(localHeader, 18, compressedSize);
+      writeU32(localHeader, 22, uncompressedSize);
+      writeU16(localHeader, 26, pathBytes.length);
+      writeU16(localHeader, 28, 0);
+      localHeader.set(pathBytes, 30);
+      return localHeader;
+    };
+    const buildZipCentralHeader = (entry, nowDos, localOffset) => {
+      const { pathBytes, crc, method, compressedSize, uncompressedSize } = entry;
+      const centralHeader = new Uint8Array(46 + pathBytes.length);
+      writeU32(centralHeader, 0, ZIP_CDFH_SIG);
+      writeU16(centralHeader, 4, 20);
+      writeU16(centralHeader, 6, 20);
+      writeU16(centralHeader, 8, 2048);
+      writeU16(centralHeader, 10, method);
+      writeU16(centralHeader, 12, nowDos.dosTime);
+      writeU16(centralHeader, 14, nowDos.dosDate);
+      writeU32(centralHeader, 16, crc);
+      writeU32(centralHeader, 20, compressedSize);
+      writeU32(centralHeader, 24, uncompressedSize);
+      writeU16(centralHeader, 28, pathBytes.length);
+      writeU16(centralHeader, 30, 0);
+      writeU16(centralHeader, 32, 0);
+      writeU16(centralHeader, 34, 0);
+      writeU16(centralHeader, 36, 0);
+      writeU32(centralHeader, 38, 0);
+      writeU32(centralHeader, 42, localOffset);
+      centralHeader.set(pathBytes, 46);
+      return centralHeader;
+    };
+    const buildZipEndOfCentralDirectory = (entryCount, centralSize, localSize) => {
       const eocd = new Uint8Array(22);
       writeU32(eocd, 0, ZIP_EOCD_SIG);
       writeU16(eocd, 4, 0);
       writeU16(eocd, 6, 0);
-      writeU16(eocd, 8, entries.length);
-      writeU16(eocd, 10, entries.length);
+      writeU16(eocd, 8, entryCount);
+      writeU16(eocd, 10, entryCount);
       writeU32(eocd, 12, centralSize);
       writeU32(eocd, 16, localSize);
       writeU16(eocd, 20, 0);
+      return eocd;
+    };
+    const concatZipChunks = (localChunks, centralChunks, eocd) => {
+      const localSize = sumByteLengths(localChunks);
+      const centralSize = sumByteLengths(centralChunks);
       const out = new Uint8Array(localSize + centralSize + eocd.length);
       let cursor = 0;
       for (const chunk of localChunks) {
@@ -136472,19 +136483,35 @@ var BUNDLED_CLI_MODULES = {
       out.set(eocd, cursor);
       return out;
     };
+    const makeZipBytes = async (entries, preferCompression) => {
+      const localChunks = [];
+      const centralChunks = [];
+      let localOffset = 0;
+      const nowDos = toDosDateTime(/* @__PURE__ */ new Date());
+      const encodedEntries = await encodeZipEntries(entries, preferCompression);
+      for (const entry of encodedEntries) {
+        const { data, compressedSize } = entry;
+        const localHeader = buildZipLocalHeader(entry, nowDos);
+        localChunks.push(localHeader, data);
+        centralChunks.push(buildZipCentralHeader(entry, nowDos, localOffset));
+        localOffset += localHeader.length + compressedSize;
+      }
+      const localSize = sumByteLengths(localChunks);
+      const centralSize = sumByteLengths(centralChunks);
+      const eocd = buildZipEndOfCentralDirectory(entries.length, centralSize, localSize);
+      return concatZipChunks(localChunks, centralChunks, eocd);
+    };
     exports.makeZipBytes = makeZipBytes;
     const makeMxlBytes = async (formattedXml) => {
-      const encoder = new TextEncoder();
       const containerXml = `<?xml version="1.0" encoding="UTF-8"?><container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container"><rootfiles><rootfile full-path="score.musicxml" media-type="application/vnd.recordare.musicxml+xml"/></rootfiles></container>`;
       return (0, exports.makeZipBytes)([
-        { path: "META-INF/container.xml", bytes: encoder.encode(containerXml) },
-        { path: "score.musicxml", bytes: encoder.encode(formattedXml) }
+        { path: "META-INF/container.xml", bytes: encodeUtf8(containerXml) },
+        { path: "score.musicxml", bytes: encodeUtf8(formattedXml) }
       ], true);
     };
     exports.makeMxlBytes = makeMxlBytes;
     const makeMsczBytes = async (mscxText) => {
-      const encoder = new TextEncoder();
-      return (0, exports.makeZipBytes)([{ path: "score.mscx", bytes: encoder.encode(mscxText) }], true);
+      return (0, exports.makeZipBytes)([{ path: "score.mscx", bytes: encodeUtf8(mscxText) }], true);
     };
     exports.makeMsczBytes = makeMsczBytes;
     const extractMusicXmlTextFromMxl = async (archiveBuffer) => {
@@ -136495,24 +136522,21 @@ var BUNDLED_CLI_MODULES = {
       }
       const containerEntry = findEntryByPath(entries, "META-INF/container.xml");
       if (containerEntry) {
-        const containerBytes = await extractEntryBytes(archiveBytes, containerEntry);
-        const containerText = decodeUtf8(containerBytes);
+        const containerText = await extractEntryText(archiveBytes, containerEntry);
         const rootPath = parseContainerRootFilePath(containerText);
         if (rootPath) {
           const rootEntry = findEntryByPath(entries, rootPath);
           if (!rootEntry) {
             throw new Error(`MusicXML root file was not found in archive: ${rootPath}`);
           }
-          const xmlBytes2 = await extractEntryBytes(archiveBytes, rootEntry);
-          return decodeUtf8(xmlBytes2);
+          return extractEntryText(archiveBytes, rootEntry);
         }
       }
       const fallbackEntry = findLikelyMusicXmlEntry(entries);
       if (!fallbackEntry) {
         throw new Error("No MusicXML file (.musicxml or .xml) was found in the MXL archive.");
       }
-      const xmlBytes = await extractEntryBytes(archiveBytes, fallbackEntry);
-      return decodeUtf8(xmlBytes);
+      return extractEntryText(archiveBytes, fallbackEntry);
     };
     exports.extractMusicXmlTextFromMxl = extractMusicXmlTextFromMxl;
     const extractTextFromZipByExtensions = async (archiveBuffer, extensions) => {
@@ -136521,8 +136545,7 @@ var BUNDLED_CLI_MODULES = {
       if (!entry) {
         throw new Error(`No matching entry was found for extensions: ${extensions.join(", ")}`);
       }
-      const bytes = await extractEntryBytes(archiveBytes, entry);
-      return decodeUtf8(bytes);
+      return extractEntryText(archiveBytes, entry);
     };
     exports.extractTextFromZipByExtensions = extractTextFromZipByExtensions;
     const listZipRootEntryPathsByExtensions = async (archiveBuffer, extensions) => {
@@ -136574,8 +136597,38 @@ var BUNDLED_CLI_MODULES = {
       var _a;
       return ((_a = slur.getAttribute("type")) !== null && _a !== void 0 ? _a : "").trim().toLowerCase();
     };
-    const sanitizeSlursForRender = (doc) => {
+    const openSlurStack = (openSlurs, number) => {
       var _a;
+      const stack = (_a = openSlurs.get(number)) !== null && _a !== void 0 ? _a : [];
+      openSlurs.set(number, stack);
+      return stack;
+    };
+    const processSlurForRender = (slur, openSlurs) => {
+      const number = getSlurNumber(slur);
+      const type = getSlurType(slur);
+      const stack = openSlurStack(openSlurs, number);
+      if (type === "start") {
+        stack.push(slur);
+        return;
+      }
+      if (type === "stop") {
+        if (stack.length > 0) {
+          stack.pop();
+        } else {
+          removeSlurAndPruneNotations(slur);
+        }
+        return;
+      }
+      if (type === "continue") {
+        if (stack.length === 0) {
+          removeSlurAndPruneNotations(slur);
+          return;
+        }
+        stack.pop();
+        stack.push(slur);
+      }
+    };
+    const sanitizeSlursForRender = (doc) => {
       const parts = Array.from(doc.querySelectorAll("score-partwise > part"));
       for (const part of parts) {
         const openSlurs = /* @__PURE__ */ new Map();
@@ -136585,31 +136638,7 @@ var BUNDLED_CLI_MODULES = {
           for (const note of notes) {
             const slurs = Array.from(note.querySelectorAll(":scope > notations > slur"));
             for (const slur of slurs) {
-              const number = getSlurNumber(slur);
-              const type = getSlurType(slur);
-              const stack = (_a = openSlurs.get(number)) !== null && _a !== void 0 ? _a : [];
-              if (type === "start") {
-                stack.push(slur);
-                openSlurs.set(number, stack);
-                continue;
-              }
-              if (type === "stop") {
-                if (stack.length > 0) {
-                  stack.pop();
-                } else {
-                  removeSlurAndPruneNotations(slur);
-                }
-                continue;
-              }
-              if (type === "continue") {
-                if (stack.length === 0) {
-                  removeSlurAndPruneNotations(slur);
-                  continue;
-                }
-                stack.pop();
-                stack.push(slur);
-                openSlurs.set(number, stack);
-              }
+              processSlurForRender(slur, openSlurs);
             }
           }
         }

--- a/mikuscore.html
+++ b/mikuscore.html
@@ -18512,8 +18512,39 @@ const getSlurType = (slur) => {
     var _a;
     return ((_a = slur.getAttribute("type")) !== null && _a !== void 0 ? _a : "").trim().toLowerCase();
 };
-const sanitizeSlursForRender = (doc) => {
+const openSlurStack = (openSlurs, number) => {
     var _a;
+    const stack = (_a = openSlurs.get(number)) !== null && _a !== void 0 ? _a : [];
+    openSlurs.set(number, stack);
+    return stack;
+};
+const processSlurForRender = (slur, openSlurs) => {
+    const number = getSlurNumber(slur);
+    const type = getSlurType(slur);
+    const stack = openSlurStack(openSlurs, number);
+    if (type === "start") {
+        stack.push(slur);
+        return;
+    }
+    if (type === "stop") {
+        if (stack.length > 0) {
+            stack.pop();
+        }
+        else {
+            removeSlurAndPruneNotations(slur);
+        }
+        return;
+    }
+    if (type === "continue") {
+        if (stack.length === 0) {
+            removeSlurAndPruneNotations(slur);
+            return;
+        }
+        stack.pop();
+        stack.push(slur);
+    }
+};
+const sanitizeSlursForRender = (doc) => {
     const parts = Array.from(doc.querySelectorAll("score-partwise > part"));
     for (const part of parts) {
         const openSlurs = new Map();
@@ -18523,32 +18554,7 @@ const sanitizeSlursForRender = (doc) => {
             for (const note of notes) {
                 const slurs = Array.from(note.querySelectorAll(":scope > notations > slur"));
                 for (const slur of slurs) {
-                    const number = getSlurNumber(slur);
-                    const type = getSlurType(slur);
-                    const stack = (_a = openSlurs.get(number)) !== null && _a !== void 0 ? _a : [];
-                    if (type === "start") {
-                        stack.push(slur);
-                        openSlurs.set(number, stack);
-                        continue;
-                    }
-                    if (type === "stop") {
-                        if (stack.length > 0) {
-                            stack.pop();
-                        }
-                        else {
-                            removeSlurAndPruneNotations(slur);
-                        }
-                        continue;
-                    }
-                    if (type === "continue") {
-                        if (stack.length === 0) {
-                            removeSlurAndPruneNotations(slur);
-                            continue;
-                        }
-                        stack.pop();
-                        stack.push(slur);
-                        openSlurs.set(number, stack);
-                    }
+                    processSlurForRender(slur, openSlurs);
                 }
             }
         }
@@ -20263,6 +20269,12 @@ const normalizeZipPath = (value) => {
 const decodeUtf8 = (bytes) => {
     return new TextDecoder("utf-8").decode(bytes);
 };
+const encodeUtf8 = (text) => {
+    return new TextEncoder().encode(text);
+};
+const normalizeZipEntryPathForWrite = (path) => {
+    return path.replace(/\\/g, "/").replace(/^\/+/, "");
+};
 const decodeZipFileName = (bytes, utf8Flag) => {
     if (utf8Flag)
         return decodeUtf8(bytes);
@@ -20366,6 +20378,9 @@ const extractEntryBytes = async (archiveBytes, entry) => {
     }
     throw new Error(`Unsupported ZIP compression method: ${entry.compressionMethod}.`);
 };
+const extractEntryText = async (archiveBytes, entry) => {
+    return decodeUtf8(await extractEntryBytes(archiveBytes, entry));
+};
 const findEntryByPath = (entries, path) => {
     var _a;
     const normalized = normalizeZipPath(path);
@@ -20459,6 +20474,9 @@ const toDosDateTime = (date) => {
     const dosDate = (((year - 1980) & 0x7f) << 9) | ((month & 0x0f) << 5) | (day & 0x1f);
     return { dosTime, dosDate };
 };
+const sumByteLengths = (chunks) => {
+    return chunks.reduce((sum, chunk) => sum + chunk.length, 0);
+};
 const compressDeflateRaw = async (input) => {
     const CS = globalThis.CompressionStream;
     if (!CS)
@@ -20504,10 +20522,9 @@ const bytesToArrayBuffer = (bytes) => {
 };
 exports.bytesToArrayBuffer = bytesToArrayBuffer;
 const encodeZipEntries = async (entries, preferCompression) => {
-    const encoder = new TextEncoder();
     const encodedEntries = [];
     for (const entry of entries) {
-        const pathBytes = encoder.encode(entry.path.replace(/\\/g, "/").replace(/^\/+/, ""));
+        const pathBytes = encodeUtf8(normalizeZipEntryPathForWrite(entry.path));
         const uncompressed = entry.bytes;
         let data = uncompressed;
         let method = 0;
@@ -20529,61 +20546,61 @@ const encodeZipEntries = async (entries, preferCompression) => {
     }
     return encodedEntries;
 };
-const makeZipBytes = async (entries, preferCompression) => {
-    const localChunks = [];
-    const centralChunks = [];
-    let localOffset = 0;
-    const nowDos = toDosDateTime(new Date());
-    const encodedEntries = await encodeZipEntries(entries, preferCompression);
-    for (const entry of encodedEntries) {
-        const { pathBytes, data, crc, method, compressedSize, uncompressedSize } = entry;
-        const localHeader = new Uint8Array(30 + pathBytes.length);
-        writeU32(localHeader, 0, ZIP_LFH_SIG);
-        writeU16(localHeader, 4, 20);
-        writeU16(localHeader, 6, 0x0800);
-        writeU16(localHeader, 8, method);
-        writeU16(localHeader, 10, nowDos.dosTime);
-        writeU16(localHeader, 12, nowDos.dosDate);
-        writeU32(localHeader, 14, crc);
-        writeU32(localHeader, 18, compressedSize);
-        writeU32(localHeader, 22, uncompressedSize);
-        writeU16(localHeader, 26, pathBytes.length);
-        writeU16(localHeader, 28, 0);
-        localHeader.set(pathBytes, 30);
-        localChunks.push(localHeader, data);
-        const centralHeader = new Uint8Array(46 + pathBytes.length);
-        writeU32(centralHeader, 0, ZIP_CDFH_SIG);
-        writeU16(centralHeader, 4, 20);
-        writeU16(centralHeader, 6, 20);
-        writeU16(centralHeader, 8, 0x0800);
-        writeU16(centralHeader, 10, method);
-        writeU16(centralHeader, 12, nowDos.dosTime);
-        writeU16(centralHeader, 14, nowDos.dosDate);
-        writeU32(centralHeader, 16, crc);
-        writeU32(centralHeader, 20, compressedSize);
-        writeU32(centralHeader, 24, uncompressedSize);
-        writeU16(centralHeader, 28, pathBytes.length);
-        writeU16(centralHeader, 30, 0);
-        writeU16(centralHeader, 32, 0);
-        writeU16(centralHeader, 34, 0);
-        writeU16(centralHeader, 36, 0);
-        writeU32(centralHeader, 38, 0);
-        writeU32(centralHeader, 42, localOffset);
-        centralHeader.set(pathBytes, 46);
-        centralChunks.push(centralHeader);
-        localOffset += localHeader.length + compressedSize;
-    }
-    const localSize = localChunks.reduce((sum, b) => sum + b.length, 0);
-    const centralSize = centralChunks.reduce((sum, b) => sum + b.length, 0);
+const buildZipLocalHeader = (entry, nowDos) => {
+    const { pathBytes, crc, method, compressedSize, uncompressedSize } = entry;
+    const localHeader = new Uint8Array(30 + pathBytes.length);
+    writeU32(localHeader, 0, ZIP_LFH_SIG);
+    writeU16(localHeader, 4, 20);
+    writeU16(localHeader, 6, 0x0800);
+    writeU16(localHeader, 8, method);
+    writeU16(localHeader, 10, nowDos.dosTime);
+    writeU16(localHeader, 12, nowDos.dosDate);
+    writeU32(localHeader, 14, crc);
+    writeU32(localHeader, 18, compressedSize);
+    writeU32(localHeader, 22, uncompressedSize);
+    writeU16(localHeader, 26, pathBytes.length);
+    writeU16(localHeader, 28, 0);
+    localHeader.set(pathBytes, 30);
+    return localHeader;
+};
+const buildZipCentralHeader = (entry, nowDos, localOffset) => {
+    const { pathBytes, crc, method, compressedSize, uncompressedSize } = entry;
+    const centralHeader = new Uint8Array(46 + pathBytes.length);
+    writeU32(centralHeader, 0, ZIP_CDFH_SIG);
+    writeU16(centralHeader, 4, 20);
+    writeU16(centralHeader, 6, 20);
+    writeU16(centralHeader, 8, 0x0800);
+    writeU16(centralHeader, 10, method);
+    writeU16(centralHeader, 12, nowDos.dosTime);
+    writeU16(centralHeader, 14, nowDos.dosDate);
+    writeU32(centralHeader, 16, crc);
+    writeU32(centralHeader, 20, compressedSize);
+    writeU32(centralHeader, 24, uncompressedSize);
+    writeU16(centralHeader, 28, pathBytes.length);
+    writeU16(centralHeader, 30, 0);
+    writeU16(centralHeader, 32, 0);
+    writeU16(centralHeader, 34, 0);
+    writeU16(centralHeader, 36, 0);
+    writeU32(centralHeader, 38, 0);
+    writeU32(centralHeader, 42, localOffset);
+    centralHeader.set(pathBytes, 46);
+    return centralHeader;
+};
+const buildZipEndOfCentralDirectory = (entryCount, centralSize, localSize) => {
     const eocd = new Uint8Array(22);
     writeU32(eocd, 0, ZIP_EOCD_SIG);
     writeU16(eocd, 4, 0);
     writeU16(eocd, 6, 0);
-    writeU16(eocd, 8, entries.length);
-    writeU16(eocd, 10, entries.length);
+    writeU16(eocd, 8, entryCount);
+    writeU16(eocd, 10, entryCount);
     writeU32(eocd, 12, centralSize);
     writeU32(eocd, 16, localSize);
     writeU16(eocd, 20, 0);
+    return eocd;
+};
+const concatZipChunks = (localChunks, centralChunks, eocd) => {
+    const localSize = sumByteLengths(localChunks);
+    const centralSize = sumByteLengths(centralChunks);
     const out = new Uint8Array(localSize + centralSize + eocd.length);
     let cursor = 0;
     for (const chunk of localChunks) {
@@ -20597,22 +20614,38 @@ const makeZipBytes = async (entries, preferCompression) => {
     out.set(eocd, cursor);
     return out;
 };
+const makeZipBytes = async (entries, preferCompression) => {
+    const localChunks = [];
+    const centralChunks = [];
+    let localOffset = 0;
+    const nowDos = toDosDateTime(new Date());
+    const encodedEntries = await encodeZipEntries(entries, preferCompression);
+    for (const entry of encodedEntries) {
+        const { data, compressedSize } = entry;
+        const localHeader = buildZipLocalHeader(entry, nowDos);
+        localChunks.push(localHeader, data);
+        centralChunks.push(buildZipCentralHeader(entry, nowDos, localOffset));
+        localOffset += localHeader.length + compressedSize;
+    }
+    const localSize = sumByteLengths(localChunks);
+    const centralSize = sumByteLengths(centralChunks);
+    const eocd = buildZipEndOfCentralDirectory(entries.length, centralSize, localSize);
+    return concatZipChunks(localChunks, centralChunks, eocd);
+};
 exports.makeZipBytes = makeZipBytes;
 const makeMxlBytes = async (formattedXml) => {
-    const encoder = new TextEncoder();
     const containerXml = `<?xml version="1.0" encoding="UTF-8"?>` +
         `<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">` +
         `<rootfiles><rootfile full-path="score.musicxml" media-type="application/vnd.recordare.musicxml+xml"/></rootfiles>` +
         `</container>`;
     return (0, exports.makeZipBytes)([
-        { path: "META-INF/container.xml", bytes: encoder.encode(containerXml) },
-        { path: "score.musicxml", bytes: encoder.encode(formattedXml) },
+        { path: "META-INF/container.xml", bytes: encodeUtf8(containerXml) },
+        { path: "score.musicxml", bytes: encodeUtf8(formattedXml) },
     ], true);
 };
 exports.makeMxlBytes = makeMxlBytes;
 const makeMsczBytes = async (mscxText) => {
-    const encoder = new TextEncoder();
-    return (0, exports.makeZipBytes)([{ path: "score.mscx", bytes: encoder.encode(mscxText) }], true);
+    return (0, exports.makeZipBytes)([{ path: "score.mscx", bytes: encodeUtf8(mscxText) }], true);
 };
 exports.makeMsczBytes = makeMsczBytes;
 const extractMusicXmlTextFromMxl = async (archiveBuffer) => {
@@ -20623,24 +20656,21 @@ const extractMusicXmlTextFromMxl = async (archiveBuffer) => {
     }
     const containerEntry = findEntryByPath(entries, "META-INF/container.xml");
     if (containerEntry) {
-        const containerBytes = await extractEntryBytes(archiveBytes, containerEntry);
-        const containerText = decodeUtf8(containerBytes);
+        const containerText = await extractEntryText(archiveBytes, containerEntry);
         const rootPath = parseContainerRootFilePath(containerText);
         if (rootPath) {
             const rootEntry = findEntryByPath(entries, rootPath);
             if (!rootEntry) {
                 throw new Error(`MusicXML root file was not found in archive: ${rootPath}`);
             }
-            const xmlBytes = await extractEntryBytes(archiveBytes, rootEntry);
-            return decodeUtf8(xmlBytes);
+            return extractEntryText(archiveBytes, rootEntry);
         }
     }
     const fallbackEntry = findLikelyMusicXmlEntry(entries);
     if (!fallbackEntry) {
         throw new Error("No MusicXML file (.musicxml or .xml) was found in the MXL archive.");
     }
-    const xmlBytes = await extractEntryBytes(archiveBytes, fallbackEntry);
-    return decodeUtf8(xmlBytes);
+    return extractEntryText(archiveBytes, fallbackEntry);
 };
 exports.extractMusicXmlTextFromMxl = extractMusicXmlTextFromMxl;
 const extractTextFromZipByExtensions = async (archiveBuffer, extensions) => {
@@ -20649,8 +20679,7 @@ const extractTextFromZipByExtensions = async (archiveBuffer, extensions) => {
     if (!entry) {
         throw new Error(`No matching entry was found for extensions: ${extensions.join(", ")}`);
     }
-    const bytes = await extractEntryBytes(archiveBytes, entry);
-    return decodeUtf8(bytes);
+    return extractEntryText(archiveBytes, entry);
 };
 exports.extractTextFromZipByExtensions = extractTextFromZipByExtensions;
 const listZipRootEntryPathsByExtensions = async (archiveBuffer, extensions) => {
@@ -21350,14 +21379,19 @@ const bridge = () => {
         return null;
     return (_a = window.UtaFormatix3TsPlusMikuscore) !== null && _a !== void 0 ? _a : null;
 };
-const isBlankText = (value) => {
-    return !String(value || "").trim();
+const textOrEmpty = (value) => {
+    return String(value || "");
 };
-const bridgeUnavailableDiagnostic = () => ({
-    code: VSQX_BRIDGE_UNAVAILABLE,
-    message: MSG_BRIDGE_UNAVAILABLE,
-});
+const trimmedTextOrEmpty = (value) => {
+    return textOrEmpty(value).trim();
+};
+const isBlankText = (value) => {
+    return !trimmedTextOrEmpty(value);
+};
 const diagnostic = (code, message) => ({ code, message });
+const bridgeUnavailableDiagnostic = () => {
+    return diagnostic(VSQX_BRIDGE_UNAVAILABLE, MSG_BRIDGE_UNAVAILABLE);
+};
 const vsqxExportErrorMessage = (error) => {
     return error instanceof Error ? error.message : MSG_EXPORT_FAILED;
 };
@@ -21382,7 +21416,7 @@ const failedMusicXmlToVsqxResult = (diagnostic) => ({
     diagnostic,
 });
 const issueLevel = (issue) => {
-    return String(issue.level || "").toLowerCase();
+    return trimmedTextOrEmpty(issue.level).toLowerCase();
 };
 const isVsqxConversionErrorIssue = (issue) => {
     return issueLevel(issue) === "error";
@@ -21392,11 +21426,11 @@ const isVsqxConversionWarningIssue = (issue) => {
     return level === "warning" || level === "info";
 };
 const issueCode = (issue, fallback) => {
-    const raw = String(issue.code || "").trim();
+    const raw = trimmedTextOrEmpty(issue.code);
     return raw || fallback;
 };
 const issueMessage = (issue, fallback) => {
-    const raw = String(issue.message || "").trim();
+    const raw = trimmedTextOrEmpty(issue.message);
     return raw || fallback;
 };
 const issueDiagnostic = (issue, fallbackCode, fallbackMessage) => {
@@ -21436,7 +21470,7 @@ const convertVsqxToMusicXml = (vsqxText, options) => {
     }
     const report = runtime.convertVsqxToMusicXmlWithReport(vsqxText, options);
     const { diagnostics, warnings } = collectVsqxConversionIssues(reportIssues(report));
-    const xml = String((report === null || report === void 0 ? void 0 : report.musicXml) || "");
+    const xml = textOrEmpty(report === null || report === void 0 ? void 0 : report.musicXml);
     if (isBlankText(xml)) {
         const fallbackDiagnostics = diagnostics.length
             ? diagnostics

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -8188,8 +8188,39 @@ const getSlurType = (slur) => {
     var _a;
     return ((_a = slur.getAttribute("type")) !== null && _a !== void 0 ? _a : "").trim().toLowerCase();
 };
-const sanitizeSlursForRender = (doc) => {
+const openSlurStack = (openSlurs, number) => {
     var _a;
+    const stack = (_a = openSlurs.get(number)) !== null && _a !== void 0 ? _a : [];
+    openSlurs.set(number, stack);
+    return stack;
+};
+const processSlurForRender = (slur, openSlurs) => {
+    const number = getSlurNumber(slur);
+    const type = getSlurType(slur);
+    const stack = openSlurStack(openSlurs, number);
+    if (type === "start") {
+        stack.push(slur);
+        return;
+    }
+    if (type === "stop") {
+        if (stack.length > 0) {
+            stack.pop();
+        }
+        else {
+            removeSlurAndPruneNotations(slur);
+        }
+        return;
+    }
+    if (type === "continue") {
+        if (stack.length === 0) {
+            removeSlurAndPruneNotations(slur);
+            return;
+        }
+        stack.pop();
+        stack.push(slur);
+    }
+};
+const sanitizeSlursForRender = (doc) => {
     const parts = Array.from(doc.querySelectorAll("score-partwise > part"));
     for (const part of parts) {
         const openSlurs = new Map();
@@ -8199,32 +8230,7 @@ const sanitizeSlursForRender = (doc) => {
             for (const note of notes) {
                 const slurs = Array.from(note.querySelectorAll(":scope > notations > slur"));
                 for (const slur of slurs) {
-                    const number = getSlurNumber(slur);
-                    const type = getSlurType(slur);
-                    const stack = (_a = openSlurs.get(number)) !== null && _a !== void 0 ? _a : [];
-                    if (type === "start") {
-                        stack.push(slur);
-                        openSlurs.set(number, stack);
-                        continue;
-                    }
-                    if (type === "stop") {
-                        if (stack.length > 0) {
-                            stack.pop();
-                        }
-                        else {
-                            removeSlurAndPruneNotations(slur);
-                        }
-                        continue;
-                    }
-                    if (type === "continue") {
-                        if (stack.length === 0) {
-                            removeSlurAndPruneNotations(slur);
-                            continue;
-                        }
-                        stack.pop();
-                        stack.push(slur);
-                        openSlurs.set(number, stack);
-                    }
+                    processSlurForRender(slur, openSlurs);
                 }
             }
         }
@@ -9939,6 +9945,12 @@ const normalizeZipPath = (value) => {
 const decodeUtf8 = (bytes) => {
     return new TextDecoder("utf-8").decode(bytes);
 };
+const encodeUtf8 = (text) => {
+    return new TextEncoder().encode(text);
+};
+const normalizeZipEntryPathForWrite = (path) => {
+    return path.replace(/\\/g, "/").replace(/^\/+/, "");
+};
 const decodeZipFileName = (bytes, utf8Flag) => {
     if (utf8Flag)
         return decodeUtf8(bytes);
@@ -10042,6 +10054,9 @@ const extractEntryBytes = async (archiveBytes, entry) => {
     }
     throw new Error(`Unsupported ZIP compression method: ${entry.compressionMethod}.`);
 };
+const extractEntryText = async (archiveBytes, entry) => {
+    return decodeUtf8(await extractEntryBytes(archiveBytes, entry));
+};
 const findEntryByPath = (entries, path) => {
     var _a;
     const normalized = normalizeZipPath(path);
@@ -10135,6 +10150,9 @@ const toDosDateTime = (date) => {
     const dosDate = (((year - 1980) & 0x7f) << 9) | ((month & 0x0f) << 5) | (day & 0x1f);
     return { dosTime, dosDate };
 };
+const sumByteLengths = (chunks) => {
+    return chunks.reduce((sum, chunk) => sum + chunk.length, 0);
+};
 const compressDeflateRaw = async (input) => {
     const CS = globalThis.CompressionStream;
     if (!CS)
@@ -10180,10 +10198,9 @@ const bytesToArrayBuffer = (bytes) => {
 };
 exports.bytesToArrayBuffer = bytesToArrayBuffer;
 const encodeZipEntries = async (entries, preferCompression) => {
-    const encoder = new TextEncoder();
     const encodedEntries = [];
     for (const entry of entries) {
-        const pathBytes = encoder.encode(entry.path.replace(/\\/g, "/").replace(/^\/+/, ""));
+        const pathBytes = encodeUtf8(normalizeZipEntryPathForWrite(entry.path));
         const uncompressed = entry.bytes;
         let data = uncompressed;
         let method = 0;
@@ -10205,61 +10222,61 @@ const encodeZipEntries = async (entries, preferCompression) => {
     }
     return encodedEntries;
 };
-const makeZipBytes = async (entries, preferCompression) => {
-    const localChunks = [];
-    const centralChunks = [];
-    let localOffset = 0;
-    const nowDos = toDosDateTime(new Date());
-    const encodedEntries = await encodeZipEntries(entries, preferCompression);
-    for (const entry of encodedEntries) {
-        const { pathBytes, data, crc, method, compressedSize, uncompressedSize } = entry;
-        const localHeader = new Uint8Array(30 + pathBytes.length);
-        writeU32(localHeader, 0, ZIP_LFH_SIG);
-        writeU16(localHeader, 4, 20);
-        writeU16(localHeader, 6, 0x0800);
-        writeU16(localHeader, 8, method);
-        writeU16(localHeader, 10, nowDos.dosTime);
-        writeU16(localHeader, 12, nowDos.dosDate);
-        writeU32(localHeader, 14, crc);
-        writeU32(localHeader, 18, compressedSize);
-        writeU32(localHeader, 22, uncompressedSize);
-        writeU16(localHeader, 26, pathBytes.length);
-        writeU16(localHeader, 28, 0);
-        localHeader.set(pathBytes, 30);
-        localChunks.push(localHeader, data);
-        const centralHeader = new Uint8Array(46 + pathBytes.length);
-        writeU32(centralHeader, 0, ZIP_CDFH_SIG);
-        writeU16(centralHeader, 4, 20);
-        writeU16(centralHeader, 6, 20);
-        writeU16(centralHeader, 8, 0x0800);
-        writeU16(centralHeader, 10, method);
-        writeU16(centralHeader, 12, nowDos.dosTime);
-        writeU16(centralHeader, 14, nowDos.dosDate);
-        writeU32(centralHeader, 16, crc);
-        writeU32(centralHeader, 20, compressedSize);
-        writeU32(centralHeader, 24, uncompressedSize);
-        writeU16(centralHeader, 28, pathBytes.length);
-        writeU16(centralHeader, 30, 0);
-        writeU16(centralHeader, 32, 0);
-        writeU16(centralHeader, 34, 0);
-        writeU16(centralHeader, 36, 0);
-        writeU32(centralHeader, 38, 0);
-        writeU32(centralHeader, 42, localOffset);
-        centralHeader.set(pathBytes, 46);
-        centralChunks.push(centralHeader);
-        localOffset += localHeader.length + compressedSize;
-    }
-    const localSize = localChunks.reduce((sum, b) => sum + b.length, 0);
-    const centralSize = centralChunks.reduce((sum, b) => sum + b.length, 0);
+const buildZipLocalHeader = (entry, nowDos) => {
+    const { pathBytes, crc, method, compressedSize, uncompressedSize } = entry;
+    const localHeader = new Uint8Array(30 + pathBytes.length);
+    writeU32(localHeader, 0, ZIP_LFH_SIG);
+    writeU16(localHeader, 4, 20);
+    writeU16(localHeader, 6, 0x0800);
+    writeU16(localHeader, 8, method);
+    writeU16(localHeader, 10, nowDos.dosTime);
+    writeU16(localHeader, 12, nowDos.dosDate);
+    writeU32(localHeader, 14, crc);
+    writeU32(localHeader, 18, compressedSize);
+    writeU32(localHeader, 22, uncompressedSize);
+    writeU16(localHeader, 26, pathBytes.length);
+    writeU16(localHeader, 28, 0);
+    localHeader.set(pathBytes, 30);
+    return localHeader;
+};
+const buildZipCentralHeader = (entry, nowDos, localOffset) => {
+    const { pathBytes, crc, method, compressedSize, uncompressedSize } = entry;
+    const centralHeader = new Uint8Array(46 + pathBytes.length);
+    writeU32(centralHeader, 0, ZIP_CDFH_SIG);
+    writeU16(centralHeader, 4, 20);
+    writeU16(centralHeader, 6, 20);
+    writeU16(centralHeader, 8, 0x0800);
+    writeU16(centralHeader, 10, method);
+    writeU16(centralHeader, 12, nowDos.dosTime);
+    writeU16(centralHeader, 14, nowDos.dosDate);
+    writeU32(centralHeader, 16, crc);
+    writeU32(centralHeader, 20, compressedSize);
+    writeU32(centralHeader, 24, uncompressedSize);
+    writeU16(centralHeader, 28, pathBytes.length);
+    writeU16(centralHeader, 30, 0);
+    writeU16(centralHeader, 32, 0);
+    writeU16(centralHeader, 34, 0);
+    writeU16(centralHeader, 36, 0);
+    writeU32(centralHeader, 38, 0);
+    writeU32(centralHeader, 42, localOffset);
+    centralHeader.set(pathBytes, 46);
+    return centralHeader;
+};
+const buildZipEndOfCentralDirectory = (entryCount, centralSize, localSize) => {
     const eocd = new Uint8Array(22);
     writeU32(eocd, 0, ZIP_EOCD_SIG);
     writeU16(eocd, 4, 0);
     writeU16(eocd, 6, 0);
-    writeU16(eocd, 8, entries.length);
-    writeU16(eocd, 10, entries.length);
+    writeU16(eocd, 8, entryCount);
+    writeU16(eocd, 10, entryCount);
     writeU32(eocd, 12, centralSize);
     writeU32(eocd, 16, localSize);
     writeU16(eocd, 20, 0);
+    return eocd;
+};
+const concatZipChunks = (localChunks, centralChunks, eocd) => {
+    const localSize = sumByteLengths(localChunks);
+    const centralSize = sumByteLengths(centralChunks);
     const out = new Uint8Array(localSize + centralSize + eocd.length);
     let cursor = 0;
     for (const chunk of localChunks) {
@@ -10273,22 +10290,38 @@ const makeZipBytes = async (entries, preferCompression) => {
     out.set(eocd, cursor);
     return out;
 };
+const makeZipBytes = async (entries, preferCompression) => {
+    const localChunks = [];
+    const centralChunks = [];
+    let localOffset = 0;
+    const nowDos = toDosDateTime(new Date());
+    const encodedEntries = await encodeZipEntries(entries, preferCompression);
+    for (const entry of encodedEntries) {
+        const { data, compressedSize } = entry;
+        const localHeader = buildZipLocalHeader(entry, nowDos);
+        localChunks.push(localHeader, data);
+        centralChunks.push(buildZipCentralHeader(entry, nowDos, localOffset));
+        localOffset += localHeader.length + compressedSize;
+    }
+    const localSize = sumByteLengths(localChunks);
+    const centralSize = sumByteLengths(centralChunks);
+    const eocd = buildZipEndOfCentralDirectory(entries.length, centralSize, localSize);
+    return concatZipChunks(localChunks, centralChunks, eocd);
+};
 exports.makeZipBytes = makeZipBytes;
 const makeMxlBytes = async (formattedXml) => {
-    const encoder = new TextEncoder();
     const containerXml = `<?xml version="1.0" encoding="UTF-8"?>` +
         `<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">` +
         `<rootfiles><rootfile full-path="score.musicxml" media-type="application/vnd.recordare.musicxml+xml"/></rootfiles>` +
         `</container>`;
     return (0, exports.makeZipBytes)([
-        { path: "META-INF/container.xml", bytes: encoder.encode(containerXml) },
-        { path: "score.musicxml", bytes: encoder.encode(formattedXml) },
+        { path: "META-INF/container.xml", bytes: encodeUtf8(containerXml) },
+        { path: "score.musicxml", bytes: encodeUtf8(formattedXml) },
     ], true);
 };
 exports.makeMxlBytes = makeMxlBytes;
 const makeMsczBytes = async (mscxText) => {
-    const encoder = new TextEncoder();
-    return (0, exports.makeZipBytes)([{ path: "score.mscx", bytes: encoder.encode(mscxText) }], true);
+    return (0, exports.makeZipBytes)([{ path: "score.mscx", bytes: encodeUtf8(mscxText) }], true);
 };
 exports.makeMsczBytes = makeMsczBytes;
 const extractMusicXmlTextFromMxl = async (archiveBuffer) => {
@@ -10299,24 +10332,21 @@ const extractMusicXmlTextFromMxl = async (archiveBuffer) => {
     }
     const containerEntry = findEntryByPath(entries, "META-INF/container.xml");
     if (containerEntry) {
-        const containerBytes = await extractEntryBytes(archiveBytes, containerEntry);
-        const containerText = decodeUtf8(containerBytes);
+        const containerText = await extractEntryText(archiveBytes, containerEntry);
         const rootPath = parseContainerRootFilePath(containerText);
         if (rootPath) {
             const rootEntry = findEntryByPath(entries, rootPath);
             if (!rootEntry) {
                 throw new Error(`MusicXML root file was not found in archive: ${rootPath}`);
             }
-            const xmlBytes = await extractEntryBytes(archiveBytes, rootEntry);
-            return decodeUtf8(xmlBytes);
+            return extractEntryText(archiveBytes, rootEntry);
         }
     }
     const fallbackEntry = findLikelyMusicXmlEntry(entries);
     if (!fallbackEntry) {
         throw new Error("No MusicXML file (.musicxml or .xml) was found in the MXL archive.");
     }
-    const xmlBytes = await extractEntryBytes(archiveBytes, fallbackEntry);
-    return decodeUtf8(xmlBytes);
+    return extractEntryText(archiveBytes, fallbackEntry);
 };
 exports.extractMusicXmlTextFromMxl = extractMusicXmlTextFromMxl;
 const extractTextFromZipByExtensions = async (archiveBuffer, extensions) => {
@@ -10325,8 +10355,7 @@ const extractTextFromZipByExtensions = async (archiveBuffer, extensions) => {
     if (!entry) {
         throw new Error(`No matching entry was found for extensions: ${extensions.join(", ")}`);
     }
-    const bytes = await extractEntryBytes(archiveBytes, entry);
-    return decodeUtf8(bytes);
+    return extractEntryText(archiveBytes, entry);
 };
 exports.extractTextFromZipByExtensions = extractTextFromZipByExtensions;
 const listZipRootEntryPathsByExtensions = async (archiveBuffer, extensions) => {
@@ -11026,14 +11055,19 @@ const bridge = () => {
         return null;
     return (_a = window.UtaFormatix3TsPlusMikuscore) !== null && _a !== void 0 ? _a : null;
 };
-const isBlankText = (value) => {
-    return !String(value || "").trim();
+const textOrEmpty = (value) => {
+    return String(value || "");
 };
-const bridgeUnavailableDiagnostic = () => ({
-    code: VSQX_BRIDGE_UNAVAILABLE,
-    message: MSG_BRIDGE_UNAVAILABLE,
-});
+const trimmedTextOrEmpty = (value) => {
+    return textOrEmpty(value).trim();
+};
+const isBlankText = (value) => {
+    return !trimmedTextOrEmpty(value);
+};
 const diagnostic = (code, message) => ({ code, message });
+const bridgeUnavailableDiagnostic = () => {
+    return diagnostic(VSQX_BRIDGE_UNAVAILABLE, MSG_BRIDGE_UNAVAILABLE);
+};
 const vsqxExportErrorMessage = (error) => {
     return error instanceof Error ? error.message : MSG_EXPORT_FAILED;
 };
@@ -11058,7 +11092,7 @@ const failedMusicXmlToVsqxResult = (diagnostic) => ({
     diagnostic,
 });
 const issueLevel = (issue) => {
-    return String(issue.level || "").toLowerCase();
+    return trimmedTextOrEmpty(issue.level).toLowerCase();
 };
 const isVsqxConversionErrorIssue = (issue) => {
     return issueLevel(issue) === "error";
@@ -11068,11 +11102,11 @@ const isVsqxConversionWarningIssue = (issue) => {
     return level === "warning" || level === "info";
 };
 const issueCode = (issue, fallback) => {
-    const raw = String(issue.code || "").trim();
+    const raw = trimmedTextOrEmpty(issue.code);
     return raw || fallback;
 };
 const issueMessage = (issue, fallback) => {
-    const raw = String(issue.message || "").trim();
+    const raw = trimmedTextOrEmpty(issue.message);
     return raw || fallback;
 };
 const issueDiagnostic = (issue, fallbackCode, fallbackMessage) => {
@@ -11112,7 +11146,7 @@ const convertVsqxToMusicXml = (vsqxText, options) => {
     }
     const report = runtime.convertVsqxToMusicXmlWithReport(vsqxText, options);
     const { diagnostics, warnings } = collectVsqxConversionIssues(reportIssues(report));
-    const xml = String((report === null || report === void 0 ? void 0 : report.musicXml) || "");
+    const xml = textOrEmpty(report === null || report === void 0 ? void 0 : report.musicXml);
     if (isBlankText(xml)) {
         const fallbackDiagnostics = diagnostics.length
             ? diagnostics

--- a/src/ts/verovio-out.ts
+++ b/src/ts/verovio-out.ts
@@ -19,6 +19,8 @@ type VerovioRuntime = {
   toolkit?: new () => VerovioToolkitApi;
 };
 
+type OpenSlurStacks = Map<string, Element[]>;
+
 const DEFAULT_SLUR_NUMBER = "1";
 const VEROVIO_INIT_TIMEOUT_MS = 8000;
 
@@ -57,41 +59,52 @@ const getSlurType = (slur: Element): string => {
   return (slur.getAttribute("type") ?? "").trim().toLowerCase();
 };
 
+const openSlurStack = (openSlurs: OpenSlurStacks, number: string): Element[] => {
+  const stack = openSlurs.get(number) ?? [];
+  openSlurs.set(number, stack);
+  return stack;
+};
+
+const processSlurForRender = (slur: Element, openSlurs: OpenSlurStacks): void => {
+  const number = getSlurNumber(slur);
+  const type = getSlurType(slur);
+  const stack = openSlurStack(openSlurs, number);
+
+  if (type === "start") {
+    stack.push(slur);
+    return;
+  }
+
+  if (type === "stop") {
+    if (stack.length > 0) {
+      stack.pop();
+    } else {
+      removeSlurAndPruneNotations(slur);
+    }
+    return;
+  }
+
+  if (type === "continue") {
+    if (stack.length === 0) {
+      removeSlurAndPruneNotations(slur);
+      return;
+    }
+    stack.pop();
+    stack.push(slur);
+  }
+};
+
 const sanitizeSlursForRender = (doc: Document): void => {
   const parts = Array.from(doc.querySelectorAll("score-partwise > part"));
   for (const part of parts) {
-    const openSlurs = new Map<string, Element[]>();
+    const openSlurs: OpenSlurStacks = new Map();
     const measures = Array.from(part.querySelectorAll(":scope > measure"));
     for (const measure of measures) {
       const notes = Array.from(measure.querySelectorAll(":scope > note"));
       for (const note of notes) {
         const slurs = Array.from(note.querySelectorAll(":scope > notations > slur"));
         for (const slur of slurs) {
-          const number = getSlurNumber(slur);
-          const type = getSlurType(slur);
-          const stack = openSlurs.get(number) ?? [];
-          if (type === "start") {
-            stack.push(slur);
-            openSlurs.set(number, stack);
-            continue;
-          }
-          if (type === "stop") {
-            if (stack.length > 0) {
-              stack.pop();
-            } else {
-              removeSlurAndPruneNotations(slur);
-            }
-            continue;
-          }
-          if (type === "continue") {
-            if (stack.length === 0) {
-              removeSlurAndPruneNotations(slur);
-              continue;
-            }
-            stack.pop();
-            stack.push(slur);
-            openSlurs.set(number, stack);
-          }
+          processSlurForRender(slur, openSlurs);
         }
       }
     }

--- a/src/ts/vsqx-io.ts
+++ b/src/ts/vsqx-io.ts
@@ -80,16 +80,23 @@ const bridge = (): UtaFormatixBridge | null => {
   return window.UtaFormatix3TsPlusMikuscore ?? null;
 };
 
-const isBlankText = (value: unknown): boolean => {
-  return !String(value || "").trim();
+const textOrEmpty = (value: unknown): string => {
+  return String(value || "");
 };
 
-const bridgeUnavailableDiagnostic = (): VsqxDiagnostic => ({
-  code: VSQX_BRIDGE_UNAVAILABLE,
-  message: MSG_BRIDGE_UNAVAILABLE,
-});
+const trimmedTextOrEmpty = (value: unknown): string => {
+  return textOrEmpty(value).trim();
+};
+
+const isBlankText = (value: unknown): boolean => {
+  return !trimmedTextOrEmpty(value);
+};
 
 const diagnostic = (code: string, message: string): VsqxDiagnostic => ({ code, message });
+
+const bridgeUnavailableDiagnostic = (): VsqxDiagnostic => {
+  return diagnostic(VSQX_BRIDGE_UNAVAILABLE, MSG_BRIDGE_UNAVAILABLE);
+};
 
 const vsqxExportErrorMessage = (error: unknown): string => {
   return error instanceof Error ? error.message : MSG_EXPORT_FAILED;
@@ -124,7 +131,7 @@ const failedMusicXmlToVsqxResult = (diagnostic: VsqxDiagnostic): MusicXmlToVsqxR
 });
 
 const issueLevel = (issue: VsqxIssue): string => {
-  return String(issue.level || "").toLowerCase();
+  return trimmedTextOrEmpty(issue.level).toLowerCase();
 };
 
 const isVsqxConversionErrorIssue = (issue: VsqxIssue): boolean => {
@@ -137,12 +144,12 @@ const isVsqxConversionWarningIssue = (issue: VsqxIssue): boolean => {
 };
 
 const issueCode = (issue: VsqxIssue, fallback: string): string => {
-  const raw = String(issue.code || "").trim();
+  const raw = trimmedTextOrEmpty(issue.code);
   return raw || fallback;
 };
 
 const issueMessage = (issue: VsqxIssue, fallback: string): string => {
-  const raw = String(issue.message || "").trim();
+  const raw = trimmedTextOrEmpty(issue.message);
   return raw || fallback;
 };
 
@@ -195,7 +202,7 @@ export const convertVsqxToMusicXml = (
   const report = runtime.convertVsqxToMusicXmlWithReport(vsqxText, options);
   const { diagnostics, warnings } = collectVsqxConversionIssues(reportIssues(report));
 
-  const xml = String(report?.musicXml || "");
+  const xml = textOrEmpty(report?.musicXml);
   if (isBlankText(xml)) {
     const fallbackDiagnostics = diagnostics.length
       ? diagnostics

--- a/src/ts/zip-io.ts
+++ b/src/ts/zip-io.ts
@@ -25,6 +25,11 @@ type EncodedZipEntry = {
   uncompressedSize: number;
 };
 
+type ZipDosDateTime = {
+  dosTime: number;
+  dosDate: number;
+};
+
 const ZIP_EOCD_SIG = 0x06054b50;
 const ZIP_CDFH_SIG = 0x02014b50;
 const ZIP_LFH_SIG = 0x04034b50;
@@ -48,6 +53,14 @@ const normalizeZipPath = (value: string): string => {
 
 const decodeUtf8 = (bytes: Uint8Array): string => {
   return new TextDecoder("utf-8").decode(bytes);
+};
+
+const encodeUtf8 = (text: string): Uint8Array => {
+  return new TextEncoder().encode(text);
+};
+
+const normalizeZipEntryPathForWrite = (path: string): string => {
+  return path.replace(/\\/g, "/").replace(/^\/+/, "");
 };
 
 const decodeZipFileName = (bytes: Uint8Array, utf8Flag: boolean): string => {
@@ -164,6 +177,10 @@ const extractEntryBytes = async (archiveBytes: Uint8Array, entry: ZipEntry): Pro
   throw new Error(`Unsupported ZIP compression method: ${entry.compressionMethod}.`);
 };
 
+const extractEntryText = async (archiveBytes: Uint8Array, entry: ZipEntry): Promise<string> => {
+  return decodeUtf8(await extractEntryBytes(archiveBytes, entry));
+};
+
 const findEntryByPath = (entries: ZipEntry[], path: string): ZipEntry | null => {
   const normalized = normalizeZipPath(path);
   return entries.find((entry) => entry.path === normalized) ?? null;
@@ -248,7 +265,7 @@ const writeU32 = (target: Uint8Array, offset: number, value: number): void => {
   target[offset + 3] = (value >>> 24) & 0xff;
 };
 
-const toDosDateTime = (date: Date): { dosTime: number; dosDate: number } => {
+const toDosDateTime = (date: Date): ZipDosDateTime => {
   const year = Math.max(1980, Math.min(2107, date.getFullYear()));
   const month = Math.max(1, Math.min(12, date.getMonth() + 1));
   const day = Math.max(1, Math.min(31, date.getDate()));
@@ -258,6 +275,10 @@ const toDosDateTime = (date: Date): { dosTime: number; dosDate: number } => {
   const dosTime = ((hours & 0x1f) << 11) | ((minutes & 0x3f) << 5) | ((Math.floor(seconds / 2)) & 0x1f);
   const dosDate = (((year - 1980) & 0x7f) << 9) | ((month & 0x0f) << 5) | (day & 0x1f);
   return { dosTime, dosDate };
+};
+
+const sumByteLengths = (chunks: Uint8Array[]): number => {
+  return chunks.reduce((sum, chunk) => sum + chunk.length, 0);
 };
 
 const compressDeflateRaw = async (input: Uint8Array): Promise<Uint8Array | null> => {
@@ -303,10 +324,9 @@ const encodeZipEntries = async (
   entries: ZipEntryPayload[],
   preferCompression: boolean
 ): Promise<EncodedZipEntry[]> => {
-  const encoder = new TextEncoder();
   const encodedEntries: EncodedZipEntry[] = [];
   for (const entry of entries) {
-    const pathBytes = encoder.encode(entry.path.replace(/\\/g, "/").replace(/^\/+/, ""));
+    const pathBytes = encodeUtf8(normalizeZipEntryPathForWrite(entry.path));
     const uncompressed = entry.bytes;
     let data = uncompressed;
     let method: 0 | 8 = 0;
@@ -329,67 +349,79 @@ const encodeZipEntries = async (
   return encodedEntries;
 };
 
-export const makeZipBytes = async (entries: ZipEntryPayload[], preferCompression: boolean): Promise<Uint8Array> => {
-  const localChunks: Uint8Array[] = [];
-  const centralChunks: Uint8Array[] = [];
-  let localOffset = 0;
-  const nowDos = toDosDateTime(new Date());
-  const encodedEntries = await encodeZipEntries(entries, preferCompression);
+const buildZipLocalHeader = (
+  entry: EncodedZipEntry,
+  nowDos: ZipDosDateTime
+): Uint8Array => {
+  const { pathBytes, crc, method, compressedSize, uncompressedSize } = entry;
+  const localHeader = new Uint8Array(30 + pathBytes.length);
+  writeU32(localHeader, 0, ZIP_LFH_SIG);
+  writeU16(localHeader, 4, 20);
+  writeU16(localHeader, 6, 0x0800);
+  writeU16(localHeader, 8, method);
+  writeU16(localHeader, 10, nowDos.dosTime);
+  writeU16(localHeader, 12, nowDos.dosDate);
+  writeU32(localHeader, 14, crc);
+  writeU32(localHeader, 18, compressedSize);
+  writeU32(localHeader, 22, uncompressedSize);
+  writeU16(localHeader, 26, pathBytes.length);
+  writeU16(localHeader, 28, 0);
+  localHeader.set(pathBytes, 30);
+  return localHeader;
+};
 
-  for (const entry of encodedEntries) {
-    const { pathBytes, data, crc, method, compressedSize, uncompressedSize } = entry;
+const buildZipCentralHeader = (
+  entry: EncodedZipEntry,
+  nowDos: ZipDosDateTime,
+  localOffset: number
+): Uint8Array => {
+  const { pathBytes, crc, method, compressedSize, uncompressedSize } = entry;
+  const centralHeader = new Uint8Array(46 + pathBytes.length);
+  writeU32(centralHeader, 0, ZIP_CDFH_SIG);
+  writeU16(centralHeader, 4, 20);
+  writeU16(centralHeader, 6, 20);
+  writeU16(centralHeader, 8, 0x0800);
+  writeU16(centralHeader, 10, method);
+  writeU16(centralHeader, 12, nowDos.dosTime);
+  writeU16(centralHeader, 14, nowDos.dosDate);
+  writeU32(centralHeader, 16, crc);
+  writeU32(centralHeader, 20, compressedSize);
+  writeU32(centralHeader, 24, uncompressedSize);
+  writeU16(centralHeader, 28, pathBytes.length);
+  writeU16(centralHeader, 30, 0);
+  writeU16(centralHeader, 32, 0);
+  writeU16(centralHeader, 34, 0);
+  writeU16(centralHeader, 36, 0);
+  writeU32(centralHeader, 38, 0);
+  writeU32(centralHeader, 42, localOffset);
+  centralHeader.set(pathBytes, 46);
+  return centralHeader;
+};
 
-    const localHeader = new Uint8Array(30 + pathBytes.length);
-    writeU32(localHeader, 0, ZIP_LFH_SIG);
-    writeU16(localHeader, 4, 20);
-    writeU16(localHeader, 6, 0x0800);
-    writeU16(localHeader, 8, method);
-    writeU16(localHeader, 10, nowDos.dosTime);
-    writeU16(localHeader, 12, nowDos.dosDate);
-    writeU32(localHeader, 14, crc);
-    writeU32(localHeader, 18, compressedSize);
-    writeU32(localHeader, 22, uncompressedSize);
-    writeU16(localHeader, 26, pathBytes.length);
-    writeU16(localHeader, 28, 0);
-    localHeader.set(pathBytes, 30);
-    localChunks.push(localHeader, data);
-
-    const centralHeader = new Uint8Array(46 + pathBytes.length);
-    writeU32(centralHeader, 0, ZIP_CDFH_SIG);
-    writeU16(centralHeader, 4, 20);
-    writeU16(centralHeader, 6, 20);
-    writeU16(centralHeader, 8, 0x0800);
-    writeU16(centralHeader, 10, method);
-    writeU16(centralHeader, 12, nowDos.dosTime);
-    writeU16(centralHeader, 14, nowDos.dosDate);
-    writeU32(centralHeader, 16, crc);
-    writeU32(centralHeader, 20, compressedSize);
-    writeU32(centralHeader, 24, uncompressedSize);
-    writeU16(centralHeader, 28, pathBytes.length);
-    writeU16(centralHeader, 30, 0);
-    writeU16(centralHeader, 32, 0);
-    writeU16(centralHeader, 34, 0);
-    writeU16(centralHeader, 36, 0);
-    writeU32(centralHeader, 38, 0);
-    writeU32(centralHeader, 42, localOffset);
-    centralHeader.set(pathBytes, 46);
-    centralChunks.push(centralHeader);
-
-    localOffset += localHeader.length + compressedSize;
-  }
-
-  const localSize = localChunks.reduce((sum, b) => sum + b.length, 0);
-  const centralSize = centralChunks.reduce((sum, b) => sum + b.length, 0);
+const buildZipEndOfCentralDirectory = (
+  entryCount: number,
+  centralSize: number,
+  localSize: number
+): Uint8Array => {
   const eocd = new Uint8Array(22);
   writeU32(eocd, 0, ZIP_EOCD_SIG);
   writeU16(eocd, 4, 0);
   writeU16(eocd, 6, 0);
-  writeU16(eocd, 8, entries.length);
-  writeU16(eocd, 10, entries.length);
+  writeU16(eocd, 8, entryCount);
+  writeU16(eocd, 10, entryCount);
   writeU32(eocd, 12, centralSize);
   writeU32(eocd, 16, localSize);
   writeU16(eocd, 20, 0);
+  return eocd;
+};
 
+const concatZipChunks = (
+  localChunks: Uint8Array[],
+  centralChunks: Uint8Array[],
+  eocd: Uint8Array
+): Uint8Array => {
+  const localSize = sumByteLengths(localChunks);
+  const centralSize = sumByteLengths(centralChunks);
   const out = new Uint8Array(localSize + centralSize + eocd.length);
   let cursor = 0;
   for (const chunk of localChunks) {
@@ -404,22 +436,43 @@ export const makeZipBytes = async (entries: ZipEntryPayload[], preferCompression
   return out;
 };
 
+export const makeZipBytes = async (entries: ZipEntryPayload[], preferCompression: boolean): Promise<Uint8Array> => {
+  const localChunks: Uint8Array[] = [];
+  const centralChunks: Uint8Array[] = [];
+  let localOffset = 0;
+  const nowDos = toDosDateTime(new Date());
+  const encodedEntries = await encodeZipEntries(entries, preferCompression);
+
+  for (const entry of encodedEntries) {
+    const { data, compressedSize } = entry;
+    const localHeader = buildZipLocalHeader(entry, nowDos);
+    localChunks.push(localHeader, data);
+
+    centralChunks.push(buildZipCentralHeader(entry, nowDos, localOffset));
+
+    localOffset += localHeader.length + compressedSize;
+  }
+
+  const localSize = sumByteLengths(localChunks);
+  const centralSize = sumByteLengths(centralChunks);
+  const eocd = buildZipEndOfCentralDirectory(entries.length, centralSize, localSize);
+  return concatZipChunks(localChunks, centralChunks, eocd);
+};
+
 export const makeMxlBytes = async (formattedXml: string): Promise<Uint8Array> => {
-  const encoder = new TextEncoder();
   const containerXml =
     `<?xml version="1.0" encoding="UTF-8"?>` +
     `<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">` +
     `<rootfiles><rootfile full-path="score.musicxml" media-type="application/vnd.recordare.musicxml+xml"/></rootfiles>` +
     `</container>`;
   return makeZipBytes([
-    { path: "META-INF/container.xml", bytes: encoder.encode(containerXml) },
-    { path: "score.musicxml", bytes: encoder.encode(formattedXml) },
+    { path: "META-INF/container.xml", bytes: encodeUtf8(containerXml) },
+    { path: "score.musicxml", bytes: encodeUtf8(formattedXml) },
   ], true);
 };
 
 export const makeMsczBytes = async (mscxText: string): Promise<Uint8Array> => {
-  const encoder = new TextEncoder();
-  return makeZipBytes([{ path: "score.mscx", bytes: encoder.encode(mscxText) }], true);
+  return makeZipBytes([{ path: "score.mscx", bytes: encodeUtf8(mscxText) }], true);
 };
 
 export const extractMusicXmlTextFromMxl = async (archiveBuffer: ArrayBuffer): Promise<string> => {
@@ -431,16 +484,14 @@ export const extractMusicXmlTextFromMxl = async (archiveBuffer: ArrayBuffer): Pr
 
   const containerEntry = findEntryByPath(entries, "META-INF/container.xml");
   if (containerEntry) {
-    const containerBytes = await extractEntryBytes(archiveBytes, containerEntry);
-    const containerText = decodeUtf8(containerBytes);
+    const containerText = await extractEntryText(archiveBytes, containerEntry);
     const rootPath = parseContainerRootFilePath(containerText);
     if (rootPath) {
       const rootEntry = findEntryByPath(entries, rootPath);
       if (!rootEntry) {
         throw new Error(`MusicXML root file was not found in archive: ${rootPath}`);
       }
-      const xmlBytes = await extractEntryBytes(archiveBytes, rootEntry);
-      return decodeUtf8(xmlBytes);
+      return extractEntryText(archiveBytes, rootEntry);
     }
   }
 
@@ -448,8 +499,7 @@ export const extractMusicXmlTextFromMxl = async (archiveBuffer: ArrayBuffer): Pr
   if (!fallbackEntry) {
     throw new Error("No MusicXML file (.musicxml or .xml) was found in the MXL archive.");
   }
-  const xmlBytes = await extractEntryBytes(archiveBytes, fallbackEntry);
-  return decodeUtf8(xmlBytes);
+  return extractEntryText(archiveBytes, fallbackEntry);
 };
 
 export const extractTextFromZipByExtensions = async (
@@ -461,8 +511,7 @@ export const extractTextFromZipByExtensions = async (
   if (!entry) {
     throw new Error(`No matching entry was found for extensions: ${extensions.join(", ")}`);
   }
-  const bytes = await extractEntryBytes(archiveBytes, entry);
-  return decodeUtf8(bytes);
+  return extractEntryText(archiveBytes, entry);
 };
 
 export const listZipRootEntryPathsByExtensions = async (


### PR DESCRIPTION
## 概要

ZIP 入出力、Verovio 描画前のスラー補正、VSQX 変換診断まわりの内部処理をリファクタリングしました。

## 変更内容

- `src/ts/zip-io.ts`
  - UTF-8 エンコード、ZIP 書き込み用パス正規化、ZIP エントリ本文のテキスト抽出を helper 化
  - ZIP local header / central header / EOCD 生成処理を関数に分割
  - ZIP チャンク結合とバイト長集計を helper 化
  - DOS 日時を `ZipDosDateTime` 型として明示

- `src/ts/verovio-out.ts`
  - 描画前スラー補正で使う open slur stack を `OpenSlurStacks` 型として明示
  - start / stop / continue のスラー処理を `processSlurForRender` に切り出し
  - stack 取得処理を `openSlurStack` に集約

- `src/ts/vsqx-io.ts`
  - 空文字判定や trim を伴う文字列化を `textOrEmpty` / `trimmedTextOrEmpty` に集約
  - bridge unavailable 診断生成を共通の `diagnostic()` 経由に整理

- 生成物を更新
  - `bundle/mikuscore.mjs`
  - `mikuscore.html`
  - `src/js/main.js`

## 確認

- `npm run typecheck` 成功
- 関連する対象テスト成功
- `npm run build` 成功、606 tests