### PR TITLE
MusicXML中心の形式変換仕様を整理

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,9 +128,15 @@ Implementation specs:
 
 - `docs/spec/SPEC.md`
 - `docs/spec/ARCHITECTURE.md`
+- `docs/spec/CANONICAL_MUSICXML.md`
+- `docs/spec/FORMAT_MAPPING.md`
+- `docs/spec/CONVERSION_DIAGNOSTICS.md`
 - `docs/spec/ABC_IO.md`
 - `docs/spec/MIDI_IO.md`
 - `docs/spec/MUSESCORE_IO.md`
+- `docs/spec/MEI_IO.md`
+- `docs/spec/LILYPOND_IO.md`
+- `docs/spec/VSQX_IO.md`
 
 ## 日本語
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,59 @@
 # TODO
 
+## Specification
+
+- [x] Create the first cross-format mapping table from the MusicXML canonical-state policy.
+  - Current source of truth:
+    - `docs/spec/CANONICAL_MUSICXML.md`
+    - `docs/spec/FORMAT_MAPPING.md`
+    - `docs/FORMAT_COVERAGE.md`
+    - `docs/spec/FORMAT_IO_CHECKLIST.md`
+
+- [x] Add current-boundary specs for MEI, LilyPond, and VSQX.
+  - Added:
+    - `docs/spec/MEI_IO.md`
+    - `docs/spec/LILYPOND_IO.md`
+    - `docs/spec/VSQX_IO.md`
+
+- [x] Add explicit mapping sections to existing ABC, MIDI, and MuseScore specs.
+  - Updated:
+    - `docs/spec/ABC_IO.md`
+    - `docs/spec/MIDI_IO.md`
+    - `docs/spec/MUSESCORE_IO.md`
+
+- [x] Align CFFP policy with the cross-format mapping table.
+  - Source of truth:
+    - `docs/spec/CANONICAL_MUSICXML.md`
+    - `docs/spec/FORMAT_MAPPING.md`
+    - `docs/FORMAT_COVERAGE.md`
+    - `docs/spec/FORMAT_IO_CHECKLIST.md`
+    - `docs/spec/TEST_CFFP.md`
+  - Result:
+    - documented how broad mapping categories relate to focused CFFP policy
+    - recorded current notable exceptions such as MIDI `CFFP-ACCIDENTAL-RESET`
+    - clarified that VSQX has no current notation-feature `must-preserve` CFFP claims
+
+- [x] Document current stable conversion diagnostic codes.
+  - Source of truth:
+    - `docs/spec/DIAGNOSTICS.md`
+    - `docs/spec/CONVERSION_DIAGNOSTICS.md`
+    - `docs/spec/CLI_DIAGNOSTICS_FIRSTCUT.md`
+    - `docs/spec/FORMAT_MAPPING.md`
+    - format-specific I/O specs
+  - Result:
+    - separated core edit diagnostics from conversion import/export diagnostics
+    - documented current stable ABC, MIDI, MuseScore, MEI, LilyPond, and VSQX conversion codes
+    - recorded promotion rules for broad warning codes
+
+- [ ] Promote broad conversion warnings into narrower stable codes only where callers need them.
+  - Source of truth:
+    - `docs/spec/CONVERSION_DIAGNOSTICS.md`
+    - format-specific I/O specs
+  - Scope:
+    - split broad codes such as `ABC_IMPORT_WARNING`, `MUSESCORE_IMPORT_WARNING`, and `LILYPOND_IMPORT_WARNING` only for real tool-caller needs
+    - keep message text human-readable but non-normative
+    - add tests when a new stable code becomes part of public behavior
+
 ## CLI
 
 - [ ] Add a CLI surface sync check whenever `src/ts/cli-api.ts` grows new or newly composable entry points.

--- a/docs/FORMAT_COVERAGE.md
+++ b/docs/FORMAT_COVERAGE.md
@@ -3,6 +3,8 @@
 ## Coverage Policy
 
 - Priority order: MusicXML fidelity > conversion breadth.
+- MusicXML is the canonical score state. Other formats are surrounding formats
+  that import into or export from MusicXML.
 - "Supported" means available in product flows, not full notation parity.
 - Supported formats may still change behavior as compatibility and parity work progress.
 - mikuscore is a converter, not a promise of lossless editing parity across all formats.
@@ -11,13 +13,13 @@
 
 | Format | Direction | Status | Notes |
 |---|---|---|---|
-| MusicXML 4.0 | import/export | Core baseline | Canonical internal target for compatibility work |
-| MuseScore (`.mscz`) | import/export | Supported | Focus on reliable conversion and parity tests |
-| MIDI (`.mid`) | import/export | Supported | Quantization/notation reconstruction has expected limits |
-| VSQX | import/export | Supported via vendored integration | Uses `utaformatix3-ts-plus` |
-| ABC | import/export | Supported | ABC standard 2.2 baseline with practical import/export coverage; some standard features remain partial or unsupported, and `mikuscore` may emit/accept extension metadata comments such as `%@mks ...` for roundtrip support |
-| MEI | import/export | Experimental | Compatibility work tracked with reference samples |
-| LilyPond (`.ly`) | import/export | Experimental | Conversion coverage is limited |
+| MusicXML 4.0 | import/export | Core baseline | Canonical score state |
+| MuseScore (`.mscx`, `.mscz`) | import/export | Supported | Surrounding notation format; focus on reliable MusicXML conversion and parity tests |
+| MIDI (`.mid`, `.midi`) | import/export | Supported | Surrounding performance-event format; import requires notation reconstruction and quantization |
+| VSQX | import/export | Supported via vendored integration | Surrounding singing/vocal timing format; uses `utaformatix3-ts-plus` |
+| ABC | import/export | Supported | Surrounding compact text notation; ABC standard 2.2 baseline with practical import/export coverage and optional `%@mks ...` roundtrip hints |
+| MEI | import/export | Experimental | Surrounding notation/archive format; compatibility work tracked with reference samples |
+| LilyPond (`.ly`) | import/export | Experimental | Surrounding text engraving format; conversion coverage is limited |
 
 ## Constraints
 
@@ -30,8 +32,14 @@
 
 ## Related Specs
 
+- `docs/spec/CANONICAL_MUSICXML.md`
+- `docs/spec/FORMAT_MAPPING.md`
+- `docs/spec/CONVERSION_DIAGNOSTICS.md`
 - `docs/spec/MIDI_IO.md`
 - `docs/spec/ABC_IO.md`
+- `docs/spec/MEI_IO.md`
+- `docs/spec/LILYPOND_IO.md`
+- `docs/spec/VSQX_IO.md`
 - `docs/spec/ABC_STANDARD_COVERAGE.md`
 - `docs/spec/DIAGNOSTICS.md`
 - `docs/spec/MISCELLANEOUS_FIELDS.md`

--- a/docs/spec/ABC_IO.md
+++ b/docs/spec/ABC_IO.md
@@ -4,6 +4,11 @@
 
 This document defines the behavior of `src/ts/abc-io.ts`.
 
+Cross-format mapping classification is summarized in
+`docs/spec/FORMAT_MAPPING.md`.
+Conversion diagnostic policy is defined in
+`docs/spec/CONVERSION_DIAGNOSTICS.md`.
+
 The module is responsible for:
 
 - parsing ABC text into an internal structure compatible with MusicXML generation
@@ -73,6 +78,27 @@ The goal is to accept broadly used ABC variants without unnecessary failure, whi
 - `exportMusicXmlDomToAbc(doc)`
 - `clefXmlFromAbcClef(rawClef?)`
 - `convertAbcToMusicXml(abcSource)`
+
+---
+
+## Mapping Policy
+
+ABC is a supported surrounding compact text notation format. It is useful for
+AI/human handoff and practical interchange, but canonical score state remains
+MusicXML.
+
+| Outcome | Current ABC policy |
+|---|---|
+| Normal MusicXML | Headers and inline fields for title, composer, meter, default note length, key, tempo, supported voices, names, clefs, notes, rests, chords, durations, ties, common slurs, tuplets, lyrics, barlines, repeats, endings, selected decorations, articulations, dynamics, technicals, beam-break hints, and supported jump markers |
+| `mks:meta:*` | `%@mks ...` comment hints preserve roundtrip behavior that plain ABC cannot carry reliably, including selected key, measure, transpose, and edge repeat/ending metadata |
+| `mks:src:*` | Not a primary ABC mechanism today; source traceability may be added later if needed |
+| `mks:diag:*` | Non-fatal parse/export issues are surfaced as warnings; persistent structured diagnostic storage may be added when needed for review or agent workflows |
+| Approximated | Overlay `&` currently expands into synthetic overlay voices/parts; beam-break intent is imported from whitespace, but exact ABC spacing is not canonical roundtrip data |
+| Skipped | Unsupported directives, unsupported inline fields, symbol lines, unsupported field continuation, unsupported decorations/text forms, malformed leftovers, and unsupported `V:` property fragments should be skipped with warnings when safely recoverable |
+| Rejected | ABC input with no usable body, no notes/rests, unrecoverable token parsing, or structurally ambiguous content that cannot safely produce canonical MusicXML |
+
+The standard ABC surface, compatibility behavior, and `mikuscore` extension
+metadata MUST remain distinguishable in this document and tests.
 
 ---
 

