### PR TITLE
MusicXMLの共通スコア機能モデルを追加

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -105,20 +105,20 @@
     - add `mikuscore convert --from musicxml --to vsqx`
     - add matching CLI help and regression tests
 
-- [ ] Add MEI CLI conversion pairs around the existing reusable format I/O.
+- [x] Add MEI CLI conversion pairs around the existing reusable format I/O.
   - Target pairs:
     - `mikuscore convert --from mei --to musicxml`
     - `mikuscore convert --from musicxml --to mei`
-  - Implementation slices:
+  - Result:
     - extend `src/ts/cli-api.ts` with `mei` facade entries
     - wire `scripts/mikuscore-cli.mjs` help and convert handlers
     - add CLI regression tests for stdin/file input, `--out`, and representative failures
 
-- [ ] Add LilyPond CLI conversion pairs around the existing reusable format I/O.
+- [x] Add LilyPond CLI conversion pairs around the existing reusable format I/O.
   - Target pairs:
     - `mikuscore convert --from lilypond --to musicxml`
     - `mikuscore convert --from musicxml --to lilypond`
-  - Implementation slices:
+  - Result:
     - extend `src/ts/cli-api.ts` with `lilypond` facade entries
     - wire `scripts/mikuscore-cli.mjs` help and convert handlers
     - add CLI regression tests for stdin/file input, `--out`, and representative failures
@@ -291,14 +291,22 @@
 
 ## Facade
 
-- [ ] Keep the non-UI CLI facade small and format-oriented.
-  - Current Step 1 functions:
+- [x] Keep the non-UI CLI facade small and format-oriented.
+  - Current facade functions include:
     - `importAbcToMusicXml(...)`
     - `exportMusicXmlToAbc(...)`
-  - Planned next functions:
+    - `importMidiToMusicXml(...)`
+    - `exportMusicXmlToMidi(...)`
     - `importMuseScoreToMusicXml(...)`
     - `exportMusicXmlToMuseScore(...)`
+    - `importMeiToMusicXml(...)`
+    - `exportMusicXmlToMei(...)`
+    - `importLilyPondToMusicXml(...)`
+    - `exportMusicXmlToLilyPond(...)`
     - `renderMusicXmlToSvg(...)`
+  - Result:
+    - keep `src/ts/cli-api.ts` as a small non-UI facade over format-oriented reusable modules
+    - keep command routing, file I/O, and CLI diagnostics in `scripts/mikuscore-cli.mjs`
 
 - [ ] Re-evaluate `core/` boundaries only if reuse pressure becomes real.
   - Do not move conversion facade code into `core/` without a concrete need.
@@ -334,6 +342,84 @@
     - only raise per-test timeout after checking whether the case can be made cheaper or better isolated
 
 ## Refactoring Priorities
+
+- [ ] Introduce small cross-format score feature models where they reduce format-local branching.
+  - Current observation:
+    - `src/ts/abc-io.ts`, `src/ts/mei-io.ts`, `src/ts/lilypond-io.ts`, `src/ts/midi-io.ts`, and `src/ts/musescore-io.ts` each contain local handling for recurring score concepts such as dynamics, wedges, articulations, ornaments, slurs, ties, tempo, repeats, and barlines
+    - tests currently verify many of these behaviors inside format-specific suites, which makes cross-format semantics harder to compare directly
+    - ABC parsing already has `src/ts/abc-parser.ts` and `docs/spec/abc-compat-parser-ebnf.md`, so grammar-oriented cleanup is plausible, but parse output, semantic mapping, and MusicXML emission are still too entangled in `src/ts/abc-io.ts`
+  - Direction:
+    - move from format-local giant conditionals toward format adapters plus small feature-specific models
+    - do not create one large generic score IR; MusicXML remains the canonical score state
+    - introduce only narrow feature models when they simplify duplicated mapping and enable feature-level tests
+  - Design note from the first implementation slice:
+    - this direction worked best when the abstraction stayed small
+    - keep `MusicXML` as the canonical score state and use feature models only as narrow adapters for repeated concepts such as dynamics and wedges
+    - avoid turning feature models into a second canonical representation of the whole score
+    - a feature model is justified when it removes duplicated format-local branching and gives the project a focused test surface
+  - Implemented slices:
+    - dynamics and wedges:
+      - added a narrow feature vocabulary for dynamic marks and wedge directions
+      - rewired ABC, MEI, LilyPond, MIDI, and MuseScore paths where the mapping was already local and low-risk
+      - added feature-level coverage in `tests/unit/score-dynamics.spec.ts`
+    - articulations:
+      - added a narrow feature vocabulary for common MusicXML articulation elements
+      - rewired ABC, MEI, LilyPond, and MuseScore paths without replacing format-specific parsing or non-articulation notation handling
+      - added feature-level coverage in `tests/unit/score-articulations.spec.ts`
+    - ornaments:
+      - added a narrow feature vocabulary for simple MusicXML ornament elements and tremolo
+      - rewired ABC, MEI, LilyPond, MIDI playback ornament detection, and MuseScore trill-mark paths where the mapping was already local
+      - kept wavy-line spanner state and trill accidental details format-local
+      - added feature-level coverage in `tests/unit/score-ornaments.spec.ts`
+    - slurs:
+      - added a narrow feature vocabulary for MusicXML slur start/stop, number, and placement
+      - rewired ABC, MEI, LilyPond, MIDI slur detection, and MuseScore slur emission/extraction where the mapping was local
+      - kept broader spanner state format-local
+      - added feature-level coverage in `tests/unit/score-slurs.spec.ts`
+    - ties:
+      - added a narrow feature vocabulary for MusicXML `<tie>` sound ties and `<tied>` notation ties
+      - rewired ABC, MEI, LilyPond, MIDI tie detection/emission, and MuseScore tie emission/extraction where the mapping was local
+      - kept tie carry, pitch matching, and format-specific tie inference in the adapters
+      - added feature-level coverage in `tests/unit/score-ties.spec.ts`
+    - tempo and direction text:
+      - added a narrow feature vocabulary for MusicXML direction words and `sound tempo`
+      - rewired ABC, MEI, LilyPond, MIDI tempo emission, and MuseScore words/tempo extraction where the mapping was local
+      - kept metronome beat-unit interpretation, jumps, markers, and format-specific direction semantics in the adapters
+      - added feature-level coverage in `tests/unit/score-direction-text.spec.ts`
+    - repeat and barline semantics:
+      - added a narrow feature vocabulary for simple MusicXML barline location, bar-style, repeat directions, and ending markers
+      - rewired MuseScore mid-measure repeat barline handling and LilyPond simple repeat/ending generation where the mapping was local
+      - kept ABC `winged` / repeat `times` metadata and broader measure-level repeat policy format-local
+      - added feature-level coverage in `tests/unit/score-barlines.spec.ts`
+  - Model examples:
+    - dynamics and wedges:
+      - dynamic marks such as `pp`, `p`, `mp`, `mf`, `f`, `ff`, `sfz`
+      - wedge controls such as crescendo, diminuendo, and stop with measure offset / staff context where available
+    - articulations:
+      - common MusicXML articulation tags such as `staccato`, `accent`, `tenuto`, `strong-accent`, `breath-mark`, and `caesura`
+    - ornaments:
+      - common MusicXML ornament tags such as `trill-mark`, `turn`, `inverted-turn`, `mordent`, `inverted-mordent`, `shake`, `schleifer`, and `tremolo`
+    - slurs:
+      - MusicXML slur controls with `type`, `number`, and start placement
+    - ties:
+      - MusicXML tie controls that preserve the distinction between direct `<tie>` and notation `<tied>`
+    - tempo and direction text:
+      - MusicXML direction words, optional font style, placement, and `sound tempo`
+    - repeat and barline semantics:
+      - simple MusicXML barline controls with location, bar-style, repeat directions, and ending markers
+  - Follow-up candidates:
+    - 1. keep reviewing the feature-model slices during nearby changes:
+      - a first cleanup pass removed additional local words/tempo and simple barline XML generation where it was clearly equivalent
+      - remaining direct XML assembly is mostly format-specific wrapping, wavy-line/trill detail, ABC repeat metadata, MEI measure policy, or notation container composition
+      - avoid expanding the shared models further until a real duplication or test-surface problem appears
+  - Test direction:
+    - add feature-level unit tests next to the new model before rewiring multiple formats
+    - keep existing format-specific regression tests as safety coverage
+    - compare equivalent feature extraction/emission across formats where behavior is intentionally shared
+  - Constraints:
+    - preserve current public entry points such as `convertAbcToMusicXml(...)`, `exportMusicXmlDomToAbc(...)`, `convertMeiToMusicXml(...)`, and related CLI facade calls
+    - extract one feature at a time; do not redesign every format module in one pass
+    - avoid hiding format-specific loss, approximation, or unsupported behavior behind an over-general abstraction
 
 - [ ] Long-range: revisit the large format I/O modules with a review-first pass, not an immediate rewrite.
   - Target modules:

--- a/src/ts/abc-io.ts
+++ b/src/ts/abc-io.ts
@@ -6,6 +6,34 @@
 // @ts-nocheck
 import { computeBeamAssignments } from "./beam-common";
 import {
+  buildMusicXmlArticulationItemsXml,
+  extractMusicXmlArticulationKinds,
+} from "./score-features/articulations";
+import {
+  buildMusicXmlDirectionFeatureXml,
+  extractMusicXmlDirectionFeatures,
+  normalizeDynamicMark,
+} from "./score-features/dynamics";
+import {
+  buildMusicXmlTempoDirectionXml,
+  buildMusicXmlWordsDirectionXml,
+  extractMusicXmlDirectionWords,
+} from "./score-features/direction-text";
+import {
+  buildMusicXmlOrnamentItemsXml,
+  buildMusicXmlOrnamentsXml,
+  extractMusicXmlOrnamentFeatures,
+} from "./score-features/ornaments";
+import {
+  buildMusicXmlSlursXml,
+  extractMusicXmlSlurFeatures,
+} from "./score-features/slurs";
+import {
+  buildMusicXmlTieItemsXml,
+  buildMusicXmlTiedItemsXml,
+  extractMusicXmlTieState,
+} from "./score-features/ties";
+import {
   parseAbcBodyEntryAt,
   parseAbcBracketTokenAt,
   parseAbcBrokenRhythmAt,
@@ -1067,7 +1095,7 @@ const buildAbcTempoDirectionXml = (
   if (!(include && tempo !== null)) {
     return "";
   }
-  return `<direction><direction-type><metronome><beat-unit>quarter</beat-unit><per-minute>${tempo}</per-minute></metronome></direction-type><sound tempo="${tempo}"/></direction>`;
+  return buildMusicXmlTempoDirectionXml({ bpm: tempo, includeQuarterMetronome: true });
 };
 
 const buildAbcMeasureHeaderXml = (
@@ -1462,14 +1490,14 @@ const buildAbcNoteHarmonyAndWordsDirectionXml = (note: AbcParsedNote): string =>
       if (harmonyXml) {
         chunks.push(harmonyXml);
       } else {
-        chunks.push(`<direction><direction-type><words>${xmlEscape(String(chordSymbol))}</words></direction-type></direction>`);
+        chunks.push(buildMusicXmlWordsDirectionXml({ text: String(chordSymbol) }));
       }
     }
   }
   if (!note.chord && Array.isArray(note.annotations) && note.annotations.length > 0) {
     for (const annotation of note.annotations) {
       if (!annotation) continue;
-      chunks.push(`<direction><direction-type><words>${xmlEscape(String(annotation))}</words></direction-type></direction>`);
+      chunks.push(buildMusicXmlWordsDirectionXml({ text: String(annotation) }));
     }
   }
   return chunks.join("");
@@ -1486,16 +1514,17 @@ const buildAbcNoteControlDirectionXml = (note: AbcParsedNote): string => {
   if (!note.chord && note.daCapo) chunks.push('<direction><sound dacapo="yes"/></direction>');
   if (!note.chord && note.dalSegno) chunks.push('<direction><sound dalsegno="segno"/></direction>');
   if (!note.chord && note.toCoda) chunks.push('<direction><sound tocoda="coda"/></direction>');
-  if (!note.chord && note.crescendoStart) chunks.push('<direction><direction-type><wedge type="crescendo"/></direction-type></direction>');
-  if (!note.chord && note.diminuendoStart) chunks.push('<direction><direction-type><wedge type="diminuendo"/></direction-type></direction>');
+  if (!note.chord && note.crescendoStart) chunks.push(buildMusicXmlDirectionFeatureXml({ kind: "wedge", wedgeType: "crescendo" }));
+  if (!note.chord && note.diminuendoStart) chunks.push(buildMusicXmlDirectionFeatureXml({ kind: "wedge", wedgeType: "diminuendo" }));
   if (!note.chord && (note.crescendoStop || note.diminuendoStop)) {
-    chunks.push('<direction><direction-type><wedge type="stop"/></direction-type></direction>');
+    chunks.push(buildMusicXmlDirectionFeatureXml({ kind: "wedge", wedgeType: "stop" }));
   }
   if (!note.chord && note.dynamicMark) {
-    chunks.push(`<direction><direction-type><dynamics><${xmlEscape(String(note.dynamicMark))}/></dynamics></direction-type></direction>`);
+    const dynamicMark = normalizeDynamicMark(String(note.dynamicMark));
+    if (dynamicMark) chunks.push(buildMusicXmlDirectionFeatureXml({ kind: "dynamic", mark: dynamicMark }));
   }
   if (!note.chord && note.sfz) {
-    chunks.push("<direction><direction-type><dynamics><sfz/></dynamics></direction-type></direction>");
+    chunks.push(buildMusicXmlDirectionFeatureXml({ kind: "dynamic", mark: "sfz" }));
   }
   return chunks.join("");
 };
