### PR TITLE
ZIP / MXL 入出力のリファクタリングと回帰テストを追加

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -281,6 +281,17 @@
 
 ## Refactoring Priorities
 
+- [ ] Long-range: revisit the large format I/O modules with a review-first pass, not an immediate rewrite.
+  - Target modules:
+    - `src/ts/musescore-io.ts`
+    - `src/ts/musicxml-io.ts`
+  - Intended first step:
+    - map public entry points, responsibility blocks, and current test coverage before changing structure
+    - classify findings into low-risk cleanup, characterization-test-first work, and intentionally deferred ideas
+  - Current stance:
+    - do not start a broad split while the current ZIP / MXL cleanup is still being finalized
+    - treat this as a distant refactoring theme to return to when there is a concrete format-coverage or maintenance need
+
 - [ ] Start the next refactoring pass from the format I/O modules before expanding format coverage.
   - Priority order:
     - `src/ts/abc-io.ts`: highest priority because ABC layout work is already waiting on cleaner parse/layout/emission boundaries.

--- a/bundle/mikuscore.mjs
+++ b/bundle/mikuscore.mjs
@@ -136145,6 +136145,22 @@ var BUNDLED_CLI_MODULES = {
     const normalizeZipEntryPathForWrite = (path2) => {
       return path2.replace(/\\/g, "/").replace(/^\/+/, "");
     };
+    const copyBytes = (bytes) => {
+      const copied = new Uint8Array(bytes.length);
+      copied.set(bytes);
+      return copied.buffer;
+    };
+    const responseBodyFromBytes = (bytes, unavailableMessage) => {
+      const body = new Response(copyBytes(bytes)).body;
+      if (!body) {
+        throw new Error(unavailableMessage);
+      }
+      return body;
+    };
+    const responseStreamToBytes = async (stream2) => {
+      const arrayBuffer = await new Response(stream2).arrayBuffer();
+      return new Uint8Array(arrayBuffer);
+    };
     const decodeZipFileName = (bytes, utf8Flag) => {
       if (utf8Flag)
         return decodeUtf8(bytes);
@@ -136161,56 +136177,70 @@ var BUNDLED_CLI_MODULES = {
       }
       return -1;
     };
-    const readZipEntries = (bytes) => {
+    const readCentralDirectoryBounds = (bytes) => {
       const eocdOffset = findEndOfCentralDirectoryOffset(bytes);
       if (eocdOffset < 0)
         throw new Error("Invalid ZIP: end of central directory was not found.");
-      const centralDirectorySize = readU32(bytes, eocdOffset + 12);
-      const centralDirectoryOffset = readU32(bytes, eocdOffset + 16);
-      const centralDirectoryEnd = centralDirectoryOffset + centralDirectorySize;
-      if (centralDirectoryEnd > bytes.length) {
+      const size = readU32(bytes, eocdOffset + 12);
+      const offset = readU32(bytes, eocdOffset + 16);
+      const end = offset + size;
+      if (end > bytes.length) {
         throw new Error("Invalid ZIP: central directory is out of range.");
       }
+      return { offset, end };
+    };
+    const readCentralDirectoryEntry = (bytes, offset) => {
+      if (readU32(bytes, offset) !== ZIP_CDFH_SIG) {
+        throw new Error("Invalid ZIP: central directory entry is malformed.");
+      }
+      const flags = readU16(bytes, offset + 8);
+      const compressionMethod = readU16(bytes, offset + 10);
+      const compressedSize = readU32(bytes, offset + 20);
+      const uncompressedSize = readU32(bytes, offset + 24);
+      const fileNameLength = readU16(bytes, offset + 28);
+      const extraLength = readU16(bytes, offset + 30);
+      const commentLength = readU16(bytes, offset + 32);
+      const localHeaderOffset = readU32(bytes, offset + 42);
+      const fileNameStart = offset + 46;
+      const fileNameEnd = fileNameStart + fileNameLength;
+      if (fileNameEnd > bytes.length) {
+        throw new Error("Invalid ZIP: entry filename is out of range.");
+      }
+      const fileName = decodeZipFileName(bytes.slice(fileNameStart, fileNameEnd), (flags & 2048) !== 0);
+      const normalizedPath = normalizeZipPath(fileName);
+      if (localHeaderOffset + 30 > bytes.length || readU32(bytes, localHeaderOffset) !== ZIP_LFH_SIG) {
+        throw new Error(`Invalid ZIP: local header is missing for "${normalizedPath}".`);
+      }
+      const localNameLength = readU16(bytes, localHeaderOffset + 26);
+      const localExtraLength = readU16(bytes, localHeaderOffset + 28);
+      const dataOffset = localHeaderOffset + 30 + localNameLength + localExtraLength;
+      if (dataOffset + compressedSize > bytes.length) {
+        throw new Error(`Invalid ZIP: data is out of range for "${normalizedPath}".`);
+      }
+      const nextOffset = fileNameEnd + extraLength + commentLength;
+      if (!normalizedPath || normalizedPath.endsWith("/")) {
+        return { entry: null, nextOffset };
+      }
+      return {
+        entry: {
+          path: normalizedPath,
+          compressionMethod,
+          compressedSize,
+          uncompressedSize,
+          dataOffset
+        },
+        nextOffset
+      };
+    };
+    const readZipEntries = (bytes) => {
+      const centralDirectory = readCentralDirectoryBounds(bytes);
       const entries = [];
-      let offset = centralDirectoryOffset;
-      while (offset < centralDirectoryEnd) {
-        if (readU32(bytes, offset) !== ZIP_CDFH_SIG) {
-          throw new Error("Invalid ZIP: central directory entry is malformed.");
-        }
-        const flags = readU16(bytes, offset + 8);
-        const compressionMethod = readU16(bytes, offset + 10);
-        const compressedSize = readU32(bytes, offset + 20);
-        const uncompressedSize = readU32(bytes, offset + 24);
-        const fileNameLength = readU16(bytes, offset + 28);
-        const extraLength = readU16(bytes, offset + 30);
-        const commentLength = readU16(bytes, offset + 32);
-        const localHeaderOffset = readU32(bytes, offset + 42);
-        const fileNameStart = offset + 46;
-        const fileNameEnd = fileNameStart + fileNameLength;
-        if (fileNameEnd > bytes.length) {
-          throw new Error("Invalid ZIP: entry filename is out of range.");
-        }
-        const fileName = decodeZipFileName(bytes.slice(fileNameStart, fileNameEnd), (flags & 2048) !== 0);
-        const normalizedPath = normalizeZipPath(fileName);
-        if (localHeaderOffset + 30 > bytes.length || readU32(bytes, localHeaderOffset) !== ZIP_LFH_SIG) {
-          throw new Error(`Invalid ZIP: local header is missing for "${normalizedPath}".`);
-        }
-        const localNameLength = readU16(bytes, localHeaderOffset + 26);
-        const localExtraLength = readU16(bytes, localHeaderOffset + 28);
-        const dataOffset = localHeaderOffset + 30 + localNameLength + localExtraLength;
-        if (dataOffset + compressedSize > bytes.length) {
-          throw new Error(`Invalid ZIP: data is out of range for "${normalizedPath}".`);
-        }
-        if (normalizedPath && !normalizedPath.endsWith("/")) {
-          entries.push({
-            path: normalizedPath,
-            compressionMethod,
-            compressedSize,
-            uncompressedSize,
-            dataOffset
-          });
-        }
-        offset = fileNameEnd + extraLength + commentLength;
+      let offset = centralDirectory.offset;
+      while (offset < centralDirectory.end) {
+        const result = readCentralDirectoryEntry(bytes, offset);
+        if (result.entry)
+          entries.push(result.entry);
+        offset = result.nextOffset;
       }
       return entries;
     };
@@ -136227,15 +136257,9 @@ var BUNDLED_CLI_MODULES = {
       if (!DS) {
         throw new Error("DecompressionStream is not available in this runtime.");
       }
-      const copied = new Uint8Array(compressed.length);
-      copied.set(compressed);
-      const source = new Response(copied).body;
-      if (!source) {
-        throw new Error("DecompressionStream source body is not available in this runtime.");
-      }
+      const source = responseBodyFromBytes(compressed, "DecompressionStream source body is not available in this runtime.");
       const stream2 = source.pipeThrough(new DS("deflate-raw"));
-      const arrayBuffer = await new Response(stream2).arrayBuffer();
-      return new Uint8Array(arrayBuffer);
+      return responseStreamToBytes(stream2);
     };
     const extractEntryBytes = async (archiveBytes, entry) => {
       const compressed = archiveBytes.slice(entry.dataOffset, entry.dataOffset + entry.compressedSize);
@@ -136352,14 +136376,9 @@ var BUNDLED_CLI_MODULES = {
       if (!CS)
         return null;
       try {
-        const source = new Uint8Array(input.length);
-        source.set(input);
-        const body = new Response(source).body;
-        if (!body)
-          return null;
+        const body = responseBodyFromBytes(input, "CompressionStream source body is not available in this runtime.");
         const stream2 = body.pipeThrough(new CS("deflate-raw"));
-        const compressedBuffer = await new Response(stream2).arrayBuffer();
-        return new Uint8Array(compressedBuffer);
+        return responseStreamToBytes(stream2);
       } catch (_a) {
         return null;
       }
@@ -136577,6 +136596,9 @@ var BUNDLED_CLI_MODULES = {
       cloned.appendChild(root);
       return cloned;
     };
+    const childElementsBySelector = (parent, selector) => {
+      return Array.from(parent.querySelectorAll(selector));
+    };
     const pruneEmptyNotations = (notations) => {
       if (!notations || notations.tagName !== "notations")
         return;
@@ -136629,14 +136651,14 @@ var BUNDLED_CLI_MODULES = {
       }
     };
     const sanitizeSlursForRender = (doc) => {
-      const parts = Array.from(doc.querySelectorAll("score-partwise > part"));
+      const parts = childElementsBySelector(doc, "score-partwise > part");
       for (const part of parts) {
         const openSlurs = /* @__PURE__ */ new Map();
-        const measures = Array.from(part.querySelectorAll(":scope > measure"));
+        const measures = childElementsBySelector(part, ":scope > measure");
         for (const measure of measures) {
-          const notes = Array.from(measure.querySelectorAll(":scope > note"));
+          const notes = childElementsBySelector(measure, ":scope > note");
           for (const note of notes) {
-            const slurs = Array.from(note.querySelectorAll(":scope > notations > slur"));
+            const slurs = childElementsBySelector(note, ":scope > notations > slur");
             for (const slur of slurs) {
               processSlurForRender(slur, openSlurs);
             }

--- a/mikuscore.html
+++ b/mikuscore.html
@@ -18492,6 +18492,9 @@ const cloneXmlDocument = (doc) => {
     cloned.appendChild(root);
     return cloned;
 };
+const childElementsBySelector = (parent, selector) => {
+    return Array.from(parent.querySelectorAll(selector));
+};
 const pruneEmptyNotations = (notations) => {
     if (!notations || notations.tagName !== "notations")
         return;
@@ -18545,14 +18548,14 @@ const processSlurForRender = (slur, openSlurs) => {
     }
 };
 const sanitizeSlursForRender = (doc) => {
-    const parts = Array.from(doc.querySelectorAll("score-partwise > part"));
+    const parts = childElementsBySelector(doc, "score-partwise > part");
     for (const part of parts) {
         const openSlurs = new Map();
-        const measures = Array.from(part.querySelectorAll(":scope > measure"));
+        const measures = childElementsBySelector(part, ":scope > measure");
         for (const measure of measures) {
-            const notes = Array.from(measure.querySelectorAll(":scope > note"));
+            const notes = childElementsBySelector(measure, ":scope > note");
             for (const note of notes) {
-                const slurs = Array.from(note.querySelectorAll(":scope > notations > slur"));
+                const slurs = childElementsBySelector(note, ":scope > notations > slur");
                 for (const slur of slurs) {
                     processSlurForRender(slur, openSlurs);
                 }
@@ -20275,6 +20278,22 @@ const encodeUtf8 = (text) => {
 const normalizeZipEntryPathForWrite = (path) => {
     return path.replace(/\\/g, "/").replace(/^\/+/, "");
 };
+const copyBytes = (bytes) => {
+    const copied = new Uint8Array(bytes.length);
+    copied.set(bytes);
+    return copied.buffer;
+};
+const responseBodyFromBytes = (bytes, unavailableMessage) => {
+    const body = new Response(copyBytes(bytes)).body;
+    if (!body) {
+        throw new Error(unavailableMessage);
+    }
+    return body;
+};
+const responseStreamToBytes = async (stream) => {
+    const arrayBuffer = await new Response(stream).arrayBuffer();
+    return new Uint8Array(arrayBuffer);
+};
 const decodeZipFileName = (bytes, utf8Flag) => {
     if (utf8Flag)
         return decodeUtf8(bytes);
@@ -20291,56 +20310,70 @@ const findEndOfCentralDirectoryOffset = (bytes) => {
     }
     return -1;
 };
-const readZipEntries = (bytes) => {
+const readCentralDirectoryBounds = (bytes) => {
     const eocdOffset = findEndOfCentralDirectoryOffset(bytes);
     if (eocdOffset < 0)
         throw new Error("Invalid ZIP: end of central directory was not found.");
-    const centralDirectorySize = readU32(bytes, eocdOffset + 12);
-    const centralDirectoryOffset = readU32(bytes, eocdOffset + 16);
-    const centralDirectoryEnd = centralDirectoryOffset + centralDirectorySize;
-    if (centralDirectoryEnd > bytes.length) {
+    const size = readU32(bytes, eocdOffset + 12);
+    const offset = readU32(bytes, eocdOffset + 16);
+    const end = offset + size;
+    if (end > bytes.length) {
         throw new Error("Invalid ZIP: central directory is out of range.");
     }
+    return { offset, end };
+};
+const readCentralDirectoryEntry = (bytes, offset) => {
+    if (readU32(bytes, offset) !== ZIP_CDFH_SIG) {
+        throw new Error("Invalid ZIP: central directory entry is malformed.");
+    }
+    const flags = readU16(bytes, offset + 8);
+    const compressionMethod = readU16(bytes, offset + 10);
+    const compressedSize = readU32(bytes, offset + 20);
+    const uncompressedSize = readU32(bytes, offset + 24);
+    const fileNameLength = readU16(bytes, offset + 28);
+    const extraLength = readU16(bytes, offset + 30);
+    const commentLength = readU16(bytes, offset + 32);
+    const localHeaderOffset = readU32(bytes, offset + 42);
+    const fileNameStart = offset + 46;
+    const fileNameEnd = fileNameStart + fileNameLength;
+    if (fileNameEnd > bytes.length) {
+        throw new Error("Invalid ZIP: entry filename is out of range.");
+    }
+    const fileName = decodeZipFileName(bytes.slice(fileNameStart, fileNameEnd), (flags & 0x0800) !== 0);
+    const normalizedPath = normalizeZipPath(fileName);
+    if (localHeaderOffset + 30 > bytes.length || readU32(bytes, localHeaderOffset) !== ZIP_LFH_SIG) {
+        throw new Error(`Invalid ZIP: local header is missing for "${normalizedPath}".`);
+    }
+    const localNameLength = readU16(bytes, localHeaderOffset + 26);
+    const localExtraLength = readU16(bytes, localHeaderOffset + 28);
+    const dataOffset = localHeaderOffset + 30 + localNameLength + localExtraLength;
+    if (dataOffset + compressedSize > bytes.length) {
+        throw new Error(`Invalid ZIP: data is out of range for "${normalizedPath}".`);
+    }
+    const nextOffset = fileNameEnd + extraLength + commentLength;
+    if (!normalizedPath || normalizedPath.endsWith("/")) {
+        return { entry: null, nextOffset };
+    }
+    return {
+        entry: {
+            path: normalizedPath,
+            compressionMethod,
+            compressedSize,
+            uncompressedSize,
+            dataOffset,
+        },
+        nextOffset,
+    };
+};
+const readZipEntries = (bytes) => {
+    const centralDirectory = readCentralDirectoryBounds(bytes);
     const entries = [];
-    let offset = centralDirectoryOffset;
-    while (offset < centralDirectoryEnd) {
-        if (readU32(bytes, offset) !== ZIP_CDFH_SIG) {
-            throw new Error("Invalid ZIP: central directory entry is malformed.");
-        }
-        const flags = readU16(bytes, offset + 8);
-        const compressionMethod = readU16(bytes, offset + 10);
-        const compressedSize = readU32(bytes, offset + 20);
-        const uncompressedSize = readU32(bytes, offset + 24);
-        const fileNameLength = readU16(bytes, offset + 28);
-        const extraLength = readU16(bytes, offset + 30);
-        const commentLength = readU16(bytes, offset + 32);
-        const localHeaderOffset = readU32(bytes, offset + 42);
-        const fileNameStart = offset + 46;
-        const fileNameEnd = fileNameStart + fileNameLength;
-        if (fileNameEnd > bytes.length) {
-            throw new Error("Invalid ZIP: entry filename is out of range.");
-        }
-        const fileName = decodeZipFileName(bytes.slice(fileNameStart, fileNameEnd), (flags & 0x0800) !== 0);
-        const normalizedPath = normalizeZipPath(fileName);
-        if (localHeaderOffset + 30 > bytes.length || readU32(bytes, localHeaderOffset) !== ZIP_LFH_SIG) {
-            throw new Error(`Invalid ZIP: local header is missing for "${normalizedPath}".`);
-        }
-        const localNameLength = readU16(bytes, localHeaderOffset + 26);
-        const localExtraLength = readU16(bytes, localHeaderOffset + 28);
-        const dataOffset = localHeaderOffset + 30 + localNameLength + localExtraLength;
-        if (dataOffset + compressedSize > bytes.length) {
-            throw new Error(`Invalid ZIP: data is out of range for "${normalizedPath}".`);
-        }
-        if (normalizedPath && !normalizedPath.endsWith("/")) {
-            entries.push({
-                path: normalizedPath,
-                compressionMethod,
-                compressedSize,
-                uncompressedSize,
-                dataOffset,
-            });
-        }
-        offset = fileNameEnd + extraLength + commentLength;
+    let offset = centralDirectory.offset;
+    while (offset < centralDirectory.end) {
+        const result = readCentralDirectoryEntry(bytes, offset);
+        if (result.entry)
+            entries.push(result.entry);
+        offset = result.nextOffset;
     }
     return entries;
 };
@@ -20357,15 +20390,9 @@ const inflateDeflateRaw = async (compressed) => {
     if (!DS) {
         throw new Error("DecompressionStream is not available in this runtime.");
     }
-    const copied = new Uint8Array(compressed.length);
-    copied.set(compressed);
-    const source = new Response(copied).body;
-    if (!source) {
-        throw new Error("DecompressionStream source body is not available in this runtime.");
-    }
+    const source = responseBodyFromBytes(compressed, "DecompressionStream source body is not available in this runtime.");
     const stream = source.pipeThrough(new DS("deflate-raw"));
-    const arrayBuffer = await new Response(stream).arrayBuffer();
-    return new Uint8Array(arrayBuffer);
+    return responseStreamToBytes(stream);
 };
 const extractEntryBytes = async (archiveBytes, entry) => {
     const compressed = archiveBytes.slice(entry.dataOffset, entry.dataOffset + entry.compressedSize);
@@ -20482,14 +20509,9 @@ const compressDeflateRaw = async (input) => {
     if (!CS)
         return null;
     try {
-        const source = new Uint8Array(input.length);
-        source.set(input);
-        const body = new Response(source).body;
-        if (!body)
-            return null;
+        const body = responseBodyFromBytes(input, "CompressionStream source body is not available in this runtime.");
         const stream = body.pipeThrough(new CS("deflate-raw"));
-        const compressedBuffer = await new Response(stream).arrayBuffer();
-        return new Uint8Array(compressedBuffer);
+        return responseStreamToBytes(stream);
     }
     catch (_a) {
         return null;

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -8168,6 +8168,9 @@ const cloneXmlDocument = (doc) => {
     cloned.appendChild(root);
     return cloned;
 };
+const childElementsBySelector = (parent, selector) => {
+    return Array.from(parent.querySelectorAll(selector));
+};
 const pruneEmptyNotations = (notations) => {
     if (!notations || notations.tagName !== "notations")
         return;
@@ -8221,14 +8224,14 @@ const processSlurForRender = (slur, openSlurs) => {
     }
 };
 const sanitizeSlursForRender = (doc) => {
-    const parts = Array.from(doc.querySelectorAll("score-partwise > part"));
+    const parts = childElementsBySelector(doc, "score-partwise > part");
     for (const part of parts) {
         const openSlurs = new Map();
-        const measures = Array.from(part.querySelectorAll(":scope > measure"));
+        const measures = childElementsBySelector(part, ":scope > measure");
         for (const measure of measures) {
-            const notes = Array.from(measure.querySelectorAll(":scope > note"));
+            const notes = childElementsBySelector(measure, ":scope > note");
             for (const note of notes) {
-                const slurs = Array.from(note.querySelectorAll(":scope > notations > slur"));
+                const slurs = childElementsBySelector(note, ":scope > notations > slur");
                 for (const slur of slurs) {
                     processSlurForRender(slur, openSlurs);
                 }
@@ -9951,6 +9954,22 @@ const encodeUtf8 = (text) => {
 const normalizeZipEntryPathForWrite = (path) => {
     return path.replace(/\\/g, "/").replace(/^\/+/, "");
 };
+const copyBytes = (bytes) => {
+    const copied = new Uint8Array(bytes.length);
+    copied.set(bytes);
+    return copied.buffer;
+};
+const responseBodyFromBytes = (bytes, unavailableMessage) => {
+    const body = new Response(copyBytes(bytes)).body;
+    if (!body) {
+        throw new Error(unavailableMessage);
+    }
+    return body;
+};
+const responseStreamToBytes = async (stream) => {
+    const arrayBuffer = await new Response(stream).arrayBuffer();
+    return new Uint8Array(arrayBuffer);
+};
 const decodeZipFileName = (bytes, utf8Flag) => {
     if (utf8Flag)
         return decodeUtf8(bytes);
@@ -9967,56 +9986,70 @@ const findEndOfCentralDirectoryOffset = (bytes) => {
     }
     return -1;
 };
-const readZipEntries = (bytes) => {
+const readCentralDirectoryBounds = (bytes) => {
     const eocdOffset = findEndOfCentralDirectoryOffset(bytes);
     if (eocdOffset < 0)
         throw new Error("Invalid ZIP: end of central directory was not found.");
-    const centralDirectorySize = readU32(bytes, eocdOffset + 12);
-    const centralDirectoryOffset = readU32(bytes, eocdOffset + 16);
-    const centralDirectoryEnd = centralDirectoryOffset + centralDirectorySize;
-    if (centralDirectoryEnd > bytes.length) {
+    const size = readU32(bytes, eocdOffset + 12);
+    const offset = readU32(bytes, eocdOffset + 16);
+    const end = offset + size;
+    if (end > bytes.length) {
         throw new Error("Invalid ZIP: central directory is out of range.");
     }
+    return { offset, end };
+};
+const readCentralDirectoryEntry = (bytes, offset) => {
+    if (readU32(bytes, offset) !== ZIP_CDFH_SIG) {
+        throw new Error("Invalid ZIP: central directory entry is malformed.");
+    }
+    const flags = readU16(bytes, offset + 8);
+    const compressionMethod = readU16(bytes, offset + 10);
+    const compressedSize = readU32(bytes, offset + 20);
+    const uncompressedSize = readU32(bytes, offset + 24);
+    const fileNameLength = readU16(bytes, offset + 28);
+    const extraLength = readU16(bytes, offset + 30);
+    const commentLength = readU16(bytes, offset + 32);
+    const localHeaderOffset = readU32(bytes, offset + 42);
+    const fileNameStart = offset + 46;
+    const fileNameEnd = fileNameStart + fileNameLength;
+    if (fileNameEnd > bytes.length) {
+        throw new Error("Invalid ZIP: entry filename is out of range.");
+    }
+    const fileName = decodeZipFileName(bytes.slice(fileNameStart, fileNameEnd), (flags & 0x0800) !== 0);
+    const normalizedPath = normalizeZipPath(fileName);
+    if (localHeaderOffset + 30 > bytes.length || readU32(bytes, localHeaderOffset) !== ZIP_LFH_SIG) {
+        throw new Error(`Invalid ZIP: local header is missing for "${normalizedPath}".`);
+    }
+    const localNameLength = readU16(bytes, localHeaderOffset + 26);
+    const localExtraLength = readU16(bytes, localHeaderOffset + 28);
+    const dataOffset = localHeaderOffset + 30 + localNameLength + localExtraLength;
+    if (dataOffset + compressedSize > bytes.length) {
+        throw new Error(`Invalid ZIP: data is out of range for "${normalizedPath}".`);
+    }
+    const nextOffset = fileNameEnd + extraLength + commentLength;
+    if (!normalizedPath || normalizedPath.endsWith("/")) {
+        return { entry: null, nextOffset };
+    }
+    return {
+        entry: {
+            path: normalizedPath,
+            compressionMethod,
+            compressedSize,
+            uncompressedSize,
+            dataOffset,
+        },
+        nextOffset,
+    };
+};
+const readZipEntries = (bytes) => {
+    const centralDirectory = readCentralDirectoryBounds(bytes);
     const entries = [];
-    let offset = centralDirectoryOffset;
-    while (offset < centralDirectoryEnd) {
-        if (readU32(bytes, offset) !== ZIP_CDFH_SIG) {
-            throw new Error("Invalid ZIP: central directory entry is malformed.");
-        }
-        const flags = readU16(bytes, offset + 8);
-        const compressionMethod = readU16(bytes, offset + 10);
-        const compressedSize = readU32(bytes, offset + 20);
-        const uncompressedSize = readU32(bytes, offset + 24);
-        const fileNameLength = readU16(bytes, offset + 28);
-        const extraLength = readU16(bytes, offset + 30);
-        const commentLength = readU16(bytes, offset + 32);
-        const localHeaderOffset = readU32(bytes, offset + 42);
-        const fileNameStart = offset + 46;
-        const fileNameEnd = fileNameStart + fileNameLength;
-        if (fileNameEnd > bytes.length) {
-            throw new Error("Invalid ZIP: entry filename is out of range.");
-        }
-        const fileName = decodeZipFileName(bytes.slice(fileNameStart, fileNameEnd), (flags & 0x0800) !== 0);
-        const normalizedPath = normalizeZipPath(fileName);
-        if (localHeaderOffset + 30 > bytes.length || readU32(bytes, localHeaderOffset) !== ZIP_LFH_SIG) {
-            throw new Error(`Invalid ZIP: local header is missing for "${normalizedPath}".`);
-        }
-        const localNameLength = readU16(bytes, localHeaderOffset + 26);
-        const localExtraLength = readU16(bytes, localHeaderOffset + 28);
-        const dataOffset = localHeaderOffset + 30 + localNameLength + localExtraLength;
-        if (dataOffset + compressedSize > bytes.length) {
-            throw new Error(`Invalid ZIP: data is out of range for "${normalizedPath}".`);
-        }
-        if (normalizedPath && !normalizedPath.endsWith("/")) {
-            entries.push({
-                path: normalizedPath,
-                compressionMethod,
-                compressedSize,
-                uncompressedSize,
-                dataOffset,
-            });
-        }
-        offset = fileNameEnd + extraLength + commentLength;
+    let offset = centralDirectory.offset;
+    while (offset < centralDirectory.end) {
+        const result = readCentralDirectoryEntry(bytes, offset);
+        if (result.entry)
+            entries.push(result.entry);
+        offset = result.nextOffset;
     }
     return entries;
 };
@@ -10033,15 +10066,9 @@ const inflateDeflateRaw = async (compressed) => {
     if (!DS) {
         throw new Error("DecompressionStream is not available in this runtime.");
     }
-    const copied = new Uint8Array(compressed.length);
-    copied.set(compressed);
-    const source = new Response(copied).body;
-    if (!source) {
-        throw new Error("DecompressionStream source body is not available in this runtime.");
-    }
+    const source = responseBodyFromBytes(compressed, "DecompressionStream source body is not available in this runtime.");
     const stream = source.pipeThrough(new DS("deflate-raw"));
-    const arrayBuffer = await new Response(stream).arrayBuffer();
-    return new Uint8Array(arrayBuffer);
+    return responseStreamToBytes(stream);
 };
 const extractEntryBytes = async (archiveBytes, entry) => {
     const compressed = archiveBytes.slice(entry.dataOffset, entry.dataOffset + entry.compressedSize);
@@ -10158,14 +10185,9 @@ const compressDeflateRaw = async (input) => {
     if (!CS)
         return null;
     try {
-        const source = new Uint8Array(input.length);
-        source.set(input);
-        const body = new Response(source).body;
-        if (!body)
-            return null;
+        const body = responseBodyFromBytes(input, "CompressionStream source body is not available in this runtime.");
         const stream = body.pipeThrough(new CS("deflate-raw"));
-        const compressedBuffer = await new Response(stream).arrayBuffer();
-        return new Uint8Array(compressedBuffer);
+        return responseStreamToBytes(stream);
     }
     catch (_a) {
         return null;

--- a/src/ts/verovio-out.ts
+++ b/src/ts/verovio-out.ts
@@ -39,6 +39,10 @@ const cloneXmlDocument = (doc: Document): Document => {
   return cloned;
 };
 
+const childElementsBySelector = (parent: ParentNode, selector: string): Element[] => {
+  return Array.from(parent.querySelectorAll(selector));
+};
+
 const pruneEmptyNotations = (notations: Element | null): void => {
   if (!notations || notations.tagName !== "notations") return;
   if (notations.children.length > 0) return;
@@ -95,14 +99,14 @@ const processSlurForRender = (slur: Element, openSlurs: OpenSlurStacks): void =>
 };
 
 const sanitizeSlursForRender = (doc: Document): void => {
-  const parts = Array.from(doc.querySelectorAll("score-partwise > part"));
+  const parts = childElementsBySelector(doc, "score-partwise > part");
   for (const part of parts) {
     const openSlurs: OpenSlurStacks = new Map();
-    const measures = Array.from(part.querySelectorAll(":scope > measure"));
+    const measures = childElementsBySelector(part, ":scope > measure");
     for (const measure of measures) {
-      const notes = Array.from(measure.querySelectorAll(":scope > note"));
+      const notes = childElementsBySelector(measure, ":scope > note");
       for (const note of notes) {
-        const slurs = Array.from(note.querySelectorAll(":scope > notations > slur"));
+        const slurs = childElementsBySelector(note, ":scope > notations > slur");
         for (const slur of slurs) {
           processSlurForRender(slur, openSlurs);
         }

--- a/src/ts/zip-io.ts
+++ b/src/ts/zip-io.ts
@@ -30,6 +30,16 @@ type ZipDosDateTime = {
   dosDate: number;
 };
 
+type ReadZipEntryResult = {
+  entry: ZipEntry | null;
+  nextOffset: number;
+};
+
+type ZipCentralDirectoryBounds = {
+  offset: number;
+  end: number;
+};
+
 const ZIP_EOCD_SIG = 0x06054b50;
 const ZIP_CDFH_SIG = 0x02014b50;
 const ZIP_LFH_SIG = 0x04034b50;
@@ -63,6 +73,25 @@ const normalizeZipEntryPathForWrite = (path: string): string => {
   return path.replace(/\\/g, "/").replace(/^\/+/, "");
 };
 
+const copyBytes = (bytes: Uint8Array): ArrayBuffer => {
+  const copied = new Uint8Array(bytes.length);
+  copied.set(bytes);
+  return copied.buffer;
+};
+
+const responseBodyFromBytes = (bytes: Uint8Array, unavailableMessage: string): ReadableStream<Uint8Array> => {
+  const body = new Response(copyBytes(bytes)).body;
+  if (!body) {
+    throw new Error(unavailableMessage);
+  }
+  return body;
+};
+
+const responseStreamToBytes = async (stream: BodyInit): Promise<Uint8Array> => {
+  const arrayBuffer = await new Response(stream).arrayBuffer();
+  return new Uint8Array(arrayBuffer);
+};
+
 const decodeZipFileName = (bytes: Uint8Array, utf8Flag: boolean): string => {
   if (utf8Flag) return decodeUtf8(bytes);
   let out = "";
@@ -78,62 +107,77 @@ const findEndOfCentralDirectoryOffset = (bytes: Uint8Array): number => {
   return -1;
 };
 
-const readZipEntries = (bytes: Uint8Array): ZipEntry[] => {
+const readCentralDirectoryBounds = (bytes: Uint8Array): ZipCentralDirectoryBounds => {
   const eocdOffset = findEndOfCentralDirectoryOffset(bytes);
   if (eocdOffset < 0) throw new Error("Invalid ZIP: end of central directory was not found.");
 
-  const centralDirectorySize = readU32(bytes, eocdOffset + 12);
-  const centralDirectoryOffset = readU32(bytes, eocdOffset + 16);
-  const centralDirectoryEnd = centralDirectoryOffset + centralDirectorySize;
-  if (centralDirectoryEnd > bytes.length) {
+  const size = readU32(bytes, eocdOffset + 12);
+  const offset = readU32(bytes, eocdOffset + 16);
+  const end = offset + size;
+  if (end > bytes.length) {
     throw new Error("Invalid ZIP: central directory is out of range.");
   }
+  return { offset, end };
+};
+
+const readCentralDirectoryEntry = (bytes: Uint8Array, offset: number): ReadZipEntryResult => {
+  if (readU32(bytes, offset) !== ZIP_CDFH_SIG) {
+    throw new Error("Invalid ZIP: central directory entry is malformed.");
+  }
+
+  const flags = readU16(bytes, offset + 8);
+  const compressionMethod = readU16(bytes, offset + 10);
+  const compressedSize = readU32(bytes, offset + 20);
+  const uncompressedSize = readU32(bytes, offset + 24);
+  const fileNameLength = readU16(bytes, offset + 28);
+  const extraLength = readU16(bytes, offset + 30);
+  const commentLength = readU16(bytes, offset + 32);
+  const localHeaderOffset = readU32(bytes, offset + 42);
+
+  const fileNameStart = offset + 46;
+  const fileNameEnd = fileNameStart + fileNameLength;
+  if (fileNameEnd > bytes.length) {
+    throw new Error("Invalid ZIP: entry filename is out of range.");
+  }
+  const fileName = decodeZipFileName(bytes.slice(fileNameStart, fileNameEnd), (flags & 0x0800) !== 0);
+  const normalizedPath = normalizeZipPath(fileName);
+
+  if (localHeaderOffset + 30 > bytes.length || readU32(bytes, localHeaderOffset) !== ZIP_LFH_SIG) {
+    throw new Error(`Invalid ZIP: local header is missing for "${normalizedPath}".`);
+  }
+  const localNameLength = readU16(bytes, localHeaderOffset + 26);
+  const localExtraLength = readU16(bytes, localHeaderOffset + 28);
+  const dataOffset = localHeaderOffset + 30 + localNameLength + localExtraLength;
+  if (dataOffset + compressedSize > bytes.length) {
+    throw new Error(`Invalid ZIP: data is out of range for "${normalizedPath}".`);
+  }
+
+  const nextOffset = fileNameEnd + extraLength + commentLength;
+  if (!normalizedPath || normalizedPath.endsWith("/")) {
+    return { entry: null, nextOffset };
+  }
+
+  return {
+    entry: {
+      path: normalizedPath,
+      compressionMethod,
+      compressedSize,
+      uncompressedSize,
+      dataOffset,
+    },
+    nextOffset,
+  };
+};
+
+const readZipEntries = (bytes: Uint8Array): ZipEntry[] => {
+  const centralDirectory = readCentralDirectoryBounds(bytes);
 
   const entries: ZipEntry[] = [];
-  let offset = centralDirectoryOffset;
-  while (offset < centralDirectoryEnd) {
-    if (readU32(bytes, offset) !== ZIP_CDFH_SIG) {
-      throw new Error("Invalid ZIP: central directory entry is malformed.");
-    }
-
-    const flags = readU16(bytes, offset + 8);
-    const compressionMethod = readU16(bytes, offset + 10);
-    const compressedSize = readU32(bytes, offset + 20);
-    const uncompressedSize = readU32(bytes, offset + 24);
-    const fileNameLength = readU16(bytes, offset + 28);
-    const extraLength = readU16(bytes, offset + 30);
-    const commentLength = readU16(bytes, offset + 32);
-    const localHeaderOffset = readU32(bytes, offset + 42);
-
-    const fileNameStart = offset + 46;
-    const fileNameEnd = fileNameStart + fileNameLength;
-    if (fileNameEnd > bytes.length) {
-      throw new Error("Invalid ZIP: entry filename is out of range.");
-    }
-    const fileName = decodeZipFileName(bytes.slice(fileNameStart, fileNameEnd), (flags & 0x0800) !== 0);
-    const normalizedPath = normalizeZipPath(fileName);
-
-    if (localHeaderOffset + 30 > bytes.length || readU32(bytes, localHeaderOffset) !== ZIP_LFH_SIG) {
-      throw new Error(`Invalid ZIP: local header is missing for "${normalizedPath}".`);
-    }
-    const localNameLength = readU16(bytes, localHeaderOffset + 26);
-    const localExtraLength = readU16(bytes, localHeaderOffset + 28);
-    const dataOffset = localHeaderOffset + 30 + localNameLength + localExtraLength;
-    if (dataOffset + compressedSize > bytes.length) {
-      throw new Error(`Invalid ZIP: data is out of range for "${normalizedPath}".`);
-    }
-
-    if (normalizedPath && !normalizedPath.endsWith("/")) {
-      entries.push({
-        path: normalizedPath,
-        compressionMethod,
-        compressedSize,
-        uncompressedSize,
-        dataOffset,
-      });
-    }
-
-    offset = fileNameEnd + extraLength + commentLength;
+  let offset = centralDirectory.offset;
+  while (offset < centralDirectory.end) {
+    const result = readCentralDirectoryEntry(bytes, offset);
+    if (result.entry) entries.push(result.entry);
+    offset = result.nextOffset;
   }
 
   return entries;
@@ -154,15 +198,9 @@ const inflateDeflateRaw = async (compressed: Uint8Array): Promise<Uint8Array> =>
     throw new Error("DecompressionStream is not available in this runtime.");
   }
 
-  const copied = new Uint8Array(compressed.length);
-  copied.set(compressed);
-  const source = new Response(copied).body;
-  if (!source) {
-    throw new Error("DecompressionStream source body is not available in this runtime.");
-  }
+  const source = responseBodyFromBytes(compressed, "DecompressionStream source body is not available in this runtime.");
   const stream = source.pipeThrough(new DS("deflate-raw") as never);
-  const arrayBuffer = await new Response(stream).arrayBuffer();
-  return new Uint8Array(arrayBuffer);
+  return responseStreamToBytes(stream);
 };
 
 const extractEntryBytes = async (archiveBytes: Uint8Array, entry: ZipEntry): Promise<Uint8Array> => {
@@ -285,13 +323,9 @@ const compressDeflateRaw = async (input: Uint8Array): Promise<Uint8Array | null>
   const CS = (globalThis as { CompressionStream?: new (format: string) => unknown }).CompressionStream;
   if (!CS) return null;
   try {
-    const source = new Uint8Array(input.length);
-    source.set(input);
-    const body = new Response(source).body;
-    if (!body) return null;
+    const body = responseBodyFromBytes(input, "CompressionStream source body is not available in this runtime.");
     const stream = body.pipeThrough(new CS("deflate-raw") as never);
-    const compressedBuffer = await new Response(stream).arrayBuffer();
-    return new Uint8Array(compressedBuffer);
+    return responseStreamToBytes(stream);
   } catch {
     return null;
   }

--- a/tests/unit/download-flow.spec.ts
+++ b/tests/unit/download-flow.spec.ts
@@ -20,6 +20,11 @@ import {
   extractZipEntryBytesByPath,
   listZipRootEntryPathsByExtensions,
 } from "../../src/ts/mxl-io";
+import { bytesToArrayBuffer, makeZipBytes } from "../../src/ts/zip-io";
+
+const encodeUtf8 = (text: string): Uint8Array => {
+  return new TextEncoder().encode(text);
+};
 
 const readBlobAsArrayBuffer = async (blob: Blob): Promise<ArrayBuffer> => {
   const reader = new FileReader();
@@ -139,6 +144,78 @@ describe("download-flow compressed export", () => {
     const extracted = await extractZipEntryBytesByPath(archiveBuffer, rootEntries[0]);
     const extractedText = new TextDecoder().decode(extracted);
     expect(extractedText).toContain("<museScore");
+  });
+
+  it("rejects archives without a ZIP end of central directory", async () => {
+    await expect(
+      extractTextFromZipByExtensions(bytesToArrayBuffer(new Uint8Array([0x50, 0x4b, 0x03, 0x04])), [".xml"])
+    ).rejects.toThrow("Invalid ZIP: end of central directory was not found.");
+  });
+
+  it("rejects empty ZIP archives for extension extraction", async () => {
+    const archiveBytes = await makeZipBytes([], false);
+
+    await expect(
+      extractTextFromZipByExtensions(bytesToArrayBuffer(archiveBytes), [".xml"])
+    ).rejects.toThrow("The ZIP archive is empty.");
+  });
+
+  it("ignores directory entries when listing ZIP root entries", async () => {
+    const archiveBytes = await makeZipBytes([
+      { path: "score.musicxml", bytes: encodeUtf8("<score-partwise/>") },
+      { path: "nested/score.musicxml", bytes: encodeUtf8("<score-partwise/>") },
+      { path: "nested/", bytes: new Uint8Array() },
+    ], false);
+
+    const rootEntries = await listZipRootEntryPathsByExtensions(bytesToArrayBuffer(archiveBytes), [".musicxml"]);
+
+    expect(rootEntries).toEqual(["score.musicxml"]);
+  });
+
+  it("falls back to a likely MusicXML entry when MXL has no container rootfile", async () => {
+    const archiveBytes = await makeZipBytes([
+      { path: "score.xml", bytes: encodeUtf8("<score-partwise><part-list/></score-partwise>") },
+    ], false);
+
+    const extracted = await extractMusicXmlTextFromMxl(bytesToArrayBuffer(archiveBytes));
+
+    expect(extracted).toContain("<score-partwise>");
+  });
+
+  it("rejects exact ZIP entry extraction when the path does not exist", async () => {
+    const archiveBytes = await makeZipBytes([
+      { path: "score.musicxml", bytes: encodeUtf8("<score-partwise/>") },
+    ], false);
+
+    await expect(
+      extractZipEntryBytesByPath(bytesToArrayBuffer(archiveBytes), "missing.musicxml")
+    ).rejects.toThrow("ZIP entry not found: missing.musicxml");
+  });
+
+  it("rejects extension extraction when no ZIP entry matches", async () => {
+    const archiveBytes = await makeZipBytes([
+      { path: "score.musicxml", bytes: encodeUtf8("<score-partwise/>") },
+    ], false);
+
+    await expect(
+      extractTextFromZipByExtensions(bytesToArrayBuffer(archiveBytes), [".mscx"])
+    ).rejects.toThrow("No matching entry was found for extensions: .mscx");
+  });
+
+  it("rejects MXL when container rootfile points to a missing entry", async () => {
+    const containerXml =
+      `<?xml version="1.0" encoding="UTF-8"?>` +
+      `<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">` +
+      `<rootfiles><rootfile full-path="missing.musicxml" media-type="application/vnd.recordare.musicxml+xml"/></rootfiles>` +
+      `</container>`;
+    const archiveBytes = await makeZipBytes([
+      { path: "META-INF/container.xml", bytes: encodeUtf8(containerXml) },
+      { path: "score.musicxml", bytes: encodeUtf8("<score-partwise/>") },
+    ], false);
+
+    await expect(
+      extractMusicXmlTextFromMxl(bytesToArrayBuffer(archiveBytes))
+    ).rejects.toThrow("MusicXML root file was not found in archive: missing.musicxml");
   });
 
   it("returns null when text-format conversion throws", () => {


### PR DESCRIPTION
## 概要

ZIP / MXL 周りの内部処理を整理し、壊れた ZIP や missing entry などの回帰テストを追加しました。あわせて、Verovio 描画前処理の DOM selector 取得を helper 化し、将来の大きめの format I/O 見直し方針を `TODO.md` に記録しています。

## 変更内容

- `src/ts/zip-io.ts`
  - ZIP central directory の範囲読み取りを `readCentralDirectoryBounds` に分離
  - central directory entry の読み取りを `readCentralDirectoryEntry` に分離
  - ZIP entry 読み取り結果と central directory 範囲を型で明示
  - CompressionStream / DecompressionStream 周りの byte copy / Response body / stream-to-bytes 処理を helper 化

- `src/ts/verovio-out.ts`
  - `querySelectorAll` から `Element[]` を得る処理を `childElementsBySelector` に集約
  - スラー補正処理の DOM 走査を少し薄く整理

- `tests/unit/download-flow.spec.ts`
  - ZIP / MXL の回帰テストを追加
  - EOCD がない壊れた ZIP
  - 空 ZIP
  - root entry 一覧での directory / nested entry 除外
  - `container.xml` なしの MusicXML fallback
  - 存在しない ZIP entry path
  - 該当拡張子なし
  - `container.xml` の rootfile が存在しないケース

- `TODO.md`
  - `src/ts/musescore-io.ts` / `src/ts/musicxml-io.ts` を将来的に review-first で見直す方針を追記
  - 大きな分割や書き換えではなく、公開 entry point / 責務 / テスト状況の棚卸しから始める方針を記録

- 生成物を更新
  - `bundle/mikuscore.mjs`
  - `mikuscore.html`
  - `src/js/main.js`

## 確認

- `npm run typecheck` 成功
- ZIP 経路の対象テスト成功
- `npm run build` 成功