--- a/docs/spec/ARCHITECTURE.md
+++ b/docs/spec/ARCHITECTURE.md
@@ -7,6 +7,7 @@ This document defines high-level architecture boundaries for mikuscore MVP.
 Scope note:
 
 - This file defines boundaries and invariants at architecture level.
+- Canonical score-state policy is defined in `docs/spec/CANONICAL_MUSICXML.md`.
 - Detailed runtime build constraints are in `docs/spec/BUILD_PROCESS.md`.
 - Detailed UI behavior is in `docs/spec/UI_SPEC.md`.
 
@@ -15,6 +16,16 @@ Scope note:
 - Baseline format: **MusicXML 4.0**
 - Stability note: as of 2026-02-14, MusicXML 4.0 is treated as the latest stable baseline for this project
 - Rule: core interfaces, validators, and fixtures MUST be authored against 4.0 semantics
+
+## Canonical Score State
+
+- Canonical state: MusicXML
+- Surrounding formats are imported into, or exported from, the current
+  MusicXML state.
+- Product semantics belong to the main application layer. Web and Agent Skills
+  surfaces expose or orchestrate those semantics; they do not redefine them.
+- Conversion loss, approximation, fallback, skipped data, and unsupported
+  behavior SHOULD be represented through diagnostics.
 
 ## Architectural Separation
 
@@ -93,6 +104,7 @@ UI MUST NOT mutate XML DOM directly.
 ## References
 
 - `docs/spec/SPEC.md`
+- `docs/spec/CANONICAL_MUSICXML.md`
 - `docs/spec/TERMS.md`
 - `docs/spec/COMMANDS.md`
 - `docs/spec/COMMAND_CATALOG.md`

--- a/docs/spec/CANONICAL_MUSICXML.md
+++ b/docs/spec/CANONICAL_MUSICXML.md
@@ -1,0 +1,152 @@
+# Canonical MusicXML State
+
+## Purpose
+
+This document defines the canonical score-state policy for mikuscore.
+
+mikuscore is MusicXML-first. MusicXML is the canonical score state used for
+conversion, inspection, diagnostics, light editing, CLI state commands, Web
+preview/download flows, and Agent Skills handoff workflows.
+
+This does not mean that mikuscore promises byte-for-byte preservation of every
+input file. It means that product semantics are centered on a current
+MusicXML state, and surrounding formats are imported into or exported from that
+state.
+
+Cross-format mapping outcomes are indexed in `docs/spec/FORMAT_MAPPING.md`.
+
+## Canonical State Rule
+
+The canonical state is a MusicXML document that mikuscore can parse, inspect,
+validate, edit in bounded ways, and serialize.
+
+The canonical state SHOULD preserve source MusicXML structure as much as
+practical. When input comes from another format, mikuscore MAY synthesize the
+MusicXML structure required to represent the imported score.
+
+The canonical state MUST NOT silently imply full fidelity for source-format
+features that MusicXML cannot represent, that mikuscore does not currently
+map, or that were approximated during import.
+
+## Product Boundary
+
+The miku-soft layer responsibilities are already defined by the shared
+miku-soft references. For mikuscore, apply them as follows:
+
+- The `10 Main Application` layer owns MusicXML canonical semantics,
+  conversion behavior, diagnostics, CLI contracts, runtime bundles, and
+  structured artifacts.
+- The `11 Web App` layer is a human operation surface over the main
+  application. It owns browser file loading, preview, diagnostics display, and
+  download behavior, but not independent conversion semantics.
+- The `40 Agent Skills` layer is an agent workflow adapter over the upstream
+  product. It owns activation, workflow guidance, runtime discovery, and
+  handoff policy, but not independent conversion semantics.
+
+If Web or Agent Skills workflows need new musical behavior, add or stabilize
+that behavior in the main application first, then expose it through the
+downstream layer.
+
+## Surrounding Format Policy
+
+Formats other than MusicXML are surrounding formats.
+
+| Format | Canonical relationship | Current policy |
+|---|---|---|
+| MusicXML | Canonical input/output state | Preserve original structure where practical; no-op save returns original text unchanged |
+| MuseScore | Surrounding notation format | Import/export through MusicXML; parity work should focus on notational meaning and diagnostics |
+| MIDI | Surrounding performance-event format | Import requires notation reconstruction; export derives playback events from MusicXML |
+| ABC | Surrounding compact text notation | Useful for AI/human handoff; import/export through MusicXML with documented subset and `mks` hints where needed |
+| MEI | Surrounding notation/archive format | Experimental import/export through MusicXML; diagnostics should make unsupported mappings visible |
+| LilyPond | Surrounding text engraving format | Experimental import/export through MusicXML; `mks` hints may preserve mikuscore-specific roundtrip metadata |
+| VSQX | Surrounding singing/vocal timing format | Import/export through vendored integration; treat vocal/timing information as source-format-specific unless mapped into MusicXML explicitly |
+
+## Import Policy
+
+Import from a surrounding format MUST produce a MusicXML state or fail with a
+diagnostic.
+
+An importer SHOULD classify each source feature into one of these outcomes:
+
+- preserved in normal MusicXML
+- represented through mikuscore extension metadata such as `mks:meta:*`
+- retained as source-preservation metadata such as `mks:src:*`
+- approximated with a warning diagnostic
+- skipped with a warning diagnostic
+- rejected with an error diagnostic
+
+Importers SHOULD avoid broad musical repair that is not required at the import
+boundary. Required structural normalization is allowed when it makes the
+resulting MusicXML loadable, inspectable, and renderable.
+
+## Export Policy
+
+Export to a surrounding format MUST start from the current canonical MusicXML
+state.
+
+An exporter SHOULD classify each MusicXML or mikuscore extension feature into
+one of these outcomes:
+
+- represented in the target format
+- represented through target-format comments or hints
+- approximated with a warning diagnostic
+- skipped with a warning diagnostic
+- rejected with an error diagnostic
+
+Exporters SHOULD keep output deterministic enough for tests and review.
+
+## Diagnostics Policy
+
+Diagnostics are part of the product contract, not incidental UI text.
+
+When conversion applies approximation, repair, fallback, skipped data, or
+unsupported behavior, the behavior SHOULD be visible through diagnostics. Where
+useful for roundtrip or downstream review, diagnostics MAY also be preserved in
+MusicXML `miscellaneous-field` values using the namespace policy in
+`docs/spec/MISCELLANEOUS_FIELDS.md`.
+
+Diagnostics intended for humans, scripts, and Agent Skills SHOULD include
+enough context to locate the issue, such as stage, source format, target
+format, part, measure, staff, voice, and feature type when available.
+
+## Roundtrip Policy
+
+mikuscore does not guarantee byte-for-byte roundtrip equality across formats.
+
+Roundtrip confidence SHOULD be based on musical and structural invariants:
+
+- measure count and ordering where applicable
+- part and voice/lane validity
+- beat-capacity validity
+- pitch, rest, duration, and chord semantics where the target format can
+  represent them
+- key, time, clef, tempo, lyrics, articulations, dynamics, and layout only to
+  the degree declared by the format-specific policy
+
+For each focused notation topic, tests SHOULD classify target formats as
+`must-preserve` or `allowed-degrade`, as described in
+`docs/spec/TEST_CFFP.md`.
+
+## AI Handoff Policy
+
+AI-facing workflows SHOULD avoid handing an entire score to an agent when a
+smaller projection is enough.
+
+Preferred MusicXML-centered edit flow:
+
+1. Inspect a bounded MusicXML projection such as one measure.
+2. Generate a bounded core command.
+3. Validate the command.
+4. Apply the command.
+5. Diff the before/after MusicXML state.
+
+The current CLI `state` family is the main public surface for this flow.
+
+## Non-Goals
+
+mikuscore is not a full score engraving editor, a full MuseScore replacement,
+or a guarantee of lossless conversion between every format pair.
+
+Deep layout editing, global re-engraving, full voice reconstruction, and
+complete source-format preservation are outside the canonical state guarantee
+unless a format-specific spec explicitly brings a feature into scope.