@@ -1586,16 +1615,17 @@ const buildAbcNoteCoreXml = (
   if (!note.chord && beamXmlByNoteIndex.has(noteIndex)) chunks.push(String(beamXmlByNoteIndex.get(noteIndex)));
   chunks.push(buildAbcNoteTimeModificationXml(note));
   chunks.push(buildAbcNoteAccidentalXml(note));
-  if (note.tieStart) chunks.push('<tie type="start"/>');
-  if (note.tieStop) chunks.push('<tie type="stop"/>');
+  chunks.push(buildMusicXmlTieItemsXml({
+    tieStart: Boolean(note.tieStart),
+    tieStop: Boolean(note.tieStop),
+  }));
   return chunks.join("");
 };
 
 const buildAbcNoteOrnamentsXml = (note: AbcParsedNote): string => {
   const chunks: string[] = [];
   if (note.trill || note.trillLineStop) {
-    const trillParts: string[] = [];
-    if (note.trill) trillParts.push("<trill-mark/>");
+    const trillParts: string[] = note.trill ? [buildMusicXmlOrnamentItemsXml([{ kind: "trill-mark" }])] : [];
     if (note.trillLineStop) {
       trillParts.push('<wavy-line type="stop"/>');
     } else if (note.trillLineStart) {
@@ -1605,40 +1635,47 @@ const buildAbcNoteOrnamentsXml = (note: AbcParsedNote): string => {
     chunks.push(`<ornaments>${trillParts.join("")}</ornaments>`);
   }
   if (note.turnType) {
-    const tag = note.turnType === "inverted-turn" ? "inverted-turn" : "turn";
-    const slashAttr = note.turnSlash ? ' slash="yes"' : "";
-    chunks.push(`<ornaments><${tag}${slashAttr}/>${note.delayedTurn ? "<delayed-turn/>" : ""}</ornaments>`);
+    chunks.push(buildMusicXmlOrnamentsXml([
+      { kind: note.turnType === "inverted-turn" ? "inverted-turn" : "turn", ...(note.turnSlash ? { slash: true } : {}) },
+      ...(note.delayedTurn ? [{ kind: "delayed-turn" as const }] : []),
+    ]));
   }
   if (note.mordentType) {
-    const tag = note.mordentType === "inverted-mordent" ? "inverted-mordent" : "mordent";
-    chunks.push(`<ornaments><${tag}/></ornaments>`);
+    chunks.push(buildMusicXmlOrnamentsXml([
+      { kind: note.mordentType === "inverted-mordent" ? "inverted-mordent" : "mordent" },
+    ]));
   }
   if (note.tremoloType) {
-    const marks = Math.max(1, Math.min(8, Math.round(Number(note.tremoloMarks) || 1)));
-    chunks.push(`<ornaments><tremolo type="${xmlEscape(String(note.tremoloType))}">${marks}</tremolo></ornaments>`);
+    chunks.push(buildMusicXmlOrnamentsXml([
+      { kind: "tremolo", tremoloType: note.tremoloType, marks: note.tremoloMarks },
+    ]));
   }
   if (note.glissandoStart) chunks.push('<glissando type="start" number="1">wavy</glissando>');
   if (note.glissandoStop) chunks.push('<glissando type="stop" number="1">wavy</glissando>');
   if (note.slideStart) chunks.push('<slide type="start" number="1"/>');
   if (note.slideStop) chunks.push('<slide type="stop" number="1"/>');
-  if (note.schleifer) chunks.push("<ornaments><schleifer/></ornaments>");
-  if (note.shake) chunks.push("<ornaments><shake/></ornaments>");
+  if (note.schleifer) chunks.push(buildMusicXmlOrnamentsXml([{ kind: "schleifer" }]));
+  if (note.shake) chunks.push(buildMusicXmlOrnamentsXml([{ kind: "shake" }]));
   if (note.arpeggiate) chunks.push("<arpeggiate/>");
   return chunks.join("");
 };
 
 const buildAbcNoteArticulationsXml = (note: AbcParsedNote): string => {
   const articulationParts: string[] = [];
-  if (note.staccato) articulationParts.push("<staccato/>");
-  if (note.staccatissimo) articulationParts.push("<staccatissimo/>");
-  if (note.accent) articulationParts.push("<accent/>");
-  if (note.tenuto) articulationParts.push("<tenuto/>");
+  const articulationKinds = [];
+  if (note.staccato) articulationKinds.push("staccato");
+  if (note.staccatissimo) articulationKinds.push("staccatissimo");
+  if (note.accent) articulationKinds.push("accent");
+  if (note.tenuto) articulationKinds.push("tenuto");
   if (note.stress) articulationParts.push("<stress/>");
   if (note.unstress) articulationParts.push("<unstress/>");
-  if (note.strongAccent) articulationParts.push("<strong-accent/>");
-  if (note.breathMark) articulationParts.push("<breath-mark/>");
-  if (note.caesura) articulationParts.push("<caesura/>");
+  if (note.strongAccent) articulationKinds.push("strong-accent");
+  if (note.breathMark) articulationKinds.push("breath-mark");
+  if (note.caesura) articulationKinds.push("caesura");
   if (note.phraseMark) articulationParts.push(`<other-articulation>${xmlEscape(String(note.phraseMark))}</other-articulation>`);
+  const featureItemsXml = buildMusicXmlArticulationItemsXml(articulationKinds);
+  if (featureItemsXml && articulationParts.length === 0) return `<articulations>${featureItemsXml}</articulations>`;
+  if (featureItemsXml) articulationParts.unshift(featureItemsXml);
   return articulationParts.length > 0 ? `<articulations>${articulationParts.join("")}</articulations>` : "";
 };
 
@@ -1680,10 +1717,14 @@ const buildAbcNoteNotationsXml = (note: AbcParsedNote): string => {
   }
   const chunks: string[] = [];
   chunks.push("<notations>");
-  if (note.tieStart) chunks.push('<tied type="start"/>');
-  if (note.tieStop) chunks.push('<tied type="stop"/>');
-  if (note.slurStart) chunks.push('<slur type="start"/>');
-  if (note.slurStop) chunks.push('<slur type="stop"/>');
+  chunks.push(buildMusicXmlTiedItemsXml({
+    tiedStart: Boolean(note.tieStart),
+    tiedStop: Boolean(note.tieStop),
+  }));
+  chunks.push(buildMusicXmlSlursXml([
+    ...(note.slurStart ? [{ type: "start" as const }] : []),
+    ...(note.slurStop ? [{ type: "stop" as const }] : []),
+  ]));
   if (note.tupletStart) chunks.push('<tuplet type="start"/>');
   if (note.tupletStop) chunks.push('<tuplet type="stop"/>');
   chunks.push(buildAbcNoteOrnamentsXml(note));
@@ -4602,8 +4643,8 @@ export const exportMusicXmlDomToAbc = (doc: Document): string => {
             for (const rehearsalText of rehearsalTexts) {
               pendingDirectionDecorations.push(`!rehearsal:${rehearsalText}!`);
             }
-            const words = Array.from(child.querySelectorAll(":scope > direction-type > words"))
-              .map((node) => abcQuotedTextEscape(node.textContent || ""))
+            const words = extractMusicXmlDirectionWords(child)
+              .map((feature) => abcQuotedTextEscape(feature.text))
               .filter(Boolean);
             pendingDirectionWords.push(...words);
             if (child.querySelector(":scope > direction-type > segno")) {
@@ -4628,23 +4669,20 @@ export const exportMusicXmlDomToAbc = (doc: Document): string => {
             if (hasToCoda && !hasDaCapo) {
               pendingDirectionDecorations.push("!tocoda!");
             }
-            for (const wedgeNode of Array.from(child.querySelectorAll(":scope > direction-type > wedge"))) {
-              const wedgeType = (wedgeNode.getAttribute("type") || "").trim().toLowerCase();
-              if (wedgeType === "crescendo") {
+            for (const feature of extractMusicXmlDirectionFeatures(child)) {
+              if (feature.kind === "wedge" && feature.wedgeType === "crescendo") {
                 pendingDirectionDecorations.push("!crescendo(!");
                 activeWedgeType = "crescendo";
-              } else if (wedgeType === "diminuendo") {
+              } else if (feature.kind === "wedge" && feature.wedgeType === "diminuendo") {
                 pendingDirectionDecorations.push("!diminuendo(!");
                 activeWedgeType = "diminuendo";
-              } else if (wedgeType === "stop") {
+              } else if (feature.kind === "wedge" && feature.wedgeType === "stop") {
                 pendingDirectionDecorations.push(activeWedgeType === "diminuendo" ? "!diminuendo)!" : "!crescendo)!");
                 activeWedgeType = "";
               }
             }
-            for (const dynamicName of ["pppp", "ppp", "pp", "p", "mp", "mf", "f", "ff", "fff", "ffff", "fp", "fz", "rfz", "sf", "sfp", "sfz"]) {
-              if (child.querySelector(`:scope > direction-type > dynamics > ${dynamicName}`)) {
-                pendingDirectionDecorations.push(`!${dynamicName}!`);
-              }
+            for (const feature of extractMusicXmlDirectionFeatures(child)) {
+              if (feature.kind === "dynamic") pendingDirectionDecorations.push(`!${feature.mark}!`);
             }
             continue;
           }
@@ -4666,18 +4704,22 @@ export const exportMusicXmlDomToAbc = (doc: Document): string => {
             ? (Number.isFinite(duration) && duration > 0 ? duration : Math.round(currentDivisions / 2))
             : duration;
 
-          const hasTieStart = Boolean(child.querySelector(':scope > tie[type="start"]'));
-          const hasTrillMark = Boolean(child.querySelector(":scope > notations > ornaments > trill-mark"));
-          const hasTurn = Boolean(child.querySelector(":scope > notations > ornaments > turn"));
-          const hasInvertedTurn = Boolean(child.querySelector(":scope > notations > ornaments > inverted-turn"));
-          const hasTurnSlash = Array.from(child.querySelectorAll(":scope > notations > ornaments > turn, :scope > notations > ornaments > inverted-turn"))
-            .some((node) => (node.getAttribute("slash") || "").trim().toLowerCase() === "yes");
-          const hasDelayedTurn = Boolean(child.querySelector(":scope > notations > ornaments > delayed-turn"));
-          const hasMordent = Boolean(child.querySelector(":scope > notations > ornaments > mordent"));
-          const hasInvertedMordent = Boolean(child.querySelector(":scope > notations > ornaments > inverted-mordent"));
-          const tremoloNode = child.querySelector(":scope > notations > ornaments > tremolo");
-          const hasSchleifer = Boolean(child.querySelector(":scope > notations > ornaments > schleifer"));
-          const hasShake = Boolean(child.querySelector(":scope > notations > ornaments > shake"));
+          const tieState = extractMusicXmlTieState(child);
+          const hasTieStart = tieState.tieStart;
+          const ornamentFeatures = extractMusicXmlOrnamentFeatures(child);
+          const ornamentKinds = new Set(ornamentFeatures.map((feature) => feature.kind));
+          const hasTrillMark = ornamentKinds.has("trill-mark");
+          const hasTurn = ornamentKinds.has("turn");
+          const hasInvertedTurn = ornamentKinds.has("inverted-turn");
+          const hasTurnSlash = ornamentFeatures.some((feature) =>
+            (feature.kind === "turn" || feature.kind === "inverted-turn") && feature.slash
+          );
+          const hasDelayedTurn = ornamentKinds.has("delayed-turn");
+          const hasMordent = ornamentKinds.has("mordent");
+          const hasInvertedMordent = ornamentKinds.has("inverted-mordent");
+          const tremoloFeature = ornamentFeatures.find((feature) => feature.kind === "tremolo");
+          const hasSchleifer = ornamentKinds.has("schleifer");
+          const hasShake = ornamentKinds.has("shake");
           const hasGlissandoStart = Boolean(child.querySelector(':scope > notations > glissando[type="start"]'));
           const hasGlissandoStop = Boolean(child.querySelector(':scope > notations > glissando[type="stop"]'));
           const hasSlideStart = Boolean(child.querySelector(':scope > notations > slide[type="start"]'));
@@ -4698,22 +4740,22 @@ export const exportMusicXmlDomToAbc = (doc: Document): string => {
           const hasTrill = hasTrillMark || hasWavyLineStart;
           const turnType: "" | "turn" | "inverted-turn" = hasInvertedTurn ? "inverted-turn" : (hasTurn ? "turn" : "");
           const mordentType: "" | "mordent" | "inverted-mordent" = hasInvertedMordent ? "inverted-mordent" : (hasMordent ? "mordent" : "");
-          const tremoloTypeRaw = (tremoloNode?.getAttribute("type") || "").trim().toLowerCase();
           const tremoloType: "" | "single" | "start" | "stop" =
-            tremoloTypeRaw === "single" || tremoloTypeRaw === "start" || tremoloTypeRaw === "stop"
-              ? tremoloTypeRaw
+            tremoloFeature?.kind === "tremolo" && tremoloFeature.tremoloType
+              ? tremoloFeature.tremoloType
               : "";
-          const tremoloMarks = Math.max(1, Math.min(8, Number.parseInt(tremoloNode?.textContent?.trim() || "", 10) || 0));
+          const tremoloMarks = tremoloFeature?.kind === "tremolo" && tremoloFeature.marks ? tremoloFeature.marks : 1;
           const trillAccidentalText = child.querySelector(":scope > notations > ornaments > accidental-mark")?.textContent?.trim() || "";
-          const hasStaccato = Boolean(child.querySelector(":scope > notations > articulations > staccato"));
-          const hasStaccatissimo = Boolean(child.querySelector(":scope > notations > articulations > staccatissimo"));
-          const hasAccent = Boolean(child.querySelector(":scope > notations > articulations > accent"));
-          const hasTenuto = Boolean(child.querySelector(":scope > notations > articulations > tenuto"));
+          const articulationKinds = new Set(extractMusicXmlArticulationKinds(child));
+          const hasStaccato = articulationKinds.has("staccato");
+          const hasStaccatissimo = articulationKinds.has("staccatissimo");
+          const hasAccent = articulationKinds.has("accent");
+          const hasTenuto = articulationKinds.has("tenuto");
           const hasStress = Boolean(child.querySelector(":scope > notations > articulations > stress"));
           const hasUnstress = Boolean(child.querySelector(":scope > notations > articulations > unstress"));
-          const hasStrongAccent = Boolean(child.querySelector(":scope > notations > articulations > strong-accent"));
-          const hasBreathMark = Boolean(child.querySelector(":scope > notations > articulations > breath-mark"));
-          const hasCaesura = Boolean(child.querySelector(":scope > notations > articulations > caesura"));
+          const hasStrongAccent = articulationKinds.has("strong-accent");
+          const hasBreathMark = articulationKinds.has("breath-mark");
+          const hasCaesura = articulationKinds.has("caesura");
           const phraseMarkText = Array.from(child.querySelectorAll(":scope > notations > articulations > other-articulation"))
             .map((node) => (node.textContent || "").trim().toLowerCase())
             .find((text) => text === "shortphrase" || text === "mediumphrase" || text === "longphrase") || "";
@@ -4744,8 +4786,9 @@ export const exportMusicXmlDomToAbc = (doc: Document): string => {
             !fermataNode
               ? ""
               : (fermataTypeRaw === "inverted" || fermataShapeRaw === "inverted" ? "inverted" : "normal");
-          const hasSlurStart = Boolean(child.querySelector(':scope > notations > slur[type="start"]'));
-          const hasSlurStop = Boolean(child.querySelector(':scope > notations > slur[type="stop"]'));
+          const slurFeatures = extractMusicXmlSlurFeatures(child);
+          const hasSlurStart = slurFeatures.some((slur) => slur.type === "start");
+          const hasSlurStop = slurFeatures.some((slur) => slur.type === "stop");
           const hasGraceSlash = (child.querySelector(":scope > grace")?.getAttribute("slash") ?? "").trim().toLowerCase() === "yes";
           const hasTupletStart = Boolean(child.querySelector(':scope > notations > tuplet[type="start"]'));
           const tmActual = Number(child.querySelector(":scope > time-modification > actual-notes")?.textContent?.trim() || "");

--- a/src/ts/lilypond-io.ts
+++ b/src/ts/lilypond-io.ts
@@ -10,6 +10,28 @@ import {
   serializeMusicXmlDocument,
 } from "./musicxml-io";
 import {
+  buildMusicXmlArticulationItemsXml,
+  extractMusicXmlArticulationKinds,
+} from "./score-features/articulations";
+import {
+  buildMusicXmlDirectionFeatureXml,
+  normalizeDynamicMark,
+} from "./score-features/dynamics";
+import { buildMusicXmlBarlineXml } from "./score-features/barlines";
+import { buildMusicXmlWordsDirectionXml } from "./score-features/direction-text";
+import {
+  buildMusicXmlOrnamentItemsXml,
+  extractMusicXmlOrnamentFeatures,
+} from "./score-features/ornaments";
+import {
+  buildMusicXmlSlursXml,
+  extractMusicXmlSlurFeatures,
+} from "./score-features/slurs";
+import {
+  buildMusicXmlTieItemsXml,
+  buildMusicXmlTiedItemsXml,
+} from "./score-features/ties";
+import {
   chooseSingleClefByKeys,
   pickStaffForClusterWithHysteresis,
   shouldUseGrandStaffByRange,
@@ -1630,20 +1652,21 @@ const parseLilyDirectBody = (
       pushEvent({
         kind: "direction",
         durationDiv: 0,
-        xml: `<barline location="left"><repeat direction="forward"/></barline>`,
+        xml: buildMusicXmlBarlineXml({ location: "left", repeats: ["forward"] }),
       });
       continue;
     }
     if (token.startsWith("@@MKS_RPT_BWD_")) {
       const timesText = token.replace(/^@@MKS_RPT_BWD_(\d+)@@$/, "$1");
       const times = Number.parseInt(timesText, 10);
-      const endingXml = Number.isFinite(times) && times > 1
-        ? `<ending number="${Math.round(times)}" type="stop"/>`
-        : "";
       pushEvent({
         kind: "direction",
         durationDiv: 0,
-        xml: `<barline location="right"><repeat direction="backward"/>${endingXml}</barline>`,
+        xml: buildMusicXmlBarlineXml({
+          location: "right",
+          repeats: ["backward"],
+          ...(Number.isFinite(times) && times > 1 ? { ending: { number: Math.round(times), type: "stop" } } : {}),
+        }),
       });
       continue;
     }
@@ -1654,7 +1677,7 @@ const parseLilyDirectBody = (
       pushEvent({
         kind: "direction",
         durationDiv: 0,
-        xml: `<barline location="left"><ending number="${numberAttr}" type="start"/></barline>`,
+        xml: buildMusicXmlBarlineXml({ location: "left", ending: { number: numberAttr, type: "start" } }),
       });
       continue;
     }
@@ -1665,7 +1688,7 @@ const parseLilyDirectBody = (
       pushEvent({
         kind: "direction",
         durationDiv: 0,
-        xml: `<barline location="right"><ending number="${numberAttr}" type="stop"/></barline>`,
+        xml: buildMusicXmlBarlineXml({ location: "right", ending: { number: numberAttr, type: "stop" } }),
       });
       continue;
     }
@@ -1695,12 +1718,12 @@ const parseLilyDirectBody = (
     }
     if (token.startsWith("\\")) {
       const dyn = token.slice(1).toLowerCase();
-      const dynamicKinds = new Set(["ppp", "pp", "p", "mp", "mf", "f", "ff", "fff", "sfz"]);
-      if (dynamicKinds.has(dyn)) {
+      const dynamicMark = normalizeDynamicMark(dyn);
+      if (dynamicMark) {
         pushEvent({
           kind: "direction",
           durationDiv: 0,
-          xml: `<direction><direction-type><dynamics><${dyn}/></dynamics></direction-type></direction>`,
+          xml: buildMusicXmlDirectionFeatureXml({ kind: "dynamic", mark: dynamicMark }),
         });
         continue;
       }
@@ -1709,7 +1732,7 @@ const parseLilyDirectBody = (
         pushEvent({
           kind: "direction",
           durationDiv: 0,
-          xml: `<direction><direction-type><wedge type="${wedgeType}"/></direction-type></direction>`,
+          xml: buildMusicXmlDirectionFeatureXml({ kind: "wedge", wedgeType }),
         });
         continue;
       }
@@ -1799,7 +1822,7 @@ const parseLilyDirectBody = (
           pushEvent({
             kind: "direction",
             durationDiv: 0,
-            xml: `<direction><direction-type><words>Sost. Ped.</words></direction-type></direction>`,
+            xml: buildMusicXmlWordsDirectionXml({ text: "Sost. Ped." }),
           });
         }
         const type = dyn === "sostenutoon" ? "start" : "stop";
@@ -1815,7 +1838,7 @@ const parseLilyDirectBody = (
         pushEvent({
           kind: "direction",
           durationDiv: 0,
-          xml: `<direction><direction-type><words>${words}</words></direction-type></direction>`,
+          xml: buildMusicXmlWordsDirectionXml({ text: words }),
         });
         const type = dyn === "unacorda" ? "start" : "stop";
         pushEvent({
@@ -2101,9 +2124,10 @@ const buildDirectMusicXmlFromStaffBlocks = (params: {
         ? `<time-modification><actual-notes>${Math.round(event.tupletActual as number)}</actual-notes><normal-notes>${Math.round(event.tupletNormal as number)}</normal-notes></time-modification>`
         : "";
     const tokens = Array.from(new Set(event.articulationSubtypes ?? []));
-    const nodes: string[] = [];
-    if (tokens.includes("staccato")) nodes.push("<staccato/>");
-    if (tokens.includes("accent")) nodes.push("<accent/>");
+    const nodesXml = buildMusicXmlArticulationItemsXml(
+      tokens.filter((token) => token === "staccato" || token === "accent")
+    );
+    const nodes: string[] = nodesXml ? [nodesXml] : [];
     if (tokens.includes("up-bow")) nodes.push("<up-bow/>");
     if (tokens.includes("down-bow")) nodes.push("<down-bow/>");
     if (tokens.includes("snap-pizzicato")) nodes.push("<snap-pizzicato/>");
@@ -2117,13 +2141,8 @@ const buildDirectMusicXmlFromStaffBlocks = (params: {
         : "";
     if (event.tupletStart) tupletNodes.push(`<tuplet type="start"${tupletNumberAttr}/>`);
     if (event.tupletStop) tupletNodes.push(`<tuplet type="stop"${tupletNumberAttr}/>`);
-    const slurNodes = (event.slurHints ?? []).map((slur) => {
-      const numberAttr = Number.isFinite(slur.number) && (slur.number as number) > 0
-        ? ` number="${Math.round(slur.number as number)}"`
-        : "";
-      const placementAttr = slur.type === "start" && slur.placement ? ` placement="${slur.placement}"` : "";
-      return `<slur type="${slur.type}"${numberAttr}${placementAttr}/>`;
-    });
+    const slurNodesXml = buildMusicXmlSlursXml(event.slurHints ?? []);
+    const slurNodes = slurNodesXml ? [slurNodesXml] : [];
     const glissNodes = (event.glissHints ?? []).map((gliss) => {
       const numberAttr = Number.isFinite(gliss.number) && (gliss.number as number) > 0
         ? ` number="${Math.round(gliss.number as number)}"`
@@ -2136,10 +2155,17 @@ const buildDirectMusicXmlFromStaffBlocks = (params: {
         : "";
       return `<wavy-line type="${wavy.type}"${numberAttr}/>`;
     });
-    const tieXml = `${event.tieStart ? '<tie type="start"/>' : ""}${event.tieStop ? '<tie type="stop"/>' : ""}`;
-    const tiedXml = `${event.tieStart ? '<tied type="start"/>' : ""}${event.tieStop ? '<tied type="stop"/>' : ""}`;
-    const ornamentsXml = event.trillMark || wavyNodes.length
-      ? `<ornaments>${event.trillMark ? "<trill-mark/>" : ""}${wavyNodes.join("")}</ornaments>`
+    const tieXml = buildMusicXmlTieItemsXml({
+      tieStart: Boolean(event.tieStart),
+      tieStop: Boolean(event.tieStop),
+    });
+    const tiedXml = buildMusicXmlTiedItemsXml({
+      tiedStart: Boolean(event.tieStart),
+      tiedStop: Boolean(event.tieStop),
+    });
+    const ornamentItemsXml = event.trillMark ? buildMusicXmlOrnamentItemsXml([{ kind: "trill-mark" }]) : "";
+    const ornamentsXml = ornamentItemsXml || wavyNodes.length
+      ? `<ornaments>${ornamentItemsXml}${wavyNodes.join("")}</ornaments>`
       : "";
     const lyricXml = event.lyricText
       ? `<lyric><syllabic>single</syllabic><text>${xmlEscape(event.lyricText)}</text></lyric>`
@@ -2195,7 +2221,7 @@ const buildDirectMusicXmlFromStaffBlocks = (params: {
           body += `<attributes><time><beats>${measureBeats}</beats><beat-type>${measureBeatType}</beat-type></time></attributes>`;
         }
         if (hint?.doubleBar === "left" || hint?.doubleBar === "both") {
-          body += `<barline location="left"><bar-style>light-light</bar-style></barline>`;
+          body += buildMusicXmlBarlineXml({ location: "left", barStyle: "light-light" });
         }
         const octaveShiftHints = staff.octaveShiftHintsByMeasure?.get(index1) ?? [];
         for (const octaveShiftHint of octaveShiftHints) {
@@ -2206,15 +2232,18 @@ const buildDirectMusicXmlFromStaffBlocks = (params: {
         if (!events.length) {
           body += `<note><rest/><duration>${measureCapacity}</duration><voice>1</voice><type>whole</type></note>`;
           if (hint?.repeat === "forward") {
-            body = `<barline location="left"><repeat direction="forward"/></barline>${body}`;
+            body = `${buildMusicXmlBarlineXml({ location: "left", repeats: ["forward"] })}${body}`;
           } else if (hint?.repeat === "backward") {
-            const timesText = Number.isFinite(hint.times) && (hint.times as number) > 1
-              ? `<bar-style>light-heavy</bar-style><repeat direction="backward"/><ending number="${Math.round(hint.times as number)}" type="stop"/>`
-              : `<repeat direction="backward"/>`;
-            body += `<barline location="right">${timesText}</barline>`;
+            body += buildMusicXmlBarlineXml({
+              location: "right",
+              repeats: ["backward"],
+              ...(Number.isFinite(hint.times) && (hint.times as number) > 1
+                ? { barStyle: "light-heavy", ending: { number: Math.round(hint.times as number), type: "stop" } }
+                : {}),
+            });
           }
           if (hint?.doubleBar === "right" || hint?.doubleBar === "both") {
-            body += `<barline location="right"><bar-style>light-light</bar-style></barline>`;
+            body += buildMusicXmlBarlineXml({ location: "right", barStyle: "light-light" });
           }
           currentBeats = measureBeats;
           currentBeatType = measureBeatType;
@@ -2251,15 +2280,18 @@ const buildDirectMusicXmlFromStaffBlocks = (params: {
           }
         }
         if (hint?.repeat === "forward") {
-          body = `<barline location="left"><repeat direction="forward"/></barline>${body}`;
+          body = `${buildMusicXmlBarlineXml({ location: "left", repeats: ["forward"] })}${body}`;
         } else if (hint?.repeat === "backward") {
-          const timesText = Number.isFinite(hint.times) && (hint.times as number) > 1
-            ? `<bar-style>light-heavy</bar-style><repeat direction="backward"/><ending number="${Math.round(hint.times as number)}" type="stop"/>`
-            : `<repeat direction="backward"/>`;
-          body += `<barline location="right">${timesText}</barline>`;
+          body += buildMusicXmlBarlineXml({
+            location: "right",
+            repeats: ["backward"],
+            ...(Number.isFinite(hint.times) && (hint.times as number) > 1
+              ? { barStyle: "light-heavy", ending: { number: Math.round(hint.times as number), type: "stop" } }
+              : {}),
+          });
         }
         if (hint?.doubleBar === "right" || hint?.doubleBar === "both") {
-          body += `<barline location="right"><bar-style>light-light</bar-style></barline>`;
+          body += buildMusicXmlBarlineXml({ location: "right", barStyle: "light-light" });
         }
         currentBeats = measureBeats;
         currentBeatType = measureBeatType;
@@ -3111,25 +3143,19 @@ export const exportMusicXmlDomToLilyPond = (doc: Document): string => {
           if (child.querySelector(":scope > chord")) continue;
           if (child.querySelector(":scope > rest")) continue;
           eventNo += 1;
-          const kinds: string[] = [];
-          if (child.querySelector(":scope > notations > articulations > staccato")) kinds.push("staccato");
-          if (child.querySelector(":scope > notations > articulations > accent")) kinds.push("accent");
+          const kinds = extractMusicXmlArticulationKinds(child).filter((kind) => kind === "staccato" || kind === "accent");
           if (kinds.length) {
             out.push(`%@mks articul voice=${voiceId} measure=${mi + 1} event=${eventNo} kind=${kinds.join(",")}`);
           }
-          const slurs = Array.from(child.querySelectorAll(":scope > notations > slur"));
-          for (const slur of slurs) {
-            const slurType = (slur.getAttribute("type") || "").trim().toLowerCase();
-            if (slurType !== "start" && slurType !== "stop") continue;
+          for (const slur of extractMusicXmlSlurFeatures(child)) {
+            const slurType = slur.type;
             const slurFields = [`%@mks slur voice=${voiceId} measure=${mi + 1} event=${eventNo} type=${slurType}`];
-            const slurNumber = Number.parseInt(slur.getAttribute("number") || "", 10);
-            if (Number.isFinite(slurNumber) && slurNumber > 0) slurFields.push(`number=${Math.round(slurNumber)}`);
-            const slurPlacement = (slur.getAttribute("placement") || "").trim().toLowerCase();
-            if (slurPlacement === "above" || slurPlacement === "below") slurFields.push(`placement=${slurPlacement}`);
+            if (slur.number) slurFields.push(`number=${Math.round(slur.number)}`);
+            if (slur.placement) slurFields.push(`placement=${slur.placement}`);
             out.push(slurFields.join(" "));
           }
-          const trillMark = child.querySelector(":scope > notations > ornaments > trill-mark");
-          if (trillMark) {
+          const ornamentKinds = new Set(extractMusicXmlOrnamentFeatures(child).map((feature) => feature.kind));
+          if (ornamentKinds.has("trill-mark")) {
             out.push(`%@mks trill voice=${voiceId} measure=${mi + 1} event=${eventNo} mark=1`);
           }
           const wavyLines = Array.from(child.querySelectorAll(":scope > notations > ornaments > wavy-line"));

--- a/src/ts/mei-io.ts
+++ b/src/ts/mei-io.ts
@@ -4,6 +4,34 @@
  */
 
 import { applyImplicitBeamsToMusicXmlText, prettyPrintMusicXmlText } from "./musicxml-io";
+import {
+  buildMusicXmlArticulationItemsXml,
+  extractMusicXmlArticulationKinds,
+  type ArticulationKind,
+} from "./score-features/articulations";
+import {
+  buildMusicXmlDirectionFeatureXml,
+  extractMusicXmlDirectionFeatures,
+  normalizeDynamicMark,
+} from "./score-features/dynamics";
+import {
+  buildMusicXmlWordsDirectionXml,
+  extractMusicXmlDirectionWords,
+  extractMusicXmlSoundTempoBpm,
+} from "./score-features/direction-text";
+import {
+  buildMusicXmlOrnamentItemsXml,
+  extractMusicXmlOrnamentFeatures,
+} from "./score-features/ornaments";
+import {
+  buildMusicXmlSlurXml,
+  buildMusicXmlSlursXml,
+  extractMusicXmlSlurFeatures,
+} from "./score-features/slurs";
+import {
+  buildMusicXmlTieItemsXml,
+  buildMusicXmlTiedItemsXml,
+} from "./score-features/ties";
 
 type StaffSlot = {
   partId: string;
@@ -242,15 +270,17 @@ const extractMeiTieFromMusicXmlNote = (note: Element): string => {
 };
 
 const extractMeiArticulationTokensFromMusicXmlNote = (note: Element): string[] => {
-  const arts = note.querySelector(":scope > notations > articulations");
-  if (!arts) return [];
-  const out: string[] = [];
-  if (arts.querySelector(":scope > staccato")) out.push("stacc");
-  if (arts.querySelector(":scope > staccatissimo")) out.push("spicc");
-  if (arts.querySelector(":scope > accent")) out.push("acc");
-  if (arts.querySelector(":scope > tenuto")) out.push("ten");
-  if (arts.querySelector(":scope > strong-accent")) out.push("marc");
-  if (arts.querySelector(":scope > marcato")) out.push("marc");
+  const tokenByKind: Partial<Record<ArticulationKind, string>> = {
+    staccato: "stacc",
+    staccatissimo: "spicc",
+    accent: "acc",
+    tenuto: "ten",
+    "strong-accent": "marc",
+  };
+  const out = extractMusicXmlArticulationKinds(note)
+    .map((kind) => tokenByKind[kind])
+    .filter((token): token is string => !!token);
+  if (note.querySelector(":scope > notations > articulations > marcato")) out.push("marc");
   return Array.from(new Set(out));
 };
 
@@ -685,20 +715,14 @@ const collectMeiDirectionControlsForStaff = (
     const placement = (direction.getAttribute("placement") || "").trim().toLowerCase();
     const placeAttr = placement === "above" || placement === "below" ? ` place="${esc(placement)}"` : "";
     const tstamp = directionTstamp(direction, sourceDivisions, beatType, onsetTicksByDirection);
-    const dynamicsNode = direction.querySelector(":scope > direction-type > dynamics");
-    if (dynamicsNode) {
-      const symbol = Array.from(dynamicsNode.children)
-        .map((child) => localNameOf(child))
-        .find((name) => !!name);
-      if (symbol) {
-        out.push(`<dynam tstamp="${esc(tstamp)}"${placeAttr}>${esc(symbol)}</dynam>`);
-        continue;
-      }
+    const dynamicFeature = extractMusicXmlDirectionFeatures(direction).find((feature) => feature.kind === "dynamic");
+    if (dynamicFeature?.kind === "dynamic") {
+      out.push(`<dynam tstamp="${esc(tstamp)}"${placeAttr}>${esc(dynamicFeature.mark)}</dynam>`);
+      continue;
     }
-    const tempoRaw = (direction.querySelector(":scope > sound")?.getAttribute("tempo") || "").trim();
-    const tempo = Number.parseFloat(tempoRaw);
-    const words = (direction.querySelector(":scope > direction-type > words")?.textContent || "").trim();
-    if (words && Number.isFinite(tempo) && tempo > 0) {
+    const tempo = extractMusicXmlSoundTempoBpm(direction);
+    const words = extractMusicXmlDirectionWords(direction)[0]?.text ?? "";
+    if (words && tempo !== null) {
       out.push(`<tempo tstamp="${esc(tstamp)}" midi.bpm="${esc(String(tempo))}"${placeAttr}>${esc(words)}</tempo>`);
       continue;
     }
@@ -709,9 +733,8 @@ const collectMeiDirectionControlsForStaff = (
   if (localStaff === 1) {
     const measureSounds = Array.from(measure.querySelectorAll(":scope > sound"));
     for (const sound of measureSounds) {
-      const tempoRaw = (sound.getAttribute("tempo") || "").trim();
-      const tempo = Number.parseFloat(tempoRaw);
-      if (!Number.isFinite(tempo) || tempo <= 0) continue;
+      const tempo = extractMusicXmlSoundTempoBpm(sound);
+      if (tempo === null) continue;
       const offsetTicks = Math.max(0, parseIntSafe(sound.getAttribute("offset"), 0));
       const tstamp = offsetTicksToTstamp(offsetTicks, sourceDivisions, beatType);
       const bpm = Number.isInteger(tempo)
@@ -726,24 +749,24 @@ const collectMeiDirectionControlsForStaff = (
   type PendingWedge = { tstamp: string; form: "cres" | "dim"; placeAttr: string };
   const pendingByNumber = new Map<string, PendingWedge>();
   for (const direction of directions) {
-    const wedge = direction.querySelector(":scope > direction-type > wedge");
-    if (!wedge) continue;
-    const type = (wedge.getAttribute("type") || "").trim().toLowerCase();
-    const number = (wedge.getAttribute("number") || "1").trim() || "1";
     const tstamp = directionTstamp(direction, sourceDivisions, beatType, onsetTicksByDirection);
     const placement = (direction.getAttribute("placement") || "").trim().toLowerCase();
     const placeAttr = placement === "above" || placement === "below" ? ` place="${esc(placement)}"` : "";
-    if (type === "crescendo" || type === "diminuendo") {
-      pendingByNumber.set(number, { tstamp, form: type === "diminuendo" ? "dim" : "cres", placeAttr });
-      continue;
-    }
-    if (type === "stop") {
-      const pending = pendingByNumber.get(number);
-      if (!pending) continue;
-      out.push(
-        `<hairpin form="${pending.form}" tstamp="${esc(pending.tstamp)}" tstamp2="${esc(tstamp)}"${pending.placeAttr}/>`
-      );
-      pendingByNumber.delete(number);
+    for (const feature of extractMusicXmlDirectionFeatures(direction)) {
+      if (feature.kind !== "wedge") continue;
+      const number = feature.number || "1";
+      if (feature.wedgeType === "crescendo" || feature.wedgeType === "diminuendo") {
+        pendingByNumber.set(number, { tstamp, form: feature.wedgeType === "diminuendo" ? "dim" : "cres", placeAttr });
+        continue;
+      }
+      if (feature.wedgeType === "stop") {
+        const pending = pendingByNumber.get(number);
+        if (!pending) continue;
+        out.push(
+          `<hairpin form="${pending.form}" tstamp="${esc(pending.tstamp)}" tstamp2="${esc(tstamp)}"${pending.placeAttr}/>`
+        );
+        pendingByNumber.delete(number);
+      }
     }
   }
   for (const pending of pendingByNumber.values()) {
@@ -827,7 +850,7 @@ const collectMeiDirectionControlsForStaff = (
       out.push(`<repeatMark tstamp="${esc(tstamp)}"${placeAttr}>coda</repeatMark>`);
       continue;
     }
-    const words = (direction.querySelector(":scope > direction-type > words")?.textContent || "").trim();
+    const words = extractMusicXmlDirectionWords(direction)[0]?.text ?? "";
     if (!words) continue;
     const lowered = words.toLowerCase();
     if (
@@ -948,15 +971,13 @@ const collectMeiTieSlurControlsForStaff = (
     const note = item.note;
     const tstamp = offsetTicksToTstamp(item.onset, divisions, beatType);
 
-    const slurs = Array.from(note.querySelectorAll(":scope > notations > slur"));
-    for (const slur of slurs) {
-      const type = (slur.getAttribute("type") || "").trim().toLowerCase();
-      const number = String(Math.max(1, parseIntSafe(slur.getAttribute("number"), 1)));
-      if (type === "start") {
+    for (const slur of extractMusicXmlSlurFeatures(note)) {
+      const number = String(slur.number ?? 1);
+      if (slur.type === "start") {
         pendingSlurByNumber.set(number, { tstamp, noteId: item.noteId });
         continue;
       }
-      if (type === "stop") {
+      if (slur.type === "stop") {
         const pending = pendingSlurByNumber.get(number);
         if (pending) {
           if (pending.noteId && item.noteId) {
@@ -1014,19 +1035,20 @@ const collectMeiOrnamentAndBreathControlsForStaff = (
     const notations = note.querySelector(":scope > notations");
     if (!notations) continue;
 
-    if (notations.querySelector(":scope > ornaments > trill-mark")) {
+    const ornamentKinds = new Set(extractMusicXmlOrnamentFeatures(note).map((feature) => feature.kind));
+    if (ornamentKinds.has("trill-mark")) {
       out.push(`<trill tstamp="${esc(tstamp)}"/>`);
     }
-    if (notations.querySelector(":scope > ornaments > turn")) {
+    if (ornamentKinds.has("turn")) {
       out.push(`<turn tstamp="${esc(tstamp)}" type="upper"/>`);
     }
-    if (notations.querySelector(":scope > ornaments > inverted-turn")) {
+    if (ornamentKinds.has("inverted-turn")) {
       out.push(`<turn tstamp="${esc(tstamp)}" type="inverted"/>`);
     }
-    if (notations.querySelector(":scope > ornaments > mordent")) {
+    if (ornamentKinds.has("mordent")) {
       out.push(`<mordent tstamp="${esc(tstamp)}" type="upper"/>`);
     }
-    if (notations.querySelector(":scope > ornaments > inverted-mordent")) {
+    if (ornamentKinds.has("inverted-mordent")) {
       out.push(`<mordent tstamp="${esc(tstamp)}" type="inverted"/>`);
     }
     const fermata = notations.querySelector(":scope > fermata");
@@ -1416,11 +1438,14 @@ const readMeiArticulationTokens = (node: Element): string[] => {
 };
 
 const appendMusicXmlArticulationsFromMeiTokens = (tokens: string[], out: string[]): void => {
-  if (tokens.includes("stacc")) out.push("<staccato/>");
-  if (tokens.includes("spicc") || tokens.includes("stacciss")) out.push("<staccatissimo/>");
-  if (tokens.includes("acc")) out.push("<accent/>");
-  if (tokens.includes("ten") || tokens.includes("tenuto")) out.push("<tenuto/>");
-  if (tokens.includes("marc") || tokens.includes("marcato")) out.push("<strong-accent/>");
+  const kinds: ArticulationKind[] = [];
+  if (tokens.includes("stacc")) kinds.push("staccato");
+  if (tokens.includes("spicc") || tokens.includes("stacciss")) kinds.push("staccatissimo");
+  if (tokens.includes("acc")) kinds.push("accent");
+  if (tokens.includes("ten") || tokens.includes("tenuto")) kinds.push("tenuto");
+  if (tokens.includes("marc") || tokens.includes("marcato")) kinds.push("strong-accent");
+  const xml = buildMusicXmlArticulationItemsXml(kinds);
+  if (xml) out.push(xml);
 };
 
 const accidToPitchAlterXml = (accid: string): string => {
@@ -1601,11 +1626,9 @@ const buildMusicXmlNoteFromMeiNote = (
   const arts: string[] = [];
   appendMusicXmlArticulationsFromMeiTokens(articTokens, arts);
   const tieFlags = parseMeiTieFlags(meiNote.getAttribute("tie") || "");
-  const tieXml = `${tieFlags.start ? '<tie type="start"/>' : ""}${tieFlags.stop ? '<tie type="stop"/>' : ""}`;
-  const tiedXml = `${tieFlags.start ? '<tied type="start"/>' : ""}${tieFlags.stop ? '<tied type="stop"/>' : ""}`;
-  const slurXml = parseMeiSlurNotations(meiNote.getAttribute("slur") || "")
-    .map((entry) => `<slur type="${entry.type}" number="${entry.number}"/>`)
-    .join("");
+  const tieXml = buildMusicXmlTieItemsXml({ tieStart: tieFlags.start, tieStop: tieFlags.stop });
+  const tiedXml = buildMusicXmlTiedItemsXml({ tiedStart: tieFlags.start, tiedStop: tieFlags.stop });
+  const slurXml = buildMusicXmlSlursXml(parseMeiSlurNotations(meiNote.getAttribute("slur") || ""));
   const tupletXml = `${hasTupletStart ? '<tuplet type="start"/>' : ""}${hasTupletStop ? '<tuplet type="stop"/>' : ""}`;
   const hasNotations = arts.length > 0 || tupletXml.length > 0 || tiedXml.length > 0 || slurXml.length > 0;
   const notationsXml = hasNotations
@@ -1765,11 +1788,9 @@ const parseLayerEvents = (
     const alterXml = resolvedAlter !== 0 ? `<alter>${resolvedAlter}</alter>` : "";
     const accidentalText = accidToMusicXmlAccidental(visualAccid);
     const accidentalXml = accidentalText ? `<accidental>${xmlEscape(accidentalText)}</accidental>` : "";
-    const tiedXml = `${tieFlags.start ? '<tied type="start"/>' : ""}${tieFlags.stop ? '<tied type="stop"/>' : ""}`;
-    const tieXml = `${tieFlags.start ? '<tie type="start"/>' : ""}${tieFlags.stop ? '<tie type="stop"/>' : ""}`;
-    const slurXml = parseMeiSlurNotations(effectiveNode.getAttribute("slur") || "")
-      .map((entry) => `<slur type="${entry.type}" number="${entry.number}"/>`)
-      .join("");
+    const tiedXml = buildMusicXmlTiedItemsXml({ tiedStart: tieFlags.start, tiedStop: tieFlags.stop });
+    const tieXml = buildMusicXmlTieItemsXml({ tieStart: tieFlags.start, tieStop: tieFlags.stop });
+    const slurXml = buildMusicXmlSlursXml(parseMeiSlurNotations(effectiveNode.getAttribute("slur") || ""));
     const hasNotations = tiedXml.length > 0 || slurXml.length > 0;
     const notationsXml = hasNotations ? `<notations>${tiedXml}${slurXml}</notations>` : "";
     events.push({
@@ -1929,11 +1950,9 @@ const parseLayerEvents = (
         const articTokens = Array.from(new Set<string>([...chordArticTokens, ...noteTokens]));
         const arts: string[] = [];
         appendMusicXmlArticulationsFromMeiTokens(articTokens, arts);
-        const tieXml = `${tieFlags.start ? '<tie type="start"/>' : ""}${tieFlags.stop ? '<tie type="stop"/>' : ""}`;
-        const tiedXml = `${tieFlags.start ? '<tied type="start"/>' : ""}${tieFlags.stop ? '<tied type="stop"/>' : ""}`;
-        const slurXml = parseMeiSlurNotations(note.getAttribute("slur") || "")
-          .map((entry) => `<slur type="${entry.type}" number="${entry.number}"/>`)
-          .join("");
+        const tieXml = buildMusicXmlTieItemsXml({ tieStart: tieFlags.start, tieStop: tieFlags.stop });
+        const tiedXml = buildMusicXmlTiedItemsXml({ tiedStart: tieFlags.start, tiedStop: tieFlags.stop });
+        const slurXml = buildMusicXmlSlursXml(parseMeiSlurNotations(note.getAttribute("slur") || ""));
         const tupletXml = index === 0
           ? `${chordTupletStart ? '<tuplet type="start"/>' : ""}${chordTupletStop ? '<tuplet type="stop"/>' : ""}`
           : "";
@@ -2088,7 +2107,7 @@ const parseLayerEvents = (
 };
 
 const addSlurNotationToSingleNoteXml = (noteXml: string, type: "start" | "stop", number: number): string => {
-  const slurXml = `<slur type="${type}" number="${number}"/>`;
+  const slurXml = buildMusicXmlSlurXml({ type, number });
   if (noteXml.includes("<notations>")) {
     return noteXml.replace("</notations>", `${slurXml}</notations>`);
   }
@@ -2096,8 +2115,8 @@ const addSlurNotationToSingleNoteXml = (noteXml: string, type: "start" | "stop",
 };
 
 const addTieToSingleNoteXml = (noteXml: string, type: "start" | "stop"): string => {
-  const tieXml = `<tie type="${type}"/>`;
-  const tiedXml = `<tied type="${type}"/>`;
+  const tieXml = buildMusicXmlTieItemsXml({ tieStart: type === "start", tieStop: type === "stop" });
+  const tiedXml = buildMusicXmlTiedItemsXml({ tiedStart: type === "start", tiedStop: type === "stop" });
   const withTie =
     noteXml.includes("<duration>")
       ? noteXml.replace("<duration>", `${tieXml}<duration>`)
@@ -2159,7 +2178,10 @@ const addTrillNotationToEventXml = (eventXml: string): string => {
   const before = eventXml.slice(0, firstNoteStart);
   const noteBlock = eventXml.slice(firstNoteStart, firstNoteEnd + "</note>".length);
   const after = eventXml.slice(firstNoteEnd + "</note>".length);
-  return before + addOrnamentXmlToSingleNoteXml(noteBlock, "<trill-mark/>") + after;
+  return before + addOrnamentXmlToSingleNoteXml(
+    noteBlock,
+    buildMusicXmlOrnamentItemsXml([{ kind: "trill-mark" }])
+  ) + after;
 };
 
 const addFermataNotationToEventXml = (eventXml: string, isBelow: boolean): string => {
@@ -2204,7 +2226,10 @@ const addTurnNotationToEventXml = (eventXml: string, isInverted: boolean): strin
   const before = eventXml.slice(0, firstNoteStart);
   const noteBlock = eventXml.slice(firstNoteStart, firstNoteEnd + "</note>".length);
   const after = eventXml.slice(firstNoteEnd + "</note>".length);
-  return before + addOrnamentXmlToSingleNoteXml(noteBlock, isInverted ? "<inverted-turn/>" : "<turn/>") + after;
+  return before + addOrnamentXmlToSingleNoteXml(
+    noteBlock,
+    buildMusicXmlOrnamentItemsXml([{ kind: isInverted ? "inverted-turn" : "turn" }])
+  ) + after;
 };
 
 const addMordentNotationToEventXml = (eventXml: string, isInverted: boolean): string => {
@@ -2215,7 +2240,10 @@ const addMordentNotationToEventXml = (eventXml: string, isInverted: boolean): st
   const before = eventXml.slice(0, firstNoteStart);
   const noteBlock = eventXml.slice(firstNoteStart, firstNoteEnd + "</note>".length);
   const after = eventXml.slice(firstNoteEnd + "</note>".length);
-  return before + addOrnamentXmlToSingleNoteXml(noteBlock, isInverted ? "<inverted-mordent/>" : "<mordent/>") + after;
+  return before + addOrnamentXmlToSingleNoteXml(
+    noteBlock,
+    buildMusicXmlOrnamentItemsXml([{ kind: isInverted ? "inverted-mordent" : "mordent" }])
+  ) + after;
 };
 
 const addBreathNotationToEventXml = (eventXml: string): string => {
@@ -2226,7 +2254,10 @@ const addBreathNotationToEventXml = (eventXml: string): string => {
   const before = eventXml.slice(0, firstNoteStart);
   const noteBlock = eventXml.slice(firstNoteStart, firstNoteEnd + "</note>".length);
   const after = eventXml.slice(firstNoteEnd + "</note>".length);
-  return before + addArticulationXmlToSingleNoteXml(noteBlock, "<breath-mark/>") + after;
+  return before + addArticulationXmlToSingleNoteXml(
+    noteBlock,
+    buildMusicXmlArticulationItemsXml(["breath-mark"])
+  ) + after;
 };
 
 const addCaesuraNotationToEventXml = (eventXml: string): string => {
@@ -2237,7 +2268,10 @@ const addCaesuraNotationToEventXml = (eventXml: string): string => {
   const before = eventXml.slice(0, firstNoteStart);
   const noteBlock = eventXml.slice(firstNoteStart, firstNoteEnd + "</note>".length);
   const after = eventXml.slice(firstNoteEnd + "</note>".length);
-  return before + addArticulationXmlToSingleNoteXml(noteBlock, "<caesura/>") + after;
+  return before + addArticulationXmlToSingleNoteXml(
+    noteBlock,
+    buildMusicXmlArticulationItemsXml(["caesura"])
+  ) + after;
 };
 
 const addTupletNotationToEventXml = (eventXml: string, type: "start" | "stop", number: number): string => {
@@ -2346,10 +2380,6 @@ const resolveControlEventEndpointIndex = (
   if (ticks === null) return null;
   return resolveEventIndexByTstamp(events, ticks);
 };
-
-const DYNAMICS_TAGS = new Set([
-  "pppp", "ppp", "pp", "p", "mp", "mf", "f", "ff", "fff", "ffff", "fp", "sf", "sfz", "sffz", "rfz", "rf", "fz",
-]);
 
 const parseHarmonyAlter = (token: string): number => {
   const v = token.trim();
@@ -2666,19 +2696,30 @@ const buildMusicXmlDirectionFromMeiDynam = (
 ): string | null => {
   const rawText = (dynam.textContent || "").trim();
   if (!rawText) return null;
-  const normalized = rawText.toLowerCase();
+  const dynamicMark = normalizeDynamicMark(rawText);
   const placement = (dynam.getAttribute("place") || dynam.getAttribute("placement") || "").trim().toLowerCase();
-  const placementAttr = placement === "above" || placement === "below" ? ` placement="${placement}"` : "";
   const offsetTicks = parseMeiTstampToTicks(dynam.getAttribute("tstamp"), divisions, beatType);
-  const offsetXml = Number.isFinite(offsetTicks) && (offsetTicks as number) > 0
-    ? `<offset>${Math.round(offsetTicks as number)}</offset>`
-    : "";
-  const directionType = DYNAMICS_TAGS.has(normalized)
-    ? `<dynamics><${normalized}/></dynamics>`
-    : `<words>${xmlEscape(rawText)}</words>`;
-  return `<direction${placementAttr}><direction-type>${directionType}</direction-type>${offsetXml}<voice>${xmlEscape(
-    voice
-  )}</voice><staff>${xmlEscape(staffNo)}</staff></direction>`;
+  const offsetDiv = Number.isFinite(offsetTicks) && (offsetTicks as number) > 0
+    ? Math.round(offsetTicks as number)
+    : undefined;
+  const placementFeature = placement === "above" || placement === "below" ? placement : undefined;
+  if (dynamicMark) {
+    return buildMusicXmlDirectionFeatureXml({
+      kind: "dynamic",
+      mark: dynamicMark,
+      offsetDiv,
+      voice,
+      staff: staffNo,
+      placement: placementFeature,
+    });
+  }
+  return buildMusicXmlWordsDirectionXml({
+    text: rawText,
+    placement: placementFeature,
+    offsetDiv,
+    voice,
+    staff: staffNo,
+  });
 };
 
 const buildMusicXmlDirectionsFromMeiHairpin = (
@@ -2694,7 +2735,6 @@ const buildMusicXmlDirectionsFromMeiHairpin = (
   const formRaw = (hairpin.getAttribute("form") || hairpin.getAttribute("type") || "").trim().toLowerCase();
   const wedgeType = formRaw.includes("dim") || formRaw.includes("decresc") ? "diminuendo" : "crescendo";
   const placement = (hairpin.getAttribute("place") || hairpin.getAttribute("placement") || "").trim().toLowerCase();
-  const placementAttr = placement === "above" || placement === "below" ? ` placement="${placement}"` : "";
   const startIndex = resolveControlEventEndpointIndex(
     (hairpin.getAttribute("startid") || "").trim(),
     hairpin.getAttribute("tstamp"),
@@ -2717,18 +2757,23 @@ const buildMusicXmlDirectionsFromMeiHairpin = (
   );
   const startTick = Number.isInteger(startIndex) ? resolveEventStartTickByIndex(events, startIndex as number) : null;
   const endTick = Number.isInteger(endIndex) ? resolveEventStartTickByIndex(events, endIndex as number) : null;
-  const startOffsetXml = Number.isFinite(startTick) && (startTick as number) > 0
-    ? `<offset>${Math.round(startTick as number)}</offset>`
-    : "";
-  const endOffsetXml = Number.isFinite(endTick) && (endTick as number) > 0
-    ? `<offset>${Math.round(endTick as number)}</offset>`
-    : "";
-  const startDir = `<direction${placementAttr}><direction-type><wedge type="${wedgeType}"/></direction-type>${startOffsetXml}<voice>${xmlEscape(
-    voice
-  )}</voice><staff>${xmlEscape(staffNo)}</staff></direction>`;
-  const stopDir = `<direction${placementAttr}><direction-type><wedge type="stop"/></direction-type>${endOffsetXml}<voice>${xmlEscape(
-    voice
-  )}</voice><staff>${xmlEscape(staffNo)}</staff></direction>`;
+  const placementFeature = placement === "above" || placement === "below" ? placement : undefined;
+  const startDir = buildMusicXmlDirectionFeatureXml({
+    kind: "wedge",
+    wedgeType,
+    offsetDiv: Number.isFinite(startTick) && (startTick as number) > 0 ? Math.round(startTick as number) : undefined,
+    voice,
+    staff: staffNo,
+    placement: placementFeature,
+  });
+  const stopDir = buildMusicXmlDirectionFeatureXml({
+    kind: "wedge",
+    wedgeType: "stop",
+    offsetDiv: Number.isFinite(endTick) && (endTick as number) > 0 ? Math.round(endTick as number) : undefined,
+    voice,
+    staff: staffNo,
+    placement: placementFeature,
+  });
   return `${startDir}${stopDir}`;
 };
 

--- a/src/ts/midi-io.ts
+++ b/src/ts/midi-io.ts
@@ -7,6 +7,19 @@ import {
   computeBeamAssignments,
 } from "./beam-common";
 import {
+  buildMusicXmlDirectionFeatureXml,
+  velocityToDynamicMark,
+  type DynamicMark,
+} from "./score-features/dynamics";
+import { buildMusicXmlTempoDirectionXml } from "./score-features/direction-text";
+import { extractMusicXmlOrnamentFeatures } from "./score-features/ornaments";
+import { extractMusicXmlSlurFeatures } from "./score-features/slurs";
+import {
+  buildMusicXmlTieItemsXml,
+  buildMusicXmlTiedItemsXml,
+  extractMusicXmlTieState,
+} from "./score-features/ties";
+import {
   chooseSingleClefByKeys,
   pickStaffForClusterWithHysteresis,
   shouldUseGrandStaffByRange,
@@ -484,28 +497,20 @@ const hasExplicitArticulation = (noteNode: Element): boolean => {
 };
 
 const getTieFlags = (noteNode: Element): { start: boolean; stop: boolean } => {
-  const directTieNodes = Array.from(noteNode.children).filter((child) => child.tagName === "tie");
-  const notationTieNodes = Array.from(noteNode.querySelectorAll("notations > tied"));
-  const allTieNodes = [...directTieNodes, ...notationTieNodes];
-  let start = false;
-  let stop = false;
-  for (const tieNode of allTieNodes) {
-    const tieType = tieNode.getAttribute("type")?.trim().toLowerCase();
-    if (tieType === "start") start = true;
-    if (tieType === "stop") stop = true;
-  }
-  return { start, stop };
+  const tie = extractMusicXmlTieState(noteNode);
+  return {
+    start: tie.tieStart || tie.tiedStart,
+    stop: tie.tieStop || tie.tiedStop,
+  };
 };
 
 const getSlurNumbers = (noteNode: Element): { starts: string[]; stops: string[] } => {
   const starts: string[] = [];
   const stops: string[] = [];
-  const slurNodes = Array.from(noteNode.querySelectorAll("notations > slur"));
-  for (const slurNode of slurNodes) {
-    const slurType = slurNode.getAttribute("type")?.trim().toLowerCase() ?? "";
-    const slurNumber = slurNode.getAttribute("number")?.trim() || "1";
-    if (slurType === "start") starts.push(slurNumber);
-    if (slurType === "stop") stops.push(slurNumber);
+  for (const slur of extractMusicXmlSlurFeatures(noteNode)) {
+    const slurNumber = String(slur.number ?? 1);
+    if (slur.type === "start") starts.push(slurNumber);
+    if (slur.type === "stop") stops.push(slurNumber);
   }
   return { starts, stops };
 };
@@ -689,9 +694,7 @@ const buildOrnamentMidiSequence = (
   }
 ): number[] => {
   if (durTicks < 2) return [baseMidi];
-  const ornamentTags = new Set(
-    Array.from(noteNode.querySelectorAll("notations > ornaments > *")).map((node) => node.tagName.toLowerCase())
-  );
+  const ornamentTags = new Set(extractMusicXmlOrnamentFeatures(noteNode).map((feature) => feature.kind));
   if (ornamentTags.size === 0) return [baseMidi];
 
   const upperNeighbor = resolveNeighborPitch(
@@ -1446,29 +1449,13 @@ type ImportedVoiceNoteSegment = {
   endTick: number;
 };
 
-type DynamicMark = "ppp" | "pp" | "p" | "mp" | "mf" | "f" | "ff" | "fff";
-
-const velocityToDynamicMark = (velocity: number): DynamicMark => {
-  const v = clampVelocity(velocity);
-  if (v <= 15) return "ppp";
-  if (v <= 31) return "pp";
-  if (v <= 47) return "p";
-  if (v <= 63) return "mp";
-  if (v <= 79) return "mf";
-  if (v <= 95) return "f";
-  if (v <= 111) return "ff";
-  return "fff";
-};
-
 const buildDynamicsDirectionXml = (dynamicMark: DynamicMark, offsetDiv: number, staff: number): string => {
-  let xml = "<direction>";
-  xml += `<direction-type><dynamics><${dynamicMark}/></dynamics></direction-type>`;
-  if (offsetDiv > 0) {
-    xml += `<offset>${offsetDiv}</offset>`;
-  }
-  xml += `<staff>${Math.max(1, Math.round(staff))}</staff>`;
-  xml += "</direction>";
-  return xml;
+  return buildMusicXmlDirectionFeatureXml({
+    kind: "dynamic",
+    mark: dynamicMark,
+    offsetDiv,
+    staff: Math.max(1, Math.round(staff)),
+  });
 };
 
 const midiToPitchComponents = (midiNumber: number): { step: string; alter: number; octave: number } => {
@@ -1906,14 +1893,12 @@ const beamLevelFromNotationType = (type: DurationNotation["type"]): number => {
 const buildTieXml = (tieStart: boolean, tieStop: boolean, withStaccato = false): string => {
   if (!tieStart && !tieStop && !withStaccato) return "";
   let xml = "";
-  if (tieStop) xml += '<tie type="stop"/>';
-  if (tieStart) xml += '<tie type="start"/>';
+  xml += buildMusicXmlTieItemsXml({ tieStart, tieStop });
   xml += "<notations>";
   if (withStaccato) {
     xml += "<articulations><staccato/></articulations>";
   }
-  if (tieStop) xml += '<tied type="stop"/>';
-  if (tieStart) xml += '<tied type="start"/>';
+  xml += buildMusicXmlTiedItemsXml({ tiedStart: tieStart, tiedStop: tieStop });
   xml += "</notations>";
   return xml;
 };
@@ -2455,15 +2440,11 @@ const buildPartMusicXml = (params: {
     if (includeTempoEvents) {
       const tempoEvents = tempoEventsByMeasure.get(measureIndex) ?? [];
       for (const event of tempoEvents) {
-        partXml += "<direction>";
-        partXml += "<direction-type><metronome><beat-unit>quarter</beat-unit>";
-        partXml += `<per-minute>${event.bpm}</per-minute>`;
-        partXml += "</metronome></direction-type>";
-        if (event.offsetDiv > 0) {
-          partXml += `<offset>${event.offsetDiv}</offset>`;
-        }
-        partXml += `<sound tempo="${event.bpm}"/>`;
-        partXml += "</direction>";
+        partXml += buildMusicXmlTempoDirectionXml({
+          bpm: event.bpm,
+          offsetDiv: event.offsetDiv,
+          includeQuarterMetronome: true,
+        });
       }
     }
     if (debugImportMetadata) {

--- a/src/ts/musescore-io.ts
+++ b/src/ts/musescore-io.ts
@@ -11,6 +11,41 @@ import {
   computeBeamAssignments,
 } from "./beam-common";
 import { applyImplicitBeamsToMusicXmlText } from "./musicxml-io";
+import {
+  buildMusicXmlArticulationsXml,
+  extractMusicXmlArticulationKinds,
+  normalizeArticulationKind,
+  type ArticulationKind,
+} from "./score-features/articulations";
+import {
+  buildMusicXmlDirectionFeatureXml,
+  extractMusicXmlDirectionFeatures,
+  normalizeDynamicMark,
+  type DynamicMark,
+} from "./score-features/dynamics";
+import {
+  buildMusicXmlBarlineXml,
+  extractMusicXmlBarlineFeature,
+} from "./score-features/barlines";
+import {
+  buildMusicXmlWordsDirectionXml,
+  buildMusicXmlTempoDirectionXml,
+  extractMusicXmlDirectionWords,
+  extractMusicXmlSoundTempoBpm,
+} from "./score-features/direction-text";
+import {
+  buildMusicXmlOrnamentItemsXml,
+  extractMusicXmlOrnamentFeatures,
+} from "./score-features/ornaments";
+import {
+  buildMusicXmlSlursXml,
+  extractMusicXmlSlurFeatures,
+} from "./score-features/slurs";
+import {
+  buildMusicXmlTieItemsXml,
+  buildMusicXmlTiedItemsXml,
+  extractMusicXmlTieState,
+} from "./score-features/ties";
 
 type MuseScoreImportOptions = {
   sourceMetadata?: boolean;
@@ -80,12 +115,12 @@ type ParsedMuseScoreEvent =
     trillStops?: number[];
     trillMarkOnly?: boolean;
     trillAccidentalMark?: string;
-    articulationTags?: string[];
+    articulationTags?: ArticulationKind[];
     technicalTags?: string[];
     grace?: boolean;
     graceSlash?: boolean;
   }
-  | { kind: "dynamic"; mark: string; voice: number; staffNo?: number; atDiv: number; soundDynamics?: number }
+  | { kind: "dynamic"; mark: DynamicMark; voice: number; staffNo?: number; atDiv: number; soundDynamics?: number }
   | { kind: "directionXml"; xml: string; voice: number; staffNo?: number; atDiv: number }
   | { kind: "barlineXml"; xml: string; voice: number; staffNo?: number; atDiv: number };
 
@@ -349,20 +384,15 @@ const buildMidMeasureRepeatBarlineXml = (
   direction: "forward" | "backward" | "end-start"
 ): string => {
   if (direction === "end-start") {
-    return "<barline location=\"middle\"><bar-style>light-heavy</bar-style><repeat direction=\"backward\"/><repeat direction=\"forward\"/></barline>";
+    return buildMusicXmlBarlineXml({ location: "middle", barStyle: "light-heavy", repeats: ["backward", "forward"] });
   }
   if (direction === "forward") {
-    return "<barline location=\"middle\"><bar-style>heavy-light</bar-style><repeat direction=\"forward\"/></barline>";
+    return buildMusicXmlBarlineXml({ location: "middle", barStyle: "heavy-light", repeats: ["forward"] });
   }
-  return "<barline location=\"middle\"><bar-style>light-heavy</bar-style><repeat direction=\"backward\"/></barline>";
+  return buildMusicXmlBarlineXml({ location: "middle", barStyle: "light-heavy", repeats: ["backward"] });
 };
 
-const parseMuseDynamicMark = (value: string): string | null => {
-  const v = String(value || "").trim().toLowerCase();
-  if (!v) return null;
-  const allow = new Set(["pppp", "ppp", "pp", "p", "mp", "mf", "f", "ff", "fff", "ffff", "sf", "sfz", "rfz"]);
-  return allow.has(v) ? v : null;
-};
+const parseMuseDynamicMark = (value: string): DynamicMark | null => normalizeDynamicMark(value);
 
 const parseMuseDynamicSoundValue = (dynamicEl: Element): number | null => {
   const velocity = firstNumber(dynamicEl, ":scope > velocity");
@@ -379,7 +409,7 @@ const isMuseElementVisible = (el: Element): boolean => {
 
 const museArticulationSubtypeToMusicXmlTag = (
   raw: string | null | undefined
-): { group: "articulations" | "technical"; tag: string } | null => {
+): { group: "articulations"; tag: ArticulationKind } | { group: "technical"; tag: string } | null => {
   const v = String(raw ?? "").trim().toLowerCase();
   if (!v) return null;
   // MuseScore left-hand pizzicato (+) variants.
@@ -448,10 +478,11 @@ const readGlobalMuseKeyMode = (score: Element): "major" | "minor" => {
   return inferred || "major";
 };
 
-const buildDynamicDirectionXml = (mark: string, options?: { soundDynamics?: number }): string => {
+const buildDynamicDirectionXml = (mark: DynamicMark, options?: { soundDynamics?: number }): string => {
   const value = options?.soundDynamics;
   const soundXml = Number.isFinite(value) ? `<sound dynamics="${Number(value).toFixed(2)}"/>` : "";
-  return `<direction><direction-type><dynamics><${mark}/></dynamics></direction-type>${soundXml}</direction>`;
+  const featureXml = buildMusicXmlDirectionFeatureXml({ kind: "dynamic", mark });
+  return soundXml ? featureXml.replace("</direction>", `${soundXml}</direction>`) : featureXml;
 };
 
 const museAccidentalSubtypeToMusicXml = (raw: string | null | undefined): string | null => {
@@ -489,11 +520,12 @@ const buildWordsDirectionXml = (
   text: string,
   options?: { placement?: "above" | "below"; soundTempo?: number | null; fontStyle?: "italic" | "normal" }
 ): string => {
-  const placementAttr = options?.placement ? ` placement="${options.placement}"` : "";
-  const fontStyleAttr = options?.fontStyle ? ` font-style="${options.fontStyle}"` : "";
-  const soundTempo = options?.soundTempo ?? null;
-  const soundXml = soundTempo !== null ? `<sound tempo="${soundTempo}"/>` : "";
-  return `<direction${placementAttr}><direction-type><words${fontStyleAttr}>${xmlEscape(text)}</words></direction-type>${soundXml}</direction>`;
+  return buildMusicXmlWordsDirectionXml({
+    text,
+    placement: options?.placement,
+    fontStyle: options?.fontStyle,
+    tempoBpm: options?.soundTempo ?? undefined,
+  });
 };
 
 const buildSegnoDirectionXml = (): string => {
@@ -529,7 +561,7 @@ const parseJumpDirectionXml = (jump: Element): { xml: string; mapped: boolean } 
   if (playUntil.toLowerCase().includes("coda") || continueAt.toLowerCase().includes("coda")) attrs.push('tocoda="coda"');
   const soundXml = attrs.length ? `<sound ${attrs.join(" ")}/>` : "";
   return {
-    xml: `<direction><direction-type><words>${xmlEscape(words)}</words></direction-type>${soundXml}</direction>`,
+    xml: buildMusicXmlWordsDirectionXml({ text: words }).replace("</direction>", `${soundXml}</direction>`),
     mapped: attrs.length > 0,
   };
 };
@@ -551,7 +583,7 @@ const parseTempoDirectionXml = (tempoEl: Element): string | null => {
     return buildWordsDirectionXml(text, { placement: "above", soundTempo: bpm });
   }
   if (bpm !== null) {
-    return `<direction><sound tempo="${bpm}"/></direction>`;
+    return buildMusicXmlTempoDirectionXml({ bpm });
   }
   return null;
 };
@@ -775,7 +807,7 @@ type MuseScoreImportChordLocalSpannerResult = {
 };
 
 type MuseScoreChordNotationSummary = {
-  articulationTags: string[];
+  articulationTags: ArticulationKind[];
   technicalTags: string[];
   hasChordLocalTrillMark: boolean;
 };
@@ -1927,7 +1959,7 @@ const applyMuseChordLocalSpanners = (
 const summarizeMuseChordNotations = (chordEl: Element): MuseScoreChordNotationSummary => {
   const articulationMappings = Array.from(chordEl.querySelectorAll(":scope > Articulation > subtype"))
     .map((node) => museArticulationSubtypeToMusicXmlTag(node.textContent))
-    .filter((mapped): mapped is { group: "articulations" | "technical"; tag: string } => mapped !== null);
+    .filter((mapped): mapped is NonNullable<ReturnType<typeof museArticulationSubtypeToMusicXmlTag>> => mapped !== null);
   const ornamentSubtypeTexts = Array.from(
     chordEl.querySelectorAll(":scope > Ornament > subtype, :scope > ornament > subtype")
   ).map((node) => (node.textContent ?? "").trim().toLowerCase());
@@ -1939,7 +1971,8 @@ const summarizeMuseChordNotations = (chordEl: Element): MuseScoreChordNotationSu
   return {
     articulationTags: allMappings
       .filter((mapped) => mapped.group === "articulations")
-      .map((mapped) => mapped.tag),
+      .map((mapped) => normalizeArticulationKind(mapped.tag))
+      .filter((kind): kind is ArticulationKind => kind !== null),
     technicalTags: allMappings
       .filter((mapped) => mapped.group === "technical")
       .map((mapped) => mapped.tag),
@@ -2865,10 +2898,10 @@ const buildMuseImportedMeasureHeaderXml = (
     body += "</attributes>";
   }
   if (primaryMeasure.leftDoubleBarline) {
-    body += `<barline location="left"><bar-style>light-light</bar-style></barline>`;
+    body += buildMusicXmlBarlineXml({ location: "left", barStyle: "light-light" });
   }
   if (primaryMeasure.repeatForward) {
-    body += `<barline location="left"><repeat direction="forward"/></barline>`;
+    body += buildMusicXmlBarlineXml({ location: "left", repeats: ["forward"] });
   }
   if (primaryMeasure.tempoText) {
     body += buildWordsDirectionXml(primaryMeasure.tempoText, {
@@ -2876,7 +2909,7 @@ const buildMuseImportedMeasureHeaderXml = (
       soundTempo: primaryMeasure.tempoBpm,
     });
   } else if (primaryMeasure.tempoBpm !== null) {
-    body += `<direction><direction-type><metronome><beat-unit>quarter</beat-unit><per-minute>${primaryMeasure.tempoBpm}</per-minute></metronome></direction-type><sound tempo="${primaryMeasure.tempoBpm}"/></direction>`;
+    body += buildMusicXmlTempoDirectionXml({ bpm: primaryMeasure.tempoBpm, includeQuarterMetronome: true });
   }
   return body;
 };
@@ -2961,10 +2994,11 @@ const finalizeMuseImportedMeasureXml = (
   const isLastMeasure = measureIndex === measureCount - 1;
   let out = body;
   if (primaryMeasure.repeatBackward || isLastMeasure) {
-    out += `<barline location="right">`;
-    if (isLastMeasure) out += "<bar-style>light-heavy</bar-style>";
-    if (primaryMeasure.repeatBackward) out += `<repeat direction="backward"/>`;
-    out += "</barline>";
+    out += buildMusicXmlBarlineXml({
+      location: "right",
+      ...(isLastMeasure ? { barStyle: "light-heavy" } : {}),
+      ...(primaryMeasure.repeatBackward ? { repeats: ["backward"] } : {}),
+    });
   }
   const implicitAttr = primaryMeasure.implicit ? ' implicit="yes"' : "";
   const measureNumber = startsWithPickup ? measureIndex : measureIndex + 1;
@@ -3051,29 +3085,28 @@ const emitMuseImportedVoiceXml = (
       continue;
     }
     const tupletXml = buildTupletMusicXml(event);
-    const slurItems: string[] = [];
-    for (const no of event.slurStarts ?? []) {
-      slurItems.push(`<slur type="start" number="${Math.max(1, Math.round(no))}"/>`);
-    }
-    for (const no of event.slurStops ?? []) {
-      slurItems.push(`<slur type="stop" number="${Math.max(1, Math.round(no))}"/>`);
-    }
+    const slurItemsXml = buildMusicXmlSlursXml([
+      ...(event.slurStarts ?? []).map((no) => ({ type: "start" as const, number: Math.max(1, Math.round(no)) })),
+      ...(event.slurStops ?? []).map((no) => ({ type: "stop" as const, number: Math.max(1, Math.round(no)) })),
+    ]);
+    const slurItems = slurItemsXml ? [slurItemsXml] : [];
     const trillItems: string[] = [];
     const trillAccidentalMarkXml = event.trillAccidentalMark
       ? `<accidental-mark>${event.trillAccidentalMark}</accidental-mark>`
       : "";
+    const trillMarkXml = buildMusicXmlOrnamentItemsXml([{ kind: "trill-mark" }]);
     const trillStarts = event.trillStarts ?? [];
     for (let i = 0; i < trillStarts.length; i += 1) {
       const no = trillStarts[i] as number;
       trillItems.push(
-        `<ornaments><trill-mark/>${i === 0 ? trillAccidentalMarkXml : ""}<wavy-line type="start" number="${Math.max(1, Math.round(no))}"/></ornaments>`
+        `<ornaments>${trillMarkXml}${i === 0 ? trillAccidentalMarkXml : ""}<wavy-line type="start" number="${Math.max(1, Math.round(no))}"/></ornaments>`
       );
     }
     for (const no of event.trillStops ?? []) {
       trillItems.push(`<ornaments><wavy-line type="stop" number="${Math.max(1, Math.round(no))}"/></ornaments>`);
     }
     if (trillStarts.length === 0 && event.trillMarkOnly) {
-      trillItems.push(`<ornaments><trill-mark/>${trillAccidentalMarkXml}</ornaments>`);
+      trillItems.push(`<ornaments>${trillMarkXml}${trillAccidentalMarkXml}</ornaments>`);
     }
     for (let ni = 0; ni < event.notes.length; ni += 1) {
       const note = event.notes[ni];
@@ -3090,11 +3123,15 @@ const emitMuseImportedVoiceXml = (
       });
       const accidentalXml = accidentalText ? `<accidental>${accidentalText}</accidental>` : "";
       const timeModificationXml = ni === 0 && !event.grace ? tupletXml.timeModificationXml : "";
-      const tieXml = `${note.tieStart ? '<tie type="start"/>' : ""}${note.tieStop ? '<tie type="stop"/>' : ""}`;
-      const tiedItems = `${note.tieStart ? '<tied type="start"/>' : ""}${note.tieStop ? '<tied type="stop"/>' : ""}`;
-      const articulationXml = ni === 0 && (event.articulationTags?.length ?? 0) > 0
-        ? `<articulations>${(event.articulationTags ?? []).map((tag) => `<${tag}/>`).join("")}</articulations>`
-        : "";
+      const tieXml = buildMusicXmlTieItemsXml({
+        tieStart: Boolean(note.tieStart),
+        tieStop: Boolean(note.tieStop),
+      });
+      const tiedItems = buildMusicXmlTiedItemsXml({
+        tiedStart: Boolean(note.tieStart),
+        tiedStop: Boolean(note.tieStop),
+      });
+      const articulationXml = ni === 0 ? buildMusicXmlArticulationsXml(event.articulationTags ?? []) : "";
       const noteTechnicalItems: string[] = [];
       if (ni === 0 && (event.technicalTags?.length ?? 0) > 0) {
         noteTechnicalItems.push(...(event.technicalTags ?? []).map((tag) => `<${tag}/>`));
@@ -3440,16 +3477,12 @@ const getPartStaffCountFromMusicXml = (part: Element): number => {
 
 type MuseDirectionSeed =
   | { kind: "tempo"; qps: number; text?: string; followText?: boolean; visible?: boolean }
-  | { kind: "dynamic"; subtype: string; velocity?: number }
+  | { kind: "dynamic"; subtype: DynamicMark; velocity?: number }
   | { kind: "expression"; text: string; italic?: boolean }
   | { kind: "marker"; subtype: "segno" | "coda" | "fine"; label: string }
   | { kind: "jump"; text: string; jumpTo?: string; playUntil?: string; continueAt?: string };
 
-const dynamicTagToMuseSubtype = (tag: string): string | null => {
-  const v = tag.trim().toLowerCase();
-  const allow = new Set(["pppp", "ppp", "pp", "p", "mp", "mf", "f", "ff", "fff", "ffff", "sf", "sfz", "rfz"]);
-  return allow.has(v) ? v : null;
-};
+const dynamicTagToMuseSubtype = (tag: string): DynamicMark | null => normalizeDynamicMark(tag);
 
 const musicXmlSoundDynamicsToMuseVelocity = (raw: string | null): number | undefined => {
   const n = Number(raw ?? "");
@@ -3492,9 +3525,8 @@ const beatUnitToQuarterFactor = (beatUnit: string, dots: number): number | null 
 };
 
 const readDirectionTempoQps = (direction: Element): number => {
-  const soundTempoText = direction.querySelector(":scope > sound")?.getAttribute("tempo") ?? "";
-  const soundTempo = Number(soundTempoText);
-  if (Number.isFinite(soundTempo) && soundTempo > 0) return soundTempo / 60;
+  const soundTempo = extractMusicXmlSoundTempoBpm(direction);
+  if (soundTempo !== null) return soundTempo / 60;
 
   const metronome = direction.querySelector(":scope > direction-type > metronome");
   if (!metronome) return 0;
@@ -3521,8 +3553,9 @@ const collectDirectionSeedsFromMusicXmlMeasure = (measure: Element, staffNo: num
     const soundToCoda = (direction.querySelector(":scope > sound")?.getAttribute("tocoda") ?? "").trim();
     const velocity = musicXmlSoundDynamicsToMuseVelocity(soundDynamics);
 
-    for (const dynNode of Array.from(direction.querySelectorAll(":scope > direction-type > dynamics > *"))) {
-      const subtype = dynamicTagToMuseSubtype(dynNode.tagName.toLowerCase());
+    for (const feature of extractMusicXmlDirectionFeatures(direction)) {
+      if (feature.kind !== "dynamic") continue;
+      const subtype = dynamicTagToMuseSubtype(feature.mark);
       if (!subtype) continue;
       out.push({ kind: "dynamic", subtype, velocity });
     }
@@ -3532,10 +3565,9 @@ const collectDirectionSeedsFromMusicXmlMeasure = (measure: Element, staffNo: num
     if (direction.querySelector(":scope > direction-type > coda") !== null) {
       out.push({ kind: "marker", subtype: "coda", label: "coda" });
     }
-    for (const words of Array.from(direction.querySelectorAll(":scope > direction-type > words"))) {
-      const text = (words.textContent ?? "").trim();
-      if (!text) continue;
-      const italic = (words.getAttribute("font-style") ?? "").trim().toLowerCase() === "italic";
+    for (const words of extractMusicXmlDirectionWords(direction)) {
+      const text = words.text;
+      const italic = words.fontStyle === "italic";
       if (hasTempo) out.push({ kind: "tempo", qps, text });
       else if (text.toLowerCase() === "fine") out.push({ kind: "marker", subtype: "fine", label: "Fine" });
       else out.push({ kind: "expression", text, italic: italic || undefined });
@@ -3683,13 +3715,11 @@ const parseMusicXmlPitchToMidi = (note: Element): number | null => {
 };
 
 const parseMusicXmlTieFlags = (note: Element): { tieStart: boolean; tieStop: boolean } => {
-  const hasStart =
-    note.querySelector(':scope > tie[type="start"]') !== null
-    || note.querySelector(':scope > notations > tied[type="start"]') !== null;
-  const hasStop =
-    note.querySelector(':scope > tie[type="stop"]') !== null
-    || note.querySelector(':scope > notations > tied[type="stop"]') !== null;
-  return { tieStart: hasStart, tieStop: hasStop };
+  const tie = extractMusicXmlTieState(note);
+  return {
+    tieStart: tie.tieStart || tie.tiedStart,
+    tieStop: tie.tieStop || tie.tiedStop,
+  };
 };
 
 const parseMusicXmlAccidentalSubtype = (note: Element): string | null => {
@@ -3706,13 +3736,10 @@ const parseMusicXmlAccidentalSubtype = (note: Element): string | null => {
 const parseMusicXmlSlurNumbers = (note: Element): { starts: number[]; stops: number[] } => {
   const starts: number[] = [];
   const stops: number[] = [];
-  for (const slur of Array.from(note.querySelectorAll(":scope > notations > slur[type]"))) {
-    const type = (slur.getAttribute("type") ?? "").trim().toLowerCase();
-    const rawNumber = (slur.getAttribute("number") ?? "").trim();
-    const number = Number(rawNumber);
-    const normalized = Number.isFinite(number) && number > 0 ? Math.round(number) : 1;
-    if (type === "start") starts.push(normalized);
-    if (type === "stop") stops.push(normalized);
+  for (const slur of extractMusicXmlSlurFeatures(note)) {
+    const normalized = slur.number ?? 1;
+    if (slur.type === "start") starts.push(normalized);
+    if (slur.type === "stop") stops.push(normalized);
   }
   return { starts, stops };
 };
@@ -3733,7 +3760,7 @@ const parseMusicXmlTrillNumbers = (note: Element): { starts: number[]; stops: nu
 
 const hasMusicXmlTrillMarkOnly = (note: Element, trill: { starts: number[]; stops: number[] }): boolean => {
   if (trill.starts.length > 0 || trill.stops.length > 0) return false;
-  return note.querySelector(":scope > notations > ornaments > trill-mark") !== null;
+  return extractMusicXmlOrnamentFeatures(note).some((feature) => feature.kind === "trill-mark");
 };
 
 const parseMusicXmlTupletTimeModification = (
@@ -3771,11 +3798,10 @@ const mergeUniqueNumbers = (base: number[] | undefined, incoming: number[]): num
 
 const parseMusicXmlArticulationSubtypes = (note: Element): string[] => {
   const out = new Set<string>();
-  for (const node of Array.from(note.querySelectorAll(":scope > notations > articulations > *"))) {
-    const tag = node.tagName.toLowerCase();
-    if (tag === "staccato") out.add("articStaccatoAbove");
-    if (tag === "accent") out.add("articAccentAbove");
-    if (tag === "tenuto") out.add("articTenutoAbove");
+  for (const kind of extractMusicXmlArticulationKinds(note)) {
+    if (kind === "staccato") out.add("articStaccatoAbove");
+    if (kind === "accent") out.add("articAccentAbove");
+    if (kind === "tenuto") out.add("articTenutoAbove");
   }
   for (const node of Array.from(note.querySelectorAll(":scope > notations > technical > *"))) {
     const tag = node.tagName.toLowerCase();
@@ -4062,12 +4088,11 @@ const parseMusicXmlDirectionMarkPayload = (
 const parseMusicXmlMidBarlineRepeatMarks = (
   barline: Element
 ): Partial<MusePendingDirectionMarks> | null => {
-  const location = (barline.getAttribute("location") ?? "").trim().toLowerCase();
-  if (location !== "middle") return null;
+  const feature = extractMusicXmlBarlineFeature(barline);
+  if (feature.location !== "middle") return null;
   let repeatForwardCount = 0;
   let repeatBackwardCount = 0;
-  for (const repeat of Array.from(barline.querySelectorAll(":scope > repeat[direction]"))) {
-    const direction = (repeat.getAttribute("direction") ?? "").trim().toLowerCase();
+  for (const direction of feature.repeats ?? []) {
     if (direction === "forward") repeatForwardCount += 1;
     if (direction === "backward") repeatBackwardCount += 1;
   }

--- a/src/ts/score-features/articulations.ts
+++ b/src/ts/score-features/articulations.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 Toshiki Iga
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export const ARTICULATION_KINDS = [
+  "staccato",
+  "staccatissimo",
+  "accent",
+  "tenuto",
+  "strong-accent",
+  "breath-mark",
+  "caesura",
+] as const;
+
+export type ArticulationKind = typeof ARTICULATION_KINDS[number];
+
+const ARTICULATION_KIND_SET = new Set<string>(ARTICULATION_KINDS);
+
+export const normalizeArticulationKind = (raw: string): ArticulationKind | null => {
+  const normalized = String(raw ?? "").trim().toLowerCase();
+  return ARTICULATION_KIND_SET.has(normalized) ? normalized as ArticulationKind : null;
+};
+
+export const buildMusicXmlArticulationItemsXml = (kinds: Iterable<ArticulationKind>): string => {
+  const unique = Array.from(new Set(kinds));
+  return unique.map((kind) => `<${kind}/>`).join("");
+};
+
+export const buildMusicXmlArticulationsXml = (kinds: Iterable<ArticulationKind>): string => {
+  const itemsXml = buildMusicXmlArticulationItemsXml(kinds);
+  return itemsXml ? `<articulations>${itemsXml}</articulations>` : "";
+};
+
+export const extractMusicXmlArticulationKinds = (note: Element): ArticulationKind[] => {
+  const out: ArticulationKind[] = [];
+  for (const node of Array.from(note.querySelectorAll(":scope > notations > articulations > *"))) {
+    const kind = normalizeArticulationKind(node.tagName);
+    if (kind) out.push(kind);
+  }
+  return Array.from(new Set(out));
+};

--- a/src/ts/score-features/barlines.ts
+++ b/src/ts/score-features/barlines.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2026 Toshiki Iga
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export type BarlineLocation = "left" | "right" | "middle";
+export type RepeatDirection = "forward" | "backward";
+export type EndingType = "start" | "stop" | "discontinue";
+
+export type BarlineFeature = {
+  location?: BarlineLocation;
+  barStyle?: string;
+  repeats?: RepeatDirection[];
+  ending?: {
+    number: string | number;
+    type: EndingType;
+  };
+};
+
+const xmlEscape = (value: string): string =>
+  String(value ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+
+const normalizeLocation = (raw: string | null | undefined): BarlineLocation | undefined => {
+  const normalized = String(raw ?? "").trim().toLowerCase();
+  return normalized === "left" || normalized === "right" || normalized === "middle" ? normalized : undefined;
+};
+
+const normalizeRepeatDirection = (raw: string | null | undefined): RepeatDirection | null => {
+  const normalized = String(raw ?? "").trim().toLowerCase();
+  return normalized === "forward" || normalized === "backward" ? normalized : null;
+};
+
+const normalizeEndingType = (raw: string | null | undefined): EndingType | null => {
+  const normalized = String(raw ?? "").trim().toLowerCase();
+  return normalized === "start" || normalized === "stop" || normalized === "discontinue" ? normalized : null;
+};
+
+export const buildMusicXmlBarlineXml = (feature: BarlineFeature): string => {
+  const locationAttr = feature.location ? ` location="${feature.location}"` : "";
+  const parts: string[] = [];
+  if (feature.barStyle) parts.push(`<bar-style>${xmlEscape(feature.barStyle)}</bar-style>`);
+  for (const repeat of feature.repeats ?? []) {
+    parts.push(`<repeat direction="${repeat}"/>`);
+  }
+  if (feature.ending) {
+    parts.push(`<ending number="${xmlEscape(String(feature.ending.number))}" type="${feature.ending.type}"/>`);
+  }
+  return parts.length ? `<barline${locationAttr}>${parts.join("")}</barline>` : "";
+};
+
+export const extractMusicXmlBarlineFeature = (barline: Element): BarlineFeature => {
+  const repeats: RepeatDirection[] = [];
+  for (const repeat of Array.from(barline.querySelectorAll(":scope > repeat[direction]"))) {
+    const direction = normalizeRepeatDirection(repeat.getAttribute("direction"));
+    if (direction) repeats.push(direction);
+  }
+  const endingNode = barline.querySelector(":scope > ending[type]");
+  const endingType = normalizeEndingType(endingNode?.getAttribute("type"));
+  const endingNumber = endingNode?.getAttribute("number")?.trim() || "";
+  return {
+    ...(normalizeLocation(barline.getAttribute("location")) ? { location: normalizeLocation(barline.getAttribute("location")) } : {}),
+    ...((barline.querySelector(":scope > bar-style")?.textContent ?? "").trim()
+      ? { barStyle: (barline.querySelector(":scope > bar-style")?.textContent ?? "").trim() }
+      : {}),
+    ...(repeats.length ? { repeats } : {}),
+    ...(endingNode && endingType && endingNumber ? { ending: { number: endingNumber, type: endingType } } : {}),
+  };
+};

--- a/src/ts/score-features/direction-text.ts
+++ b/src/ts/score-features/direction-text.ts
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2026 Toshiki Iga
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export type DirectionPlacement = "above" | "below";
+export type DirectionFontStyle = "italic" | "normal";
+
+export type DirectionWordsFeature = {
+  text: string;
+  placement?: DirectionPlacement;
+  fontStyle?: DirectionFontStyle;
+  tempoBpm?: number;
+  offsetDiv?: number;
+  voice?: string;
+  staff?: string | number;
+};
+
+export type DirectionTempoFeature = {
+  bpm: number;
+  text?: string;
+  placement?: DirectionPlacement;
+  offsetDiv?: number;
+  voice?: string;
+  staff?: string | number;
+  includeQuarterMetronome?: boolean;
+};
+
+const xmlEscape = (value: string): string =>
+  String(value ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+
+const positiveRounded = (value: unknown): number | null => {
+  const n = Number(value);
+  if (!Number.isFinite(n) || n <= 0) return null;
+  return Math.round(n);
+};
+
+const normalizePlacement = (value: string | null | undefined): DirectionPlacement | undefined => {
+  const normalized = String(value ?? "").trim().toLowerCase();
+  return normalized === "above" || normalized === "below" ? normalized : undefined;
+};
+
+const normalizeFontStyle = (value: string | null | undefined): DirectionFontStyle | undefined => {
+  const normalized = String(value ?? "").trim().toLowerCase();
+  return normalized === "italic" || normalized === "normal" ? normalized : undefined;
+};
+
+const directionTailXml = (feature: { offsetDiv?: number; voice?: string; staff?: string | number }): string => {
+  const offset = positiveRounded(feature.offsetDiv);
+  const offsetXml = offset === null ? "" : `<offset>${offset}</offset>`;
+  const voiceXml = feature.voice ? `<voice>${xmlEscape(feature.voice)}</voice>` : "";
+  const staffXml = feature.staff == null || String(feature.staff).trim() === ""
+    ? ""
+    : `<staff>${xmlEscape(String(feature.staff))}</staff>`;
+  return `${offsetXml}${voiceXml}${staffXml}`;
+};
+
+export const normalizeTempoBpm = (raw: unknown): number | null => {
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0) return null;
+  return n;
+};
+
+export const formatTempoBpm = (bpm: number): string => {
+  const normalized = normalizeTempoBpm(bpm);
+  if (normalized === null) return "";
+  return Number.isInteger(normalized)
+    ? String(Math.round(normalized))
+    : normalized.toFixed(2).replace(/\.00$/, "").replace(/(\.\d)0$/, "$1");
+};
+
+export const buildMusicXmlWordsDirectionXml = (feature: DirectionWordsFeature): string => {
+  const text = String(feature.text ?? "").trim();
+  if (!text) return "";
+  const placementAttr = feature.placement ? ` placement="${feature.placement}"` : "";
+  const fontStyleAttr = feature.fontStyle ? ` font-style="${feature.fontStyle}"` : "";
+  const tempo = normalizeTempoBpm(feature.tempoBpm);
+  const soundXml = tempo === null ? "" : `<sound tempo="${formatTempoBpm(tempo)}"/>`;
+  return `<direction${placementAttr}><direction-type><words${fontStyleAttr}>${xmlEscape(text)}</words></direction-type>${directionTailXml(feature)}${soundXml}</direction>`;
+};
+
+export const buildMusicXmlTempoDirectionXml = (feature: DirectionTempoFeature): string => {
+  const tempo = normalizeTempoBpm(feature.bpm);
+  if (tempo === null) return "";
+  const placementAttr = feature.placement ? ` placement="${feature.placement}"` : "";
+  const text = String(feature.text ?? "").trim();
+  const directionTypes: string[] = [];
+  if (text) directionTypes.push(`<direction-type><words>${xmlEscape(text)}</words></direction-type>`);
+  if (feature.includeQuarterMetronome) {
+    directionTypes.push(
+      `<direction-type><metronome><beat-unit>quarter</beat-unit><per-minute>${formatTempoBpm(tempo)}</per-minute></metronome></direction-type>`
+    );
+  }
+  const directionTypeXml = directionTypes.join("");
+  return `<direction${placementAttr}>${directionTypeXml}${directionTailXml(feature)}<sound tempo="${formatTempoBpm(tempo)}"/></direction>`;
+};
+
+export const extractMusicXmlDirectionWords = (
+  direction: Element
+): Array<{ text: string; fontStyle?: DirectionFontStyle }> => {
+  const out: Array<{ text: string; fontStyle?: DirectionFontStyle }> = [];
+  for (const words of Array.from(direction.querySelectorAll(":scope > direction-type > words"))) {
+    const text = (words.textContent ?? "").trim();
+    if (!text) continue;
+    const fontStyle = normalizeFontStyle(words.getAttribute("font-style"));
+    out.push({ text, ...(fontStyle ? { fontStyle } : {}) });
+  }
+  return out;
+};
+
+export const extractMusicXmlSoundTempoBpm = (directionOrMeasure: Element): number | null => {
+  const tempoText = directionOrMeasure.matches("sound")
+    ? directionOrMeasure.getAttribute("tempo")
+    : directionOrMeasure.querySelector(":scope > sound")?.getAttribute("tempo");
+  return normalizeTempoBpm(tempoText ?? "");
+};
+
+export const extractMusicXmlDirectionPlacement = (direction: Element): DirectionPlacement | undefined =>
+  normalizePlacement(direction.getAttribute("placement"));

--- a/src/ts/score-features/dynamics.ts
+++ b/src/ts/score-features/dynamics.ts
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2026 Toshiki Iga
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export const DYNAMIC_MARKS = [
+  "pppp",
+  "ppp",
+  "pp",
+  "p",
+  "mp",
+  "mf",
+  "f",
+  "ff",
+  "fff",
+  "ffff",
+  "fp",
+  "fz",
+  "sffz",
+  "rf",
+  "sf",
+  "sfp",
+  "sfz",
+  "rfz",
+] as const;
+
+export type DynamicMark = typeof DYNAMIC_MARKS[number];
+export type WedgeType = "crescendo" | "diminuendo" | "stop";
+export type DirectionPlacement = "above" | "below";
+
+export type DynamicFeature =
+  | {
+    kind: "dynamic";
+    mark: DynamicMark;
+    offsetDiv?: number;
+    voice?: string;
+    staff?: string | number;
+    placement?: DirectionPlacement;
+  }
+  | {
+    kind: "wedge";
+    wedgeType: WedgeType;
+    number?: string;
+    offsetDiv?: number;
+    voice?: string;
+    staff?: string | number;
+    placement?: DirectionPlacement;
+  };
+
+const DYNAMIC_MARK_SET = new Set<string>(DYNAMIC_MARKS);
+
+const xmlEscape = (value: string): string =>
+  String(value ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+
+const positiveRounded = (value: unknown): number | null => {
+  const n = Number(value);
+  if (!Number.isFinite(n) || n <= 0) return null;
+  return Math.round(n);
+};
+
+const normalizePlacement = (value: string | null | undefined): DirectionPlacement | undefined => {
+  const normalized = String(value ?? "").trim().toLowerCase();
+  return normalized === "above" || normalized === "below" ? normalized : undefined;
+};
+
+export const normalizeDynamicMark = (raw: string): DynamicMark | null => {
+  const normalized = String(raw ?? "").trim().toLowerCase();
+  return DYNAMIC_MARK_SET.has(normalized) ? normalized as DynamicMark : null;
+};
+
+export const velocityToDynamicMark = (velocity: number): DynamicMark => {
+  const v = Math.max(1, Math.min(127, Math.round(Number.isFinite(velocity) ? velocity : 64)));
+  if (v <= 15) return "ppp";
+  if (v <= 31) return "pp";
+  if (v <= 47) return "p";
+  if (v <= 63) return "mp";
+  if (v <= 79) return "mf";
+  if (v <= 95) return "f";
+  if (v <= 111) return "ff";
+  return "fff";
+};
+
+export const buildMusicXmlDirectionFeatureXml = (feature: DynamicFeature): string => {
+  const placementAttr = feature.placement ? ` placement="${feature.placement}"` : "";
+  const offset = positiveRounded(feature.offsetDiv);
+  const offsetXml = offset === null ? "" : `<offset>${offset}</offset>`;
+  const voiceXml = feature.voice ? `<voice>${xmlEscape(feature.voice)}</voice>` : "";
+  const staffXml = feature.staff == null || String(feature.staff).trim() === ""
+    ? ""
+    : `<staff>${xmlEscape(String(feature.staff))}</staff>`;
+
+  const directionType = feature.kind === "dynamic"
+    ? `<dynamics><${feature.mark}/></dynamics>`
+    : `<wedge type="${feature.wedgeType}"${feature.number ? ` number="${xmlEscape(feature.number)}"` : ""}/>`;
+
+  return `<direction${placementAttr}><direction-type>${directionType}</direction-type>${offsetXml}${voiceXml}${staffXml}</direction>`;
+};
+
+export const extractMusicXmlDirectionFeatures = (direction: Element): DynamicFeature[] => {
+  const offset = positiveRounded(direction.querySelector(":scope > offset")?.textContent ?? "");
+  const voice = direction.querySelector(":scope > voice")?.textContent?.trim() || undefined;
+  const staff = direction.querySelector(":scope > staff")?.textContent?.trim() || undefined;
+  const placement = normalizePlacement(direction.getAttribute("placement"));
+  const common = {
+    ...(offset === null ? {} : { offsetDiv: offset }),
+    ...(voice ? { voice } : {}),
+    ...(staff ? { staff } : {}),
+    ...(placement ? { placement } : {}),
+  };
+  const features: DynamicFeature[] = [];
+
+  for (const node of Array.from(direction.querySelectorAll(":scope > direction-type > dynamics > *"))) {
+    const mark = normalizeDynamicMark(node.tagName);
+    if (mark) features.push({ kind: "dynamic", mark, ...common });
+  }
+
+  for (const wedge of Array.from(direction.querySelectorAll(":scope > direction-type > wedge"))) {
+    const rawType = (wedge.getAttribute("type") ?? "").trim().toLowerCase();
+    if (rawType !== "crescendo" && rawType !== "diminuendo" && rawType !== "stop") continue;
+    const number = wedge.getAttribute("number")?.trim() || undefined;
+    features.push({
+      kind: "wedge",
+      wedgeType: rawType,
+      ...(number ? { number } : {}),
+      ...common,
+    });
+  }
+
+  return features;
+};

--- a/src/ts/score-features/ornaments.ts
+++ b/src/ts/score-features/ornaments.ts
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2026 Toshiki Iga
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export const ORNAMENT_KINDS = [
+  "trill-mark",
+  "turn",
+  "inverted-turn",
+  "delayed-turn",
+  "mordent",
+  "inverted-mordent",
+  "shake",
+  "schleifer",
+] as const;
+
+export type OrnamentKind = typeof ORNAMENT_KINDS[number];
+export type TremoloType = "single" | "start" | "stop";
+
+export type OrnamentFeature =
+  | {
+    kind: OrnamentKind;
+    slash?: boolean;
+  }
+  | {
+    kind: "tremolo";
+    tremoloType?: TremoloType;
+    marks?: number;
+  };
+
+const ORNAMENT_KIND_SET = new Set<string>(ORNAMENT_KINDS);
+
+const xmlEscape = (value: string): string =>
+  String(value ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+
+const normalizeTremoloType = (raw: string | null | undefined): TremoloType | undefined => {
+  const normalized = String(raw ?? "").trim().toLowerCase();
+  return normalized === "single" || normalized === "start" || normalized === "stop" ? normalized : undefined;
+};
+
+const normalizeTremoloMarks = (raw: unknown): number | undefined => {
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) return undefined;
+  return Math.max(1, Math.min(8, Math.round(parsed)));
+};
+
+export const normalizeOrnamentKind = (raw: string): OrnamentKind | null => {
+  const normalized = String(raw ?? "").trim().toLowerCase();
+  return ORNAMENT_KIND_SET.has(normalized) ? normalized as OrnamentKind : null;
+};
+
+export const buildMusicXmlOrnamentItemsXml = (features: Iterable<OrnamentFeature>): string => {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const feature of features) {
+    if (feature.kind === "tremolo") {
+      const typeAttr = feature.tremoloType ? ` type="${feature.tremoloType}"` : "";
+      const marks = normalizeTremoloMarks(feature.marks) ?? 1;
+      const key = `tremolo:${feature.tremoloType ?? ""}:${marks}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      out.push(`<tremolo${typeAttr}>${marks}</tremolo>`);
+      continue;
+    }
+    const slashAttr = (feature.kind === "turn" || feature.kind === "inverted-turn") && feature.slash
+      ? ' slash="yes"'
+      : "";
+    const key = `${feature.kind}:${slashAttr}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(`<${xmlEscape(feature.kind)}${slashAttr}/>`);
+  }
+  return out.join("");
+};
+
+export const buildMusicXmlOrnamentsXml = (features: Iterable<OrnamentFeature>): string => {
+  const itemsXml = buildMusicXmlOrnamentItemsXml(features);
+  return itemsXml ? `<ornaments>${itemsXml}</ornaments>` : "";
+};
+
+export const extractMusicXmlOrnamentFeatures = (note: Element): OrnamentFeature[] => {
+  const out: OrnamentFeature[] = [];
+  const seen = new Set<string>();
+  for (const node of Array.from(note.querySelectorAll(":scope > notations > ornaments > *"))) {
+    const tag = node.tagName.toLowerCase();
+    if (tag === "tremolo") {
+      const tremoloType = normalizeTremoloType(node.getAttribute("type"));
+      const marks = normalizeTremoloMarks(node.textContent?.trim());
+      const key = `tremolo:${tremoloType ?? ""}:${marks ?? ""}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      out.push({ kind: "tremolo", ...(tremoloType ? { tremoloType } : {}), ...(marks ? { marks } : {}) });
+      continue;
+    }
+    const kind = normalizeOrnamentKind(tag);
+    if (!kind) continue;
+    const slash = (kind === "turn" || kind === "inverted-turn")
+      && (node.getAttribute("slash") || "").trim().toLowerCase() === "yes";
+    const key = `${kind}:${slash}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push({ kind, ...(slash ? { slash } : {}) });
+  }
+  return out;
+};

--- a/src/ts/score-features/slurs.ts
+++ b/src/ts/score-features/slurs.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026 Toshiki Iga
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export type SlurType = "start" | "stop";
+export type SlurPlacement = "above" | "below";
+
+export type SlurFeature = {
+  type: SlurType;
+  number?: number;
+  placement?: SlurPlacement;
+};
+
+const normalizeSlurType = (raw: string | null | undefined): SlurType | null => {
+  const normalized = String(raw ?? "").trim().toLowerCase();
+  return normalized === "start" || normalized === "stop" ? normalized : null;
+};
+
+const normalizeSlurPlacement = (raw: string | null | undefined): SlurPlacement | undefined => {
+  const normalized = String(raw ?? "").trim().toLowerCase();
+  return normalized === "above" || normalized === "below" ? normalized : undefined;
+};
+
+const positiveRounded = (raw: unknown): number | undefined => {
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) return undefined;
+  return Math.round(parsed);
+};
+
+export const buildMusicXmlSlurXml = (feature: SlurFeature): string => {
+  const numberAttr = feature.number && feature.number > 0 ? ` number="${Math.round(feature.number)}"` : "";
+  const placementAttr = feature.type === "start" && feature.placement ? ` placement="${feature.placement}"` : "";
+  return `<slur type="${feature.type}"${numberAttr}${placementAttr}/>`;
+};
+
+export const buildMusicXmlSlursXml = (features: Iterable<SlurFeature>): string =>
+  Array.from(features).map(buildMusicXmlSlurXml).join("");
+
+export const extractMusicXmlSlurFeatures = (note: Element): SlurFeature[] => {
+  const out: SlurFeature[] = [];
+  for (const slur of Array.from(note.querySelectorAll(":scope > notations > slur[type]"))) {
+    const type = normalizeSlurType(slur.getAttribute("type"));
+    if (!type) continue;
+    const number = positiveRounded(slur.getAttribute("number"));
+    const placement = normalizeSlurPlacement(slur.getAttribute("placement"));
+    out.push({
+      type,
+      ...(number ? { number } : {}),
+      ...(type === "start" && placement ? { placement } : {}),
+    });
+  }
+  return out;
+};

--- a/src/ts/score-features/ties.ts
+++ b/src/ts/score-features/ties.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 Toshiki Iga
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export type TieType = "start" | "stop";
+
+export type TieState = {
+  tieStart: boolean;
+  tieStop: boolean;
+  tiedStart: boolean;
+  tiedStop: boolean;
+};
+
+const normalizeTieType = (raw: string | null | undefined): TieType | null => {
+  const normalized = String(raw ?? "").trim().toLowerCase();
+  return normalized === "start" || normalized === "stop" ? normalized : null;
+};
+
+export const buildMusicXmlTieItemsXml = (state: Pick<TieState, "tieStart" | "tieStop">): string =>
+  `${state.tieStop ? '<tie type="stop"/>' : ""}${state.tieStart ? '<tie type="start"/>' : ""}`;
+
+export const buildMusicXmlTiedItemsXml = (state: Pick<TieState, "tiedStart" | "tiedStop">): string =>
+  `${state.tiedStop ? '<tied type="stop"/>' : ""}${state.tiedStart ? '<tied type="start"/>' : ""}`;
+
+export const extractMusicXmlTieState = (note: Element): TieState => {
+  const state: TieState = {
+    tieStart: false,
+    tieStop: false,
+    tiedStart: false,
+    tiedStop: false,
+  };
+  for (const tie of Array.from(note.querySelectorAll(":scope > tie[type]"))) {
+    const type = normalizeTieType(tie.getAttribute("type"));
+    if (type === "start") state.tieStart = true;
+    if (type === "stop") state.tieStop = true;
+  }
+  for (const tied of Array.from(note.querySelectorAll(":scope > notations > tied[type]"))) {
+    const type = normalizeTieType(tied.getAttribute("type"));
+    if (type === "start") state.tiedStart = true;
+    if (type === "stop") state.tiedStop = true;
+  }
+  return state;
+};

--- a/tests/unit/score-articulations.spec.ts
+++ b/tests/unit/score-articulations.spec.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026 Toshiki Iga
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// @vitest-environment jsdom
+import { describe, expect, it } from "vitest";
+import {
+  buildMusicXmlArticulationItemsXml,
+  buildMusicXmlArticulationsXml,
+  extractMusicXmlArticulationKinds,
+  normalizeArticulationKind,
+} from "../../src/ts/score-features/articulations";
+
+const parseNote = (articulationsXml: string): Element => {
+  const doc = new DOMParser().parseFromString(
+    `<note><notations>${articulationsXml}</notations></note>`,
+    "application/xml"
+  );
+  const note = doc.querySelector("note");
+  expect(note).not.toBeNull();
+  if (!note) throw new Error("Missing note fixture.");
+  return note;
+};
+
+describe("score articulations feature model", () => {
+  it("normalizes supported articulation kinds", () => {
+    expect(normalizeArticulationKind("Accent")).toBe("accent");
+    expect(normalizeArticulationKind("breath-mark")).toBe("breath-mark");
+    expect(normalizeArticulationKind("trill-mark")).toBeNull();
+  });
+
+  it("builds MusicXML articulations with stable deduplication", () => {
+    expect(buildMusicXmlArticulationItemsXml(["staccato", "accent", "staccato"])).toBe(
+      "<staccato/><accent/>"
+    );
+    expect(buildMusicXmlArticulationsXml(["staccato", "accent", "staccato"])).toBe(
+      "<articulations><staccato/><accent/></articulations>"
+    );
+  });
+
+  it("extracts supported MusicXML articulation kinds", () => {
+    const note = parseNote("<articulations><staccato/><accent/><caesura/><other-articulation>x</other-articulation></articulations>");
+    expect(extractMusicXmlArticulationKinds(note)).toEqual(["staccato", "accent", "caesura"]);
+  });
+});

--- a/tests/unit/score-barlines.spec.ts
+++ b/tests/unit/score-barlines.spec.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026 Toshiki Iga
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// @vitest-environment jsdom
+import { describe, expect, it } from "vitest";
+import {
+  buildMusicXmlBarlineXml,
+  extractMusicXmlBarlineFeature,
+} from "../../src/ts/score-features/barlines";
+
+const parseBarline = (xml: string): Element => {
+  const doc = new DOMParser().parseFromString(`<root>${xml}</root>`, "application/xml");
+  const barline = doc.querySelector("barline");
+  expect(barline).not.toBeNull();
+  if (!barline) throw new Error("Missing barline fixture.");
+  return barline;
+};
+
+describe("score barlines feature model", () => {
+  it("builds MusicXML barline features", () => {
+    expect(buildMusicXmlBarlineXml({
+      location: "right",
+      barStyle: "light-heavy",
+      repeats: ["backward"],
+      ending: { number: 2, type: "stop" },
+    })).toBe(
+      '<barline location="right"><bar-style>light-heavy</bar-style><repeat direction="backward"/><ending number="2" type="stop"/></barline>'
+    );
+  });
+
+  it("extracts MusicXML barline features", () => {
+    const barline = parseBarline(
+      '<barline location="middle"><bar-style>light-heavy</bar-style><repeat direction="backward"/><repeat direction="forward"/></barline>'
+    );
+    expect(extractMusicXmlBarlineFeature(barline)).toEqual({
+      location: "middle",
+      barStyle: "light-heavy",
+      repeats: ["backward", "forward"],
+    });
+  });
+});

--- a/tests/unit/score-direction-text.spec.ts
+++ b/tests/unit/score-direction-text.spec.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026 Toshiki Iga
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// @vitest-environment jsdom
+import { describe, expect, it } from "vitest";
+import {
+  buildMusicXmlTempoDirectionXml,
+  buildMusicXmlWordsDirectionXml,
+  extractMusicXmlDirectionPlacement,
+  extractMusicXmlDirectionWords,
+  extractMusicXmlSoundTempoBpm,
+  formatTempoBpm,
+} from "../../src/ts/score-features/direction-text";
+
+const parseDirection = (xml: string): Element => {
+  const doc = new DOMParser().parseFromString(`<root>${xml}</root>`, "application/xml");
+  const direction = doc.querySelector("direction");
+  expect(direction).not.toBeNull();
+  if (!direction) throw new Error("Missing direction fixture.");
+  return direction;
+};
+
+describe("score direction text feature model", () => {
+  it("formats tempo bpm values", () => {
+    expect(formatTempoBpm(120)).toBe("120");
+    expect(formatTempoBpm(116.5)).toBe("116.5");
+  });
+
+  it("builds and extracts MusicXML words directions", () => {
+    const xml = buildMusicXmlWordsDirectionXml({
+      text: "sempre legato",
+      placement: "above",
+      fontStyle: "italic",
+      tempoBpm: 96,
+    });
+    expect(xml).toBe(
+      '<direction placement="above"><direction-type><words font-style="italic">sempre legato</words></direction-type><sound tempo="96"/></direction>'
+    );
+    const direction = parseDirection(xml);
+    expect(extractMusicXmlDirectionPlacement(direction)).toBe("above");
+    expect(extractMusicXmlDirectionWords(direction)).toEqual([{ text: "sempre legato", fontStyle: "italic" }]);
+    expect(extractMusicXmlSoundTempoBpm(direction)).toBe(96);
+  });
+
+  it("builds MusicXML tempo directions with optional quarter metronome", () => {
+    expect(buildMusicXmlTempoDirectionXml({ bpm: 132, includeQuarterMetronome: true })).toBe(
+      '<direction><direction-type><metronome><beat-unit>quarter</beat-unit><per-minute>132</per-minute></metronome></direction-type><sound tempo="132"/></direction>'
+    );
+  });
+});

--- a/tests/unit/score-dynamics.spec.ts
+++ b/tests/unit/score-dynamics.spec.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2026 Toshiki Iga
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// @vitest-environment jsdom
+import { describe, expect, it } from "vitest";
+import {
+  buildMusicXmlDirectionFeatureXml,
+  extractMusicXmlDirectionFeatures,
+  normalizeDynamicMark,
+  velocityToDynamicMark,
+} from "../../src/ts/score-features/dynamics";
+
+const parseDirection = (xml: string): Element => {
+  const doc = new DOMParser().parseFromString(`<root>${xml}</root>`, "application/xml");
+  const direction = doc.querySelector("direction");
+  expect(direction).not.toBeNull();
+  if (!direction) throw new Error("Missing direction fixture.");
+  return direction;
+};
+
+describe("score dynamics feature model", () => {
+  it("normalizes supported dynamic marks", () => {
+    expect(normalizeDynamicMark("MF")).toBe("mf");
+    expect(normalizeDynamicMark(" sfz ")).toBe("sfz");
+    expect(normalizeDynamicMark("unknown")).toBeNull();
+  });
+
+  it("maps MIDI velocity bands to dynamic marks", () => {
+    expect(velocityToDynamicMark(1)).toBe("ppp");
+    expect(velocityToDynamicMark(64)).toBe("mf");
+    expect(velocityToDynamicMark(127)).toBe("fff");
+  });
+
+  it("builds and extracts MusicXML dynamic directions", () => {
+    const xml = buildMusicXmlDirectionFeatureXml({
+      kind: "dynamic",
+      mark: "mf",
+      offsetDiv: 12,
+      voice: "1",
+      staff: 2,
+      placement: "below",
+    });
+    expect(xml).toBe(
+      '<direction placement="below"><direction-type><dynamics><mf/></dynamics></direction-type><offset>12</offset><voice>1</voice><staff>2</staff></direction>'
+    );
+    expect(extractMusicXmlDirectionFeatures(parseDirection(xml))).toEqual([
+      {
+        kind: "dynamic",
+        mark: "mf",
+        offsetDiv: 12,
+        voice: "1",
+        staff: "2",
+        placement: "below",
+      },
+    ]);
+  });
+
+  it("builds and extracts MusicXML wedge directions", () => {
+    const xml = buildMusicXmlDirectionFeatureXml({
+      kind: "wedge",
+      wedgeType: "crescendo",
+      number: "2",
+      offsetDiv: 4,
+      staff: 1,
+    });
+    expect(xml).toBe(
+      '<direction><direction-type><wedge type="crescendo" number="2"/></direction-type><offset>4</offset><staff>1</staff></direction>'
+    );
+    expect(extractMusicXmlDirectionFeatures(parseDirection(xml))).toEqual([
+      {
+        kind: "wedge",
+        wedgeType: "crescendo",
+        number: "2",
+        offsetDiv: 4,
+        staff: "1",
+      },
+    ]);
+  });
+});

--- a/tests/unit/score-ornaments.spec.ts
+++ b/tests/unit/score-ornaments.spec.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 Toshiki Iga
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// @vitest-environment jsdom
+import { describe, expect, it } from "vitest";
+import {
+  buildMusicXmlOrnamentItemsXml,
+  buildMusicXmlOrnamentsXml,
+  extractMusicXmlOrnamentFeatures,
+  normalizeOrnamentKind,
+} from "../../src/ts/score-features/ornaments";
+
+const parseNote = (ornamentsXml: string): Element => {
+  const doc = new DOMParser().parseFromString(
+    `<note><notations>${ornamentsXml}</notations></note>`,
+    "application/xml"
+  );
+  const note = doc.querySelector("note");
+  expect(note).not.toBeNull();
+  if (!note) throw new Error("Missing note fixture.");
+  return note;
+};
+
+describe("score ornaments feature model", () => {
+  it("normalizes supported ornament kinds", () => {
+    expect(normalizeOrnamentKind("Trill-Mark")).toBe("trill-mark");
+    expect(normalizeOrnamentKind("inverted-mordent")).toBe("inverted-mordent");
+    expect(normalizeOrnamentKind("wavy-line")).toBeNull();
+  });
+
+  it("builds MusicXML ornament items with stable deduplication", () => {
+    expect(buildMusicXmlOrnamentItemsXml([
+      { kind: "trill-mark" },
+      { kind: "turn", slash: true },
+      { kind: "trill-mark" },
+      { kind: "tremolo", tremoloType: "single", marks: 3 },
+    ])).toBe('<trill-mark/><turn slash="yes"/><tremolo type="single">3</tremolo>');
+    expect(buildMusicXmlOrnamentsXml([{ kind: "mordent" }])).toBe("<ornaments><mordent/></ornaments>");
+  });
+
+  it("extracts supported MusicXML ornament features", () => {
+    const note = parseNote(
+      '<ornaments><trill-mark/><turn slash="yes"/><tremolo type="start">2</tremolo><wavy-line type="start"/></ornaments>'
+    );
+    expect(extractMusicXmlOrnamentFeatures(note)).toEqual([
+      { kind: "trill-mark" },
+      { kind: "turn", slash: true },
+      { kind: "tremolo", tremoloType: "start", marks: 2 },
+    ]);
+  });
+});

--- a/tests/unit/score-slurs.spec.ts
+++ b/tests/unit/score-slurs.spec.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 Toshiki Iga
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// @vitest-environment jsdom
+import { describe, expect, it } from "vitest";
+import {
+  buildMusicXmlSlurXml,
+  buildMusicXmlSlursXml,
+  extractMusicXmlSlurFeatures,
+} from "../../src/ts/score-features/slurs";
+
+const parseNote = (slursXml: string): Element => {
+  const doc = new DOMParser().parseFromString(
+    `<note><notations>${slursXml}</notations></note>`,
+    "application/xml"
+  );
+  const note = doc.querySelector("note");
+  expect(note).not.toBeNull();
+  if (!note) throw new Error("Missing note fixture.");
+  return note;
+};
+
+describe("score slurs feature model", () => {
+  it("builds MusicXML slur items", () => {
+    expect(buildMusicXmlSlurXml({ type: "start", number: 2, placement: "above" })).toBe(
+      '<slur type="start" number="2" placement="above"/>'
+    );
+    expect(buildMusicXmlSlursXml([{ type: "start" }, { type: "stop", number: 1 }])).toBe(
+      '<slur type="start"/><slur type="stop" number="1"/>'
+    );
+  });
+
+  it("extracts supported MusicXML slur features", () => {
+    const note = parseNote('<slur type="start" number="2" placement="below"/><slur type="stop" number="2"/><slur type="continue"/>');
+    expect(extractMusicXmlSlurFeatures(note)).toEqual([
+      { type: "start", number: 2, placement: "below" },
+      { type: "stop", number: 2 },
+    ]);
+  });
+});

--- a/tests/unit/score-ties.spec.ts
+++ b/tests/unit/score-ties.spec.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 Toshiki Iga
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// @vitest-environment jsdom
+import { describe, expect, it } from "vitest";
+import {
+  buildMusicXmlTieItemsXml,
+  buildMusicXmlTiedItemsXml,
+  extractMusicXmlTieState,
+} from "../../src/ts/score-features/ties";
+
+const parseNote = (xml: string): Element => {
+  const doc = new DOMParser().parseFromString(`<note>${xml}</note>`, "application/xml");
+  const note = doc.querySelector("note");
+  expect(note).not.toBeNull();
+  if (!note) throw new Error("Missing note fixture.");
+  return note;
+};
+
+describe("score ties feature model", () => {
+  it("builds MusicXML tie and tied items", () => {
+    expect(buildMusicXmlTieItemsXml({ tieStart: true, tieStop: true })).toBe(
+      '<tie type="stop"/><tie type="start"/>'
+    );
+    expect(buildMusicXmlTiedItemsXml({ tiedStart: true, tiedStop: false })).toBe('<tied type="start"/>');
+  });
+
+  it("extracts sound tie and notation tied state separately", () => {
+    const note = parseNote('<tie type="start"/><notations><tied type="stop"/></notations>');
+    expect(extractMusicXmlTieState(note)).toEqual({
+      tieStart: true,
+      tieStop: false,
+      tiedStart: false,
+      tiedStop: true,
+    });
+  });
+});


### PR DESCRIPTION
  ## 概要

  MusicXMLの繰り返し表現を扱う小さな共通モデルを追加し、ABC / MEI / LilyPond /
  MIDI / MuseScore の各I/O実装で重複していたXML生成・抽出処理の一部を共通化しま
  した。

  ## 変更内容

  - `src/ts/score-features/` に、以下のMusicXML向け機能モデルを追加
    - articulations
    - barlines
    - direction text / tempo
    - dynamics / wedge
    - ornaments
    - slurs
    - ties
  - `abc-io.ts`、`mei-io.ts`、`lilypond-io.ts`、`midi-io.ts`、`musescore-io.ts` で、該当するMusicXML生成・抽出処理を共通モデル経由に変更
  - `TODO.md` に、共通スコア機能モデルの実装済みスライスと今後の整理方針を追記
  - 追加した各機能モデルに対する単体テストを追加

  ## 確認

  - `npx vitest run tests/unit/score-articulations.spec.ts tests/unit/score- barlines.spec.ts tests/unit/score-direction-text.spec.ts tests/unit/score- dynamics.spec.ts tests/unit/score-ornaments.spec.ts tests/unit/score- slurs.spec.ts tests/unit/score-ties.spec.ts`
    - 7 files passed
    - 19 tests passed