--- a/docs/spec/CLI_DIAGNOSTICS_FIRSTCUT.md
+++ b/docs/spec/CLI_DIAGNOSTICS_FIRSTCUT.md
@@ -159,6 +159,17 @@ That means:
 - CLI diagnostics describe command execution, I/O context, and exit semantics
 - core diagnostics describe music-edit validity and execution outcomes inside the bounded command layer
 
+## Relationship To Conversion Diagnostics
+
+Conversion diagnostics are defined in
+`docs/spec/CONVERSION_DIAGNOSTICS.md`.
+
+The CLI diagnostics contract should wrap conversion diagnostics without
+renaming them. For example, `MIDI_KEY_SIGNATURE_INFERRED` or
+`VSQX_BRIDGE_UNAVAILABLE` may appear as warning/error entries inside CLI JSON
+diagnostics, while the CLI wrapper still describes command, I/O, and exit
+status.
+
 ## Multi-stage Commands
 
 Some future CLI commands may cross multiple internal stages.

--- a/docs/spec/CONVERSION_DIAGNOSTICS.md
+++ b/docs/spec/CONVERSION_DIAGNOSTICS.md
@@ -1,0 +1,190 @@
+# Conversion Diagnostics
+
+## Purpose
+
+This document defines the conversion-diagnostics policy for mikuscore import
+and export paths.
+
+It is separate from `docs/spec/DIAGNOSTICS.md`, which is the core bounded-edit
+diagnostics catalog. Conversion diagnostics describe format I/O behavior:
+unsupported input, approximation, repair, dropped events, inferred metadata,
+fallbacks, and bridge/runtime failures.
+
+## Diagnostic Layers
+
+| Layer | Document | Scope |
+|---|---|---|
+| Core edit diagnostics | `docs/spec/DIAGNOSTICS.md` | `ScoreCore` command/save validity and atomicity |
+| Conversion diagnostics | this document | Format import/export loss, repair, fallback, and runtime failures |
+| CLI diagnostics | `docs/spec/CLI_DIAGNOSTICS_FIRSTCUT.md` | Command execution, stdio, exit status, and machine-readable wrapper shape |
+| Stored metadata | `docs/spec/MISCELLANEOUS_FIELDS.md` | `mks:diag:*` storage inside MusicXML `miscellaneous-field` |
+
+The layers may wrap each other, but they should not replace each other. For
+example, CLI JSON diagnostics may contain conversion warning codes, and
+MusicXML may store conversion warnings in `mks:diag:*`.
+
+## Stability Rule
+
+A conversion diagnostic code is stable when it is one of these:
+
+- documented in this file
+- asserted by tests as a `code`
+- emitted into `mks:diag:*`
+- part of a public result object used by Web, CLI, or Agent Skills
+
+Stable codes SHOULD NOT be renamed casually. If a code needs replacement,
+document the replacement and keep compatibility until callers can migrate.
+
+Human-readable `message` text is not stable unless a format-specific spec says
+otherwise.
+
+## Severity
+
+Use these levels:
+
+- `info`
+  - successful fallback, inserted default, or non-lossy normalization worth
+    surfacing to automation
+- `warn`
+  - import/export succeeded, but data was inferred, approximated, repaired,
+    skipped, clamped, split, or otherwise changed in a way that may matter
+- `error`
+  - import/export failed or should fail
+
+`mks:diag:*` payloads SHOULD use the same `level` values.
+
+## Payload Shape
+
+Structured diagnostics SHOULD use these fields when available:
+
+- `level`
+- `code`
+- `fmt`
+- `stage`
+- `message`
+- `part`
+- `measure`
+- `staff`
+- `voice`
+- `event`
+- `action`
+
+Additional format-specific fields are allowed when they are stable enough for
+debugging or agent workflows, such as `sourceTicks`, `capacityTicks`,
+`droppedEvents`, `droppedTicks`, `trimmedEvents`, `trimmedTicks`,
+`movedEvents`, `channel`, `track`, `tick`, or `grid`.
+
+## Current Stable Codes
+
+### ABC
+
+| Code | Level | Meaning |
+|---|---|---|
+| `ABC_IMPORT_WARNING` | warn | Non-fatal ABC import warning, including unsupported syntax, skipped compatibility fragments, fallback defaults, or recoverable parse issues |
+
+Current ABC warning messages are more specific than the code. They are useful
+for humans, but callers should treat `ABC_IMPORT_WARNING` as the stable code
+until narrower codes are promoted.
+
+### MIDI
+
+| Code | Level | Meaning |
+|---|---|---|
+| `MIDI_INVALID_FILE` | error | MIDI input is not a valid Standard MIDI File or is structurally unreadable |
+| `MIDI_UNSUPPORTED_FORMAT` | error | MIDI file format is unsupported |
+| `MIDI_UNSUPPORTED_DIVISION` | error | MIDI time division is unsupported, such as SMPTE division |
+| `MIDI_NOTE_PAIR_BROKEN` | warn | Note-on / note-off pairing could not be completed cleanly |
+| `MIDI_QUANTIZE_CLAMPED` | warn | Quantization clamped or adjusted timing to keep a valid notation event |
+| `MIDI_EVENT_DROPPED` | warn | MIDI event was dropped because it is unsupported, malformed, or outside current scope |
+| `MIDI_TIME_SIGNATURE_PICKUP_NORMALIZED` | warn | Leading time-signature/pickup information was normalized into a canonical pickup measure |
+| `MIDI_KEY_SIGNATURE_INFERRED` | warn | Key signature was inferred because MIDI did not provide a usable key meta event |
+| `MIDI_POLYPHONY_VOICE_ASSIGNED` | warn | Overlapping notes required automatic voice assignment |
+| `MIDI_POLYPHONY_VOICE_OVERFLOW` | warn | Polyphony exceeded the current voice assignment capacity or policy |
+| `MIDI_DRUM_CHANNEL_SEPARATED` | warn | MIDI channel 10 was separated into a dedicated drum part |
+| `MIDI_DRUM_NOTE_UNMAPPED` | warn | Drum note could not be mapped to a known unpitched notation representation |
+
+Current MIDI export also emits `info`-level metadata strings for inserted
+default tempo, time signature, and key signature. Those are useful but not yet
+promoted here as stable public conversion codes.
+
+### MuseScore
+
+| Code | Level | Meaning |
+|---|---|---|
+| `MUSESCORE_IMPORT_WARNING` | warn | Non-fatal MuseScore import warning, usually unknown or unsupported input that could be skipped while preserving usable musical structure |
+
+MuseScore currently uses a broad stable warning code with message details.
+Promote narrower codes only when callers need machine-readable branching.
+
+### MEI
+
+| Code | Level | Meaning |
+|---|---|---|
+| `OVERFULL_CLAMPED` | warn | MEI import detected overfull layer/staff content and clamped, trimmed, or dropped material to produce valid canonical MusicXML |
+
+`OVERFULL_CLAMPED` is currently stored in `mks:diag:*` payloads with MEI
+context fields such as `measure`, `staff`, `sourceTicks`, `capacityTicks`,
+`droppedEvents`, `droppedTicks`, `trimmedEvents`, and `trimmedTicks`.
+
+Future MEI work should prefer `MEI_*` codes for new warnings unless the code is
+intentionally shared across formats.
+
+### LilyPond
+
+| Code | Level | Meaning |
+|---|---|---|
+| `LILYPOND_IMPORT_WARNING` | warn | Non-fatal LilyPond import warning, including unsupported commands/tokens, overfull handling, skipped chords/notes, or other bounded degradation |
+| `LILYPOND_EXPORT_WARNING` | warn | Non-fatal LilyPond export warning, including skipped malformed or unsupported MusicXML material |
+
+LilyPond currently uses broad warning codes with specific message text.
+
+### VSQX
+
+| Code | Level | Meaning |
+|---|---|---|
+| `VSQX_BRIDGE_UNAVAILABLE` | error | VSQX converter bundle is not loaded |
+| `VSQX_CONVERT_EMPTY_RESULT` | error | VSQX import returned empty MusicXML |
+| `VSQX_EXPORT_EMPTY_RESULT` | error | MusicXML export returned empty VSQX |
+| `VSQX_EXPORT_FAILED` | error | MusicXML to VSQX conversion threw or failed |
+| `VSQX_CONVERT_ERROR_N` | error | Bridge import report contained an error issue |
+| `VSQX_CONVERT_WARNING_N` | warn | Bridge import report contained a warning/info issue |
+
+The numbered VSQX bridge codes preserve the bridge issue order. Callers should
+use the code prefix when they do not need item-specific ordering.
+
+## Promotion Rules
+
+Promote a broad warning into narrower stable codes when at least one is true:
+
+- Agent Skills or CLI callers need different recovery behavior.
+- A warning needs to be counted or filtered separately in JSON diagnostics.
+- A warning appears in `mks:diag:*` and should be stable across releases.
+- A focused CFFP policy depends on distinguishing the warning from other
+  warnings in the same format.
+
+Do not promote one-off debug messages into stable codes just because they are
+useful during local investigation.
+
+## Relationship to `mks:diag:*`
+
+When a conversion diagnostic is stored in MusicXML, use
+`miscellaneous-field[name="mks:diag:NNNN"]` with a semicolon-delimited payload.
+
+Recommended key order:
+
+```text
+level;code;fmt;stage;part;measure;staff;voice;event;action;message
+```
+
+Add numeric context fields after those common keys.
+
+Stored diagnostics should be concise. Raw source data belongs under
+`mks:src:*`, and volatile tracing belongs under `mks:dbg:*`.
+
+## Non-Goals
+
+Conversion diagnostics do not provide a complete musicological diff.
+
+They should make important loss, repair, approximation, unsupported behavior,
+and runtime failures visible enough for humans, scripts, and Agent Skills to
+avoid treating incomplete conversion as complete.

--- a/docs/spec/DIAGNOSTICS.md
+++ b/docs/spec/DIAGNOSTICS.md
@@ -4,6 +4,9 @@
 
 Single source of truth for diagnostics emitted by core.
 
+Conversion import/export diagnostics are defined separately in
+`docs/spec/CONVERSION_DIAGNOSTICS.md`.
+
 ## Error Diagnostics
 
 1. `MEASURE_OVERFULL`

--- a/docs/spec/FORMAT_IO_CHECKLIST.md
+++ b/docs/spec/FORMAT_IO_CHECKLIST.md
@@ -12,6 +12,11 @@ When adding a new format (e.g. ABC / MEI / future formats), use this checklist t
   - Import only / Export only / both
   - Supported notation subset (note/rest/chord/tuplet/ornament/etc.)
   - Explicit out-of-scope items for first release
+- [ ] Define the format's relationship to canonical MusicXML:
+  - surrounding notation format
+  - surrounding performance-event format
+  - surrounding singing/vocal timing format
+  - other documented role
 - [ ] Define degradation policy:
   - What must be preserved
   - What may degrade
@@ -23,6 +28,7 @@ When adding a new format (e.g. ABC / MEI / future formats), use this checklist t
 
 - [ ] Parser/decoder handles invalid input safely (no crash, diagnostic returned)
 - [ ] Generated MusicXML is valid XML and parseable by existing loader
+- [ ] Generated MusicXML conforms to the canonical state policy in `docs/spec/CANONICAL_MUSICXML.md`
 - [ ] Output MusicXML is pretty-printed (human-readable)
 - [ ] Apply only bounded structural normalization required for loader/renderer interoperability:
   - [ ] Allowed example: synthesize missing `part-list` and `part/@id` / `score-part/@id` linkage when absent
@@ -42,6 +48,13 @@ When adding a new format (e.g. ABC / MEI / future formats), use this checklist t
 - [ ] Unsupported feature handling is explicit:
   - [ ] either diagnostic + skip
   - [ ] or hard error + fail import
+- [ ] Source features are classified:
+  - [ ] preserved in normal MusicXML
+  - [ ] preserved as `mks:meta:*`
+  - [ ] preserved as `mks:src:*`
+  - [ ] approximated with diagnostics
+  - [ ] skipped with diagnostics
+  - [ ] rejected with diagnostics
 
 ---
 
@@ -61,6 +74,12 @@ When adding a new format (e.g. ABC / MEI / future formats), use this checklist t
   - [ ] `miscellaneous-field` equivalent
   - [ ] comment-level metadata/hints (if any) are versioned and parseable (e.g. `%@mks ...`)
 - [ ] If loss is unavoidable, degradation behavior is documented
+- [ ] Exported MusicXML features are classified:
+  - [ ] represented in the target format
+  - [ ] represented through target-format hints/comments
+  - [ ] approximated with diagnostics
+  - [ ] skipped with diagnostics
+  - [ ] rejected with diagnostics
 
 ---
 

--- a/docs/spec/FORMAT_MAPPING.md
+++ b/docs/spec/FORMAT_MAPPING.md
@@ -1,0 +1,246 @@
+# Format Mapping Policy
+
+## Purpose
+
+This document is the first cross-format mapping table for mikuscore.
+
+It refines the canonical MusicXML state policy in
+`docs/spec/CANONICAL_MUSICXML.md` by classifying each surrounding format
+against the same set of outcomes:
+
+- represented in normal MusicXML
+- preserved through mikuscore extension metadata (`mks:meta:*`)
+- preserved as source-format metadata (`mks:src:*`)
+- approximated with diagnostics
+- skipped with diagnostics
+- rejected with diagnostics
+
+This is a specification planning document. Format-specific details remain in
+the format-specific specs, but this file is the cross-format index used to
+avoid treating every converter as a separate product.
+
+## Mapping Terms
+
+| Term | Meaning |
+|---|---|
+| Normal MusicXML | Standard MusicXML elements and attributes used as the canonical score state |
+| `mks:meta:*` | mikuscore extension metadata needed for product behavior or roundtrip support |
+| `mks:src:*` | source-format-only data retained for traceability or possible reconstruction |
+| `mks:diag:*` | structured conversion diagnostics stored in MusicXML metadata when useful |
+| Approximated | Converted into a close MusicXML representation but not guaranteed equivalent |
+| Skipped | Recognized but omitted because it is outside current scope |
+| Rejected | Causes import/export failure because continuing would be unsafe or misleading |
+
+## Format Roles
+
+| Format | Role | Canonical relationship |
+|---|---|---|
+| MusicXML | Canonical notation state | The score state mikuscore reads, validates, edits, serializes, renders, and exports from |
+| MuseScore | Surrounding notation format | High-priority import/export through MusicXML with parity checks |
+| MIDI | Surrounding performance-event format | Export derives performance events from MusicXML; import reconstructs notation from timed events |
+| ABC | Surrounding compact text notation | Practical AI/human handoff notation imported/exported through MusicXML |
+| MEI | Surrounding notation/archive format | Experimental import/export through MusicXML |
+| LilyPond | Surrounding text engraving format | Experimental text notation/engraving import/export through MusicXML |
+| VSQX | Surrounding singing/vocal timing format | Integration-backed import/export for vocal timing and pitch material |
+
+## Core MusicXML Expectations
+
+Every successful surrounding-format import SHOULD produce MusicXML with:
+
+- a `score-partwise` document
+- `part-list` / `score-part` linkage
+- one or more `part` elements
+- measure structure
+- valid note/rest durations where the source provides enough timing information
+- time/key/clef where available or safely synthesized
+
+Every surrounding-format export SHOULD start from the current canonical
+MusicXML state and avoid adding product semantics in the export adapter that
+are not present in the MusicXML state or documented `mks:*` metadata.
+
+## ABC Mapping
+
+Status: supported surrounding compact text notation.
+
+Source spec: `docs/spec/ABC_IO.md`.
+
+| Outcome | Current policy |
+|---|---|
+| Normal MusicXML | Headers such as title, composer, meter, default note length, key, tempo, supported voices, clefs, notes, rests, chords, barlines, repeats, endings, slurs, ties, tuplets, selected decorations, beam-break hints, and supported inline fields |
+| `mks:meta:*` | `%@mks ...` comment hints for roundtrip behavior where plain ABC cannot carry enough information |
+| `mks:src:*` | Not the primary current ABC mechanism; source traceability may be added later if needed |
+| `mks:diag:*` | Conversion warnings may be surfaced as diagnostics; storage in MusicXML metadata is allowed when useful |
+| Approximated | Overlay `&` is imported through synthetic overlay voices/parts; exact one-part overlay semantics are not currently guaranteed |
+| Skipped | Unsupported directives, unsupported inline fields, symbol lines, unsupported decorations/text forms, malformed leftover body tokens, and out-of-scope field continuation behavior should be skipped with warnings where possible |
+| Rejected | Structurally broken or musically uninterpretable ABC input that cannot be converted safely |
+
+Notes:
+
+- ABC support distinguishes standard ABC surface, real-world compatibility
+  behavior, and mikuscore extension metadata.
+- `%@mks ...` is mikuscore-specific extension metadata, not standard ABC
+  musical notation.
+- Exact ABC source whitespace is not canonical roundtrip data.
+
+## MIDI Mapping
+
+Status: supported surrounding performance-event format.
+
+Source spec: `docs/spec/MIDI_IO.md`.
+
+| Outcome | Current policy |
+|---|---|
+| Normal MusicXML | Imported MIDI reconstructs parts/tracks, measures, notes/rests, durations, voices/lane equivalents where possible, tempo, key/time metadata where available, and quantized notation structure |
+| `mks:meta:*` | MIDI export may emit mikuscore text meta events such as title, movement title, composer, pickup ticks, part-name/track hints, and metadata version |
+| `mks:src:*` | Not the primary current MIDI mechanism; source-event trace preservation is not a first-cut guarantee |
+| `mks:diag:*` | Conversion diagnostics should describe quantization, pairing, unsupported division, malformed events, and other import/export issues when available |
+| Approximated | MIDI import necessarily reconstructs notation from timed events; quantization, enharmonic spelling, voices, beams, articulations, and rests may be inferred |
+| Skipped | DAW-specific, device-specific, or unrecognized MIDI events outside current playback/export scope may be skipped with diagnostics |
+| Rejected | Unsupported SMPTE time division, invalid SMF structure, no playable note events for export, or event structures that cannot be paired safely |
+
+Notes:
+
+- MIDI is not a notation source. Import quality is bounded by timing,
+  quantization, and event-pairing policy.
+- MIDI export is a derived performance artifact from MusicXML, not a separate
+  canonical score state.
+
+## MuseScore Mapping
+
+Status: supported surrounding notation format.
+
+Source spec: `docs/spec/MUSESCORE_IO.md`.
+
+| Outcome | Current policy |
+|---|---|
+| Normal MusicXML | Time/key/tempo, staff/voice events, notes/rests, tuplets, slurs, ties, ottava, trills, dynamics, directions, repeats, barlines, accidental spelling where recoverable, and beam information |
+| `mks:meta:*` | May be used when mikuscore-specific roundtrip behavior becomes necessary |
+| `mks:src:*` | Source chunks may be stored in `mks:src:mscx:*` when source metadata is enabled |
+| `mks:diag:*` | Import warnings may be exported to `miscellaneous-field` entries when debug metadata is enabled |
+| Approximated | Implicit beams may be inferred when MuseScore beam mode is absent; unsupported layout or engraving details may be approximated |
+| Skipped | Unknown/unsupported MuseScore input may generate `MUSESCORE_IMPORT_WARNING` and be skipped |
+| Rejected | Input that is not parseable XML, lacks a usable MuseScore `Score`, or cannot be mapped safely |
+
+Notes:
+
+- MuseScore parity should prioritize MusicXML notational meaning and focused
+  parity tests over textual MuseScore XML equality.
+- Key signature import has explicit written-pitch policy for transposing parts.
+
+## MEI Mapping
+
+Status: experimental surrounding notation/archive format.
+
+Source spec: `docs/spec/MEI_IO.md`.
+
+| Outcome | Current policy |
+|---|---|
+| Normal MusicXML | Basic score, part/staff, measure, pitch, rest, duration, key, meter, clef, and supported notation structures where implemented |
+| `mks:meta:*` | Allowed for mikuscore-specific roundtrip hints if required by future MEI parity work |
+| `mks:src:*` | Candidate home for MEI-only source constructs that do not map cleanly to MusicXML |
+| `mks:diag:*` | Should record unsupported MEI constructs, repairs, approximation, and dropped material when practical |
+| Approximated | MEI structures without direct MusicXML equivalents may be approximated into the closest canonical MusicXML representation |
+| Skipped | Out-of-scope MEI editorial, analytical, facsimile, layout, or archive-specific data may be skipped with diagnostics |
+| Rejected | Invalid XML or MEI input whose musical timing/structure cannot produce a valid canonical MusicXML state |
+
+Notes:
+
+- MEI remains experimental. Do not treat the current converter as a full MEI
+  preservation engine.
+- MEI has a dedicated current-boundary spec, but remains experimental rather
+  than a full MEI preservation engine.
+
+## LilyPond Mapping
+
+Status: experimental surrounding text engraving format.
+
+Source spec: `docs/spec/LILYPOND_IO.md`.
+
+| Outcome | Current policy |
+|---|---|
+| Normal MusicXML | Basic score, part/staff, measure, pitch, rest, duration, key, meter, clef, slur, and supported notation structures where implemented |
+| `mks:meta:*` | `%@mks lanes ...` stores per-measure multi-lane token streams for same-staff multi-voice restoration; `%@mks slur ...` stores slur start/stop metadata for roundtrip restoration |
+| `mks:src:*` | Candidate home for LilyPond-only source constructs that do not map cleanly to MusicXML |
+| `mks:diag:*` | Should record unsupported LilyPond constructs, approximation, and dropped material when practical |
+| Approximated | Engraving-oriented syntax, layout directives, and constructs without direct MusicXML equivalents may be approximated or ignored |
+| Skipped | Out-of-scope layout, paper, markup, Scheme, and engraving directives may be skipped with diagnostics |
+| Rejected | LilyPond input whose musical token stream cannot be parsed into a valid canonical MusicXML state |
+
+Notes:
+
+- LilyPond support is not a complete LilyPond interpreter.
+- LilyPond has a dedicated current-boundary spec, but remains experimental
+  rather than a complete LilyPond interpreter.
+
+## VSQX Mapping
+
+Status: supported through vendored integration, with CLI support currently
+constrained by integration/runtime shape.
+
+Source specs: `docs/spec/VSQX_IO.md` and
+`docs/integrations/utaformatix3-ts-plus.mikuscore.iife.js.md`.
+
+| Outcome | Current policy |
+|---|---|
+| Normal MusicXML | Vocal pitch/timing material that can be represented as score notes, rests, measures, tempo, and related canonical MusicXML structures |
+| `mks:meta:*` | Allowed for mikuscore-specific roundtrip or provenance metadata when VSQX information cannot be represented directly |
+| `mks:src:*` | Candidate home for VSQX-only singer, lyric, phoneme, or parameter data when retained for traceability |
+| `mks:diag:*` | Should record unsupported VSQX parameters, approximation, dropped vocal controls, and integration limitations |
+| Approximated | Singing/vocal timing and pitch data may be approximated into notated MusicXML; expressive vocal parameters may not have score equivalents |
+| Skipped | VSQX-only automation, synthesis parameters, singer settings, or phonetic details outside current mapping may be skipped with diagnostics |
+| Rejected | Invalid VSQX or integration failures that prevent a valid canonical MusicXML state |
+
+Notes:
+
+- VSQX is a vocal/timing format, not a general notation format.
+- Missing CLI support for VSQX should be solved by stabilizing the upstream
+  callable integration shape before adding skill-local or CLI-local workarounds.
+
+## Cross-Format Preservation Baseline
+
+The following table is a planning baseline, not a claim that all entries are
+fully implemented today.
+
+| Topic | ABC | MIDI | MuseScore | MEI | LilyPond | VSQX |
+|---|---|---|---|---|---|---|
+| Pitch/rest/duration | normal | approximated on import, normal on export | normal | normal/experimental | normal/experimental | approximated |
+| Measure structure | normal | reconstructed | normal | normal/experimental | normal/experimental | reconstructed |
+| Voice/lane structure | normal/metadata-assisted | approximated | normal | experimental | metadata-assisted | approximated |
+| Key/time/clef | normal | partial metadata/reconstructed | normal | experimental | experimental | partial |
+| Tempo | normal | normal where available | normal | experimental | experimental | normal where available |
+| Lyrics | partial | not a primary MIDI guarantee | partial/normal | experimental | experimental | vocal text candidate |
+| Articulations/dynamics | partial | derived/limited on export, weak on import | normal where mapped | experimental | experimental | not primary |
+| Slurs/ties | partial | tie-like duration pairing only | normal where mapped | experimental | metadata-assisted | not primary |
+| Layout/engraving | skipped | not applicable | partial/skipped | skipped | skipped | not applicable |
+| Source-specific controls | metadata/diagnostics | metadata/diagnostics | `mks:src:*`/diagnostics | `mks:src:*` candidate | `mks:src:*` candidate | `mks:src:*` candidate |
+
+Format-specific specs and tests should either confirm these classifications or
+replace them with narrower implemented behavior.
+
+## CFFP Alignment
+
+`docs/spec/TEST_CFFP.md` is the authoritative focused roundtrip policy for
+implemented CFFP cases.
+
+Use this document to understand broad format roles and likely preservation
+classes. Use CFFP to decide whether one named notation topic is currently
+`must-preserve` or `allowed-degrade` for a specific format.
+
+Important interpretation rules:
+
+- Broad `normal` mapping does not automatically mean every CFFP topic in that
+  area is `must-preserve`.
+- A format can be experimental and still have individual `must-preserve` CFFP
+  topics when tests prove that slice.
+- MIDI and VSQX are not notation-preservation targets by default; focused
+  preservation claims should stay narrow.
+- If a future CFFP case requires a feature that this document classifies as
+  approximated, skipped, or not applicable, update this mapping document in the
+  same change or explain why the CFFP case is a narrow exception.
+
+## Next Specification Work
+
+- Keep `docs/spec/CONVERSION_DIAGNOSTICS.md` aligned when format import/export
+  warning codes are promoted or renamed.
+- Keep `docs/spec/TEST_CFFP.md` aligned whenever focused preservation policy
+  changes.

--- a/docs/spec/LILYPOND_IO.md
+++ b/docs/spec/LILYPOND_IO.md
@@ -1,0 +1,137 @@
+# LilyPond I/O Specification
+
+## Purpose
+
+This document defines the current public behavior of
+`src/ts/lilypond-io.ts`.
+
+LilyPond support is an experimental surrounding text notation/engraving path.
+It is not a complete LilyPond interpreter. The product boundary is practical
+conversion to and from canonical MusicXML.
+
+LilyPond import/export is centered on canonical MusicXML as defined in
+`docs/spec/CANONICAL_MUSICXML.md` and classified in
+`docs/spec/FORMAT_MAPPING.md`.
+Conversion diagnostic policy is defined in
+`docs/spec/CONVERSION_DIAGNOSTICS.md`.
+
+## Public API
+
+- `convertLilyPondToMusicXml(source, options): string`
+- `exportMusicXmlDomToLilyPond(doc): string`
+
+### Import Options
+
+- `debugMetadata?: boolean`
+- `debugPrettyPrint?: boolean`
+- `sourceMetadata?: boolean`
+
+## Import (`LilyPond -> MusicXML`)
+
+The importer accepts a bounded LilyPond text subset and emits MusicXML
+`score-partwise`.
+
+Current supported mapping includes:
+
+- title/header metadata where implemented
+- notes, rests, chords, durations, dots, accidentals, relative/absolute octave
+  handling, clef, key, meter, transpose, tempo, part names, and staff choice
+- repeat/volta and alternative markers through internal marker expansion
+- tuplets, articulations, grace notes, trills, slurs, glissando, octave shift,
+  lyrics, and selected direction/event hints where implemented
+- implicit beam generation for short-note groups
+
+The importer MAY use a direct parser path or a compatibility path through an
+ABC-like intermediate representation when that is the practical current
+implementation.
+
+## Export (`MusicXML -> LilyPond`)
+
+The exporter emits LilyPond text from the current canonical MusicXML state.
+
+Current supported mapping includes:
+
+- `\version` / score structure
+- title or movement-title metadata
+- parts/staves, clef, key, time, transpose, notes, rests, chords, tuplets,
+  repeats, endings, slurs, trills, accidentals, grace notes, lyrics, and
+  selected articulations where implemented
+- multi-lane restoration hints for same-staff voice structures
+
+Output is intended as practical LilyPond text for conversion and review. It is
+not a guarantee of preserving every engraving directive from a source file.
+
+## `mks` Comment Metadata
+
+LilyPond import/export uses `%@mks ...` comments as mikuscore extension
+metadata. These comments are not standard LilyPond musical syntax.
+
+Current supported comment families include:
+
+- `%@mks transpose ...`
+- `%@mks measure ...`
+- `%@mks articul ...`
+- `%@mks grace ...`
+- `%@mks tuplet ...`
+- `%@mks accidental ...`
+- `%@mks lanes ...`
+- `%@mks slur ...`
+- `%@mks trill ...`
+- `%@mks octshift ...`
+- `%@mks diag ...`
+
+Important roundtrip metadata:
+
+- `%@mks lanes ...`
+  - stores per-measure multi-lane token streams for same-staff multi-voice
+    restoration
+- `%@mks slur ...`
+  - stores slur start/stop metadata such as type, number, and placement
+- `%@mks diag ...`
+  - carries import/export diagnostics in a reviewable comment form
+
+## Source Metadata and Diagnostics
+
+When `sourceMetadata` is enabled, import may store raw source chunks under
+`mks:src:lilypond:*` fields in MusicXML `miscellaneous-field` metadata.
+
+When warnings occur, import may store structured diagnostics in `mks:diag:*`
+with `LILYPOND_IMPORT_WARNING`. Export may emit diagnostic comments for
+`LILYPOND_EXPORT_WARNING`.
+
+Warnings should be used for unsupported commands, unsupported chord tokens,
+unparseable pitches, overfull material, dropped events, and other bounded
+degradation.
+
+## Approximation and Degradation
+
+The following are not full-fidelity guarantees:
+
+- Scheme code
+- paper/layout/engraving directives
+- arbitrary markup
+- all LilyPond commands
+- exact source formatting and comments
+- every possible relative-mode or simultaneous-music construct
+
+Unsupported constructs SHOULD be skipped with diagnostics when the remaining
+music can still produce valid canonical MusicXML. Input that cannot produce a
+safe MusicXML state should fail.
+
+## Roundtrip Policy
+
+The primary confidence target is musical and structural roundtrip:
+
+- valid MusicXML after import
+- no overfull canonical MusicXML state unless explicitly rejected
+- preservation of mapped pitch/rest/duration, measure, staff/part, and selected
+  notation semantics where tests declare `must-preserve`
+- metadata-assisted restoration for multi-lane and slur cases where plain
+  LilyPond output would not carry enough information
+
+Full LilyPond source roundtrip is not guaranteed.
+
+## Related Tests
+
+- `tests/unit/lilypond-io.spec.ts`
+- `tests/unit/cffp-series.spec.ts`

--- a/docs/spec/MEI_IO.md
+++ b/docs/spec/MEI_IO.md
@@ -1,0 +1,123 @@
+# MEI I/O Specification
+
+## Purpose
+
+This document defines the current public behavior of `src/ts/mei-io.ts`.
+
+MEI support is an experimental surrounding notation/archive format path. It is
+not a promise of full MEI preservation, but the implemented import/export
+surface is large enough to require an explicit spec boundary.
+
+MEI import/export is centered on canonical MusicXML as defined in
+`docs/spec/CANONICAL_MUSICXML.md` and classified in
+`docs/spec/FORMAT_MAPPING.md`.
+Conversion diagnostic policy is defined in
+`docs/spec/CONVERSION_DIAGNOSTICS.md`.
+
+## Public API
+
+- `convertMeiToMusicXml(meiSource, options): string`
+- `exportMusicXmlDomToMei(doc, options): string`
+
+### Import Options
+
+- `debugMetadata?: boolean`
+- `sourceMetadata?: boolean`
+- `failOnOverfullDrop?: boolean`
+- `meiCorpusIndex?: number`
+
+### Export Options
+
+- `meiVersion?: string`
+
+## Import (`MEI -> MusicXML`)
+
+The importer accepts parseable MEI XML and emits MusicXML `score-partwise`.
+
+Current supported mapping includes:
+
+- title metadata
+- score/part/staff/measure structure
+- note, rest, space, `mRest`, and `mSpace` timing
+- pitch, accidental, key signature, meter, clef, and transposition
+- lyrics where mapped through MEI verse/syllable data
+- slur, tie, beam, tuplet, grace, articulation, trill, turn, mordent, fermata,
+  breath, caesura, glissando, slide, dynamics, wedge, pedal, octave shift,
+  segno, coda, fine, repeat marks, and harmony where implemented
+- selected official MEI CMN fixture behavior covered by tests
+
+The importer MAY synthesize MusicXML structure required by the canonical state
+policy, such as part-list linkage, divisions, measures, attributes, and
+implicit beams.
+
+## Export (`MusicXML -> MEI`)
+
+The exporter emits MEI XML from the current canonical MusicXML state.
+
+Current supported mapping includes:
+
+- MEI root with configurable `meiversion`
+- score metadata and title
+- `scoreDef`, `staffDef`, meter, key, clef, and transposition
+- notes, rests, full-measure rests, invisible rests, chords, grace notes,
+  tuplets, ties, slurs, articulations, accidentals, dynamics, wedges, pedal,
+  octave shift, repeat marks, glissando, slide, ornaments, fermata, breath,
+  caesura, harmony, and tempo where implemented
+
+Output is intended to be deterministic enough for focused tests and parity
+review, not byte-for-byte equivalent to a specialist MEI editor.
+
+## Metadata and Diagnostics
+
+MEI import/export uses MusicXML `miscellaneous-field` metadata when needed.
+
+Current metadata policy:
+
+- `mks:src:mei:*`
+  - preserves MEI source chunks or source-only values when `sourceMetadata` is
+    enabled
+  - non-namespaced MEI misc labels are mapped into the `mks:src:mei:*`
+    namespace
+- `mks:dbg:mei:*`
+  - stores optional debug metadata when `debugMetadata` is enabled
+- `mks:diag:*`
+  - records structured diagnostics such as overfull event dropping when useful
+- `musicxml-measure-meta` / `mks:measure-meta` MEI annotations
+  - preserve MusicXML measure metadata needed for roundtrip behavior, such as
+    selected section-boundary and explicit-time details
+
+If `failOnOverfullDrop` is true, import should fail instead of silently
+dropped overfull events.
+
+## Approximation and Degradation
+
+The following are not full-fidelity guarantees:
+
+- MEI editorial, analytical, facsimile, layout, archive, and source-critical
+  apparatus data
+- exact source element ordering outside mapped musical semantics
+- engraving details that have no current MusicXML mapping
+- all MEI control-event addressing variants
+- all MEI version or corpus variants
+
+Unsupported or degraded behavior SHOULD be surfaced through diagnostics or
+`mks:*` metadata when practical.
+
+## Roundtrip Policy
+
+The primary confidence target is musical and structural roundtrip:
+
+- valid MusicXML after import
+- no overfull canonical MusicXML state unless explicitly rejected
+- preservation of mapped pitch/rest/duration, measure, staff/part, and selected
+  notation semantics where tests declare `must-preserve`
+- documented degradation for CFFP topics marked `allowed-degrade`
+
+Full MEI source roundtrip is not guaranteed.
+
+## Related Tests
+
+- `tests/unit/mei-io.spec.ts`
+- `tests/unit/cffp-series.spec.ts`
+- `tests/spot/local-mei-roundtrip-parity.spot.spec.ts`
+- `tests/spot/local-mei-official-visual.spot.spec.ts`

--- a/docs/spec/MIDI_IO.md
+++ b/docs/spec/MIDI_IO.md
@@ -4,6 +4,11 @@
 
 This document defines the behavior of `src/ts/midi-io.ts`.
 
+Cross-format mapping classification is summarized in
+`docs/spec/FORMAT_MAPPING.md`.
+Conversion diagnostic policy is defined in
+`docs/spec/CONVERSION_DIAGNOSTICS.md`.
+
 The module is responsible for:
 
 - building playback events from MusicXML
@@ -34,6 +39,27 @@ The module is responsible for:
 - `buildPlaybackEventsFromMusicXmlDoc(doc, ticksPerQuarter, options)`
 - `buildPlaybackEventsFromXml(xml, ticksPerQuarter)`
 - `convertMidiToMusicXml(midiBytes, options)` (planned/import path)
+
+---
+
+## Mapping Policy
+
+MIDI is a supported surrounding performance-event format. MIDI export derives
+performance events from canonical MusicXML. MIDI import reconstructs notation
+from timed events and is inherently approximate.
+
+| Outcome | Current MIDI policy |
+|---|---|
+| Normal MusicXML | Import reconstructs score/part/measure structure, note/rest timing, quantized durations, voices through auto voice split, drum part separation, program metadata, tempo, time signatures, and key signatures when available |
+| `mks:meta:*` | Export may emit mikuscore text meta events such as metadata version, title, movement title, composer, pickup ticks, and part-name/track hints |
+| `mks:src:*` | Not a primary current MIDI mechanism; raw event preservation is not a first-cut guarantee |
+| `mks:diag:*` | Planned/stabilizing diagnostics should cover unsupported divisions, broken note pairing, quantization clamping, dropped events, voice assignment/overflow, drum separation, and unmapped drum notes |
+| Approximated | Import necessarily approximates notation from performance events, including quantization, rests, enharmonic spelling, voice assignment, beams, articulations, and score layout |
+| Skipped | DAW-specific, device-specific, SysEx, controller, meta, or unrecognized events outside current export/import scope may be skipped or ignored unless mapped explicitly |
+| Rejected | Invalid SMF structure, unsupported SMPTE time division, unpairable note streams that cannot be handled safely, and export with no playable note events |
+
+MIDI output is a derived playback artifact. It MUST NOT become an independent
+canonical score state.
 
 ---
 

--- a/docs/spec/MISCELLANEOUS_FIELDS.md
+++ b/docs/spec/MISCELLANEOUS_FIELDS.md
@@ -107,6 +107,7 @@ Payload keys:
 - `mks:diag:0001` ... `mks:diag:####`
 
 `mks:diag:0001` 以降は `;` 区切りの構造化文字列。
+安定コードの方針は `docs/spec/CONVERSION_DIAGNOSTICS.md` を参照。
 例:
 
 - `level=warn;code=OVERFULL_CLAMPED;fmt=mei;...`

--- a/docs/spec/MUSESCORE_IO.md
+++ b/docs/spec/MUSESCORE_IO.md
@@ -4,6 +4,11 @@
 
 This document defines the behavior of `src/ts/musescore-io.ts`.
 
+Cross-format mapping classification is summarized in
+`docs/spec/FORMAT_MAPPING.md`.
+Conversion diagnostic policy is defined in
+`docs/spec/CONVERSION_DIAGNOSTICS.md`.
+
 The module is responsible for:
 
 - importing MuseScore XML (`.mscx` content) into MusicXML
@@ -28,6 +33,26 @@ The module is responsible for:
 ### `exportMusicXmlDomToMuseScore` options
 
 - `normalizeCutTimeToTwoTwo?: boolean` (default: `false`)
+
+---
+
+## Mapping Policy
+
+MuseScore is a supported surrounding notation format. It is the highest-priority
+notation-tool parity target, but canonical score state remains MusicXML.
+
+| Outcome | Current MuseScore policy |
+|---|---|
+| Normal MusicXML | Time, key, tempo, staff/voice events, notes, rests, tuplets, slurs, ties, ottava, trills, dynamics, directions, repeats, barlines, accidental spelling where recoverable, beam information, and selected notation semantics |
+| `mks:meta:*` | May be used if future MuseScore roundtrip behavior needs mikuscore-specific extension metadata |
+| `mks:src:*` | Source chunks may be stored in `mks:src:mscx:*` when `sourceMetadata` is enabled |
+| `mks:diag:*` | Import warnings may be exported to MusicXML `miscellaneous-field` entries when `debugMetadata` is enabled |
+| Approximated | Missing beam modes may be filled through implicit beam inference; unsupported layout or engraving-only details may be approximated or omitted |
+| Skipped | Unknown or unsupported MuseScore elements may generate `MUSESCORE_IMPORT_WARNING` and be skipped when the musical structure remains usable |
+| Rejected | Input that is not parseable XML, lacks a usable MuseScore `Score`, or cannot be mapped safely into canonical MusicXML |
+
+MuseScore parity SHOULD be judged by focused MusicXML semantic comparison and
+reference-guided parity tests, not textual MuseScore XML equality.
 
 ---
 

--- a/docs/spec/TEST_CFFP.md
+++ b/docs/spec/TEST_CFFP.md
@@ -7,6 +7,7 @@
 Scope note:
 
 - This file is the authoritative CFFP case catalog and per-format policy source.
+- Cross-format capability classes are summarized in `docs/spec/FORMAT_MAPPING.md`.
 - `docs/spec/TEST_MATRIX.md` tracks required automated gates at matrix level.
 
 One topic at a time:
@@ -37,6 +38,39 @@ All topics should still keep baseline checks across all formats:
 - first pitched note pitch class / octave
 - first pitched note start timing baseline
 - no malformed MusicXML after roundtrip
+
+### Relationship to Format Mapping
+
+`docs/spec/FORMAT_MAPPING.md` classifies broad format capability. CFFP policies
+classify one focused notation topic at a time.
+
+These two levels intentionally do not use a 1:1 mapping:
+
+- `Normal MusicXML` in a format mapping means the format path has a normal
+  MusicXML representation for that broad class of data. It does not mean every
+  CFFP topic in that class is `must-preserve`.
+- `metadata-assisted` behavior may be `must-preserve` for a focused topic when
+  the importer/exporter and tests explicitly cover that metadata path.
+- `allowed-degrade` is not a failure. It means the format may still produce
+  valid canonical MusicXML and preserve baseline pitch/start checks, while the
+  focused feature may be absent, simplified, or represented differently.
+- MIDI and VSQX are performance/vocal timing formats. They should usually be
+  `allowed-degrade` for notation-specific topics unless a focused test proves a
+  narrow invariant.
+- MEI and LilyPond remain experimental product formats even when individual
+  CFFP topics are `must-preserve`.
+
+Current alignment result:
+
+- No CFFP policy currently requires a notation feature from VSQX.
+- MIDI currently has one `must-preserve` focused case,
+  `CFFP-ACCIDENTAL-RESET`; this is a pitch-alter/reset invariant, not a claim
+  that MIDI preserves visual accidental spelling.
+- MuseScore is the strongest notation parity target, but layout-heavy and
+  advanced notation topics may still be `allowed-degrade`.
+- ABC, MEI, and LilyPond use a mix of normal and metadata-assisted paths;
+  `must-preserve` means the specific path is covered by current tests, not that
+  the whole source format is lossless.
 
 ---
 
@@ -554,6 +588,9 @@ All topics should still keep baseline checks across all formats:
 - Avoid mixing multiple semantics in one case.
 - Keep assertions deterministic and narrow.
 - If policy changes, update this file and `docs/spec/TEST_MATRIX.md` together.
+- If a CFFP policy contradicts `docs/spec/FORMAT_MAPPING.md`, update one of
+  them in the same change and explain whether the conflict was a broad mapping
+  issue or a focused test-policy issue.
 
 ---
 

--- a/docs/spec/VSQX_IO.md
+++ b/docs/spec/VSQX_IO.md
@@ -1,0 +1,125 @@
+# VSQX I/O Specification
+
+## Purpose
+
+This document defines the current public behavior of `src/ts/vsqx-io.ts`.
+
+VSQX support is a surrounding singing/vocal timing format path backed by the
+vendored `utaformatix3-ts-plus` integration. It is not a general notation
+format and should not be treated as equivalent to MuseScore, MEI, ABC, or
+LilyPond.
+
+VSQX import/export is centered on canonical MusicXML as defined in
+`docs/spec/CANONICAL_MUSICXML.md` and classified in
+`docs/spec/FORMAT_MAPPING.md`.
+Conversion diagnostic policy is defined in
+`docs/spec/CONVERSION_DIAGNOSTICS.md`.
+
+## Public API
+
+- `isVsqxBridgeAvailable(): boolean`
+- `installVsqxMusicXmlNormalizationHook(normalizeImportedMusicXmlText): void`
+- `convertVsqxToMusicXml(vsqxText, options): VsqxToMusicXmlResult`
+- `convertMusicXmlToVsqx(musicXmlText, options): MusicXmlToVsqxResult`
+
+### Import Options
+
+- `defaultLyric?: string`
+
+### Export Options
+
+- `musicXml.defaultLyric?: string`
+- `splitPartStaves?: boolean`
+
+## Runtime Boundary
+
+The current bridge is browser-global and provided by
+`src/vendor/utaformatix3/utaformatix3-ts-plus.mikuscore.iife.js`.
+
+The expected global is:
+
+- `window.UtaFormatix3TsPlusMikuscore`
+
+The integration guide is:
+
+- `docs/integrations/utaformatix3-ts-plus.mikuscore.iife.js.md`
+
+The bridge dependency means VSQX behavior belongs to a thin adapter around the
+vendored runtime. Product-level MusicXML normalization and diagnostics should
+remain visible on the mikuscore side.
+
+## Import (`VSQX -> MusicXML`)
+
+The importer calls the bridge `convertVsqxToMusicXmlWithReport` operation and
+returns:
+
+- `ok`
+- `xml`
+- `diagnostics`
+- `warnings`
+
+Bridge report issues with level `error` become diagnostics. Bridge report
+issues with level `warning` or `info` become warnings.
+
+The importer fails when:
+
+- the bridge is unavailable
+- the bridge returns an empty MusicXML result
+- bridge issues include errors
+
+## Export (`MusicXML -> VSQX`)
+
+The exporter calls the bridge `convertMusicXmlToVsqx` operation and returns:
+
+- `ok`
+- `vsqx`
+- `diagnostic` when export failed
+
+The exporter fails when:
+
+- the bridge is unavailable
+- the bridge returns empty output
+- the bridge throws
+
+## Stable Diagnostic Codes
+
+Current stable adapter diagnostics:
+
+| Code | Meaning |
+|---|---|
+| `VSQX_BRIDGE_UNAVAILABLE` | VSQX converter bundle is not loaded |
+| `VSQX_CONVERT_EMPTY_RESULT` | VSQX import returned empty MusicXML |
+| `VSQX_EXPORT_EMPTY_RESULT` | MusicXML export returned empty VSQX |
+| `VSQX_EXPORT_FAILED` | MusicXML to VSQX conversion threw or failed |
+| `VSQX_CONVERT_ERROR_N` | Bridge import report contained an error issue |
+| `VSQX_CONVERT_WARNING_N` | Bridge import report contained a warning/info issue |
+
+## Mapping Policy
+
+VSQX is treated as a vocal/timing source.
+
+Current mapping confidence:
+
+- pitch/timing material may become MusicXML notes, rests, measures, and tempo
+- lyrics may use a default lyric when needed
+- singer settings, phoneme-level details, vocal expression controls, synthesis
+  parameters, and automation are not current canonical MusicXML guarantees
+- unsupported VSQX-only data should become diagnostics or source metadata if
+  preserved later
+
+## CLI Status
+
+VSQX Web import/export exists through the bridge-backed adapter. CLI support is
+not a normal non-browser callable path yet because the current bridge shape is
+browser-oriented.
+
+The preferred follow-up is to stabilize an upstream non-browser callable
+entrypoint or equivalent runtime shape before adding CLI conversion pairs.
+Avoid implementing VSQX product semantics in Agent Skills or CLI wrapper code
+as a workaround.
+
+## Related Tests
+
+- `tests/unit/vsqx-io.spec.ts`
+- `tests/unit/load-flow.spec.ts`
+- `tests/unit/cffp-series.spec.ts`


### PR DESCRIPTION
## 概要

mikuscore の形式変換仕様を、MusicXML を canonical score state とする方針に沿って整理しました。

## 変更内容

- `docs/spec/CANONICAL_MUSICXML.md` を追加し、MusicXML を中心にした canonical state、import/export、diagnostics、roundtrip、AI handoff の方針を定義
- `docs/spec/FORMAT_MAPPING.md` を追加し、ABC、MIDI、MuseScore、MEI、LilyPond、VSQX の変換上の役割と保存・近似・スキップ・拒否ポリシーを横断的に整理
- `docs/spec/CONVERSION_DIAGNOSTICS.md` を追加し、変換 diagnostics の層、安定コード、severity、payload 方針を文書化
- MEI、LilyPond、VSQX の current-boundary 仕様として `docs/spec/MEI_IO.md`、`docs/spec/LILYPOND_IO.md`、`docs/spec/VSQX_IO.md` を追加
- ABC、MIDI、MuseScore の既存 I/O 仕様に mapping policy と conversion diagnostics 参照を追加
- `docs/FORMAT_COVERAGE.md`、`docs/spec/ARCHITECTURE.md`、`docs/spec/FORMAT_IO_CHECKLIST.md`、`docs/spec/TEST_CFFP.md` を canonical MusicXML 方針と cross-format mapping に合わせて更新
- `TODO.md` に仕様整理の完了項目と、今後の broad conversion warning 分割タスクを記録