### PR TITLE
ABC入出力処理の展開と生成物更新

### DIFF
--- a/bundle/mikuscore.mjs
+++ b/bundle/mikuscore.mjs
@@ -152361,7 +152361,7 @@ var BUNDLED_CLI_MODULES = {
       return reduceFraction(a.num * b.den, a.den * b.num, fallback);
     };
     const parseFractionText = (text, fallback = DEFAULT_UNIT) => {
-      const m = String(text || "").match(/^\s*(\d+)\/(\d+)\s*$/);
+      const m = String(text !== null && text !== void 0 ? text : "").match(/^\s*(\d+)\/(\d+)\s*$/);
       if (!m) {
         return { num: fallback.num, den: fallback.den };
       }
@@ -152372,21 +152372,21 @@ var BUNDLED_CLI_MODULES = {
       }
       return reduceFraction(num, den, fallback);
     };
-    const isAbcjsWrapperLine = (text) => /^\[\s*\/?\s*abcjs(?:-[A-Za-z0-9_-]+)?(?:\s+[^\]]*)?\]$/i.test(String(text || "").trim());
+    const isAbcjsWrapperLine = (text) => /^\[\s*\/?\s*abcjs(?:-[A-Za-z0-9_-]+)?(?:\s+[^\]]*)?\]$/i.test(String(text !== null && text !== void 0 ? text : "").trim());
     const estimateAbcMeasureContentDiv = (notes) => {
-      var _a, _b;
+      var _a, _b, _c, _d;
       const byVoice = /* @__PURE__ */ new Map();
       const lastStartByVoice = /* @__PURE__ */ new Map();
       for (const note of Array.isArray(notes) ? notes : []) {
         if (!note || note.grace)
           continue;
-        const voice = String(note.voice || "1");
-        const durationDiv = Math.max(0, Math.round(Number(note.duration) || 0));
+        const voice = String((_a = note.voice) !== null && _a !== void 0 ? _a : "1");
+        const durationDiv = Math.max(0, Math.round(Number((_b = note.duration) !== null && _b !== void 0 ? _b : 0)));
         if (durationDiv <= 0)
           continue;
-        const current = (_a = byVoice.get(voice)) !== null && _a !== void 0 ? _a : 0;
+        const current = (_c = byVoice.get(voice)) !== null && _c !== void 0 ? _c : 0;
         if (note.chord) {
-          const startDiv = (_b = lastStartByVoice.get(voice)) !== null && _b !== void 0 ? _b : current;
+          const startDiv = (_d = lastStartByVoice.get(voice)) !== null && _d !== void 0 ? _d : current;
           byVoice.set(voice, Math.max(current, startDiv + durationDiv));
           continue;
         }
@@ -152437,7 +152437,7 @@ var BUNDLED_CLI_MODULES = {
       return `${reduced.num}/${reduced.den}`;
     };
     const abcPitchFromStepOctave = (step, octave) => {
-      const upperStep = String(step || "").toUpperCase();
+      const upperStep = String(step !== null && step !== void 0 ? step : "").toUpperCase();
       if (!/^[A-G]$/.test(upperStep)) {
         return "C";
       }
@@ -152460,7 +152460,7 @@ var BUNDLED_CLI_MODULES = {
       if (idx < 0 || idx >= major.length) {
         return "C";
       }
-      const lowerMode = String(mode || "").toLowerCase();
+      const lowerMode = String(mode !== null && mode !== void 0 ? mode : "").toLowerCase();
       if (lowerMode === "minor") {
         return minor[idx];
       }
@@ -152541,9 +152541,10 @@ var BUNDLED_CLI_MODULES = {
       }
     };
     const appendAbcBodyTextEntries = (rawBodyText, lineNo, voiceId, registry, bodyEntries, splitBodyTextByInlineVoice2, splitBodyTextByOverlay2) => {
-      const normalizedBodyText = String(rawBodyText || "").replace(/\\\s*$/, "");
+      var _a;
+      const normalizedBodyText = String(rawBodyText !== null && rawBodyText !== void 0 ? rawBodyText : "").replace(/\\\s*$/, "");
       if (!normalizedBodyText.trim()) {
-        return { appended: false, finalVoiceId: String(voiceId || "1").trim() || "1" };
+        return { appended: false, finalVoiceId: String(voiceId !== null && voiceId !== void 0 ? voiceId : "1").trim() || "1" };
       }
       const { segments: inlineVoiceSegments, finalVoiceId } = splitBodyTextByInlineVoice2(normalizedBodyText, voiceId);
       for (const segment of inlineVoiceSegments) {
@@ -152563,15 +152564,16 @@ var BUNDLED_CLI_MODULES = {
           bodyEntries.push({ text: overlaySegment.text, lineNo, voiceId: overlaySegment.voiceId });
         }
       }
-      return { appended: true, finalVoiceId: String(finalVoiceId || voiceId || "1").trim() || "1" };
+      return { appended: true, finalVoiceId: String((_a = finalVoiceId !== null && finalVoiceId !== void 0 ? finalVoiceId : voiceId) !== null && _a !== void 0 ? _a : "1").trim() || "1" };
     };
     const applyAbcVoiceDirective = (value, lineNo, lineState, voiceRegistry, warnings, userDefinedDecorationBySymbol, parseVoiceDirectiveTail2, expandUserDefinedDecorationSymbols2, pushBodyText) => {
+      var _a, _b, _c;
       const m = value.match(/^(\S+)\s*(.*)$/);
       if (!m)
         return;
       lineState.currentVoiceId = m[1];
       ensureAbcDeclaredVoice(voiceRegistry, lineState.currentVoiceId);
-      const rest = m[2].trim();
+      const rest = (_b = (_a = m[2]) === null || _a === void 0 ? void 0 : _a.trim()) !== null && _b !== void 0 ? _b : "";
       const parsedVoice = parseVoiceDirectiveTail2(rest);
       if (parsedVoice.name) {
         voiceRegistry.voiceNameById[lineState.currentVoiceId] = parsedVoice.name;
@@ -152585,7 +152587,7 @@ var BUNDLED_CLI_MODULES = {
       if (parsedVoice.skippedText) {
         warnings.push("line " + lineNo + ": Skipped unsupported V: directive tail token: " + parsedVoice.skippedText);
       }
-      for (const unsupportedKey of parsedVoice.unsupportedKeys || []) {
+      for (const unsupportedKey of (_c = parsedVoice.unsupportedKeys) !== null && _c !== void 0 ? _c : []) {
         warnings.push("line " + lineNo + ": Skipped unsupported V: property: " + unsupportedKey);
       }
       if (parsedVoice.bodyText) {
@@ -152642,10 +152644,11 @@ var BUNDLED_CLI_MODULES = {
       return params;
     };
     const applyAbcTrillMeta = (params, trillWidthHintByKey) => {
-      const voiceId = String(params.voice || "").trim();
-      const measureNo = Number.parseInt(String(params.measure || ""), 10);
-      const eventNo = Number.parseInt(String(params.event || ""), 10);
-      const upper = String(params.upper || "").trim();
+      var _a, _b, _c, _d;
+      const voiceId = String((_a = params.voice) !== null && _a !== void 0 ? _a : "").trim();
+      const measureNo = Number.parseInt(String((_b = params.measure) !== null && _b !== void 0 ? _b : ""), 10);
+      const eventNo = Number.parseInt(String((_c = params.event) !== null && _c !== void 0 ? _c : ""), 10);
+      const upper = String((_d = params.upper) !== null && _d !== void 0 ? _d : "").trim();
       if (voiceId && Number.isFinite(measureNo) && measureNo > 0 && Number.isFinite(eventNo) && eventNo > 0 && upper) {
         trillWidthHintByKey.set(`${voiceId}#${measureNo}#${eventNo}`, upper);
         return true;
@@ -152653,9 +152656,10 @@ var BUNDLED_CLI_MODULES = {
       return false;
     };
     const applyAbcKeyMeta = (params, keyHintFifthsByKey) => {
-      const voiceId = String(params.voice || "").trim();
-      const measureNo = Number.parseInt(String(params.measure || ""), 10);
-      const fifths = Number.parseInt(String(params.fifths || ""), 10);
+      var _a, _b, _c;
+      const voiceId = String((_a = params.voice) !== null && _a !== void 0 ? _a : "").trim();
+      const measureNo = Number.parseInt(String((_b = params.measure) !== null && _b !== void 0 ? _b : ""), 10);
+      const fifths = Number.parseInt(String((_c = params.fifths) !== null && _c !== void 0 ? _c : ""), 10);
       if (voiceId && Number.isFinite(measureNo) && measureNo > 0 && Number.isFinite(fifths)) {
         const key = `${voiceId}#${measureNo}`;
         if (!keyHintFifthsByKey.has(key)) {
@@ -152666,19 +152670,20 @@ var BUNDLED_CLI_MODULES = {
       return false;
     };
     const applyAbcMeasureMeta = (params, measureMetaByKey) => {
-      const voiceId = String(params.voice || "").trim();
-      const measureNo = Number.parseInt(String(params.measure || ""), 10);
+      var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l;
+      const voiceId = String((_a = params.voice) !== null && _a !== void 0 ? _a : "").trim();
+      const measureNo = Number.parseInt(String((_b = params.measure) !== null && _b !== void 0 ? _b : ""), 10);
       if (!(voiceId && Number.isFinite(measureNo) && measureNo > 0))
         return false;
-      const measureNumberText = String(params.number || "").trim();
-      const implicitRaw = String(params.implicit || "").trim().toLowerCase();
-      const repeatRaw = String(params.repeat || "").trim().toLowerCase();
-      const leftRepeatRaw = String(params["left-repeat"] || "").trim().toLowerCase();
-      const rightRepeatRaw = String(params["right-repeat"] || "").trim().toLowerCase();
-      const repeatTimesRaw = Number.parseInt(String(params.times || ""), 10);
-      const endingStart = String(params["ending-start"] || "").trim();
-      const endingStop = String(params["ending-stop"] || "").trim();
-      const endingStopTypeRaw = String(params["ending-type"] || "").trim().toLowerCase();
+      const measureNumberText = String((_c = params.number) !== null && _c !== void 0 ? _c : "").trim();
+      const implicitRaw = String((_d = params.implicit) !== null && _d !== void 0 ? _d : "").trim().toLowerCase();
+      const repeatRaw = String((_e = params.repeat) !== null && _e !== void 0 ? _e : "").trim().toLowerCase();
+      const leftRepeatRaw = String((_f = params["left-repeat"]) !== null && _f !== void 0 ? _f : "").trim().toLowerCase();
+      const rightRepeatRaw = String((_g = params["right-repeat"]) !== null && _g !== void 0 ? _g : "").trim().toLowerCase();
+      const repeatTimesRaw = Number.parseInt(String((_h = params.times) !== null && _h !== void 0 ? _h : ""), 10);
+      const endingStart = String((_j = params["ending-start"]) !== null && _j !== void 0 ? _j : "").trim();
+      const endingStop = String((_k = params["ending-stop"]) !== null && _k !== void 0 ? _k : "").trim();
+      const endingStopTypeRaw = String((_l = params["ending-type"]) !== null && _l !== void 0 ? _l : "").trim().toLowerCase();
       measureMetaByKey.set(`${voiceId}#${measureNo}`, {
         number: measureNumberText || String(measureNo),
         implicit: implicitRaw === "1" || implicitRaw === "true" || implicitRaw === "yes",
@@ -152692,9 +152697,10 @@ var BUNDLED_CLI_MODULES = {
       return true;
     };
     const applyAbcTransposeMeta = (params, transposeHintByVoiceId) => {
-      const voiceId = String(params.voice || "").trim();
-      const chromatic = Number.parseInt(String(params.chromatic || ""), 10);
-      const diatonic = Number.parseInt(String(params.diatonic || ""), 10);
+      var _a, _b, _c;
+      const voiceId = String((_a = params.voice) !== null && _a !== void 0 ? _a : "").trim();
+      const chromatic = Number.parseInt(String((_b = params.chromatic) !== null && _b !== void 0 ? _b : ""), 10);
+      const diatonic = Number.parseInt(String((_c = params.diatonic) !== null && _c !== void 0 ? _c : ""), 10);
       if (!(voiceId && (Number.isFinite(chromatic) || Number.isFinite(diatonic))))
         return false;
       const metaTranspose = {};
@@ -152709,11 +152715,12 @@ var BUNDLED_CLI_MODULES = {
       return false;
     };
     const handleAbcMetaDirectiveLine = (rawTrimmed, trillWidthHintByKey, keyHintFifthsByKey, measureMetaByKey, transposeHintByVoiceId) => {
+      var _a, _b;
       const metaMatch = rawTrimmed.match(/^%@mks\s+(trill|key|measure|transpose)\s+(.+)$/i);
       if (!metaMatch)
         return false;
-      const kind = String(metaMatch[1] || "").toLowerCase();
-      const params = parseAbcMetaParams(String(metaMatch[2] || ""));
+      const kind = String((_a = metaMatch[1]) !== null && _a !== void 0 ? _a : "").toLowerCase();
+      const params = parseAbcMetaParams(String((_b = metaMatch[2]) !== null && _b !== void 0 ? _b : ""));
       if (kind === "trill")
         return applyAbcTrillMeta(params, trillWidthHintByKey);
       if (kind === "key")
@@ -152783,7 +152790,7 @@ var BUNDLED_CLI_MODULES = {
       context.pushBodyText(expandedBodyText, lineNo, context.lineState.currentVoiceId);
     };
     const buildAbcVoiceMeasureMetaByIndex = (voiceId, normalizedMeasures, keyHintFifthsByKey, notationMeasureMetaByVoice, measureMetaByKey, meterByMeasureByVoice, tempoByMeasureByVoice) => {
-      var _a, _b, _c, _d, _e, _f, _g;
+      var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p, _q, _r, _s;
       const keyByMeasure = {};
       const meterByMeasure = {};
       const tempoByMeasure = {};
@@ -152793,20 +152800,20 @@ var BUNDLED_CLI_MODULES = {
         if (Number.isFinite(hinted)) {
           keyByMeasure[m] = Number(hinted);
         }
-        const notationMeta = ((_a = notationMeasureMetaByVoice[voiceId]) === null || _a === void 0 ? void 0 : _a[m]) || null;
-        const hintedMeta = measureMetaByKey.get(`${voiceId}#${m}`) || null;
-        const meterHint = ((_b = meterByMeasureByVoice[voiceId]) === null || _b === void 0 ? void 0 : _b[m]) || null;
-        const tempoHint = ((_c = tempoByMeasureByVoice[voiceId]) === null || _c === void 0 ? void 0 : _c[m]) || null;
+        const notationMeta = (_b = (_a = notationMeasureMetaByVoice[voiceId]) === null || _a === void 0 ? void 0 : _a[m]) !== null && _b !== void 0 ? _b : null;
+        const hintedMeta = (_c = measureMetaByKey.get(`${voiceId}#${m}`)) !== null && _c !== void 0 ? _c : null;
+        const meterHint = (_e = (_d = meterByMeasureByVoice[voiceId]) === null || _d === void 0 ? void 0 : _d[m]) !== null && _e !== void 0 ? _e : null;
+        const tempoHint = (_g = (_f = tempoByMeasureByVoice[voiceId]) === null || _f === void 0 ? void 0 : _f[m]) !== null && _g !== void 0 ? _g : null;
         if (notationMeta || hintedMeta) {
           measureMetaByIndex[m] = {
             number: (hintedMeta === null || hintedMeta === void 0 ? void 0 : hintedMeta.number) || (notationMeta === null || notationMeta === void 0 ? void 0 : notationMeta.number) || String(m),
-            implicit: (_e = (_d = hintedMeta === null || hintedMeta === void 0 ? void 0 : hintedMeta.implicit) !== null && _d !== void 0 ? _d : notationMeta === null || notationMeta === void 0 ? void 0 : notationMeta.implicit) !== null && _e !== void 0 ? _e : false,
-            repeatStart: Boolean((notationMeta === null || notationMeta === void 0 ? void 0 : notationMeta.repeatStart) || (hintedMeta === null || hintedMeta === void 0 ? void 0 : hintedMeta.repeatStart)),
-            repeatEnd: Boolean((notationMeta === null || notationMeta === void 0 ? void 0 : notationMeta.repeatEnd) || (hintedMeta === null || hintedMeta === void 0 ? void 0 : hintedMeta.repeatEnd)),
-            repeatTimes: (_g = (_f = hintedMeta === null || hintedMeta === void 0 ? void 0 : hintedMeta.repeatTimes) !== null && _f !== void 0 ? _f : notationMeta === null || notationMeta === void 0 ? void 0 : notationMeta.repeatTimes) !== null && _g !== void 0 ? _g : null,
-            endingStart: String((notationMeta === null || notationMeta === void 0 ? void 0 : notationMeta.endingStart) || (hintedMeta === null || hintedMeta === void 0 ? void 0 : hintedMeta.endingStart) || ""),
-            endingStop: String((notationMeta === null || notationMeta === void 0 ? void 0 : notationMeta.endingStop) || (hintedMeta === null || hintedMeta === void 0 ? void 0 : hintedMeta.endingStop) || ""),
-            endingStopType: (hintedMeta === null || hintedMeta === void 0 ? void 0 : hintedMeta.endingStopType) || (notationMeta === null || notationMeta === void 0 ? void 0 : notationMeta.endingStopType) || ""
+            implicit: (_j = (_h = hintedMeta === null || hintedMeta === void 0 ? void 0 : hintedMeta.implicit) !== null && _h !== void 0 ? _h : notationMeta === null || notationMeta === void 0 ? void 0 : notationMeta.implicit) !== null && _j !== void 0 ? _j : false,
+            repeatStart: !!((notationMeta === null || notationMeta === void 0 ? void 0 : notationMeta.repeatStart) || (hintedMeta === null || hintedMeta === void 0 ? void 0 : hintedMeta.repeatStart)),
+            repeatEnd: !!((notationMeta === null || notationMeta === void 0 ? void 0 : notationMeta.repeatEnd) || (hintedMeta === null || hintedMeta === void 0 ? void 0 : hintedMeta.repeatEnd)),
+            repeatTimes: (_l = (_k = hintedMeta === null || hintedMeta === void 0 ? void 0 : hintedMeta.repeatTimes) !== null && _k !== void 0 ? _k : notationMeta === null || notationMeta === void 0 ? void 0 : notationMeta.repeatTimes) !== null && _l !== void 0 ? _l : null,
+            endingStart: String((_o = (_m = notationMeta === null || notationMeta === void 0 ? void 0 : notationMeta.endingStart) !== null && _m !== void 0 ? _m : hintedMeta === null || hintedMeta === void 0 ? void 0 : hintedMeta.endingStart) !== null && _o !== void 0 ? _o : ""),
+            endingStop: String((_q = (_p = notationMeta === null || notationMeta === void 0 ? void 0 : notationMeta.endingStop) !== null && _p !== void 0 ? _p : hintedMeta === null || hintedMeta === void 0 ? void 0 : hintedMeta.endingStop) !== null && _q !== void 0 ? _q : ""),
+            endingStopType: (_s = (_r = hintedMeta === null || hintedMeta === void 0 ? void 0 : hintedMeta.endingStopType) !== null && _r !== void 0 ? _r : notationMeta === null || notationMeta === void 0 ? void 0 : notationMeta.endingStopType) !== null && _s !== void 0 ? _s : ""
           };
         }
         if (meterHint) {
@@ -152822,6 +152829,7 @@ var BUNDLED_CLI_MODULES = {
       return { keyByMeasure, meterByMeasure, tempoByMeasure, measureMetaByIndex };
     };
     const buildAbcNormalizedVoiceDataById = (orderedVoiceIds, voiceRegistry, measuresByVoice, measureCapacity, overfullCompatibilityMode, settings, transposeHintByVoiceId, keyHintFifthsByKey, notationMeasureMetaByVoice, measureMetaByKey, meterByMeasureByVoice, tempoByMeasureByVoice, importDiagnostics) => {
+      var _a;
       const normalizedVoiceDataById = /* @__PURE__ */ new Map();
       for (const voiceId of orderedVoiceIds) {
         const partName = voiceRegistry.voiceNameById[voiceId] || "Voice " + voiceId;
@@ -152844,7 +152852,7 @@ var BUNDLED_CLI_MODULES = {
         const measureData = buildAbcVoiceMeasureMetaByIndex(voiceId, normalizedMeasures, keyHintFifthsByKey, notationMeasureMetaByVoice, measureMetaByKey, meterByMeasureByVoice, tempoByMeasureByVoice);
         normalizedVoiceDataById.set(voiceId, {
           partName,
-          clef: voiceRegistry.voiceClefById[voiceId] || "",
+          clef: (_a = voiceRegistry.voiceClefById[voiceId]) !== null && _a !== void 0 ? _a : "",
           transpose,
           voiceId,
           keyByMeasure: measureData.keyByMeasure,
@@ -152856,33 +152864,11 @@ var BUNDLED_CLI_MODULES = {
       }
       return normalizedVoiceDataById;
     };
-    const buildAbcGroupedStaffClefXml = (staffVoices) => {
-      return staffVoices.map((staffVoice) => {
-        const clefXml = (0, exports.clefXmlFromAbcClef)(staffVoice.clef || "");
-        return clefXml.replace("<clef>", `<clef number="${staffVoice.staff}">`);
-      }).join("");
-    };
-    const buildAbcPartTransposeXml = (transpose) => {
-      return (0, transposition_1.buildMusicXmlTransposeXml)(transpose);
-    };
-    const buildAbcTempoDirectionXml = (tempo, include) => {
-      if (!(include && tempo !== null)) {
-        return "";
-      }
-      return (0, direction_text_1.buildMusicXmlTempoDirectionXml)({ bpm: tempo, includeQuarterMetronome: true });
-    };
-    const buildAbcMeasureHeaderXml = (part, partIndex, measureIndex, currentPartFifths, currentPartMeter, currentPartTempo, hintedFifths, hintedMeter) => {
-      if (measureIndex === 0) {
-        const headerXml2 = buildAbcMeasureHeaderInitialParts(part, currentPartFifths, currentPartMeter).join("");
-        const tempoDirectionXml = buildAbcTempoDirectionXml(currentPartTempo, partIndex === 0);
-        return { headerXml: headerXml2, tempoDirectionXml };
-      }
-      const headerXml = hintedFifths !== null || hintedMeter ? buildAbcMeasureHeaderUpdateParts(currentPartFifths, currentPartMeter, hintedFifths, hintedMeter).join("") : "";
-      return {
-        headerXml,
-        tempoDirectionXml: ""
-      };
-    };
+    const buildAbcGroupedStaffClefXml = (staffVoices) => staffVoices.map((staffVoice) => {
+      var _a;
+      const clefXml = (0, exports.clefXmlFromAbcClef)((_a = staffVoice.clef) !== null && _a !== void 0 ? _a : "");
+      return clefXml.replace("<clef>", `<clef number="${staffVoice.staff}">`);
+    }).join("");
     const buildAbcMeasureHeaderInitialParts = (part, currentPartFifths, currentPartMeter) => [
       "<attributes>",
       "<divisions>960</divisions>",
@@ -152892,49 +152878,16 @@ var BUNDLED_CLI_MODULES = {
         beatType: currentPartMeter.beatType
       }),
       (0, abc_layout_1.hasAbcGroupedStaffVoices)(part) ? `<staves>${part.staffVoices.length}</staves>` : "",
-      buildAbcPartTransposeXml(part.transpose),
+      (0, transposition_1.buildMusicXmlTransposeXml)(part.transpose),
       (0, abc_layout_1.hasAbcGroupedStaffVoices)(part) ? buildAbcGroupedStaffClefXml(part.staffVoices) : (0, exports.clefXmlFromAbcClef)(part.clef),
       "</attributes>"
     ];
     const buildAbcMeasureHeaderUpdateParts = (currentPartFifths, currentPartMeter, hintedFifths, hintedMeter) => [
       "<attributes>",
-      buildAbcMeasureHeaderUpdateKeyPart(currentPartFifths, hintedFifths),
-      buildAbcMeasureHeaderUpdateTimePart(currentPartMeter, hintedMeter),
+      hintedFifths !== null ? (0, key_signatures_1.buildMusicXmlKeySignatureXml)({ fifths: currentPartFifths }) : "",
+      hintedMeter ? (0, time_signatures_1.buildMusicXmlTimeSignatureXml)({ beats: currentPartMeter.beats, beatType: currentPartMeter.beatType }) : "",
       "</attributes>"
     ];
-    const buildAbcMeasureHeaderUpdateKeyPart = (currentPartFifths, hintedFifths) => buildAbcMeasureHeaderUpdateKeyPartXml(currentPartFifths, hintedFifths);
-    const buildAbcMeasureHeaderUpdateKeyPartXml = (currentPartFifths, hintedFifths) => hintedFifths !== null ? buildAbcMeasureHeaderUpdateKeySignatureXml(currentPartFifths) : "";
-    const buildAbcMeasureHeaderUpdateKeySignatureXml = (currentPartFifths) => (0, key_signatures_1.buildMusicXmlKeySignatureXml)({ fifths: currentPartFifths });
-    const buildAbcMeasureHeaderUpdateTimePart = (currentPartMeter, hintedMeter) => buildAbcMeasureHeaderUpdateTimePartXml(currentPartMeter, hintedMeter);
-    const buildAbcMeasureHeaderUpdateTimePartXml = (currentPartMeter, hintedMeter) => hintedMeter ? buildAbcMeasureHeaderUpdateTimeSignatureXml(currentPartMeter) : "";
-    const buildAbcMeasureHeaderUpdateTimeSignatureXml = (currentPartMeter) => (0, time_signatures_1.buildMusicXmlTimeSignatureXml)({
-      beats: currentPartMeter.beats,
-      beatType: currentPartMeter.beatType
-    });
-    const buildAbcMeasureTempoDirectionXml = (hintedTempo, partIndex, measureIndex) => {
-      return buildAbcTempoDirectionXml(hintedTempo, measureIndex > 0 && partIndex === 0);
-    };
-    const buildAbcMeasureRepeatStartXml = (measureMeta) => {
-      const leftBarlineChunks = buildAbcMeasureRepeatStartChunks(measureMeta);
-      return leftBarlineChunks.length > 0 ? `<barline location="left">${leftBarlineChunks.join("")}</barline>` : "";
-    };
-    const buildAbcMeasureRepeatStartChunks = (measureMeta) => [
-      (measureMeta === null || measureMeta === void 0 ? void 0 : measureMeta.endingStart) ? `<ending number="${xmlEscape(String(measureMeta.endingStart))}" type="start"/>` : "",
-      (measureMeta === null || measureMeta === void 0 ? void 0 : measureMeta.repeatStart) ? '<repeat direction="forward" winged="none"/>' : ""
-    ].filter(Boolean);
-    const buildAbcMeasureRepeatEndXml = (measureMeta) => {
-      const rightBarlineChunks = buildAbcMeasureRepeatEndChunks(measureMeta);
-      return rightBarlineChunks.length > 0 ? `<barline location="right">${rightBarlineChunks.join("")}</barline>` : "";
-    };
-    const buildAbcMeasureRepeatEndChunks = (measureMeta) => [
-      (measureMeta === null || measureMeta === void 0 ? void 0 : measureMeta.endingStop) ? `<ending number="${xmlEscape(String(measureMeta.endingStop))}" type="${measureMeta.endingStopType || "stop"}"/>` : "",
-      (measureMeta === null || measureMeta === void 0 ? void 0 : measureMeta.repeatEnd) ? `<repeat direction="backward" winged="none"${Number.isFinite(measureMeta.repeatTimes) && Number(measureMeta.repeatTimes) > 1 ? ` times="${Math.round(Number(measureMeta.repeatTimes))}"` : ""}/>` : ""
-    ].filter(Boolean);
-    const buildAbcMeasureXml = (measureNo, measureNumberText, implicit, repeatStartXml, headerXml, tempoDirectionXml, debugMiscXml, diagMiscXml, sourceMiscXml, notesXml, repeatEndXml) => {
-      const xmlMeasureNumber = xmlEscape(String(measureNumberText || measureNo));
-      const implicitAttr = implicit ? ' implicit="yes"' : "";
-      return `<measure number="${xmlMeasureNumber}"${implicitAttr}>${repeatStartXml}${headerXml}${tempoDirectionXml}${debugMiscXml}${diagMiscXml}${sourceMiscXml}${notesXml}${repeatEndXml}</measure>`;
-    };
     const buildAbcPartMeasureRenderContext = (part, measureIndex, state, beats, beatType) => {
       var _a, _b, _c, _d, _e, _f, _g, _h, _j;
       const measureNo = measureIndex + 1;
@@ -152967,50 +152920,93 @@ var BUNDLED_CLI_MODULES = {
     };
     const buildAbcRenderedPartMeasureXml = (context) => {
       const { part, partIndex, measureIndex, measureNo, notes, measureMeta, hintedFifths, hintedMeter, hintedTempo, currentPartFifths, currentPartMeter, currentPartTempo, currentMeasureDurationDiv, inferredImplicitPickup, debugMetadata, sourceMetadata, diagnostics, abcSource, buildMeasureNotesXml } = context;
-      const { headerXml, tempoDirectionXml: headerTempoDirectionXml } = buildAbcMeasureHeaderXml(part, partIndex, measureIndex, currentPartFifths, currentPartMeter, currentPartTempo, hintedFifths, hintedMeter);
-      const tempoDirectionXml = headerTempoDirectionXml || buildAbcMeasureTempoDirectionXml(hintedTempo, partIndex, measureIndex);
+      const headerXml = measureIndex === 0 ? buildAbcMeasureHeaderInitialParts(part, currentPartFifths, currentPartMeter).join("") : hintedFifths !== null || hintedMeter !== null ? buildAbcMeasureHeaderUpdateParts(currentPartFifths, currentPartMeter, hintedFifths, hintedMeter).join("") : "";
+      const headerTempoDirectionXml = measureIndex === 0 && partIndex === 0 && currentPartTempo !== null ? (0, direction_text_1.buildMusicXmlTempoDirectionXml)({ bpm: currentPartTempo, includeQuarterMetronome: true }) : "";
+      const tempoDirectionXml = headerTempoDirectionXml || (measureIndex > 0 && partIndex === 0 && hintedTempo !== null ? (0, direction_text_1.buildMusicXmlTempoDirectionXml)({ bpm: hintedTempo, includeQuarterMetronome: true }) : "");
       const notesXml = (0, abc_layout_1.hasAbcGroupedStaffVoices)(part) ? (0, abc_layout_1.buildAbcGroupedStaffMeasureNotesXml)(part.staffVoices, measureIndex, currentMeasureDurationDiv, buildMeasureNotesXml) : buildMeasureNotesXml(notes);
-      const repeatStartXml = buildAbcMeasureRepeatStartXml(measureMeta);
-      const repeatEndXml = buildAbcMeasureRepeatEndXml(measureMeta);
-      const { debugMiscXml, diagMiscXml, sourceMiscXml } = buildAbcRenderedMeasureMiscXml({
-        part,
-        partIndex,
-        measureNo,
-        notes,
-        debugMetadata,
-        sourceMetadata,
-        diagnostics,
-        abcSource
-      });
-      return buildAbcMeasureXml(measureNo, String((measureMeta === null || measureMeta === void 0 ? void 0 : measureMeta.number) || measureNo), Boolean((measureMeta === null || measureMeta === void 0 ? void 0 : measureMeta.implicit) || inferredImplicitPickup), repeatStartXml, headerXml, tempoDirectionXml, debugMiscXml, diagMiscXml, sourceMiscXml, notesXml, repeatEndXml);
+      const repeatStartXml = measureMeta ? (() => {
+        const chunks = [
+          ...measureMeta.endingStart ? [`<ending number="${xmlEscape(String(measureMeta.endingStart))}" type="start"/>`] : [],
+          ...measureMeta.repeatStart ? ['<repeat direction="forward" winged="none"/>'] : []
+        ];
+        return chunks.length > 0 ? `<barline location="left">${chunks.join("")}</barline>` : "";
+      })() : "";
+      const repeatEndXml = measureMeta ? (() => {
+        const chunks = [
+          ...measureMeta.endingStop ? [
+            `<ending number="${xmlEscape(String(measureMeta.endingStop))}" type="${measureMeta.endingStopType || "stop"}"/>`
+          ] : [],
+          ...measureMeta.repeatEnd ? [
+            `<repeat direction="backward" winged="none"${Number.isFinite(measureMeta.repeatTimes) && Number(measureMeta.repeatTimes) > 1 ? ` times="${Math.round(Number(measureMeta.repeatTimes))}"` : ""}/>`
+          ] : []
+        ];
+        return chunks.length > 0 ? `<barline location="right">${chunks.join("")}</barline>` : "";
+      })() : "";
+      const debugMiscXml = debugMetadata ? `<attributes><miscellaneous><miscellaneous-field name="mks:dbg:abc:meta:count">${toHex(notes.length, 4)}</miscellaneous-field>${notes.map((note, index) => {
+        var _a;
+        return `<miscellaneous-field name="mks:dbg:abc:meta:${String(index + 1).padStart(4, "0")}">${[
+          [
+            `idx=${toHex(index, 4)}`,
+            `m=${toHex(measureNo, 4)}`,
+            `v=${xmlEscape(normalizeVoiceForMusicXml(note.voice))}`
+          ].join(";"),
+          [
+            `r=${note.isRest ? "1" : "0"}`,
+            `g=${note.grace ? "1" : "0"}`,
+            `ch=${note.chord ? "1" : "0"}`,
+            `st=${note.isRest ? "R" : /^[A-G]$/.test(String((_a = note.step) !== null && _a !== void 0 ? _a : "").toUpperCase()) ? String(note.step).toUpperCase() : "C"}`,
+            `al=${String(Number.isFinite(Number(note.alter)) ? Math.round(Number(note.alter)) : 0)}`,
+            `oc=${toHex(Number.isFinite(Number(note.octave)) ? Math.max(0, Math.min(9, Math.round(Number(note.octave)))) : 4, 2)}`,
+            `dd=${toHex(note.grace ? 0 : Math.max(1, Math.round(Number(note.duration) || 1)), 4)}`,
+            `tp=${xmlEscape(normalizeTypeForMusicXml(note.type))}`
+          ].join(";")
+        ].join(";")}</miscellaneous-field>`;
+      }).join("")}</miscellaneous></attributes>` : "";
+      const diagMiscNotes = partIndex === 0 && measureNo === 1 ? (diagnostics !== null && diagnostics !== void 0 ? diagnostics : []).filter((diag) => {
+        var _a;
+        return !diag.voiceId || diag.voiceId === ((_a = part.voiceId) !== null && _a !== void 0 ? _a : "");
+      }) : [];
+      const diagMiscXml = diagMiscNotes.length ? `<attributes><miscellaneous><miscellaneous-field name="mks:diag:count">${Math.min(256, diagMiscNotes.length)}</miscellaneous-field>${Array.from({ length: Math.min(256, diagMiscNotes.length) }, (_, i) => `<miscellaneous-field name="mks:diag:${String(i + 1).padStart(4, "0")}">${[
+        `level=${diagMiscNotes[i].level}`,
+        `code=${diagMiscNotes[i].code}`,
+        `fmt=${diagMiscNotes[i].fmt}`,
+        ...diagMiscNotes[i].measure !== void 0 && Number.isFinite(diagMiscNotes[i].measure) ? [`measure=${Math.max(1, Math.round(Number(diagMiscNotes[i].measure)))}`] : [],
+        ...diagMiscNotes[i].movedEvents !== void 0 && Number.isFinite(diagMiscNotes[i].movedEvents) ? [`movedEvents=${Math.max(0, Math.round(Number(diagMiscNotes[i].movedEvents)))}`] : [],
+        ...diagMiscNotes[i].voiceId ? [`voice=${xmlEscape(diagMiscNotes[i].voiceId)}`] : [],
+        ...diagMiscNotes[i].action ? [`action=${xmlEscape(diagMiscNotes[i].action)}`] : [],
+        ...diagMiscNotes[i].message ? [`message=${xmlEscape(diagMiscNotes[i].message)}`] : []
+      ].join(";")}</miscellaneous-field>`).join("")}</miscellaneous></attributes>` : "";
+      const sourceMiscXml = sourceMetadata && partIndex === 0 && measureNo === 1 ? (() => {
+        const source = String(abcSource !== null && abcSource !== void 0 ? abcSource : "");
+        if (!source.length)
+          return "";
+        const encoded = source.replace(/\\/g, "\\\\").replace(/\r/g, "\\r").replace(/\n/g, "\\n");
+        const CHUNK_SIZE = 240;
+        const MAX_CHUNKS = 512;
+        const chunks = [];
+        for (let i = 0; i < encoded.length && chunks.length < MAX_CHUNKS; i += CHUNK_SIZE) {
+          chunks.push(encoded.slice(i, i + CHUNK_SIZE));
+        }
+        const truncated = chunks.join("").length < encoded.length;
+        return `<attributes><miscellaneous>${[
+          `<miscellaneous-field name="mks:src:abc:raw-encoding">escape-v1</miscellaneous-field>`,
+          `<miscellaneous-field name="mks:src:abc:raw-length">${xmlEscape(String(source.length))}</miscellaneous-field>`,
+          `<miscellaneous-field name="mks:src:abc:raw-encoded-length">${xmlEscape(String(encoded.length))}</miscellaneous-field>`,
+          `<miscellaneous-field name="mks:src:abc:raw-chunks">${xmlEscape(String(chunks.length))}</miscellaneous-field>`,
+          `<miscellaneous-field name="mks:src:abc:raw-truncated">${truncated ? "1" : "0"}</miscellaneous-field>`,
+          ...chunks.map((chunk, index) => `<miscellaneous-field name="mks:src:abc:raw-${String(index + 1).padStart(4, "0")}">${xmlEscape(chunk)}</miscellaneous-field>`)
+        ].join("")}</miscellaneous></attributes>`;
+      })() : "";
+      const xmlMeasureNumber = xmlEscape(String((measureMeta === null || measureMeta === void 0 ? void 0 : measureMeta.number) || measureNo));
+      const implicitAttr = (measureMeta === null || measureMeta === void 0 ? void 0 : measureMeta.implicit) || inferredImplicitPickup ? ' implicit="yes"' : "";
+      return `<measure number="${xmlMeasureNumber}"${implicitAttr}>${repeatStartXml}${headerXml}${tempoDirectionXml}${debugMiscXml}${diagMiscXml}${sourceMiscXml}${notesXml}${repeatEndXml}</measure>`;
     };
-    const buildAbcRenderedMeasureMiscXml = (context) => {
-      const { part, partIndex, measureNo, notes, debugMetadata, sourceMetadata, diagnostics, abcSource } = context;
-      return {
-        debugMiscXml: buildAbcRenderedMeasureDebugMiscXml(debugMetadata, notes, measureNo),
-        diagMiscXml: buildAbcRenderedMeasureDiagMiscXml(part, partIndex, measureNo, diagnostics),
-        sourceMiscXml: buildAbcRenderedMeasureSourceMiscXml(sourceMetadata, partIndex, measureNo, abcSource)
-      };
-    };
-    const buildAbcRenderedMeasureDebugMiscXml = (debugMetadata, notes, measureNo) => debugMetadata ? buildAbcMeasureDebugMiscXml(notes, measureNo) : "";
-    const buildAbcRenderedMeasureDiagMiscXml = (part, partIndex, measureNo, diagnostics) => {
-      const filteredDiagnostics = buildAbcRenderedMeasureDiagMiscDiagnostics(part, partIndex, measureNo, diagnostics);
-      return filteredDiagnostics.length > 0 ? buildAbcDiagMiscXml(filteredDiagnostics) : "";
-    };
-    const buildAbcRenderedMeasureDiagMiscDiagnostics = (part, partIndex, measureNo, diagnostics) => partIndex === 0 && measureNo === 1 ? (diagnostics !== null && diagnostics !== void 0 ? diagnostics : []).filter((diag) => !diag.voiceId || diag.voiceId === (part.voiceId || "")) : [];
-    const buildAbcRenderedMeasureSourceMiscXml = (sourceMetadata, partIndex, measureNo, abcSource) => sourceMetadata && partIndex === 0 && measureNo === 1 ? buildAbcSourceMiscXml(abcSource) : "";
     const createInitialAbcPartRenderState = (defaultFifths, beats, beatType, tempoBpm) => ({
       currentPartFifths: Math.max(-7, Math.min(7, Math.round(defaultFifths))),
       currentPartMeter: { beats: Math.round(beats), beatType: Math.round(beatType) },
       currentPartTempo: tempoBpm
     });
     const buildAbcPartXml = (part, partIndex, measureCount, defaultFifths, beats, beatType, tempoBpm, debugMetadata, sourceMetadata, diagnostics, abcSource, buildMeasureNotesXml) => {
-      return buildAbcPartXmlWrapper(part.partId, buildAbcPartXmlMeasures(part, partIndex, measureCount, defaultFifths, beats, beatType, tempoBpm, debugMetadata, sourceMetadata, diagnostics, abcSource, buildMeasureNotesXml));
-    };
-    const buildAbcPartXmlWrapper = (partId, measuresXml) => `<part id="${xmlEscape(partId)}">${measuresXml}</part>`;
-    const buildAbcPartXmlMeasures = (part, partIndex, measureCount, defaultFifths, beats, beatType, tempoBpm, debugMetadata, sourceMetadata, diagnostics, abcSource, buildMeasureNotesXml) => buildAbcPartXmlMeasureEntries(part, partIndex, measureCount, defaultFifths, beats, beatType, tempoBpm, debugMetadata, sourceMetadata, diagnostics, abcSource, buildMeasureNotesXml);
-    const buildAbcPartXmlMeasureEntries = (part, partIndex, measureCount, defaultFifths, beats, beatType, tempoBpm, debugMetadata, sourceMetadata, diagnostics, abcSource, buildMeasureNotesXml) => buildAbcPartXmlMeasureEntryParts(part, partIndex, measureCount, defaultFifths, beats, beatType, tempoBpm, debugMetadata, sourceMetadata, diagnostics, abcSource, buildMeasureNotesXml).join("");
-    const buildAbcPartXmlMeasureEntryParts = (part, partIndex, measureCount, defaultFifths, beats, beatType, tempoBpm, debugMetadata, sourceMetadata, diagnostics, abcSource, buildMeasureNotesXml) => {
       const measureParts = [];
       let state = createInitialAbcPartRenderState(defaultFifths, beats, beatType, tempoBpm);
       for (let i = 0; i < measureCount; i += 1) {
@@ -153040,324 +153036,30 @@ var BUNDLED_CLI_MODULES = {
           buildMeasureNotesXml
         }));
       }
-      return measureParts;
+      return `<part id="${xmlEscape(part.partId)}">${measureParts.join("")}</part>`;
     };
-    const buildAbcPartListXml = (resolvedParts) => {
-      return resolvedParts.map((part, index) => buildAbcPartListEntryXml(part, index)).join("");
+    const hasAbcNoteNotations = (note) => hasAbcNoteTieOrSlurNotations(note) || hasAbcNoteOrnaments(note) || hasAbcNoteArticulations(note) || hasAbcNoteTechnicalNotations(note) || hasAbcNoteFermataNotation(note) || hasAbcNoteTupletNotations(note);
+    const hasAbcNoteTieOrSlurNotations = (note) => note.tieStart || note.tieStop || note.slurStart || note.slurStop;
+    const hasAbcNoteOrnaments = (note) => hasAbcNoteOrnamentFeatureNotations(note) || hasAbcNoteOrnamentMotionNotations(note);
+    const hasAbcNoteOrnamentFeatureNotations = (note) => note.trill || note.trillLineStop || note.turnType || note.delayedTurn || note.mordentType || note.tremoloType || note.schleifer || note.shake;
+    const hasAbcNoteOrnamentMotionNotations = (note) => note.glissandoStart || note.glissandoStop || note.slideStart || note.slideStop || note.arpeggiate;
+    const hasAbcNoteArticulations = (note) => hasAbcNoteArticulationFeatureNotations(note) || hasAbcNoteArticulationDecorativeNotations(note);
+    const hasAbcNoteArticulationFeatureNotations = (note) => note.staccato || note.staccatissimo || note.accent || note.tenuto || note.strongAccent || note.breathMark || note.caesura;
+    const hasAbcNoteArticulationDecorativeNotations = (note) => note.stress || note.unstress || note.phraseMark;
+    const hasAbcNoteTechnicalNotations = (note) => hasAbcNoteTechnicalPlainNotations(note) || hasAbcNoteTechnicalCollectionNotations(note) || hasAbcNoteTechnicalFlagNotations(note);
+    const hasAbcNoteTechnicalPlainNotations = (note) => !!(note.upBow || note.downBow || note.doubleTongue || note.tripleTongue || note.heel || note.toe);
+    const hasAbcNoteTechnicalCollectionNotations = (note) => {
+      var _a, _b, _c;
+      return !!(((_a = note.fingerings) === null || _a === void 0 ? void 0 : _a.length) || ((_b = note.strings) === null || _b === void 0 ? void 0 : _b.length) || ((_c = note.plucks) === null || _c === void 0 ? void 0 : _c.length));
     };
-    const buildAbcPartListEntryXml = (part, index) => {
-      const midiChannel = index % 16 + 1 === 10 ? 11 : index % 16 + 1;
-      return [
-        `<score-part id="${xmlEscape(part.partId)}">`,
-        `<part-name>${xmlEscape(part.partName || part.partId)}</part-name>`,
-        `<midi-instrument id="${xmlEscape(part.partId)}-I1">`,
-        `<midi-channel>${midiChannel}</midi-channel>`,
-        `<midi-program>6</midi-program>`,
-        "</midi-instrument>",
-        "</score-part>"
-      ].join("");
-    };
-    const buildAbcPartBodyXml = (resolvedParts, measureCount, defaultFifths, beats, beatType, tempoBpm, debugMetadata, sourceMetadata, diagnostics, abcSource, buildMeasureNotesXml) => {
-      return buildAbcPartBodyParts(resolvedParts, measureCount, defaultFifths, beats, beatType, tempoBpm, debugMetadata, sourceMetadata, diagnostics, abcSource, buildMeasureNotesXml);
-    };
-    const buildAbcPartBodyParts = (resolvedParts, measureCount, defaultFifths, beats, beatType, tempoBpm, debugMetadata, sourceMetadata, diagnostics, abcSource, buildMeasureNotesXml) => buildAbcPartBodyPartEntries(resolvedParts, measureCount, defaultFifths, beats, beatType, tempoBpm, debugMetadata, sourceMetadata, diagnostics, abcSource, buildMeasureNotesXml);
-    const buildAbcPartBodyPartEntries = (resolvedParts, measureCount, defaultFifths, beats, beatType, tempoBpm, debugMetadata, sourceMetadata, diagnostics, abcSource, buildMeasureNotesXml) => buildAbcPartBodyPartItems(resolvedParts, measureCount, defaultFifths, beats, beatType, tempoBpm, debugMetadata, sourceMetadata, diagnostics, abcSource, buildMeasureNotesXml).join("");
-    const buildAbcPartBodyPartItems = (resolvedParts, measureCount, defaultFifths, beats, beatType, tempoBpm, debugMetadata, sourceMetadata, diagnostics, abcSource, buildMeasureNotesXml) => resolvedParts.map((part, partIndex) => buildAbcPartXml(part, partIndex, measureCount, defaultFifths, beats, beatType, tempoBpm, debugMetadata, sourceMetadata, diagnostics, abcSource, buildMeasureNotesXml));
-    const buildAbcNoteHarmonyAndWordsDirectionXml = (note) => {
-      const chunks = [];
-      if (!note.chord && Array.isArray(note.chordSymbols) && note.chordSymbols.length > 0) {
-        for (const chordSymbol of note.chordSymbols) {
-          const harmonyXml = buildHarmonyXmlFromChordSymbol(chordSymbol);
-          if (harmonyXml) {
-            chunks.push(harmonyXml);
-          } else {
-            chunks.push((0, direction_text_1.buildMusicXmlWordsDirectionXml)({ text: String(chordSymbol) }));
-          }
-        }
-      }
-      if (!note.chord && Array.isArray(note.annotations) && note.annotations.length > 0) {
-        for (const annotation of note.annotations) {
-          if (!annotation)
-            continue;
-          chunks.push((0, direction_text_1.buildMusicXmlWordsDirectionXml)({ text: String(annotation) }));
-        }
-      }
-      return chunks.join("");
-    };
-    const buildAbcNoteControlDirectionXml = (note) => {
-      const chunks = [];
-      if (!note.chord && note.segno)
-        chunks.push("<direction><direction-type><segno/></direction-type></direction>");
-      if (!note.chord && note.coda)
-        chunks.push("<direction><direction-type><coda/></direction-type></direction>");
-      if (!note.chord && note.rehearsalMark) {
-        chunks.push(`<direction><direction-type><rehearsal>${xmlEscape(String(note.rehearsalMark))}</rehearsal></direction-type></direction>`);
-      }
-      if (!note.chord && note.fine)
-        chunks.push('<direction><sound fine="yes"/></direction>');
-      if (!note.chord && note.daCapo)
-        chunks.push('<direction><sound dacapo="yes"/></direction>');
-      if (!note.chord && note.dalSegno)
-        chunks.push('<direction><sound dalsegno="segno"/></direction>');
-      if (!note.chord && note.toCoda)
-        chunks.push('<direction><sound tocoda="coda"/></direction>');
-      if (!note.chord && note.crescendoStart)
-        chunks.push((0, dynamics_1.buildMusicXmlDirectionFeatureXml)({ kind: "wedge", wedgeType: "crescendo" }));
-      if (!note.chord && note.diminuendoStart)
-        chunks.push((0, dynamics_1.buildMusicXmlDirectionFeatureXml)({ kind: "wedge", wedgeType: "diminuendo" }));
-      if (!note.chord && (note.crescendoStop || note.diminuendoStop)) {
-        chunks.push((0, dynamics_1.buildMusicXmlDirectionFeatureXml)({ kind: "wedge", wedgeType: "stop" }));
-      }
-      if (!note.chord && note.dynamicMark) {
-        const dynamicMark = (0, dynamics_1.normalizeDynamicMark)(String(note.dynamicMark));
-        if (dynamicMark)
-          chunks.push((0, dynamics_1.buildMusicXmlDirectionFeatureXml)({ kind: "dynamic", mark: dynamicMark }));
-      }
-      if (!note.chord && note.sfz) {
-        chunks.push((0, dynamics_1.buildMusicXmlDirectionFeatureXml)({ kind: "dynamic", mark: "sfz" }));
-      }
-      return chunks.join("");
-    };
-    const buildAbcNoteLeadingDirectionXml = (note) => {
-      const chunks = [];
-      chunks.push(buildAbcNoteHarmonyAndWordsDirectionXml(note));
-      chunks.push(buildAbcNoteControlDirectionXml(note));
-      return chunks.join("");
-    };
-    const buildAbcNotePitchOrRestXml = (note) => {
-      if (note.isRest) {
-        return "<rest/>";
-      }
-      return (0, pitches_1.buildMusicXmlPitchXml)({
-        step: note.step,
-        alter: note.alter,
-        octave: note.octave
-      });
-    };
-    const buildAbcNoteLyricXml = (note) => {
-      return (0, note_elements_1.buildMusicXmlLyricXml)({
-        text: note.lyricText,
-        syllabic: note.lyricSyllabic || "single",
-        extend: note.lyricExtend
-      });
-    };
-    const buildAbcNoteTimeModificationXml = (note) => {
-      var _a, _b;
-      return (0, tuplets_1.buildMusicXmlTimeModificationXml)({
-        actualNotes: (_a = note.timeModification) === null || _a === void 0 ? void 0 : _a.actual,
-        normalNotes: (_b = note.timeModification) === null || _b === void 0 ? void 0 : _b.normal
-      });
-    };
-    const buildAbcNoteAccidentalXml = (note) => {
-      return (0, note_elements_1.buildMusicXmlAccidentalXml)({
-        text: note.accidentalText,
-        editorial: note.accidentalEditorial,
-        cautionary: note.accidentalCautionary
-      });
-    };
-    const buildAbcNoteCoreXml = (note, noteIndex, staffOverride, beamXmlByNoteIndex) => {
-      const chunks = [];
-      chunks.push(...buildAbcNoteCoreOpenParts(note, staffOverride));
-      if (!note.chord && beamXmlByNoteIndex.has(noteIndex))
-        chunks.push(String(beamXmlByNoteIndex.get(noteIndex)));
-      chunks.push(...buildAbcNoteCoreTailParts(note));
-      return chunks.join("");
-    };
-    const buildAbcNoteCoreOpenParts = (note, staffOverride) => {
-      const chunks = ["<note>"];
-      if (note.chord)
-        chunks.push("<chord/>");
-      if (note.grace)
-        chunks.push((0, note_elements_1.buildMusicXmlGraceXml)({ slash: note.graceSlash }));
-      chunks.push(buildAbcNotePitchOrRestXml(note));
-      if (!note.grace) {
-        const duration = Math.max(1, Math.round(Number(note.duration) || 1));
-        chunks.push(`<duration>${duration}</duration>`);
-      }
-      chunks.push(`<voice>${xmlEscape(normalizeVoiceForMusicXml(note.voice))}</voice>`);
-      if (staffOverride !== null || Number.isFinite(note.staff)) {
-        const staffNumber = staffOverride !== null ? staffOverride : Math.max(1, Math.round(Number(note.staff) || 1));
-        chunks.push(`<staff>${staffNumber}</staff>`);
-      }
-      chunks.push(buildAbcNoteLyricXml(note));
-      chunks.push(`<type>${normalizeTypeForMusicXml(note.type)}</type>`);
-      return chunks;
-    };
-    const buildAbcNoteCoreTailParts = (note) => [...buildAbcNoteCoreModifierTailParts(note), buildAbcNoteCoreTieTailPart(note)];
-    const buildAbcNoteCoreModifierTailParts = (note) => [
-      buildAbcNoteTimeModificationXml(note),
-      buildAbcNoteAccidentalXml(note)
-    ];
-    const buildAbcNoteCoreTieTailPart = (note) => (0, ties_1.buildMusicXmlTieItemsXml)({
-      tieStart: Boolean(note.tieStart),
-      tieStop: Boolean(note.tieStop)
-    });
-    const buildAbcNoteOrnamentsXml = (note) => {
-      return [buildAbcNoteOrnamentsFeatureParts(note), buildAbcNoteOrnamentsMotionParts(note)].join("");
-    };
-    const buildAbcNoteOrnamentsFeatureParts = (note) => [
-      buildAbcNoteOrnamentsWavyLinePart(note),
-      buildAbcNoteOrnamentsTurnPart(note),
-      buildAbcNoteOrnamentsMordentPart(note),
-      buildAbcNoteOrnamentsTremoloPart(note),
-      buildAbcNoteOrnamentsSchleiferPart(note),
-      buildAbcNoteOrnamentsShakePart(note)
-    ].join("");
-    const buildAbcNoteOrnamentsMotionParts = (note) => buildAbcNoteOrnamentsMotionItemParts(note).join("");
-    const buildAbcNoteOrnamentsMotionItemParts = (note) => [
-      note.glissandoStart ? '<glissando type="start" number="1">wavy</glissando>' : "",
-      note.glissandoStop ? '<glissando type="stop" number="1">wavy</glissando>' : "",
-      note.slideStart ? '<slide type="start" number="1"/>' : "",
-      note.slideStop ? '<slide type="stop" number="1"/>' : "",
-      note.arpeggiate ? "<arpeggiate/>" : ""
-    ].filter(Boolean);
-    const buildAbcNoteOrnamentsWavyLinePart = (note) => {
-      if (!note.trill && !note.trillLineStop)
-        return "";
-      const trillParts = note.trill ? [(0, ornaments_1.buildMusicXmlOrnamentItemsXml)([{ kind: "trill-mark" }])] : [];
-      if (note.trillLineStop) {
-        trillParts.push('<wavy-line type="stop"/>');
-      } else if (note.trillLineStart) {
-        trillParts.push('<wavy-line type="start"/>');
-      }
-      if (note.trillAccidentalText)
-        trillParts.push(`<accidental-mark>${xmlEscape(String(note.trillAccidentalText))}</accidental-mark>`);
-      return `<ornaments>${trillParts.join("")}</ornaments>`;
-    };
-    const buildAbcNoteOrnamentsTurnPart = (note) => {
-      if (!note.turnType)
-        return "";
-      return (0, ornaments_1.buildMusicXmlOrnamentsXml)([
-        { kind: note.turnType === "inverted-turn" ? "inverted-turn" : "turn", ...note.turnSlash ? { slash: true } : {} },
-        ...note.delayedTurn ? [{ kind: "delayed-turn" }] : []
-      ]);
-    };
-    const buildAbcNoteOrnamentsMordentPart = (note) => {
-      if (!note.mordentType)
-        return "";
-      return (0, ornaments_1.buildMusicXmlOrnamentsXml)([
-        { kind: note.mordentType === "inverted-mordent" ? "inverted-mordent" : "mordent" }
-      ]);
-    };
-    const buildAbcNoteOrnamentsTremoloPart = (note) => {
-      if (!note.tremoloType)
-        return "";
-      return (0, ornaments_1.buildMusicXmlOrnamentsXml)([
-        { kind: "tremolo", tremoloType: note.tremoloType, marks: note.tremoloMarks }
-      ]);
-    };
-    const buildAbcNoteOrnamentsSchleiferPart = (note) => note.schleifer ? (0, ornaments_1.buildMusicXmlOrnamentsXml)([{ kind: "schleifer" }]) : "";
-    const buildAbcNoteOrnamentsShakePart = (note) => note.shake ? (0, ornaments_1.buildMusicXmlOrnamentsXml)([{ kind: "shake" }]) : "";
-    const buildAbcNoteArticulationsXml = (note) => {
-      const featureItemsXml = buildAbcNoteArticulationFeatureItemsXml(note);
-      const decorativeParts = buildAbcNoteArticulationDecorativeParts(note);
-      if (featureItemsXml && decorativeParts.length === 0)
-        return `<articulations>${featureItemsXml}</articulations>`;
-      if (featureItemsXml)
-        decorativeParts.unshift(featureItemsXml);
-      return decorativeParts.length > 0 ? `<articulations>${decorativeParts.join("")}</articulations>` : "";
-    };
-    const buildAbcNoteArticulationDecorativeParts = (note) => {
-      const articulationParts = [];
-      if (note.stress)
-        articulationParts.push("<stress/>");
-      if (note.unstress)
-        articulationParts.push("<unstress/>");
-      if (note.phraseMark)
-        articulationParts.push(`<other-articulation>${xmlEscape(String(note.phraseMark))}</other-articulation>`);
-      return articulationParts;
-    };
-    const buildAbcNoteArticulationFeatureItemsXml = (note) => (0, articulations_1.buildMusicXmlArticulationItemsXml)(buildAbcNoteArticulationFeatureKinds(note));
-    const buildAbcNoteArticulationFeatureKinds = (note) => {
-      const articulationKinds = [];
-      if (note.staccato)
-        articulationKinds.push("staccato");
-      if (note.staccatissimo)
-        articulationKinds.push("staccatissimo");
-      if (note.accent)
-        articulationKinds.push("accent");
-      if (note.tenuto)
-        articulationKinds.push("tenuto");
-      if (note.strongAccent)
-        articulationKinds.push("strong-accent");
-      if (note.breathMark)
-        articulationKinds.push("breath-mark");
-      if (note.caesura)
-        articulationKinds.push("caesura");
-      return articulationKinds;
-    };
-    const buildAbcNoteTechnicalXml = (note) => {
-      const technicalParts = [];
-      technicalParts.push(...buildAbcNoteTechnicalPlainParts(note));
-      technicalParts.push(...buildAbcNoteTechnicalCollectionParts(note));
-      technicalParts.push(...buildAbcNoteTechnicalFlagParts(note));
-      return (0, note_elements_1.buildMusicXmlTechnicalXml)(technicalParts);
-    };
-    const buildAbcNoteTechnicalPlainParts = (note) => [
-      note.upBow ? "<up-bow/>" : "",
-      note.downBow ? "<down-bow/>" : "",
-      note.doubleTongue ? "<double-tongue/>" : "",
-      note.tripleTongue ? "<triple-tongue/>" : "",
-      note.heel ? "<heel/>" : "",
-      note.toe ? "<toe/>" : ""
-    ].filter(Boolean);
-    const buildAbcNoteTechnicalCollectionParts = (note) => {
-      return buildAbcNoteTechnicalCollectionItemParts(note);
-    };
-    const buildAbcNoteTechnicalCollectionItemParts = (note) => {
-      const collectionParts = [];
-      if (Array.isArray(note.fingerings) && note.fingerings.length > 0) {
-        for (const fingering of note.fingerings)
-          collectionParts.push((0, note_elements_1.buildMusicXmlFingeringXml)(fingering));
-      }
-      if (Array.isArray(note.strings) && note.strings.length > 0) {
-        for (const stringText of note.strings)
-          collectionParts.push((0, note_elements_1.buildMusicXmlStringNumberXml)(stringText));
-      }
-      if (Array.isArray(note.plucks) && note.plucks.length > 0) {
-        for (const pluckText of note.plucks)
-          if (pluckText)
-            collectionParts.push(`<pluck>${xmlEscape(String(pluckText))}</pluck>`);
-      }
-      return collectionParts;
-    };
-    const buildAbcNoteTechnicalFlagParts = (note) => [
-      note.openString ? "<open-string/>" : "",
-      note.snapPizzicato ? "<snap-pizzicato/>" : "",
-      note.harmonic ? "<harmonic/>" : "",
-      note.stopped ? "<stopped/>" : "",
-      note.thumbPosition ? "<thumb-position/>" : ""
-    ].filter(Boolean);
-    const hasAbcNoteNotations = (note) => Boolean(note.tieStart || note.tieStop || note.slurStart || note.slurStop || note.trill || note.trillLineStop || note.turnType || note.delayedTurn || note.mordentType || note.tremoloType || note.glissandoStart || note.glissandoStop || note.slideStart || note.slideStop || note.schleifer || note.shake || note.arpeggiate || note.staccato || note.staccatissimo || note.accent || note.tenuto || note.stress || note.unstress || note.fermataType || note.strongAccent || note.breathMark || note.caesura || note.phraseMark || note.upBow || note.downBow || note.doubleTongue || note.tripleTongue || note.heel || note.toe || Array.isArray(note.fingerings) && note.fingerings.length > 0 || Array.isArray(note.strings) && note.strings.length > 0 || Array.isArray(note.plucks) && note.plucks.length > 0 || note.openString || note.snapPizzicato || note.harmonic || note.stopped || note.thumbPosition || note.tupletStart || note.tupletStop);
-    const buildAbcNoteNotationsXml = (note) => {
-      if (!hasAbcNoteNotations(note))
-        return "";
-      return `<notations>${buildAbcNoteNotationsFeatureChunks(note)}</notations>`;
-    };
-    const buildAbcNoteNotationsFeatureChunks = (note) => [
-      (0, ties_1.buildMusicXmlTiedItemsXml)({
-        tiedStart: Boolean(note.tieStart),
-        tiedStop: Boolean(note.tieStop)
-      }),
-      (0, slurs_1.buildMusicXmlSlursXml)([
-        ...note.slurStart ? [{ type: "start" }] : [],
-        ...note.slurStop ? [{ type: "stop" }] : []
-      ]),
-      note.tupletStart ? '<tuplet type="start"/>' : "",
-      note.tupletStop ? '<tuplet type="stop"/>' : "",
-      buildAbcNoteOrnamentsXml(note),
-      buildAbcNoteArticulationsXml(note),
-      buildAbcNoteTechnicalXml(note),
-      note.fermataType ? `<fermata>${note.fermataType === "inverted" ? "inverted" : "normal"}</fermata>` : ""
-    ].join("");
-    const buildAbcEmptyMeasureNotesXml = (measureDurationDiv, emptyMeasureRestType, staffOverride) => {
-      return `<note><rest/><duration>${measureDurationDiv}</duration><voice>1</voice><type>${emptyMeasureRestType}</type>${staffOverride !== null ? `<staff>${staffOverride}</staff>` : ""}</note>`;
-    };
+    const hasAbcNoteTechnicalFlagNotations = (note) => note.openString || note.snapPizzicato || note.harmonic || note.stopped || note.thumbPosition;
+    const hasAbcNoteFermataNotation = (note) => !!note.fermataType;
+    const hasAbcNoteTupletNotations = (note) => !!(note.tupletStart || note.tupletStop);
     const buildAbcBeamXmlByNoteIndex = (notes, beatDiv) => {
       var _a;
       const out = /* @__PURE__ */ new Map();
       const levelFromType = (typeText) => {
-        switch (String(typeText || "").trim().toLowerCase()) {
+        switch (String(typeText !== null && typeText !== void 0 ? typeText : "").trim().toLowerCase()) {
           case "eighth":
             return 1;
           case "16th":
@@ -153390,8 +153092,8 @@ var BUNDLED_CLI_MODULES = {
           const type = normalizeTypeForMusicXml((_a2 = ev.note) === null || _a2 === void 0 ? void 0 : _a2.type);
           return {
             timed: true,
-            chord: !Boolean((_b = ev.note) === null || _b === void 0 ? void 0 : _b.isRest),
-            grace: Boolean((_c = ev.note) === null || _c === void 0 ? void 0 : _c.grace),
+            chord: !((_b = ev.note) === null || _b === void 0 ? void 0 : _b.isRest),
+            grace: !!((_c = ev.note) === null || _c === void 0 ? void 0 : _c.grace),
             durationDiv: ((_d = ev.note) === null || _d === void 0 ? void 0 : _d.grace) ? 0 : Math.max(1, Math.round(Number((_e = ev.note) === null || _e === void 0 ? void 0 : _e.duration) || 1)),
             levels: levelFromType(type),
             explicitMode: (_f = ev.note) === null || _f === void 0 ? void 0 : _f.beamMode
@@ -153410,16 +153112,149 @@ var BUNDLED_CLI_MODULES = {
       return out;
     };
     const buildAbcNoteXml = (note, noteIndex, staffOverride, beamXmlByNoteIndex) => {
+      var _a, _b, _c, _d, _e, _f;
+      const voice = normalizeVoiceForMusicXml(note.voice);
+      const staff = Number(note.staff);
+      const staffValue = staffOverride !== null && staffOverride !== void 0 ? staffOverride : Number.isFinite(staff) ? Math.max(1, Math.round(staff || 1)) : null;
       const chunks = [];
-      chunks.push(buildAbcNoteLeadingDirectionXml(note));
-      chunks.push(buildAbcNoteCoreXml(note, noteIndex, staffOverride, beamXmlByNoteIndex));
-      chunks.push(buildAbcNoteNotationsXml(note));
+      chunks.push(note.chord ? "" : [
+        (_b = (_a = note.chordSymbols) === null || _a === void 0 ? void 0 : _a.map((chordSymbol) => buildHarmonyXmlFromChordSymbol(chordSymbol) || (0, direction_text_1.buildMusicXmlWordsDirectionXml)({ text: String(chordSymbol) })).join("")) !== null && _b !== void 0 ? _b : "",
+        (_d = (_c = note.annotations) === null || _c === void 0 ? void 0 : _c.filter((annotation) => annotation.trim().length > 0).map((annotation) => (0, direction_text_1.buildMusicXmlWordsDirectionXml)({ text: String(annotation) })).join("")) !== null && _d !== void 0 ? _d : "",
+        [
+          note.segno ? "<direction><direction-type><segno/></direction-type></direction>" : "",
+          note.coda ? "<direction><direction-type><coda/></direction-type></direction>" : "",
+          note.rehearsalMark ? `<direction><direction-type><rehearsal>${xmlEscape(String(note.rehearsalMark))}</rehearsal></direction-type></direction>` : "",
+          note.fine ? '<direction><sound fine="yes"/></direction>' : "",
+          note.daCapo ? '<direction><sound dacapo="yes"/></direction>' : "",
+          note.dalSegno ? '<direction><sound dalsegno="segno"/></direction>' : "",
+          note.toCoda ? '<direction><sound tocoda="coda"/></direction>' : "",
+          note.crescendoStart ? (0, dynamics_1.buildMusicXmlDirectionFeatureXml)({ kind: "wedge", wedgeType: "crescendo" }) : note.diminuendoStart ? (0, dynamics_1.buildMusicXmlDirectionFeatureXml)({ kind: "wedge", wedgeType: "diminuendo" }) : note.crescendoStop || note.diminuendoStop ? (0, dynamics_1.buildMusicXmlDirectionFeatureXml)({ kind: "wedge", wedgeType: "stop" }) : "",
+          note.dynamicMark ? (0, dynamics_1.buildMusicXmlDirectionFeatureXml)({ kind: "dynamic", mark: (0, dynamics_1.normalizeDynamicMark)(String(note.dynamicMark)) }) : "",
+          note.sfz ? (0, dynamics_1.buildMusicXmlDirectionFeatureXml)({ kind: "dynamic", mark: "sfz" }) : ""
+        ].filter((part) => part.length > 0).join("")
+      ].filter((part) => part.length > 0).join(""));
+      chunks.push([
+        "<note>",
+        ...note.chord ? ["<chord/>"] : [],
+        ...note.grace ? [(0, note_elements_1.buildMusicXmlGraceXml)({ slash: note.graceSlash })] : [],
+        note.isRest ? "<rest/>" : (0, pitches_1.buildMusicXmlPitchXml)({
+          step: note.step,
+          alter: note.alter,
+          octave: note.octave
+        }),
+        ...note.grace ? [] : [`<duration>${Math.max(1, Math.round(Number(note.duration) || 1))}</duration>`],
+        `<voice>${xmlEscape(voice)}</voice>`,
+        ...staffValue ? [`<staff>${staffValue}</staff>`] : [],
+        (0, note_elements_1.buildMusicXmlLyricXml)({
+          text: note.lyricText,
+          syllabic: note.lyricSyllabic || "single",
+          extend: note.lyricExtend
+        }),
+        `<type>${normalizeTypeForMusicXml(note.type)}</type>`,
+        !note.chord && beamXmlByNoteIndex.has(noteIndex) ? String(beamXmlByNoteIndex.get(noteIndex)) : "",
+        (0, tuplets_1.buildMusicXmlTimeModificationXml)({
+          actualNotes: (_e = note.timeModification) === null || _e === void 0 ? void 0 : _e.actual,
+          normalNotes: (_f = note.timeModification) === null || _f === void 0 ? void 0 : _f.normal
+        }),
+        (0, note_elements_1.buildMusicXmlAccidentalXml)({
+          text: note.accidentalText,
+          editorial: note.accidentalEditorial,
+          cautionary: note.accidentalCautionary
+        }),
+        (0, ties_1.buildMusicXmlTieItemsXml)({
+          tieStart: !!note.tieStart,
+          tieStop: !!note.tieStop
+        })
+      ].join(""));
+      chunks.push(hasAbcNoteNotations(note) ? [
+        (0, ties_1.buildMusicXmlTiedItemsXml)({
+          tiedStart: !!note.tieStart,
+          tiedStop: !!note.tieStop
+        }),
+        (0, slurs_1.buildMusicXmlSlursXml)([
+          ...note.slurStart ? [{ type: "start" }] : [],
+          ...note.slurStop ? [{ type: "stop" }] : []
+        ]),
+        `${note.tupletStart ? '<tuplet type="start"/>' : ""}${note.tupletStop ? '<tuplet type="stop"/>' : ""}`,
+        [
+          [
+            note.trill ? (0, ornaments_1.buildMusicXmlOrnamentItemsXml)([{ kind: "trill-mark" }]) : "",
+            note.trillLineStop ? '<wavy-line type="stop"/>' : note.trillLineStart ? '<wavy-line type="start"/>' : "",
+            note.trillAccidentalText ? `<accidental-mark>${xmlEscape(String(note.trillAccidentalText))}</accidental-mark>` : ""
+          ].filter((part) => part.length > 0).join("").replace(/^/, "<ornaments>").concat("</ornaments>"),
+          note.turnType ? (0, ornaments_1.buildMusicXmlOrnamentsXml)([
+            {
+              kind: note.turnType === "inverted-turn" ? "inverted-turn" : "turn",
+              ...note.turnSlash ? { slash: true } : {}
+            },
+            ...note.delayedTurn ? [{ kind: "delayed-turn" }] : []
+          ]) : "",
+          note.mordentType ? (0, ornaments_1.buildMusicXmlOrnamentsXml)([
+            {
+              kind: note.mordentType === "inverted-mordent" ? "inverted-mordent" : "mordent"
+            }
+          ]) : "",
+          note.tremoloType ? (0, ornaments_1.buildMusicXmlOrnamentsXml)([
+            {
+              kind: "tremolo",
+              tremoloType: note.tremoloType,
+              marks: note.tremoloMarks
+            }
+          ]) : "",
+          note.schleifer ? (0, ornaments_1.buildMusicXmlOrnamentsXml)([{ kind: "schleifer" }]) : "",
+          note.shake ? (0, ornaments_1.buildMusicXmlOrnamentsXml)([{ kind: "shake" }]) : "",
+          `${note.glissandoStart ? '<glissando type="start" number="1">wavy</glissando>' : ""}${note.glissandoStop ? '<glissando type="stop" number="1">wavy</glissando>' : ""}`,
+          `${note.slideStart ? '<slide type="start" number="1"/>' : ""}${note.slideStop ? '<slide type="stop" number="1"/>' : ""}`,
+          note.arpeggiate ? "<arpeggiate/>" : ""
+        ].filter((part) => part.length > 0).join(""),
+        [
+          (0, articulations_1.buildMusicXmlArticulationItemsXml)([
+            ...[
+              note.staccato ? "staccato" : "",
+              note.staccatissimo ? "staccatissimo" : "",
+              note.accent ? "accent" : "",
+              note.tenuto ? "tenuto" : ""
+            ].filter((part) => part.length > 0),
+            ...[
+              note.strongAccent ? "strong-accent" : "",
+              note.breathMark ? "breath-mark" : "",
+              note.caesura ? "caesura" : ""
+            ].filter((part) => part.length > 0)
+          ]),
+          note.stress ? "<stress/>" : "",
+          note.unstress ? "<unstress/>" : "",
+          note.phraseMark ? `<other-articulation>${xmlEscape(String(note.phraseMark))}</other-articulation>` : ""
+        ].filter((part) => part.length > 0).join("").replace(/^/, "<articulations>").concat("</articulations>"),
+        (0, note_elements_1.buildMusicXmlTechnicalXml)([
+          ...[
+            note.upBow ? "<up-bow/>" : "",
+            note.downBow ? "<down-bow/>" : "",
+            note.doubleTongue ? "<double-tongue/>" : "",
+            note.tripleTongue ? "<triple-tongue/>" : ""
+          ].filter((part) => part.length > 0),
+          ...[
+            note.heel ? "<heel/>" : "",
+            note.toe ? "<toe/>" : ""
+          ].filter((part) => part.length > 0),
+          ...note.fingerings ? note.fingerings.map((fingering) => (0, note_elements_1.buildMusicXmlFingeringXml)(fingering)) : [],
+          ...note.strings ? note.strings.map((stringText) => (0, note_elements_1.buildMusicXmlStringNumberXml)(stringText)) : [],
+          ...note.plucks ? note.plucks.map((pluckText) => pluckText ? `<pluck>${xmlEscape(pluckText)}</pluck>` : "") : [],
+          ...[
+            note.openString ? "<open-string/>" : "",
+            note.snapPizzicato ? "<snap-pizzicato/>" : "",
+            note.harmonic ? "<harmonic/>" : "",
+            note.stopped ? "<stopped/>" : "",
+            note.thumbPosition ? "<thumb-position/>" : ""
+          ].filter((part) => part.length > 0)
+        ]),
+        note.fermataType ? `<fermata>${note.fermataType === "inverted" ? "inverted" : "normal"}</fermata>` : ""
+      ].filter((part) => part.length > 0).join("").replace(/^/, "<notations>").concat("</notations>") : "");
       chunks.push("</note>");
       return chunks.join("");
     };
     const buildAbcMeasureNotesXml = (notes, measureDurationDiv, emptyMeasureRestType, beatDiv, staffOverride = null) => {
       if (!notes.length) {
-        return buildAbcEmptyMeasureNotesXml(measureDurationDiv, emptyMeasureRestType, staffOverride);
+        return `<note><rest/><duration>${measureDurationDiv}</duration><voice>1</voice><type>${emptyMeasureRestType}</type>${staffOverride !== null ? `<staff>${staffOverride}</staff>` : ""}</note>`;
       }
       const beamXmlByNoteIndex = buildAbcBeamXmlByNoteIndex(notes, beatDiv);
       return notes.map((note, noteIndex) => buildAbcNoteXml(note, noteIndex, staffOverride, beamXmlByNoteIndex)).join("");
@@ -153471,12 +153306,13 @@ var BUNDLED_CLI_MODULES = {
       return stores.tempoByMeasureByVoice[voiceId];
     };
     const finalizeAbcActiveEndings = (stores) => {
+      var _a;
       for (const voiceId of Object.keys(stores.measuresByVoice)) {
         const measures = stores.measuresByVoice[voiceId];
         while (measures.length > 1 && measures[measures.length - 1].length === 0) {
           measures.pop();
         }
-        const activeEndingMarker = String(stores.activeEndingByVoice[voiceId] || "");
+        const activeEndingMarker = String((_a = stores.activeEndingByVoice[voiceId]) !== null && _a !== void 0 ? _a : "");
         if (activeEndingMarker) {
           const lastMeasureNo = measures.length;
           if (lastMeasureNo >= 1) {
@@ -153560,7 +153396,7 @@ var BUNDLED_CLI_MODULES = {
         return { handled: true, activeKeyFifths, activeKeySignatureAccidentals, activeUnitLength, activeMeter, activeTempoBpm, measureAccidentals };
       }
       if (fieldName === "Q") {
-        activeTempoBpm = parseTempoFromQ(fieldValue || "", context.warnings);
+        activeTempoBpm = parseTempoFromQ(fieldValue !== null && fieldValue !== void 0 ? fieldValue : "", context.warnings);
         if (Number.isFinite(activeTempoBpm)) {
           ensureAbcTempoByMeasure(context.voiceStores, context.entryVoiceId)[context.currentMeasureNo] = Math.max(20, Math.min(300, Math.round(Number(activeTempoBpm))));
         }
@@ -153637,23 +153473,6 @@ var BUNDLED_CLI_MODULES = {
       }
       context.commitPlayableEvent(eventNotes, context.resolution.commitOptions);
       return true;
-    };
-    const buildAbcPlayableEventNotes = (context) => {
-      const notes = [];
-      for (let pitchIndex = 0; pitchIndex < context.pitchSources.length; pitchIndex += 1) {
-        const note = context.buildPlayableNoteForBody(context.pitchSources[pitchIndex], context.timing.absoluteLength, context.timing.dur, context.octaveWarningMessage);
-        if (!note) {
-          notes.length = 0;
-          break;
-        }
-        if (pitchIndex === 0) {
-          context.finalizePlayableEventStart(note, context.timing.dur, context.timing.activeTuplet, context.firstNoteOptions);
-        } else {
-          note.chord = true;
-        }
-        notes.push(note);
-      }
-      return notes;
     };
     const processAbcSimpleBodyToken = (bodyToken, context) => {
       if (!bodyToken) {
@@ -153778,7 +153597,7 @@ var BUNDLED_CLI_MODULES = {
         Ebm: -6,
         Abm: -7
       };
-      const normalized = String(raw || "").trim().replace(/\s+/g, "");
+      const normalized = String(raw !== null && raw !== void 0 ? raw : "").trim().replace(/\s+/g, "");
       if (Object.prototype.hasOwnProperty.call(table, normalized)) {
         return table[normalized];
       }
@@ -153843,10 +153662,10 @@ var BUNDLED_CLI_MODULES = {
     const STOPPED_DECORATIONS = /* @__PURE__ */ new Set(["stopped", "+", "plus", "stopped horn", "stopped-horn"]);
     const THUMB_POSITION_DECORATIONS = /* @__PURE__ */ new Set(["thumb", "thumbposition", "thumb-position", "thumbpos", "thumb pos", "thumb position"]);
     function tokenizeAbcLyricLine(text) {
-      const raw = String(text || "").trim();
+      const raw = String(text !== null && text !== void 0 ? text : "").trim();
       if (!raw)
         return [];
-      const chunks = raw.replace(/\|/g, " ").split(/\s+/).map((token) => token.trim()).filter(Boolean);
+      const chunks = raw.replace(/\|/g, " ").split(/\s+/).map((token) => token.trim()).filter((token) => token.length > 0);
       const tokens = [];
       let pendingHyphenWord = false;
       for (const chunk of chunks) {
@@ -153887,10 +153706,11 @@ var BUNDLED_CLI_MODULES = {
       return tokens;
     }
     function splitBodyTextByInlineVoice(text, initialVoiceId) {
+      var _a;
       const segments = [];
-      let activeVoiceId = String(initialVoiceId || "1").trim() || "1";
+      let activeVoiceId = String(initialVoiceId !== null && initialVoiceId !== void 0 ? initialVoiceId : "1").trim() || "1";
       let buffer = "";
-      const raw = String(text || "");
+      const raw = String(text !== null && text !== void 0 ? text : "");
       let idx = 0;
       while (idx < raw.length) {
         if (raw[idx] === "[") {
@@ -153901,7 +153721,7 @@ var BUNDLED_CLI_MODULES = {
               segments.push({ voiceId: activeVoiceId, text: buffer });
             }
             buffer = "";
-            const voiceMatch = String(inlineField.fieldValue || "").match(/^(\S+)/);
+            const voiceMatch = String((_a = inlineField.fieldValue) !== null && _a !== void 0 ? _a : "").match(/^(\S+)/);
             if (voiceMatch) {
               activeVoiceId = voiceMatch[1];
             } else {
@@ -153923,8 +153743,8 @@ var BUNDLED_CLI_MODULES = {
       };
     }
     function splitBodyTextByOverlay(text, baseVoiceId) {
-      const raw = String(text || "");
-      const normalizedBaseVoiceId = String(baseVoiceId || "1").trim() || "1";
+      const raw = String(text !== null && text !== void 0 ? text : "");
+      const normalizedBaseVoiceId = String(baseVoiceId !== null && baseVoiceId !== void 0 ? baseVoiceId : "1").trim() || "1";
       const overlayBuffers = [""];
       let completedMeasureSkeleton = "";
       let activeOverlayIndex = 0;
@@ -153992,12 +153812,13 @@ var BUNDLED_CLI_MODULES = {
       })).filter((segment) => segment.text.trim().length > 0);
     }
     function parseUserDefinedDecoration(rawValue) {
-      const text = String(rawValue || "").trim();
+      var _a, _b;
+      const text = String(rawValue !== null && rawValue !== void 0 ? rawValue : "").trim();
       const match = text.match(/^(\S)(?:\s*=\s*|\s+)(.+)$/);
       if (!match)
         return null;
-      const symbol = String(match[1] || "");
-      const rhs = String(match[2] || "").trim();
+      const symbol = String((_a = match[1]) !== null && _a !== void 0 ? _a : "");
+      const rhs = String((_b = match[2]) !== null && _b !== void 0 ? _b : "").trim();
       if (!symbol || !rhs)
         return null;
       const wrapped = rhs.match(/^[!+](.+)[!+]$/);
@@ -154007,8 +153828,8 @@ var BUNDLED_CLI_MODULES = {
       return { symbol, decoration };
     }
     function expandUserDefinedDecorationSymbols(text, userDefinedDecorationBySymbol) {
-      const raw = String(text || "");
-      const symbolMap = userDefinedDecorationBySymbol || {};
+      const raw = String(text !== null && text !== void 0 ? text : "");
+      const symbolMap = userDefinedDecorationBySymbol !== null && userDefinedDecorationBySymbol !== void 0 ? userDefinedDecorationBySymbol : {};
       if (!raw || Object.keys(symbolMap).length === 0) {
         return raw;
       }
@@ -154038,7 +153859,7 @@ var BUNDLED_CLI_MODULES = {
       return out;
     }
     function parseTempoFromQ(rawQ, warnings) {
-      const raw = String(rawQ || "").trim();
+      const raw = String(rawQ !== null && rawQ !== void 0 ? rawQ : "").trim();
       if (!raw) {
         return null;
       }
@@ -154071,8 +153892,9 @@ var BUNDLED_CLI_MODULES = {
       return null;
     }
     function parseForMusicXml(source, settings) {
+      var _a, _b, _c;
       const warnings = [];
-      const lines = String(source || "").split("\n");
+      const lines = String(source !== null && source !== void 0 ? source : "").split("\n");
       const trillWidthHintByKey = /* @__PURE__ */ new Map();
       const keyHintFifthsByKey = /* @__PURE__ */ new Map();
       const measureMetaByKey = /* @__PURE__ */ new Map();
@@ -154127,7 +153949,7 @@ var BUNDLED_CLI_MODULES = {
       const meter = parseMeter(headers.M || "4/4", warnings);
       const unitLength = parseFraction(headers.L || "1/8", "L", warnings);
       const keyInfo = parseKey(headers.K || "C", warnings);
-      const tempoBpm = parseTempoFromQ(headers.Q || "", warnings);
+      const tempoBpm = parseTempoFromQ((_a = headers.Q) !== null && _a !== void 0 ? _a : "", warnings);
       const keySignatureAccidentals = keySignatureAlterByStep(keyInfo.fifths);
       const voiceStores = createAbcVoiceStores();
       let noteCount = 0;
@@ -154137,7 +153959,7 @@ var BUNDLED_CLI_MODULES = {
         let measureAccidentals = {};
         let activeUnitLength = unitLength;
         let activeMeter = meter;
-        let activeTempoBpm = Number.isFinite(tempoBpm) ? Number(tempoBpm) : null;
+        let activeTempoBpm = tempoBpm !== null && tempoBpm !== void 0 ? tempoBpm : null;
         let activeKeyFifths = Number.isFinite(voiceStores.currentKeyFifthsByVoice[entry.voiceId]) ? Number(voiceStores.currentKeyFifthsByVoice[entry.voiceId]) : keyInfo.fifths;
         let activeKeySignatureAccidentals = keySignatureAlterByStep(activeKeyFifths);
         let lastNote = null;
@@ -154210,9 +154032,9 @@ var BUNDLED_CLI_MODULES = {
         let beamRunActive = false;
         let sawInterEventWhitespace = false;
         let beamCursorDiv = 0;
-        let activeEndingMarker = String(voiceStores.activeEndingByVoice[entry.voiceId] || "");
+        let activeEndingMarker = String((_b = voiceStores.activeEndingByVoice[entry.voiceId]) !== null && _b !== void 0 ? _b : "");
         let idx = 0;
-        const text = entry.text;
+        const text = (_c = entry.text) !== null && _c !== void 0 ? _c : "";
         const warnBody = (message) => {
           warnings.push("line " + entry.lineNo + ": " + message);
         };
@@ -154916,20 +154738,22 @@ var BUNDLED_CLI_MODULES = {
           }
         };
         const finalizePlayableEventStart = (note, dur, activeTuplet, options = {}) => {
+          var _a2;
           const applyTieStop = options.applyTieStop !== false;
           applyBeamModeForEvent(note, dur);
           currentEventNo += 1;
-          const trillHint = trillWidthHintByKey.get(`${entry.voiceId}#${currentMeasureNo}#${currentEventNo}`) || "";
+          const trillHint = (_a2 = trillWidthHintByKey.get(`${entry.voiceId}#${currentMeasureNo}#${currentEventNo}`)) !== null && _a2 !== void 0 ? _a2 : "";
           applyPendingToPlayableNote(note, { applySlurStart: true, applyTieStop, trillHint });
           applyTupletToEventStart(note, activeTuplet);
           note.voice = entry.voiceId;
         };
         const buildPlayableNoteForBody = (pitchSource, absoluteLength, dur, octaveWarningMessage) => {
+          var _a2;
           let note;
           try {
             note = buildNoteData(pitchSource.pitchChar, pitchSource.accidentalText, pitchSource.octaveShift, absoluteLength, dur, entry.lineNo, activeKeySignatureAccidentals, measureAccidentals);
           } catch (error) {
-            if (error instanceof Error && /Octave out of range/i.test(error.message || "")) {
+            if (error instanceof Error && /Octave out of range/i.test((_a2 = error.message) !== null && _a2 !== void 0 ? _a2 : "")) {
               warnBody(octaveWarningMessage);
               return null;
             }
@@ -154946,6 +154770,7 @@ var BUNDLED_CLI_MODULES = {
           lastEventNotes = [];
         };
         const commitPlayableEvent = (notes, options = {}) => {
+          var _a2;
           const applyChordTieStop = options.applyChordTieStop === true;
           if (applyChordTieStop && pendingTieToNext && notes.length > 0) {
             for (const note of notes) {
@@ -154962,22 +154787,30 @@ var BUNDLED_CLI_MODULES = {
             clearLastEventState();
             return false;
           }
-          lastNote = notes[0] || null;
+          lastNote = (_a2 = notes[0]) !== null && _a2 !== void 0 ? _a2 : null;
           lastEventNotes = notes;
           noteCount += notes.length;
           return true;
         };
         const buildPlayableEventFromPitches = (pitchSources, timing, options = {}) => {
-          const octaveWarningMessage = options.octaveWarningMessage || "Skipped note with unsupported octave range.";
-          const firstNoteOptions = options.firstNoteOptions || {};
-          return buildAbcPlayableEventNotes({
-            pitchSources,
-            timing,
-            octaveWarningMessage,
-            firstNoteOptions,
-            buildPlayableNoteForBody,
-            finalizePlayableEventStart
-          });
+          var _a2, _b2;
+          const octaveWarningMessage = (_a2 = options.octaveWarningMessage) !== null && _a2 !== void 0 ? _a2 : "Skipped note with unsupported octave range.";
+          const firstNoteOptions = (_b2 = options.firstNoteOptions) !== null && _b2 !== void 0 ? _b2 : {};
+          const notes = [];
+          for (let pitchIndex = 0; pitchIndex < pitchSources.length; pitchIndex += 1) {
+            const note = buildPlayableNoteForBody(pitchSources[pitchIndex], timing.absoluteLength, timing.dur, octaveWarningMessage);
+            if (!note) {
+              notes.length = 0;
+              break;
+            }
+            if (pitchIndex === 0) {
+              finalizePlayableEventStart(note, timing.dur, timing.activeTuplet, firstNoteOptions);
+            } else {
+              note.chord = true;
+            }
+            notes.push(note);
+          }
+          return notes;
         };
         const playableEventOptionsForSource = (source2) => ({
           invalidLengthMessage: source2 === "chord" ? "Skipped chord with invalid length." : "Skipped note with invalid length.",
@@ -155328,7 +155161,10 @@ var BUNDLED_CLI_MODULES = {
           }
           return false;
         };
-        const isBeamableAbcNote = (note) => Boolean(note && !note.isRest && !note.grace && ["eighth", "16th", "32nd", "64th"].includes(String(note.type || "").trim().toLowerCase()));
+        const isBeamableAbcNote = (note) => {
+          var _a2;
+          return !!(note && !note.isRest && !note.grace && ["eighth", "16th", "32nd", "64th"].includes(String((_a2 = note.type) !== null && _a2 !== void 0 ? _a2 : "").trim().toLowerCase()));
+        };
         const applyBeamModeForEvent = (note, durationDiv) => {
           const resolvedDurationDiv = Math.max(0, Math.round(Number(durationDiv) || 0));
           const beatDiv = Math.max(1, Math.round(960 * 4 / Math.max(1, Math.round(Number(activeMeter === null || activeMeter === void 0 ? void 0 : activeMeter.beatType) || 4))));
@@ -155413,28 +155249,30 @@ var BUNDLED_CLI_MODULES = {
       };
     }
     function parseVoiceDirectiveTail(raw) {
+      var _a, _b;
       if (!raw) {
         return { name: "", clef: "", transpose: null, bodyText: "", skippedText: "", unsupportedKeys: [] };
       }
-      let bodyText = String(raw);
+      let bodyText = String(raw !== null && raw !== void 0 ? raw : "");
       let name = "";
       let clef = "";
       let transpose = null;
       const unsupportedKeys = [];
       const bareClefMatch = bodyText.match(/^\s*(bass|treble|alto|tenor|c3|c4)(?=\s|$)/i);
       if (bareClefMatch) {
-        clef = String(bareClefMatch[1] || "").trim().toLowerCase();
+        clef = String((_a = bareClefMatch[1]) !== null && _a !== void 0 ? _a : "").trim().toLowerCase();
         bodyText = bodyText.slice(bareClefMatch[0].length);
       }
       const attrRegex = /([A-Za-z][A-Za-z0-9_-]*)\s*=\s*("([^"]*)"|(\S+))/g;
       bodyText = bodyText.replace(attrRegex, (_full, key, _quotedValue, quotedInner, bareValue) => {
+        var _a2, _b2, _c;
         const lowerKey = String(key).toLowerCase();
         if (lowerKey === "name") {
-          name = quotedInner || bareValue || "";
+          name = (_a2 = quotedInner !== null && quotedInner !== void 0 ? quotedInner : bareValue) !== null && _a2 !== void 0 ? _a2 : "";
         } else if (lowerKey === "clef") {
-          clef = String(quotedInner || bareValue || "").trim().toLowerCase();
+          clef = String((_b2 = quotedInner !== null && quotedInner !== void 0 ? quotedInner : bareValue) !== null && _b2 !== void 0 ? _b2 : "").trim().toLowerCase();
         } else if (lowerKey === "transpose") {
-          const parsed = Number.parseInt(String(quotedInner || bareValue || "").trim(), 10);
+          const parsed = Number.parseInt(String((_c = quotedInner !== null && quotedInner !== void 0 ? quotedInner : bareValue) !== null && _c !== void 0 ? _c : "").trim(), 10);
           if (Number.isFinite(parsed) && parsed >= -24 && parsed <= 24) {
             transpose = { chromatic: parsed };
           }
@@ -155446,7 +155284,7 @@ var BUNDLED_CLI_MODULES = {
       bodyText = bodyText.trim();
       let skippedText = "";
       const firstTokenMatch = bodyText.match(/^(\S+)/);
-      const firstToken = firstTokenMatch ? firstTokenMatch[1] : "";
+      const firstToken = firstTokenMatch ? (_b = firstTokenMatch[1]) !== null && _b !== void 0 ? _b : "" : "";
       if (firstToken && /^[A-Za-z][A-Za-z0-9_-]*$/.test(firstToken) && /[^A-Ga-gzZxX]/.test(firstToken)) {
         skippedText = firstToken;
         bodyText = bodyText.slice(firstToken.length).trim();
@@ -155461,6 +155299,7 @@ var BUNDLED_CLI_MODULES = {
       };
     }
     function inferTransposeFromPartName(partName) {
+      var _a;
       if (!partName) {
         return null;
       }
@@ -155469,7 +155308,7 @@ var BUNDLED_CLI_MODULES = {
       if (!m) {
         return null;
       }
-      const tonic = String(m[1]).toUpperCase() + (m[2] || "");
+      const tonic = String(m[1]).toUpperCase() + ((_a = m[2]) !== null && _a !== void 0 ? _a : "");
       const semitoneByTonic = {
         C: 0,
         "C#": 1,
@@ -155502,7 +155341,7 @@ var BUNDLED_CLI_MODULES = {
       return { chromatic };
     }
     function parseMeter(raw, warnings) {
-      const normalized = String(raw || "").trim();
+      const normalized = String(raw !== null && raw !== void 0 ? raw : "").trim();
       if (normalized === "C") {
         return { beats: 4, beatType: 4 };
       }
@@ -155518,11 +155357,11 @@ var BUNDLED_CLI_MODULES = {
     }
     function parseFraction(raw, fieldName, warnings) {
       const parsed = abcCommon.parseFractionText(raw, { num: 1, den: 8 });
-      if (parsed.num === 1 && parsed.den === 8 && !/^\s*\d+\/\d+\s*$/.test(String(raw || ""))) {
+      if (parsed.num === 1 && parsed.den === 8 && !/^\s*\d+\/\d+\s*$/.test(String(raw !== null && raw !== void 0 ? raw : ""))) {
         warnings.push(fieldName + " has invalid format; defaulted to 1/8: " + raw);
         return parsed;
       }
-      const m = String(raw || "").match(/^\s*(\d+)\/(\d+)\s*$/);
+      const m = String(raw !== null && raw !== void 0 ? raw : "").match(/^\s*(\d+)\/(\d+)\s*$/);
       if (!m || !Number(m[1]) || !Number(m[2])) {
         warnings.push(fieldName + " has invalid value; defaulted to 1/8: " + raw);
         return { num: 1, den: 8 };
@@ -155542,6 +155381,7 @@ var BUNDLED_CLI_MODULES = {
       return abcCommon.parseAbcLengthToken(token, lineNo);
     }
     function parseGraceGroupAt(text, startIdx, lineNo, unitLength, keySignatureAccidentals, measureAccidentals, voiceId, warnings) {
+      var _a;
       const parsedGrace = (0, abc_parser_1.parseAbcGraceGroupAt)(text, startIdx, lineNo, warnings);
       if (!parsedGrace)
         return null;
@@ -155560,7 +155400,7 @@ var BUNDLED_CLI_MODULES = {
         try {
           note = buildNoteData(pitchChar, accidentalText, octaveShift, absoluteLength, dur, lineNo, keySignatureAccidentals, graceAccidentals);
         } catch (error) {
-          if (error instanceof Error && /Octave out of range/i.test(error.message || "")) {
+          if (error instanceof Error && /Octave out of range/i.test((_a = error.message) !== null && _a !== void 0 ? _a : "")) {
             warnings.push("line " + lineNo + ": Skipped grace note with unsupported octave range.");
             continue;
           }
@@ -155832,18 +155672,6 @@ var BUNDLED_CLI_MODULES = {
       const parsed = Number(raw);
       return Number.isFinite(parsed) ? parsed : null;
     };
-    const buildAbcExportPartNameById = (doc) => {
-      var _a, _b, _c;
-      const partNameById = /* @__PURE__ */ new Map();
-      for (const scorePart of Array.from(doc.querySelectorAll("part-list > score-part"))) {
-        const id = (_a = scorePart.getAttribute("id")) !== null && _a !== void 0 ? _a : "";
-        if (!id)
-          continue;
-        const name = ((_c = (_b = scorePart.querySelector("part-name")) === null || _b === void 0 ? void 0 : _b.textContent) === null || _c === void 0 ? void 0 : _c.trim()) || id;
-        partNameById.set(id, name);
-      }
-      return partNameById;
-    };
     const compareAbcExportLanes = (a, b) => {
       var _a, _b;
       const staffA = a.staff === null ? Number.POSITIVE_INFINITY : Number(a.staff);
@@ -155882,130 +155710,107 @@ var BUNDLED_CLI_MODULES = {
         return { ...lane, voiceId: `${partId}${staffSuffix}${voiceSuffix || `_l${laneIndex + 1}`}` };
       });
     };
-    const buildAbcExportLaneName = (partName, laneCount, lane) => {
-      if (laneCount <= 1)
-        return partName;
-      if (lane.staff && lane.voice)
-        return `${partName} (Staff ${lane.staff} Voice ${lane.voice})`;
-      if (lane.staff)
-        return `${partName} (Staff ${lane.staff})`;
-      if (lane.voice)
-        return `${partName} (Voice ${lane.voice})`;
-      return `${partName} (Lane)`;
-    };
-    const buildAbcExportTransposeMetaLine = (normalizedVoiceId, measure) => {
-      var _a, _b, _c, _d;
-      const transposeNode = measure.querySelector(":scope > attributes > transpose");
-      if (!transposeNode)
-        return null;
-      const chromatic = Number(((_b = (_a = transposeNode.querySelector(":scope > chromatic")) === null || _a === void 0 ? void 0 : _a.textContent) === null || _b === void 0 ? void 0 : _b.trim()) || "");
-      const diatonic = Number(((_d = (_c = transposeNode.querySelector(":scope > diatonic")) === null || _c === void 0 ? void 0 : _c.textContent) === null || _d === void 0 ? void 0 : _d.trim()) || "");
-      if (!Number.isFinite(chromatic) && !Number.isFinite(diatonic))
-        return null;
-      const parts = [`%@mks transpose voice=${normalizedVoiceId}`];
-      if (Number.isFinite(chromatic))
-        parts.push(`chromatic=${Math.round(chromatic)}`);
-      if (Number.isFinite(diatonic))
-        parts.push(`diatonic=${Math.round(diatonic)}`);
-      return parts.join(" ");
-    };
-    const buildAbcExportDiagMetaLines = (normalizedVoiceId, measure, safeMeasureNumber) => {
-      const fields = Array.from(measure.querySelectorAll(':scope > attributes > miscellaneous > miscellaneous-field[name^="mks:diag:"]'));
-      if (!fields.length)
-        return [];
-      const byName = /* @__PURE__ */ new Map();
-      for (const field of fields) {
-        const name = (field.getAttribute("name") || "").trim();
-        if (!name)
-          continue;
-        const value = (field.textContent || "").trim();
-        byName.set(name, value);
-      }
-      const orderedNames = Array.from(byName.keys()).sort((a, b) => {
-        const isCountA = a === "mks:diag:count";
-        const isCountB = b === "mks:diag:count";
-        if (isCountA && !isCountB)
-          return -1;
-        if (!isCountA && isCountB)
-          return 1;
-        return a.localeCompare(b);
-      });
-      return orderedNames.map((name) => {
-        const value = byName.get(name) || "";
-        return `%@mks diag voice=${normalizedVoiceId} measure=${safeMeasureNumber} name=${name} enc=uri-v1 value=${encodeURIComponent(value)}`;
-      });
-    };
-    const buildAbcExportMeasureMetaLine = (normalizedVoiceId, measure, safeMeasureNumber, hasRightRepeat, rightEndingNumber, rightEndingType) => {
-      const rawMeasureNumber = (measure.getAttribute("number") || "").trim() || String(safeMeasureNumber);
-      const implicitAttr = (measure.getAttribute("implicit") || "").trim().toLowerCase();
-      const isImplicit = implicitAttr === "yes" || implicitAttr === "true" || implicitAttr === "1";
-      const rightRepeatNode = measure.querySelector(':scope > barline[location="right"] > repeat');
-      const repeatTimes = Number.parseInt(String((rightRepeatNode === null || rightRepeatNode === void 0 ? void 0 : rightRepeatNode.getAttribute("times")) || ""), 10);
-      if (!isImplicit && rawMeasureNumber === String(safeMeasureNumber) && (!hasRightRepeat || !Number.isFinite(repeatTimes) || repeatTimes <= 2) && (!rightEndingNumber || rightEndingType !== "discontinue")) {
-        return null;
-      }
-      const metaChunks = [
-        `%@mks measure voice=${normalizedVoiceId} measure=${safeMeasureNumber}`,
-        `number=${rawMeasureNumber}`,
-        `implicit=${isImplicit ? 1 : 0}`
-      ];
-      if (hasRightRepeat && Number.isFinite(repeatTimes) && repeatTimes > 2) {
-        metaChunks.push(`times=${Math.round(repeatTimes)}`);
-      }
-      if (rightEndingNumber && rightEndingType === "discontinue") {
-        metaChunks.push(`ending-stop=${rightEndingNumber}`);
-        metaChunks.push(`ending-type=${rightEndingType}`);
-      }
-      return metaChunks.join(" ");
-    };
     const applyAbcExportDirectionToPending = (direction, pendingDirectionWords, pendingDirectionDecorations, activeWedgeType) => {
-      const rehearsalTexts = Array.from(direction.querySelectorAll(":scope > direction-type > rehearsal")).map((node) => abcQuotedTextEscape(node.textContent || "")).filter(Boolean);
-      for (const rehearsalText of rehearsalTexts) {
-        pendingDirectionDecorations.push(`!rehearsal:${rehearsalText}!`);
+      appendAbcExportDirectionWords(direction, pendingDirectionWords);
+      appendAbcExportDirectionTextDecorations(direction, pendingDirectionDecorations);
+      appendAbcExportDirectionSoundDecorations(direction, pendingDirectionDecorations);
+      return appendAbcExportDirectionFeatureDecorations(direction, pendingDirectionDecorations, activeWedgeType);
+    };
+    const appendAbcExportDirectionWords = (direction, pendingDirectionWords) => {
+      pendingDirectionWords.push(...(0, direction_text_1.extractMusicXmlDirectionWords)(direction).map((feature) => abcQuotedTextEscape(feature.text)).filter((word) => word.length > 0));
+    };
+    const appendAbcExportDirectionTextDecorations = (direction, pendingDirectionDecorations) => {
+      for (const rehearsalText of Array.from(direction.querySelectorAll(":scope > direction-type > rehearsal")).map((node) => {
+        var _a;
+        return abcQuotedTextEscape((_a = node.textContent) !== null && _a !== void 0 ? _a : "");
+      }).filter((text) => text.length > 0)) {
+        appendAbcExportDirectionPresenceDecoration(pendingDirectionDecorations, true, `!rehearsal:${rehearsalText}!`);
       }
-      const words = (0, direction_text_1.extractMusicXmlDirectionWords)(direction).map((feature) => abcQuotedTextEscape(feature.text)).filter(Boolean);
-      pendingDirectionWords.push(...words);
-      if (direction.querySelector(":scope > direction-type > segno")) {
-        pendingDirectionDecorations.push("!segno!");
-      }
-      if (direction.querySelector(":scope > direction-type > coda")) {
-        pendingDirectionDecorations.push("!coda!");
-      }
-      if (direction.querySelector(':scope > sound[fine="yes"]')) {
-        pendingDirectionDecorations.push("!fine!");
-      }
-      const hasDaCapo = Boolean(direction.querySelector(':scope > sound[dacapo="yes"]'));
-      const hasToCoda = Boolean(direction.querySelector(":scope > sound[tocoda]"));
-      if (hasDaCapo && hasToCoda) {
-        pendingDirectionDecorations.push("!dacoda!");
-      } else if (hasDaCapo) {
-        pendingDirectionDecorations.push("!dacapo!");
-      }
-      if (direction.querySelector(":scope > sound[dalsegno]")) {
-        pendingDirectionDecorations.push("!dalsegno!");
-      }
-      if (hasToCoda && !hasDaCapo) {
-        pendingDirectionDecorations.push("!tocoda!");
-      }
+    };
+    const appendAbcExportDirectionSoundDecorations = (direction, pendingDirectionDecorations) => {
+      appendAbcExportDirectionMarkerDecorations(direction, pendingDirectionDecorations);
+      appendAbcExportDirectionJumpDecorations(direction, pendingDirectionDecorations);
+    };
+    const appendAbcExportDirectionMarkerDecorations = (direction, pendingDirectionDecorations) => {
+      appendAbcExportDirectionPresenceDecorations(pendingDirectionDecorations, [
+        [direction.querySelector(":scope > direction-type > segno") !== null, "!segno!"],
+        [direction.querySelector(":scope > direction-type > coda") !== null, "!coda!"],
+        [direction.querySelector(':scope > sound[fine="yes"]') !== null, "!fine!"]
+      ]);
+    };
+    const appendAbcExportDirectionJumpDecorations = (direction, pendingDirectionDecorations) => {
+      appendAbcExportDirectionDaCapoDecorations(direction, pendingDirectionDecorations);
+      appendAbcExportDirectionDalSegnoDecorations(direction, pendingDirectionDecorations);
+      appendAbcExportDirectionToCodaDecorations(direction, pendingDirectionDecorations);
+    };
+    const appendAbcExportDirectionDaCapoDecorations = (direction, pendingDirectionDecorations) => {
+      const hasDaCapo = direction.querySelector(':scope > sound[dacapo="yes"]') !== null;
+      const hasToCoda = direction.querySelector(":scope > sound[tocoda]") !== null;
+      appendAbcExportDirectionPresenceDecoration(pendingDirectionDecorations, hasDaCapo && hasToCoda, "!dacoda!");
+      appendAbcExportDirectionPresenceDecoration(pendingDirectionDecorations, hasDaCapo && !hasToCoda, "!dacapo!");
+    };
+    const appendAbcExportDirectionDalSegnoDecorations = (direction, pendingDirectionDecorations) => {
+      appendAbcExportDirectionPresenceDecoration(pendingDirectionDecorations, direction.querySelector(":scope > sound[dalsegno]") !== null, "!dalsegno!");
+    };
+    const appendAbcExportDirectionToCodaDecorations = (direction, pendingDirectionDecorations) => {
+      appendAbcExportDirectionPresenceDecoration(pendingDirectionDecorations, direction.querySelector(":scope > sound[tocoda]") !== null && direction.querySelector(':scope > sound[dacapo="yes"]') === null, "!tocoda!");
+    };
+    const appendAbcExportDirectionFeatureDecorations = (direction, pendingDirectionDecorations, activeWedgeType) => {
       const directionFeatures = (0, dynamics_1.extractMusicXmlDirectionFeatures)(direction);
+      appendAbcExportDirectionDynamicDecorations(directionFeatures, pendingDirectionDecorations);
+      return appendAbcExportDirectionWedgeDecorations(directionFeatures, pendingDirectionDecorations, activeWedgeType);
+    };
+    const appendAbcExportDirectionWedgeDecorations = (directionFeatures, pendingDirectionDecorations, activeWedgeType) => appendAbcExportDirectionWedgeStopDecorations(directionFeatures, pendingDirectionDecorations, appendAbcExportDirectionWedgeStartDecorations(directionFeatures, pendingDirectionDecorations, activeWedgeType));
+    const appendAbcExportDirectionWedgeStartDecorations = (directionFeatures, pendingDirectionDecorations, activeWedgeType) => {
+      const crescendoWedgeType = appendAbcExportDirectionWedgeMatch(directionFeatures, pendingDirectionDecorations, activeWedgeType, (feature) => feature.kind === "wedge" && feature.wedgeType === "crescendo", "!crescendo(!", "crescendo");
+      return appendAbcExportDirectionWedgeMatch(directionFeatures, pendingDirectionDecorations, crescendoWedgeType, (feature) => feature.kind === "wedge" && feature.wedgeType === "diminuendo", "!diminuendo(!", "diminuendo");
+    };
+    const appendAbcExportDirectionWedgeStopDecorations = (directionFeatures, pendingDirectionDecorations, activeWedgeType) => {
       let nextWedgeType = activeWedgeType;
       for (const feature of directionFeatures) {
-        if (feature.kind === "wedge" && feature.wedgeType === "crescendo") {
-          pendingDirectionDecorations.push("!crescendo(!");
-          nextWedgeType = "crescendo";
-        } else if (feature.kind === "wedge" && feature.wedgeType === "diminuendo") {
-          pendingDirectionDecorations.push("!diminuendo(!");
-          nextWedgeType = "diminuendo";
-        } else if (feature.kind === "wedge" && feature.wedgeType === "stop") {
+        if (feature.kind === "wedge" && feature.wedgeType === "stop") {
           pendingDirectionDecorations.push(nextWedgeType === "diminuendo" ? "!diminuendo)!" : "!crescendo)!");
           nextWedgeType = "";
         }
       }
-      for (const feature of directionFeatures) {
-        if (feature.kind === "dynamic")
-          pendingDirectionDecorations.push(`!${feature.mark}!`);
-      }
       return nextWedgeType;
+    };
+    const appendAbcExportDirectionWedgeMatch = (directionFeatures, pendingDirectionDecorations, activeWedgeType, predicate, decoration, nextWedgeType) => {
+      let result = activeWedgeType;
+      for (const feature of directionFeatures) {
+        if (predicate(feature)) {
+          pendingDirectionDecorations.push(decoration);
+          result = nextWedgeType;
+        }
+      }
+      return result;
+    };
+    const appendAbcExportDirectionDynamicDecorations = (directionFeatures, pendingDirectionDecorations) => {
+      appendAbcExportDirectionSfzDecorations(directionFeatures, pendingDirectionDecorations);
+      appendAbcExportDirectionStandardDynamicDecorations(directionFeatures, pendingDirectionDecorations);
+    };
+    const appendAbcExportDirectionSfzDecorations = (directionFeatures, pendingDirectionDecorations) => {
+      appendAbcExportDirectionFeatureMatches(directionFeatures, pendingDirectionDecorations, (feature) => feature.kind === "dynamic" && feature.mark === "sfz", () => "!sfz!");
+    };
+    const appendAbcExportDirectionStandardDynamicDecorations = (directionFeatures, pendingDirectionDecorations) => {
+      appendAbcExportDirectionFeatureMatches(directionFeatures, pendingDirectionDecorations, (feature) => feature.kind === "dynamic" && feature.mark !== "sfz", (feature) => `!${feature.mark}!`);
+    };
+    const appendAbcExportDirectionPresenceDecoration = (pendingDirectionDecorations, hasDecoration, decoration) => {
+      if (hasDecoration) {
+        pendingDirectionDecorations.push(decoration);
+      }
+    };
+    const appendAbcExportDirectionPresenceDecorations = (pendingDirectionDecorations, entries) => {
+      for (const [hasDecoration, decoration] of entries) {
+        appendAbcExportDirectionPresenceDecoration(pendingDirectionDecorations, hasDecoration, decoration);
+      }
+    };
+    const appendAbcExportDirectionFeatureMatches = (directionFeatures, pendingDirectionDecorations, predicate, decorationFromFeature) => {
+      for (const feature of directionFeatures) {
+        if (predicate(feature)) {
+          pendingDirectionDecorations.push(decorationFromFeature(feature));
+        }
+      }
     };
     const isMusicXmlNoteInAbcExportLane = (note, lane) => {
       var _a, _b, _c, _d, _e, _f;
@@ -156023,7 +155828,7 @@ var BUNDLED_CLI_MODULES = {
       return true;
     };
     const buildAbcExportPitchToken = (note, keyAlterMap, measureAccidentalByStepOctave) => {
-      var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l;
+      var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o;
       if (note.querySelector(":scope > rest"))
         return "z";
       const step = ((_b = (_a = note.querySelector(":scope > pitch > step")) === null || _a === void 0 ? void 0 : _a.textContent) === null || _b === void 0 ? void 0 : _b.trim()) || "C";
@@ -156036,10 +155841,10 @@ var BUNDLED_CLI_MODULES = {
       const accidentalNode = note.querySelector(":scope > accidental");
       const accidentalText = (_j = (_h = accidentalNode === null || accidentalNode === void 0 ? void 0 : accidentalNode.textContent) === null || _h === void 0 ? void 0 : _h.trim()) !== null && _j !== void 0 ? _j : "";
       const accidentalAlter = musicXmlAccidentalTextToAlter(accidentalText);
-      const accidentalEditorial = ((accidentalNode === null || accidentalNode === void 0 ? void 0 : accidentalNode.getAttribute("editorial")) || "").trim().toLowerCase() === "yes";
-      const accidentalCautionary = ((accidentalNode === null || accidentalNode === void 0 ? void 0 : accidentalNode.getAttribute("cautionary")) || "").trim().toLowerCase() === "yes";
-      const keyAlter = (_k = keyAlterMap[upperStep]) !== null && _k !== void 0 ? _k : 0;
-      const currentAlter = measureAccidentalByStepOctave.has(stepOctaveKey) ? (_l = measureAccidentalByStepOctave.get(stepOctaveKey)) !== null && _l !== void 0 ? _l : 0 : keyAlter;
+      const accidentalEditorial = ((_k = accidentalNode === null || accidentalNode === void 0 ? void 0 : accidentalNode.getAttribute("editorial")) !== null && _k !== void 0 ? _k : "").trim().toLowerCase() === "yes";
+      const accidentalCautionary = ((_l = accidentalNode === null || accidentalNode === void 0 ? void 0 : accidentalNode.getAttribute("cautionary")) !== null && _l !== void 0 ? _l : "").trim().toLowerCase() === "yes";
+      const keyAlter = (_m = keyAlterMap[upperStep]) !== null && _m !== void 0 ? _m : 0;
+      const currentAlter = measureAccidentalByStepOctave.has(stepOctaveKey) ? (_o = measureAccidentalByStepOctave.get(stepOctaveKey)) !== null && _o !== void 0 ? _o : 0 : keyAlter;
       let targetAlter = explicitAlter !== null ? explicitAlter : 0;
       if (accidentalAlter !== null) {
         targetAlter = accidentalAlter;
@@ -156067,14 +155872,6 @@ var BUNDLED_CLI_MODULES = {
       const merged = last.startsWith("[") ? last.replace("]", `${graceSlashPrefix}${pitchToken}]`) : `[${last}${graceSlashPrefix}${pitchToken}]`;
       pendingGraceTokens.push(merged);
     };
-    const readAbcExportTimeModification = (note) => {
-      var _a, _b, _c, _d;
-      const actual = Number(((_b = (_a = note.querySelector(":scope > time-modification > actual-notes")) === null || _a === void 0 ? void 0 : _a.textContent) === null || _b === void 0 ? void 0 : _b.trim()) || "");
-      const normal = Number(((_d = (_c = note.querySelector(":scope > time-modification > normal-notes")) === null || _c === void 0 ? void 0 : _c.textContent) === null || _d === void 0 ? void 0 : _d.trim()) || "");
-      if (!Number.isFinite(actual) || actual <= 0 || !Number.isFinite(normal) || normal <= 0)
-        return null;
-      return { actual: Math.round(actual), normal: Math.round(normal) };
-    };
     const buildAbcExportLengthToken = (noteDuration, currentDivisions, unitLength, timeModification) => {
       const rawWholeFraction = exports.AbcCommon.reduceFraction(noteDuration, currentDivisions * 4, { num: 1, den: 4 });
       const abcBaseWholeFraction = timeModification ? exports.AbcCommon.multiplyFractions(rawWholeFraction, {
@@ -156096,11 +155893,6 @@ var BUNDLED_CLI_MODULES = {
       }
       return activeTuplet;
     };
-    const buildAbcExportTupletPrefix = (activeTuplet, isChord) => {
-      if (isChord || !activeTuplet || activeTuplet.remaining !== activeTuplet.actual)
-        return "";
-      return `(${activeTuplet.actual}:${activeTuplet.normal}:${activeTuplet.actual}`;
-    };
     const advanceAbcExportActiveTupletAfterEvent = (activeTuplet, isChord) => {
       if (isChord || !activeTuplet)
         return activeTuplet;
@@ -156108,143 +155900,26 @@ var BUNDLED_CLI_MODULES = {
       return activeTuplet.remaining <= 0 ? null : activeTuplet;
     };
     const takeAbcExportQueuedEventPrefix = (isChord, pendingHarmonySymbols, pendingDirectionWords, pendingDirectionDecorations, pendingGraceTokens) => {
-      const harmonyPrefix = !isChord && pendingHarmonySymbols.length > 0 ? `${pendingHarmonySymbols.map((symbol) => `"${abcQuotedTextEscape(symbol)}"`).join("")}` : "";
-      const wordsPrefix = !isChord && pendingDirectionWords.length > 0 ? `${pendingDirectionWords.map((word) => `"${word}"`).join("")}` : "";
-      const directionDecorationPrefix = !isChord && pendingDirectionDecorations.length > 0 ? pendingDirectionDecorations.join("") : "";
+      const harmonyPrefix = !isChord && pendingHarmonySymbols.length > 0 ? pendingHarmonySymbols.map((item) => `"${abcQuotedTextEscape(item)}"`).join("") : "";
+      const wordsPrefix = !isChord && pendingDirectionWords.length > 0 ? pendingDirectionWords.map((item) => `"${item}"`).join("") : "";
+      const decorationPrefix = !isChord && pendingDirectionDecorations.length > 0 ? pendingDirectionDecorations.join("") : "";
       const gracePrefix = pendingGraceTokens.length > 0 ? `{${pendingGraceTokens.join("")}}` : "";
-      if (!isChord && pendingHarmonySymbols.length > 0) {
+      if (!isChord) {
         pendingHarmonySymbols.length = 0;
-      }
-      if (!isChord && pendingDirectionWords.length > 0) {
         pendingDirectionWords.length = 0;
-      }
-      if (!isChord && pendingDirectionDecorations.length > 0) {
         pendingDirectionDecorations.length = 0;
-      }
-      if (pendingGraceTokens.length > 0) {
         pendingGraceTokens.length = 0;
       }
-      return `${harmonyPrefix}${wordsPrefix}${directionDecorationPrefix}${gracePrefix}`;
-    };
-    const buildAbcExportTrillMetaLine = (normalizedVoiceId, measure, fallbackMeasureNumber, eventNo, trillAccidentalText) => {
-      const measureNumber = measure.getAttribute("number") || fallbackMeasureNumber;
-      return `%@mks trill voice=${normalizedVoiceId} measure=${measureNumber} event=${eventNo} upper=${trillAccidentalText}`;
-    };
-    const buildAbcExportOrnamentPrefixInfo = (note) => {
-      var _a, _b;
-      const ornamentFeatures = (0, ornaments_1.extractMusicXmlOrnamentFeatures)(note);
-      const ornamentKinds = new Set(ornamentFeatures.map((feature) => feature.kind));
-      const hasTrillMark = ornamentKinds.has("trill-mark");
-      const hasTurn = ornamentKinds.has("turn");
-      const hasInvertedTurn = ornamentKinds.has("inverted-turn");
-      const hasTurnSlash = ornamentFeatures.some((feature) => (feature.kind === "turn" || feature.kind === "inverted-turn") && feature.slash);
-      const hasDelayedTurn = ornamentKinds.has("delayed-turn");
-      const hasMordent = ornamentKinds.has("mordent");
-      const hasInvertedMordent = ornamentKinds.has("inverted-mordent");
-      const tremoloFeature = ornamentFeatures.find((feature) => feature.kind === "tremolo");
-      const hasSchleifer = ornamentKinds.has("schleifer");
-      const hasShake = ornamentKinds.has("shake");
-      const hasGlissandoStart = Boolean(note.querySelector(':scope > notations > glissando[type="start"]'));
-      const hasGlissandoStop = Boolean(note.querySelector(':scope > notations > glissando[type="stop"]'));
-      const hasSlideStart = Boolean(note.querySelector(':scope > notations > slide[type="start"]'));
-      const hasSlideStop = Boolean(note.querySelector(':scope > notations > slide[type="stop"]'));
-      const hasArpeggiate = Boolean(note.querySelector(":scope > notations > arpeggiate"));
-      const hasWavyLineStart = Array.from(note.querySelectorAll(":scope > notations > ornaments > wavy-line")).some((node) => {
-        var _a2;
-        const type = ((_a2 = node.getAttribute("type")) !== null && _a2 !== void 0 ? _a2 : "").trim().toLowerCase();
-        return type === "" || type === "start";
-      });
-      const hasWavyLineStop = Array.from(note.querySelectorAll(":scope > notations > ornaments > wavy-line")).some((node) => {
-        var _a2;
-        const type = ((_a2 = node.getAttribute("type")) !== null && _a2 !== void 0 ? _a2 : "").trim().toLowerCase();
-        return type === "stop";
-      });
-      const hasTrill = hasTrillMark || hasWavyLineStart;
-      const turnType = hasInvertedTurn ? "inverted-turn" : hasTurn ? "turn" : "";
-      const mordentType = hasInvertedMordent ? "inverted-mordent" : hasMordent ? "mordent" : "";
-      const tremoloType = (tremoloFeature === null || tremoloFeature === void 0 ? void 0 : tremoloFeature.kind) === "tremolo" && tremoloFeature.tremoloType ? tremoloFeature.tremoloType : "";
-      const tremoloMarks = (tremoloFeature === null || tremoloFeature === void 0 ? void 0 : tremoloFeature.kind) === "tremolo" && tremoloFeature.marks ? tremoloFeature.marks : 1;
-      const trillAccidentalText = ((_b = (_a = note.querySelector(":scope > notations > ornaments > accidental-mark")) === null || _a === void 0 ? void 0 : _a.textContent) === null || _b === void 0 ? void 0 : _b.trim()) || "";
-      const trillPrefix = hasWavyLineStop ? "!trill)!" : hasWavyLineStart && !hasTrillMark ? "!trill!" : hasWavyLineStart ? "!trill(!" : hasTrill ? "!trill!" : "";
-      const turnPrefix = turnType === "inverted-turn" ? hasDelayedTurn ? "!delayedinvertedturn!" : hasTurnSlash ? "!invertedturnx!" : "!invertedturn!" : turnType === "turn" ? hasDelayedTurn ? "!delayedturn!" : hasTurnSlash ? "!turnx!" : "!turn!" : "";
-      const mordentPrefix = mordentType === "inverted-mordent" ? "!pralltriller!" : mordentType === "mordent" ? "!mordent!" : "";
-      const tremoloPrefix = tremoloType ? `!tremolo-${tremoloType}-${tremoloMarks}!` : "";
-      const glissandoPrefix = hasGlissandoStart ? "!gliss-start!" : hasGlissandoStop ? "!gliss-stop!" : "";
-      const slidePrefix = hasSlideStart ? "!slide!" : hasSlideStop ? "!slide-stop!" : "";
-      const schleiferPrefix = hasSchleifer ? "!schleifer!" : "";
-      const shakePrefix = hasShake ? "!shake!" : "";
-      const arpeggiatePrefix = hasArpeggiate ? "!arpeggio!" : "";
-      return {
-        prefix: `${trillPrefix}${turnPrefix}${mordentPrefix}${tremoloPrefix}${glissandoPrefix}${slidePrefix}${schleiferPrefix}${shakePrefix}${arpeggiatePrefix}`,
-        hasTrill,
-        trillAccidentalText
-      };
-    };
-    const buildAbcExportTechnicalPrefix = (note) => {
-      const hasUpBow = Boolean(note.querySelector(":scope > notations > technical > up-bow"));
-      const hasDownBow = Boolean(note.querySelector(":scope > notations > technical > down-bow"));
-      const hasDoubleTongue = Boolean(note.querySelector(":scope > notations > technical > double-tongue"));
-      const hasTripleTongue = Boolean(note.querySelector(":scope > notations > technical > triple-tongue"));
-      const hasHeel = Boolean(note.querySelector(":scope > notations > technical > heel"));
-      const hasToe = Boolean(note.querySelector(":scope > notations > technical > toe"));
-      const fingeringTexts = Array.from(note.querySelectorAll(":scope > notations > technical > fingering")).map((node) => (node.textContent || "").trim()).filter(Boolean);
-      const stringTexts = Array.from(note.querySelectorAll(":scope > notations > technical > string")).map((node) => (node.textContent || "").trim()).filter(Boolean);
-      const pluckTexts = Array.from(note.querySelectorAll(":scope > notations > technical > pluck")).map((node) => (node.textContent || "").trim()).filter(Boolean);
-      const hasOpenString = Boolean(note.querySelector(":scope > notations > technical > open-string"));
-      const hasSnapPizzicato = Boolean(note.querySelector(":scope > notations > technical > snap-pizzicato"));
-      const hasHarmonic = Boolean(note.querySelector(":scope > notations > technical > harmonic"));
-      const hasStopped = Boolean(note.querySelector(":scope > notations > technical > stopped"));
-      const hasThumbPosition = Boolean(note.querySelector(":scope > notations > technical > thumb-position"));
-      const fingeringPrefix = fingeringTexts.map((value) => /^[0-5]$/.test(value) ? `!${value}!` : `!fingering:${value}!`).join("");
-      return [
-        hasUpBow ? "!upbow!" : "",
-        hasDownBow ? "!downbow!" : "",
-        hasDoubleTongue ? "!doubletongue!" : "",
-        hasTripleTongue ? "!tripletongue!" : "",
-        hasHeel ? "!heel!" : "",
-        hasToe ? "!toe!" : "",
-        fingeringPrefix,
-        stringTexts.map((value) => `!string:${value}!`).join(""),
-        pluckTexts.map((value) => `!pluck:${value}!`).join(""),
-        hasOpenString ? "!open!" : "",
-        hasSnapPizzicato ? "!snap!" : "",
-        hasHarmonic ? "!harmonic!" : "",
-        hasStopped ? "!stopped!" : "",
-        hasThumbPosition ? "!thumb!" : ""
-      ].join("");
-    };
-    const buildAbcExportFermataPrefix = (note) => {
-      var _a, _b;
-      const fermata = note.querySelector(":scope > notations > fermata");
-      if (!fermata)
-        return "";
-      const type = ((_a = fermata.getAttribute("type")) === null || _a === void 0 ? void 0 : _a.trim().toLowerCase()) || "";
-      const shape = ((_b = fermata.textContent) === null || _b === void 0 ? void 0 : _b.trim().toLowerCase()) || "";
-      return type === "inverted" || shape === "inverted" ? "!invertedfermata!" : "!fermata!";
-    };
-    const buildAbcExportArticulationPrefix = (note) => {
-      const articulationKinds = new Set((0, articulations_1.extractMusicXmlArticulationKinds)(note));
-      const phraseMarkText = Array.from(note.querySelectorAll(":scope > notations > articulations > other-articulation")).map((node) => (node.textContent || "").trim().toLowerCase()).find((text) => text === "shortphrase" || text === "mediumphrase" || text === "longphrase") || "";
-      return [
-        articulationKinds.has("staccatissimo") ? "!wedge!" : articulationKinds.has("staccato") ? "!staccato!" : "",
-        articulationKinds.has("accent") ? "!accent!" : "",
-        articulationKinds.has("tenuto") ? "!tenuto!" : "",
-        note.querySelector(":scope > notations > articulations > stress") ? "!stress!" : "",
-        note.querySelector(":scope > notations > articulations > unstress") ? "!unstress!" : "",
-        articulationKinds.has("strong-accent") ? "!marcato!" : "",
-        articulationKinds.has("breath-mark") ? "!breath!" : "",
-        articulationKinds.has("caesura") ? "!caesura!" : "",
-        phraseMarkText === "shortphrase" || phraseMarkText === "mediumphrase" || phraseMarkText === "longphrase" ? `!${phraseMarkText}!` : ""
-      ].join("");
+      return `${harmonyPrefix}${wordsPrefix}${decorationPrefix}${gracePrefix}`;
     };
     const appendAbcExportLyricToken = (note, lyricTokens, pendingLyricExtension) => {
-      var _a, _b, _c, _d;
+      var _a, _b, _c, _d, _e, _f;
       if (note.querySelector(":scope > rest"))
         return pendingLyricExtension;
       const lyric = note.querySelector(":scope > lyric");
-      const lyricText = ((_b = (_a = lyric === null || lyric === void 0 ? void 0 : lyric.querySelector(":scope > text")) === null || _a === void 0 ? void 0 : _a.textContent) === null || _b === void 0 ? void 0 : _b.trim()) || "";
-      const lyricSyllabic = ((_d = (_c = lyric === null || lyric === void 0 ? void 0 : lyric.querySelector(":scope > syllabic")) === null || _c === void 0 ? void 0 : _c.textContent) === null || _d === void 0 ? void 0 : _d.trim()) || "single";
-      const lyricExtend = Boolean(lyric === null || lyric === void 0 ? void 0 : lyric.querySelector(":scope > extend"));
+      const lyricText = (_c = (_b = (_a = lyric === null || lyric === void 0 ? void 0 : lyric.querySelector(":scope > text")) === null || _a === void 0 ? void 0 : _a.textContent) === null || _b === void 0 ? void 0 : _b.trim()) !== null && _c !== void 0 ? _c : "";
+      const lyricSyllabic = (_f = (_e = (_d = lyric === null || lyric === void 0 ? void 0 : lyric.querySelector(":scope > syllabic")) === null || _d === void 0 ? void 0 : _d.textContent) === null || _e === void 0 ? void 0 : _e.trim()) !== null && _f !== void 0 ? _f : "single";
+      const lyricExtend = (lyric === null || lyric === void 0 ? void 0 : lyric.querySelector(":scope > extend")) !== null;
       if (lyricText) {
         lyricTokens.push(abcLyricTokenFromMusicXml(lyricText, lyricSyllabic));
         return lyricExtend;
@@ -156256,69 +155931,69 @@ var BUNDLED_CLI_MODULES = {
       lyricTokens.push("*");
       return false;
     };
-    const buildAbcExportPendingEventToken = (pending) => {
-      const tieSuffix = pending.tie ? "-" : "";
-      const slurStopSuffix = pending.slurStop ? ")" : "";
-      if (pending.pitches.length === 1) {
-        return `${pending.prefix}${pending.pitches[0]}${pending.len}${tieSuffix}${slurStopSuffix}`;
-      }
-      return `${pending.prefix}[${pending.pitches.join("")}]${pending.len}${tieSuffix}${slurStopSuffix}`;
-    };
     const flushAbcExportPendingEvent = (pending, tokens) => {
       if (pending) {
-        tokens.push(buildAbcExportPendingEventToken(pending));
+        const tieSuffix = pending.tie ? "-" : "";
+        const slurStopSuffix = pending.slurStop ? ")" : "";
+        tokens.push(pending.pitches.length === 1 ? `${pending.prefix}${pending.pitches[0]}${pending.len}${tieSuffix}${slurStopSuffix}` : `${pending.prefix}[${pending.pitches.join("")}]${pending.len}${tieSuffix}${slurStopSuffix}`);
       }
       return null;
     };
-    const createAbcExportPendingEvent = (pitchToken, len, hasTieStart, hasSlurStop, eventPrefix) => ({
-      pitches: [pitchToken],
-      len,
-      tie: hasTieStart,
-      slurStop: hasSlurStop,
-      prefix: eventPrefix
-    });
     const appendAbcExportChordPitchToPendingEvent = (pending, pitchToken, hasTieStart, hasSlurStop) => {
       pending.pitches.push(pitchToken);
       pending.tie = pending.tie || hasTieStart;
       pending.slurStop = pending.slurStop || hasSlurStop;
     };
-    const appendAbcExportTrillMetaLineIfNeeded = (metaLines, normalizedVoiceId, measure, fallbackMeasureNumber, eventNo, ornamentPrefixInfo) => {
-      if (!ornamentPrefixInfo.hasTrill || !ornamentPrefixInfo.trillAccidentalText)
-        return;
-      metaLines.push(buildAbcExportTrillMetaLine(normalizedVoiceId, measure, fallbackMeasureNumber, eventNo, ornamentPrefixInfo.trillAccidentalText));
-    };
-    const readAbcExportNoteEventInfo = (note, currentDivisions, unitLength) => {
-      var _a, _b, _c, _d;
-      const isChord = Boolean(note.querySelector(":scope > chord"));
-      const isGrace = Boolean(note.querySelector(":scope > grace"));
-      const duration = Number(((_b = (_a = note.querySelector(":scope > duration")) === null || _a === void 0 ? void 0 : _a.textContent) === null || _b === void 0 ? void 0 : _b.trim()) || "0");
-      if (!isGrace && (!Number.isFinite(duration) || duration <= 0))
-        return null;
-      const noteDuration = isGrace ? Number.isFinite(duration) && duration > 0 ? duration : Math.round(currentDivisions / 2) : duration;
-      const tieState = (0, ties_1.extractMusicXmlTieState)(note);
-      const slurFeatures = (0, slurs_1.extractMusicXmlSlurFeatures)(note);
-      const timeModification = readAbcExportTimeModification(note);
+    const startAbcExportPendingEventForNote = (flushPending, pending, tokens, metaLines, normalizedVoiceId, measure, fallbackMeasureNumber, ornamentPrefixInfo, pitchToken, len, hasTieStart, hasSlurStop, eventPrefix, eventNo) => {
+      const nextEventNo = eventNo + 1;
+      const trillMetaLine = ornamentPrefixInfo.hasTrill && ornamentPrefixInfo.trillAccidentalText ? `%@mks trill voice=${normalizedVoiceId} measure=${measure.getAttribute("number") || fallbackMeasureNumber} event=${nextEventNo} upper=${ornamentPrefixInfo.trillAccidentalText}` : "";
+      if (trillMetaLine)
+        metaLines.push(trillMetaLine);
+      if (flushPending)
+        flushAbcExportPendingEvent(pending, tokens);
       return {
-        isChord,
-        isGrace,
-        hasTieStart: tieState.tieStart,
-        ornamentPrefixInfo: buildAbcExportOrnamentPrefixInfo(note),
-        hasSlurStart: slurFeatures.some((slur) => slur.type === "start"),
-        hasSlurStop: slurFeatures.some((slur) => slur.type === "stop"),
-        hasGraceSlash: ((_d = (_c = note.querySelector(":scope > grace")) === null || _c === void 0 ? void 0 : _c.getAttribute("slash")) !== null && _d !== void 0 ? _d : "").trim().toLowerCase() === "yes",
-        hasTupletStart: Boolean(note.querySelector(':scope > notations > tuplet[type="start"]')),
-        timeModification,
-        len: buildAbcExportLengthToken(noteDuration, currentDivisions, unitLength, timeModification)
+        pending: {
+          pitches: [pitchToken],
+          len,
+          tie: hasTieStart,
+          slurStop: hasSlurStop,
+          prefix: eventPrefix
+        },
+        eventNo: nextEventNo
       };
     };
     const buildAbcExportEventPrefix = (note, noteEventInfo, activeTuplet, pendingHarmonySymbols, pendingDirectionWords, pendingDirectionDecorations, pendingGraceTokens) => {
-      const tupletPrefix = buildAbcExportTupletPrefix(activeTuplet, noteEventInfo.isChord);
-      const articulationPrefix = buildAbcExportArticulationPrefix(note);
-      const technicalPrefix = buildAbcExportTechnicalPrefix(note);
-      const fermataPrefix = buildAbcExportFermataPrefix(note);
+      var _a, _b, _c;
+      const tupletPrefix = noteEventInfo.isChord || !activeTuplet || activeTuplet.remaining !== activeTuplet.actual ? "" : `(${activeTuplet.actual}:${activeTuplet.normal}:${activeTuplet.actual}`;
+      const articulationKinds = new Set((0, articulations_1.extractMusicXmlArticulationKinds)(note));
+      const otherPhrase = (_a = Array.from(note.querySelectorAll(":scope > notations > articulations > other-articulation")).map((node) => {
+        var _a2;
+        return ((_a2 = node.textContent) !== null && _a2 !== void 0 ? _a2 : "").trim().toLowerCase();
+      }).find((text) => text === "shortphrase" || text === "mediumphrase" || text === "longphrase")) !== null && _a !== void 0 ? _a : "";
+      const articulationPrefix = `${articulationKinds.has("staccatissimo") ? "!wedge!" : articulationKinds.has("staccato") ? "!staccato!" : ""}${articulationKinds.has("accent") ? "!accent!" : ""}${articulationKinds.has("tenuto") ? "!tenuto!" : ""}${note.querySelector(":scope > notations > articulations > stress") !== null ? "!stress!" : ""}${note.querySelector(":scope > notations > articulations > unstress") !== null ? "!unstress!" : ""}${articulationKinds.has("strong-accent") ? "!marcato!" : ""}${articulationKinds.has("breath-mark") ? "!breath!" : ""}${articulationKinds.has("caesura") ? "!caesura!" : ""}${otherPhrase ? `!${otherPhrase}!` : ""}`;
+      const technicalPrefix = `${`${note.querySelector(":scope > notations > technical > up-bow") ? "!upbow!" : ""}${note.querySelector(":scope > notations > technical > down-bow") ? "!downbow!" : ""}`}${`${note.querySelector(":scope > notations > technical > double-tongue") ? "!doubletongue!" : ""}${note.querySelector(":scope > notations > technical > triple-tongue") ? "!tripletongue!" : ""}${note.querySelector(":scope > notations > technical > heel") ? "!heel!" : ""}${note.querySelector(":scope > notations > technical > toe") ? "!toe!" : ""}`}${Array.from(note.querySelectorAll(":scope > notations > technical > fingering")).map((node) => {
+        var _a2;
+        return ((_a2 = node.textContent) !== null && _a2 !== void 0 ? _a2 : "").trim();
+      }).filter((text) => text.length > 0).map((value) => /^[0-5]$/.test(value) ? `!${value}!` : `!fingering:${value}!`).join("")}${Array.from(note.querySelectorAll(":scope > notations > technical > string")).map((node) => {
+        var _a2;
+        return ((_a2 = node.textContent) !== null && _a2 !== void 0 ? _a2 : "").trim();
+      }).filter((text) => text.length > 0).map((value) => `!string:${value}!`).join("")}${Array.from(note.querySelectorAll(":scope > notations > technical > pluck")).map((node) => {
+        var _a2;
+        return ((_a2 = node.textContent) !== null && _a2 !== void 0 ? _a2 : "").trim();
+      }).filter((text) => text.length > 0).map((value) => `!pluck:${value}!`).join("")}${`${note.querySelector(":scope > notations > technical > open-string") ? "!open!" : ""}${note.querySelector(":scope > notations > technical > snap-pizzicato") ? "!snap!" : ""}${note.querySelector(":scope > notations > technical > harmonic") ? "!harmonic!" : ""}${note.querySelector(":scope > notations > technical > stopped") ? "!stopped!" : ""}${note.querySelector(":scope > notations > technical > thumb-position") ? "!thumb!" : ""}`}`;
+      const fermata = note.querySelector(":scope > notations > fermata");
+      const fermataPrefix = fermata ? ((_b = fermata.getAttribute("type")) === null || _b === void 0 ? void 0 : _b.trim().toLowerCase()) === "inverted" || ((_c = fermata.textContent) === null || _c === void 0 ? void 0 : _c.trim().toLowerCase()) === "inverted" ? "!invertedfermata!" : "!fermata!" : "";
       const slurStartPrefix = noteEventInfo.hasSlurStart ? "(" : "";
-      const queuedPrefix = takeAbcExportQueuedEventPrefix(noteEventInfo.isChord, pendingHarmonySymbols, pendingDirectionWords, pendingDirectionDecorations, pendingGraceTokens);
-      return `${queuedPrefix}${tupletPrefix}${slurStartPrefix}${noteEventInfo.ornamentPrefixInfo.prefix}${articulationPrefix}${technicalPrefix}${fermataPrefix}`;
+      const parts = [
+        takeAbcExportQueuedEventPrefix(noteEventInfo.isChord, pendingHarmonySymbols, pendingDirectionWords, pendingDirectionDecorations, pendingGraceTokens),
+        tupletPrefix,
+        slurStartPrefix,
+        noteEventInfo.ornamentPrefixInfo.prefix,
+        articulationPrefix,
+        technicalPrefix,
+        fermataPrefix
+      ];
+      return parts.join("");
     };
     const flushAbcExportPendingGraceTokens = (pendingGraceTokens, tokens) => {
       if (pendingGraceTokens.length === 0)
@@ -156334,35 +156009,6 @@ var BUNDLED_CLI_MODULES = {
       const lenRatio = exports.AbcCommon.divideFractions(wholeFraction, unitLength, { num: 1, den: 1 });
       tokens.push(`z${exports.AbcCommon.abcLengthTokenFromFraction(lenRatio)}`);
     };
-    const buildAbcExportMeasureText = (tokens, needsInlineKeyChange, currentFifths, boundaryInfo) => {
-      const measureTokenText = tokens.join(" ");
-      const keyPrefix = needsInlineKeyChange ? `[K:${exports.AbcCommon.keyFromFifthsMode(Math.max(-7, Math.min(7, Math.round(currentFifths))), "major")}]` : "";
-      const leftPrefix = `${boundaryInfo.hasLeftRepeat ? "|:" : ""}${boundaryInfo.leftEndingNumber ? `[${boundaryInfo.leftEndingNumber}` : ""}`;
-      let rightSuffix = "|";
-      if (boundaryInfo.hasRightRepeat && boundaryInfo.rightEndingNumber) {
-        rightSuffix = `:|]`;
-      } else if (boundaryInfo.hasRightRepeat) {
-        rightSuffix = ":|";
-      } else if (boundaryInfo.rightEndingNumber) {
-        rightSuffix = "]|";
-      }
-      return `${leftPrefix}${leftPrefix ? " " : ""}${keyPrefix}${keyPrefix ? " " : ""}${measureTokenText} ${rightSuffix}`.trim();
-    };
-    const readAbcExportMeasureBoundaryInfo = (measure) => {
-      const leftRepeatNode = measure.querySelector(':scope > barline[location="left"] > repeat');
-      const rightRepeatNode = measure.querySelector(':scope > barline[location="right"] > repeat');
-      const leftEndingNode = measure.querySelector(':scope > barline[location="left"] > ending');
-      const rightEndingNode = measure.querySelector(':scope > barline[location="right"] > ending');
-      const leftRepeatDir = ((leftRepeatNode === null || leftRepeatNode === void 0 ? void 0 : leftRepeatNode.getAttribute("direction")) || "").trim().toLowerCase();
-      const rightRepeatDir = ((rightRepeatNode === null || rightRepeatNode === void 0 ? void 0 : rightRepeatNode.getAttribute("direction")) || "").trim().toLowerCase();
-      return {
-        hasLeftRepeat: leftRepeatDir === "forward",
-        hasRightRepeat: rightRepeatDir === "backward",
-        leftEndingNumber: ((leftEndingNode === null || leftEndingNode === void 0 ? void 0 : leftEndingNode.getAttribute("number")) || "").trim(),
-        rightEndingNumber: ((rightEndingNode === null || rightEndingNode === void 0 ? void 0 : rightEndingNode.getAttribute("number")) || "").trim(),
-        rightEndingType: ((rightEndingNode === null || rightEndingNode === void 0 ? void 0 : rightEndingNode.getAttribute("type")) || "").trim().toLowerCase()
-      };
-    };
     const applyAbcExportMeasureAttributesToState = (measure, state) => {
       var _a, _b, _c, _d;
       const parsedDiv = parseOptionalMusicXmlNumber((_a = measure.querySelector("attributes > divisions")) === null || _a === void 0 ? void 0 : _a.textContent);
@@ -156377,10 +156023,44 @@ var BUNDLED_CLI_MODULES = {
       };
     };
     const appendAbcExportMeasureMetaLines = (metaLines, normalizedVoiceId, measure, safeMeasureNumber, boundaryInfo) => {
-      const measureMetaLine = buildAbcExportMeasureMetaLine(normalizedVoiceId, measure, safeMeasureNumber, boundaryInfo.hasRightRepeat, boundaryInfo.rightEndingNumber, boundaryInfo.rightEndingType);
+      var _a, _b, _c, _d, _e;
+      const rawMeasureNumber = ((_a = measure.getAttribute("number")) !== null && _a !== void 0 ? _a : "").trim() || String(safeMeasureNumber);
+      const implicitAttr = ((_b = measure.getAttribute("implicit")) !== null && _b !== void 0 ? _b : "").trim().toLowerCase();
+      const isImplicit = implicitAttr === "yes" || implicitAttr === "true" || implicitAttr === "1";
+      const rightRepeatNode = measure.querySelector(':scope > barline[location="right"] > repeat');
+      const repeatTimes = Number.parseInt(String((_c = rightRepeatNode === null || rightRepeatNode === void 0 ? void 0 : rightRepeatNode.getAttribute("times")) !== null && _c !== void 0 ? _c : ""), 10);
+      const measureMetaLine = !isImplicit && rawMeasureNumber === String(safeMeasureNumber) && (!boundaryInfo.hasRightRepeat || !Number.isFinite(repeatTimes) || repeatTimes <= 2) && (!boundaryInfo.rightEndingNumber || boundaryInfo.rightEndingType !== "discontinue") ? null : [
+        `%@mks measure voice=${normalizedVoiceId} measure=${safeMeasureNumber}`,
+        `number=${rawMeasureNumber}`,
+        `implicit=${isImplicit ? 1 : 0}`,
+        ...boundaryInfo.hasRightRepeat && Number.isFinite(repeatTimes) && repeatTimes > 2 ? [`times=${Math.round(repeatTimes)}`] : [],
+        ...boundaryInfo.rightEndingNumber && boundaryInfo.rightEndingType === "discontinue" ? [`ending-stop=${boundaryInfo.rightEndingNumber}`, `ending-type=${boundaryInfo.rightEndingType}`] : []
+      ].join(" ");
       if (measureMetaLine)
         metaLines.push(measureMetaLine);
-      metaLines.push(...buildAbcExportDiagMetaLines(normalizedVoiceId, measure, safeMeasureNumber));
+      const diagFields = Array.from(measure.querySelectorAll(':scope > attributes > miscellaneous > miscellaneous-field[name^="mks:diag:"]'));
+      if (diagFields.length > 0) {
+        const byName = /* @__PURE__ */ new Map();
+        for (const field of diagFields) {
+          const name = ((_d = field.getAttribute("name")) !== null && _d !== void 0 ? _d : "").trim();
+          if (!name)
+            continue;
+          byName.set(name, ((_e = field.textContent) !== null && _e !== void 0 ? _e : "").trim());
+        }
+        const orderedNames = Array.from(byName.keys()).sort((a, b) => {
+          const isCountA = a === "mks:diag:count";
+          const isCountB = b === "mks:diag:count";
+          if (isCountA && !isCountB)
+            return -1;
+          if (!isCountA && isCountB)
+            return 1;
+          return a.localeCompare(b);
+        });
+        metaLines.push(...orderedNames.map((name) => {
+          var _a2;
+          return `%@mks diag voice=${normalizedVoiceId} measure=${safeMeasureNumber} name=${name} enc=uri-v1 value=${encodeURIComponent((_a2 = byName.get(name)) !== null && _a2 !== void 0 ? _a2 : "")}`;
+        }));
+      }
     };
     const applyAbcExportNonNoteChildToPending = (child, pendingHarmonySymbols, pendingDirectionWords, pendingDirectionDecorations, activeWedgeType) => {
       if (child.tagName === "harmony") {
@@ -156408,33 +156088,39 @@ var BUNDLED_CLI_MODULES = {
     const updateAbcExportPendingEventForNote = (pending, tokens, eventNo, metaLines, normalizedVoiceId, measure, fallbackMeasureNumber, noteEventInfo, pitchToken, eventPrefix) => {
       const { isChord, hasTieStart, ornamentPrefixInfo, hasSlurStop, len } = noteEventInfo;
       if (!isChord) {
-        const nextEventNo = eventNo + 1;
-        appendAbcExportTrillMetaLineIfNeeded(metaLines, normalizedVoiceId, measure, fallbackMeasureNumber, nextEventNo, ornamentPrefixInfo);
-        flushAbcExportPendingEvent(pending, tokens);
-        return {
-          pending: createAbcExportPendingEvent(pitchToken, len, hasTieStart, hasSlurStop, eventPrefix),
-          eventNo: nextEventNo
-        };
+        return startAbcExportPendingEventForNote(true, pending, tokens, metaLines, normalizedVoiceId, measure, fallbackMeasureNumber, ornamentPrefixInfo, pitchToken, len, hasTieStart, hasSlurStop, eventPrefix, eventNo);
       }
       if (!pending) {
-        const nextEventNo = eventNo + 1;
-        appendAbcExportTrillMetaLineIfNeeded(metaLines, normalizedVoiceId, measure, fallbackMeasureNumber, nextEventNo, ornamentPrefixInfo);
-        return {
-          pending: createAbcExportPendingEvent(pitchToken, len, hasTieStart, hasSlurStop, eventPrefix),
-          eventNo: nextEventNo
-        };
+        return startAbcExportPendingEventForNote(false, pending, tokens, metaLines, normalizedVoiceId, measure, fallbackMeasureNumber, ornamentPrefixInfo, pitchToken, len, hasTieStart, hasSlurStop, eventPrefix, eventNo);
       }
       appendAbcExportChordPitchToPendingEvent(pending, pitchToken, hasTieStart, hasSlurStop);
       return { pending, eventNo };
     };
     const updateAbcExportStateAfterNoteEvent = (note, noteEventInfo, activeTuplet, lyricTokens, pendingLyricExtension) => {
-      const nextActiveTuplet = advanceAbcExportActiveTupletAfterEvent(activeTuplet, noteEventInfo.isChord);
       return {
-        activeTuplet: nextActiveTuplet,
+        activeTuplet: advanceAbcExportActiveTupletAfterEvent(activeTuplet, noteEventInfo.isChord),
         pendingLyricExtension: noteEventInfo.isChord ? pendingLyricExtension : appendAbcExportLyricToken(note, lyricTokens, pendingLyricExtension)
       };
     };
+    const applyAbcExportNoteEvent = (child, noteEventInfo, activeTuplet, pending, eventNo, pendingGraceTokens, pendingHarmonySymbols, pendingDirectionWords, pendingDirectionDecorations, tokens, metaLines, normalizedVoiceId, measure, fallbackMeasureNumber, keyAlterMap, measureAccidentalByStepOctave, lyricTokens, pendingLyricExtension) => {
+      const pitchToken = buildAbcExportPitchToken(child, keyAlterMap, measureAccidentalByStepOctave);
+      if (applyAbcExportGraceNoteToPending(noteEventInfo, pendingGraceTokens, pitchToken)) {
+        return { handled: true, pending, eventNo, activeTuplet, pendingLyricExtension };
+      }
+      const nextActiveTuplet = updateAbcExportActiveTupletBeforeNoteEvent(activeTuplet, noteEventInfo);
+      const eventPrefix = buildAbcExportEventPrefix(child, noteEventInfo, nextActiveTuplet, pendingHarmonySymbols, pendingDirectionWords, pendingDirectionDecorations, pendingGraceTokens);
+      const pendingEventUpdate = updateAbcExportPendingEventForNote(pending, tokens, eventNo, metaLines, normalizedVoiceId, measure, fallbackMeasureNumber, noteEventInfo, pitchToken, eventPrefix);
+      const postNoteEventState = updateAbcExportStateAfterNoteEvent(child, noteEventInfo, nextActiveTuplet, lyricTokens, pendingLyricExtension);
+      return {
+        handled: true,
+        pending: pendingEventUpdate.pending,
+        eventNo: pendingEventUpdate.eventNo,
+        activeTuplet: postNoteEventState.activeTuplet,
+        pendingLyricExtension: postNoteEventState.pendingLyricExtension
+      };
+    };
     const processAbcExportNoteChild = (context) => {
+      var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p;
       const { child, lane, currentDivisions, unitLength, keyAlterMap, measureAccidentalByStepOctave, pendingGraceTokens, pendingHarmonySymbols, pendingDirectionWords, pendingDirectionDecorations, tokens, metaLines, normalizedVoiceId, measure, fallbackMeasureNumber, lyricTokens } = context;
       let { activeTuplet, pending, eventNo, pendingLyricExtension } = context;
       if (child.tagName !== "note") {
@@ -156443,28 +156129,115 @@ var BUNDLED_CLI_MODULES = {
       if (!isMusicXmlNoteInAbcExportLane(child, lane)) {
         return { handled: true, pending, eventNo, activeTuplet, pendingLyricExtension };
       }
-      const noteEventInfo = readAbcExportNoteEventInfo(child, currentDivisions, unitLength);
-      if (!noteEventInfo) {
+      const isChord = child.querySelector(":scope > chord") !== null;
+      const isGrace = child.querySelector(":scope > grace") !== null;
+      const duration = Number((_c = (_b = (_a = child.querySelector(":scope > duration")) === null || _a === void 0 ? void 0 : _a.textContent) === null || _b === void 0 ? void 0 : _b.trim()) !== null && _c !== void 0 ? _c : "0");
+      if (!isGrace && (!Number.isFinite(duration) || duration <= 0)) {
         return { handled: true, pending, eventNo, activeTuplet, pendingLyricExtension };
       }
-      const pitchToken = buildAbcExportPitchToken(child, keyAlterMap, measureAccidentalByStepOctave);
-      if (applyAbcExportGraceNoteToPending(noteEventInfo, pendingGraceTokens, pitchToken)) {
-        return { handled: true, pending, eventNo, activeTuplet, pendingLyricExtension };
-      }
-      activeTuplet = updateAbcExportActiveTupletBeforeNoteEvent(activeTuplet, noteEventInfo);
-      const eventPrefix = buildAbcExportEventPrefix(child, noteEventInfo, activeTuplet, pendingHarmonySymbols, pendingDirectionWords, pendingDirectionDecorations, pendingGraceTokens);
-      const pendingEventUpdate = updateAbcExportPendingEventForNote(pending, tokens, eventNo, metaLines, normalizedVoiceId, measure, fallbackMeasureNumber, noteEventInfo, pitchToken, eventPrefix);
-      pending = pendingEventUpdate.pending;
-      eventNo = pendingEventUpdate.eventNo;
-      const postNoteEventState = updateAbcExportStateAfterNoteEvent(child, noteEventInfo, activeTuplet, lyricTokens, pendingLyricExtension);
-      return {
-        handled: true,
-        pending,
-        eventNo,
-        activeTuplet: postNoteEventState.activeTuplet,
-        pendingLyricExtension: postNoteEventState.pendingLyricExtension
+      const noteDuration = isGrace ? Number.isFinite(duration) && duration > 0 ? duration : Math.round(currentDivisions / 2) : duration;
+      const tieState = (0, ties_1.extractMusicXmlTieState)(child);
+      const slurFeatures = (0, slurs_1.extractMusicXmlSlurFeatures)(child);
+      const actualNotes = Number((_f = (_e = (_d = child.querySelector(":scope > time-modification > actual-notes")) === null || _d === void 0 ? void 0 : _d.textContent) === null || _e === void 0 ? void 0 : _e.trim()) !== null && _f !== void 0 ? _f : "");
+      const normalNotes = Number((_j = (_h = (_g = child.querySelector(":scope > time-modification > normal-notes")) === null || _g === void 0 ? void 0 : _g.textContent) === null || _h === void 0 ? void 0 : _h.trim()) !== null && _j !== void 0 ? _j : "");
+      const timeModification = Number.isFinite(actualNotes) && actualNotes > 0 && Number.isFinite(normalNotes) && normalNotes > 0 ? { actual: Math.round(actualNotes), normal: Math.round(normalNotes) } : null;
+      const ornamentFeatures = (0, ornaments_1.extractMusicXmlOrnamentFeatures)(child);
+      const ornamentKinds = new Set(ornamentFeatures.map((feature) => feature.kind));
+      const hasTrillMark = ornamentKinds.has("trill-mark");
+      const hasWavyLineStart = Array.from(child.querySelectorAll(":scope > notations > ornaments > wavy-line")).some((node) => {
+        var _a2, _b2;
+        return ((_a2 = node.getAttribute("type")) !== null && _a2 !== void 0 ? _a2 : "").trim().toLowerCase() === "" || ((_b2 = node.getAttribute("type")) !== null && _b2 !== void 0 ? _b2 : "").trim().toLowerCase() === "start";
+      });
+      const hasWavyLineStop = Array.from(child.querySelectorAll(":scope > notations > ornaments > wavy-line")).some((node) => {
+        var _a2;
+        return ((_a2 = node.getAttribute("type")) !== null && _a2 !== void 0 ? _a2 : "").trim().toLowerCase() === "stop";
+      });
+      const ornamentTrillPrefix = hasWavyLineStop ? "!trill)!" : hasWavyLineStart && !hasTrillMark ? "!trill!" : hasWavyLineStart ? "!trill(!" : hasTrillMark ? "!trill!" : "";
+      const noteEventInfo = {
+        isChord,
+        isGrace,
+        hasTieStart: tieState.tieStart,
+        ornamentPrefixInfo: {
+          prefix: `${ornamentTrillPrefix}${`${ornamentKinds.has("inverted-turn") ? ornamentKinds.has("delayed-turn") ? "!delayedinvertedturn!" : ornamentFeatures.some((feature) => feature.kind === "inverted-turn" && feature.slash) ? "!invertedturnx!" : "!invertedturn!" : ""}${ornamentKinds.has("turn") ? ornamentKinds.has("delayed-turn") ? "!delayedturn!" : ornamentFeatures.some((feature) => feature.kind === "turn" && feature.slash) ? "!turnx!" : "!turn!" : ""}`}${`${ornamentKinds.has("inverted-mordent") ? "!pralltriller!" : ""}${ornamentKinds.has("mordent") ? "!mordent!" : ""}`}${["single", "start", "stop"].map((tremoloType) => {
+            const tremoloFeature = ornamentFeatures.find((feature) => feature.kind === "tremolo" && feature.tremoloType === tremoloType);
+            return tremoloFeature ? `!tremolo-${tremoloType}-${tremoloFeature.marks ? tremoloFeature.marks : 1}!` : "";
+          }).join("")}${`${child.querySelector(':scope > notations > glissando[type="start"]') ? "!gliss-start!" : ""}${child.querySelector(':scope > notations > glissando[type="stop"]') ? "!gliss-stop!" : ""}${child.querySelector(':scope > notations > slide[type="start"]') ? "!slide!" : ""}${child.querySelector(':scope > notations > slide[type="stop"]') ? "!slide-stop!" : ""}${ornamentKinds.has("schleifer") ? "!schleifer!" : ""}${ornamentKinds.has("shake") ? "!shake!" : ""}${child.querySelector(":scope > notations > arpeggiate") ? "!arpeggio!" : ""}`}`,
+          hasTrill: hasTrillMark || hasWavyLineStart,
+          trillAccidentalText: (_m = (_l = (_k = child.querySelector(":scope > notations > ornaments > accidental-mark")) === null || _k === void 0 ? void 0 : _k.textContent) === null || _l === void 0 ? void 0 : _l.trim()) !== null && _m !== void 0 ? _m : ""
+        },
+        hasSlurStart: slurFeatures.some((slur) => slur.type === "start"),
+        hasSlurStop: slurFeatures.some((slur) => slur.type === "stop"),
+        hasGraceSlash: ((_p = (_o = child.querySelector(":scope > grace")) === null || _o === void 0 ? void 0 : _o.getAttribute("slash")) !== null && _p !== void 0 ? _p : "").trim().toLowerCase() === "yes",
+        hasTupletStart: child.querySelector(':scope > notations > tuplet[type="start"]') !== null,
+        timeModification,
+        len: buildAbcExportLengthToken(noteDuration, currentDivisions, unitLength, timeModification)
       };
+      return applyAbcExportNoteEvent(child, noteEventInfo, activeTuplet, pending, eventNo, pendingGraceTokens, pendingHarmonySymbols, pendingDirectionWords, pendingDirectionDecorations, tokens, metaLines, normalizedVoiceId, measure, fallbackMeasureNumber, keyAlterMap, measureAccidentalByStepOctave, lyricTokens, pendingLyricExtension);
     };
+    const processAbcExportMeasureChild = (child, state) => {
+      if (processAbcExportMeasureNonNoteChild(child, state)) {
+        return;
+      }
+      processAbcExportMeasureNoteChild(child, state);
+    };
+    const processAbcExportMeasureNonNoteChild = (child, state) => {
+      const nonNoteDispatch = applyAbcExportNonNoteChildToPending(child, state.pendingHarmonySymbols, state.pendingDirectionWords, state.pendingDirectionDecorations, state.activeWedgeType);
+      state.activeWedgeType = nonNoteDispatch.activeWedgeType;
+      return nonNoteDispatch.handled;
+    };
+    const processAbcExportMeasureNoteChild = (child, state) => {
+      const noteChildProcess = processAbcExportNoteChild({
+        child,
+        lane: state.lane,
+        currentDivisions: state.currentDivisions,
+        unitLength: state.unitLength,
+        keyAlterMap: state.keyAlterMap,
+        measureAccidentalByStepOctave: state.measureAccidentalByStepOctave,
+        pendingGraceTokens: state.pendingGraceTokens,
+        activeTuplet: state.activeTuplet,
+        pendingHarmonySymbols: state.pendingHarmonySymbols,
+        pendingDirectionWords: state.pendingDirectionWords,
+        pendingDirectionDecorations: state.pendingDirectionDecorations,
+        pending: state.pending,
+        tokens: state.tokens,
+        eventNo: state.eventNo,
+        metaLines: state.metaLines,
+        normalizedVoiceId: state.normalizedVoiceId,
+        measure: state.measure,
+        fallbackMeasureNumber: state.fallbackMeasureNumber,
+        lyricTokens: state.lyricTokens,
+        pendingLyricExtension: state.pendingLyricExtension
+      });
+      if (!noteChildProcess.handled) {
+        return;
+      }
+      state.pending = noteChildProcess.pending;
+      state.eventNo = noteChildProcess.eventNo;
+      state.activeTuplet = noteChildProcess.activeTuplet;
+      state.pendingLyricExtension = noteChildProcess.pendingLyricExtension;
+    };
+    const createAbcExportMeasureChildProcessingState = (context, pendingGraceTokens, pendingHarmonySymbols, pendingDirectionWords, pendingDirectionDecorations) => ({
+      lane: context.lane,
+      currentDivisions: context.currentDivisions,
+      unitLength: context.unitLength,
+      keyAlterMap: context.keyAlterMap,
+      measureAccidentalByStepOctave: context.measureAccidentalByStepOctave,
+      pendingGraceTokens,
+      pendingHarmonySymbols,
+      pendingDirectionWords,
+      pendingDirectionDecorations,
+      tokens: context.tokens,
+      metaLines: context.metaLines,
+      normalizedVoiceId: context.normalizedVoiceId,
+      measure: context.measure,
+      fallbackMeasureNumber: context.fallbackMeasureNumber,
+      lyricTokens: context.lyricTokens,
+      pending: null,
+      eventNo: 0,
+      activeTuplet: null,
+      pendingLyricExtension: context.pendingLyricExtension,
+      activeWedgeType: ""
+    });
     const processAbcExportMeasureChildren = (context) => {
       const { measure, lane, currentDivisions, unitLength, keyAlterMap, measureAccidentalByStepOctave, tokens, metaLines, normalizedVoiceId, fallbackMeasureNumber, lyricTokens } = context;
       let { pendingLyricExtension } = context;
@@ -156473,55 +156246,32 @@ var BUNDLED_CLI_MODULES = {
       const pendingHarmonySymbols = [];
       const pendingDirectionWords = [];
       const pendingDirectionDecorations = [];
-      let activeWedgeType = "";
-      let activeTuplet = null;
-      let eventNo = 0;
+      const state = createAbcExportMeasureChildProcessingState(context, pendingGraceTokens, pendingHarmonySymbols, pendingDirectionWords, pendingDirectionDecorations);
       for (const child of Array.from(measure.children)) {
-        const nonNoteDispatch = applyAbcExportNonNoteChildToPending(child, pendingHarmonySymbols, pendingDirectionWords, pendingDirectionDecorations, activeWedgeType);
-        activeWedgeType = nonNoteDispatch.activeWedgeType;
-        if (nonNoteDispatch.handled) {
-          continue;
-        }
-        const noteChildProcess = processAbcExportNoteChild({
-          child,
-          lane,
-          currentDivisions,
-          unitLength,
-          keyAlterMap,
-          measureAccidentalByStepOctave,
-          pendingGraceTokens,
-          activeTuplet,
-          pendingHarmonySymbols,
-          pendingDirectionWords,
-          pendingDirectionDecorations,
-          pending,
-          tokens,
-          eventNo,
-          metaLines,
-          normalizedVoiceId,
-          measure,
-          fallbackMeasureNumber,
-          lyricTokens,
-          pendingLyricExtension
-        });
-        if (!noteChildProcess.handled)
-          continue;
-        pending = noteChildProcess.pending;
-        eventNo = noteChildProcess.eventNo;
-        activeTuplet = noteChildProcess.activeTuplet;
-        pendingLyricExtension = noteChildProcess.pendingLyricExtension;
+        processAbcExportMeasureChild(child, state);
       }
       return {
-        pending,
+        pending: state.pending,
         pendingGraceTokens,
-        pendingLyricExtension
+        pendingLyricExtension: state.pendingLyricExtension
       };
     };
     const renderAbcExportMeasureText = (context) => {
+      var _a, _b, _c, _d, _e;
       const { measure, lane, lastEmittedKeyFifths, unitLength, metaLines, normalizedVoiceId, fallbackMeasureNumber, lyricTokens } = context;
       let { pendingLyricExtension } = context;
       const measureState = applyAbcExportMeasureAttributesToState(measure, context.measureState);
-      const boundaryInfo = readAbcExportMeasureBoundaryInfo(measure);
+      const leftRepeatNode = measure.querySelector(':scope > barline[location="left"] > repeat');
+      const rightRepeatNode = measure.querySelector(':scope > barline[location="right"] > repeat');
+      const leftEndingNode = measure.querySelector(':scope > barline[location="left"] > ending');
+      const rightEndingNode = measure.querySelector(':scope > barline[location="right"] > ending');
+      const boundaryInfo = {
+        hasLeftRepeat: ((_a = leftRepeatNode === null || leftRepeatNode === void 0 ? void 0 : leftRepeatNode.getAttribute("direction")) !== null && _a !== void 0 ? _a : "").trim().toLowerCase() === "forward",
+        hasRightRepeat: ((_b = rightRepeatNode === null || rightRepeatNode === void 0 ? void 0 : rightRepeatNode.getAttribute("direction")) !== null && _b !== void 0 ? _b : "").trim().toLowerCase() === "backward",
+        leftEndingNumber: ((_c = leftEndingNode === null || leftEndingNode === void 0 ? void 0 : leftEndingNode.getAttribute("number")) !== null && _c !== void 0 ? _c : "").trim(),
+        rightEndingNumber: ((_d = rightEndingNode === null || rightEndingNode === void 0 ? void 0 : rightEndingNode.getAttribute("number")) !== null && _d !== void 0 ? _d : "").trim(),
+        rightEndingType: ((_e = rightEndingNode === null || rightEndingNode === void 0 ? void 0 : rightEndingNode.getAttribute("type")) !== null && _e !== void 0 ? _e : "").trim().toLowerCase()
+      };
       appendAbcExportMeasureMetaLines(metaLines, normalizedVoiceId, measure, fallbackMeasureNumber, boundaryInfo);
       const { currentDivisions, currentFifths, currentBeats, currentBeatType } = measureState;
       const needsInlineKeyChange = lastEmittedKeyFifths === null || lastEmittedKeyFifths !== currentFifths;
@@ -156546,435 +156296,313 @@ var BUNDLED_CLI_MODULES = {
       flushAbcExportPendingGraceTokens(measureChildren.pendingGraceTokens, tokens);
       flushAbcExportPendingEvent(measureChildren.pending, tokens);
       appendAbcExportEmptyMeasureRestTokenIfNeeded(tokens, currentDivisions, currentBeats, currentBeatType, unitLength);
+      const boundaryPrefix = `${boundaryInfo.hasLeftRepeat ? "|:" : ""}${boundaryInfo.leftEndingNumber ? `[${boundaryInfo.leftEndingNumber}` : ""}`;
+      const keyPrefix = needsInlineKeyChange ? `[K:${exports.AbcCommon.keyFromFifthsMode(Math.max(-7, Math.min(7, Math.round(currentFifths))), "major")}]` : "";
+      const boundarySuffix = boundaryInfo.hasRightRepeat ? boundaryInfo.rightEndingNumber ? ":|]" : ":|" : boundaryInfo.rightEndingNumber ? "]|" : "|";
       return {
-        measureText: buildAbcExportMeasureText(tokens, needsInlineKeyChange, currentFifths, boundaryInfo),
+        measureText: [
+          ...boundaryPrefix ? [boundaryPrefix] : [],
+          ...keyPrefix ? [keyPrefix] : [],
+          tokens.join(" "),
+          ...boundarySuffix ? [boundarySuffix] : []
+        ].join(" ").trim(),
         measureState,
         lastEmittedKeyFifths: currentFifths,
         pendingLyricExtension
       };
-    };
-    const appendAbcExportLaneHeader = (context) => {
-      const { part, partName, measures, laneDefs, lane, headerLines, metaLines } = context;
-      const normalizedVoiceId = lane.voiceId.replace(/[^A-Za-z0-9_.-]/g, "_");
-      const laneName = buildAbcExportLaneName(partName, laneDefs.length, lane);
-      const abcClef = resolveAbcExportLaneClef(part, measures, lane.staff);
-      const clefSuffix = abcClef ? ` clef=${abcClef}` : "";
-      headerLines.push(`V:${normalizedVoiceId} name="${laneName}"${clefSuffix}`);
-      for (const measure of measures) {
-        const transposeMetaLine = buildAbcExportTransposeMetaLine(normalizedVoiceId, measure);
-        if (transposeMetaLine)
-          metaLines.push(transposeMetaLine);
-        break;
-      }
-      return normalizedVoiceId;
     };
     const readAbcExportPartInitialFifths = (part, fallbackFifths) => {
       var _a;
       const partInitialFifthsRaw = parseOptionalMusicXmlNumber((_a = part.querySelector(":scope > measure > attributes > key > fifths")) === null || _a === void 0 ? void 0 : _a.textContent);
       return partInitialFifthsRaw !== null ? Math.round(partInitialFifthsRaw) : Number.isFinite(fallbackFifths) ? Math.round(fallbackFifths) : 0;
     };
-    const createAbcExportInitialMeasureState = (part, fifths, meterBeats, meterBeatType) => ({
+    const createAbcExportInitialMeasureStateFromPart = (part, fifths, meterBeats, meterBeatType) => ({
       currentDivisions: 480,
       currentFifths: readAbcExportPartInitialFifths(part, fifths),
       currentBeats: Number(meterBeats) || 4,
       currentBeatType: Number(meterBeatType) || 4
     });
-    const renderAbcExportLaneBody = (context, normalizedVoiceId) => {
-      const { part, measures, lane, fifths, meterBeats, meterBeatType, unitLength, metaLines } = context;
-      let measureState = createAbcExportInitialMeasureState(part, fifths, meterBeats, meterBeatType);
-      let lastEmittedKeyFifths = Number.isFinite(fifths) ? Math.round(fifths) : 0;
-      const measureTexts = [];
-      const lyricTokens = [];
-      let pendingLyricExtension = false;
-      for (const measure of measures) {
-        const safeMeasureNumber = measureTexts.length + 1;
-        const renderedMeasure = renderAbcExportMeasureText({
-          measure,
-          lane,
-          measureState,
-          lastEmittedKeyFifths,
-          unitLength,
-          metaLines,
-          normalizedVoiceId,
-          fallbackMeasureNumber: safeMeasureNumber,
-          lyricTokens,
-          pendingLyricExtension
-        });
-        measureState = renderedMeasure.measureState;
-        lastEmittedKeyFifths = renderedMeasure.lastEmittedKeyFifths;
-        pendingLyricExtension = renderedMeasure.pendingLyricExtension;
-        measureTexts.push(renderedMeasure.measureText);
-      }
-      return { measureTexts, lyricTokens };
+    const createAbcExportLaneBodyStateFromPart = (part, fifths, meterBeats, meterBeatType) => ({
+      measureState: createAbcExportInitialMeasureStateFromPart(part, fifths, meterBeats, meterBeatType),
+      lastEmittedKeyFifths: Number.isFinite(fifths) ? Math.round(fifths) : 0,
+      measureTexts: [],
+      lyricTokens: [],
+      pendingLyricExtension: false
+    });
+    const appendAbcExportLaneBodyMeasure = (state, measure, lane, unitLength, metaLines, normalizedVoiceId) => {
+      const renderedMeasure = renderAbcExportMeasureText({
+        measure,
+        lane,
+        measureState: state.measureState,
+        lastEmittedKeyFifths: state.lastEmittedKeyFifths,
+        unitLength,
+        metaLines,
+        normalizedVoiceId,
+        fallbackMeasureNumber: state.measureTexts.length + 1,
+        lyricTokens: state.lyricTokens,
+        pendingLyricExtension: state.pendingLyricExtension
+      });
+      state.measureState = renderedMeasure.measureState;
+      state.lastEmittedKeyFifths = renderedMeasure.lastEmittedKeyFifths;
+      state.pendingLyricExtension = renderedMeasure.pendingLyricExtension;
+      state.measureTexts.push(renderedMeasure.measureText);
     };
-    const appendAbcExportRenderedLaneBody = (bodyLines, normalizedVoiceId, renderedLaneBody) => {
-      const { measureTexts, lyricTokens } = renderedLaneBody;
-      bodyLines.push(`V:${normalizedVoiceId}`);
-      bodyLines.push(measureTexts.join(" "));
-      if (lyricTokens.some((token) => token !== "*")) {
-        bodyLines.push(`w: ${lyricTokens.join(" ")}`);
-      }
-    };
-    const appendAbcExportLaneBody = (context, normalizedVoiceId) => {
-      const { bodyLines } = context;
-      appendAbcExportRenderedLaneBody(bodyLines, normalizedVoiceId, renderAbcExportLaneBody(context, normalizedVoiceId));
-    };
-    const appendAbcExportLane = (context) => {
-      const normalizedVoiceId = appendAbcExportLaneHeader(context);
-      appendAbcExportLaneBody(context, normalizedVoiceId);
-    };
-    const createAbcExportPartRenderInfo = (part, partIndex, partNameById) => {
-      const partId = part.getAttribute("id") || `P${partIndex + 1}`;
-      return {
-        partName: partNameById.get(partId) || partId,
-        measures: Array.from(part.querySelectorAll(":scope > measure")),
-        laneDefs: buildAbcExportLaneDefinitions(part, partId)
-      };
-    };
-    const appendAbcExportPartLanes = (context, partRenderInfo) => {
-      const { part, fifths, meterBeats, meterBeatType, unitLength, headerLines, bodyLines, metaLines } = context;
-      const { partName, measures, laneDefs } = partRenderInfo;
+    const appendAbcExportPartFromRenderContext = (context) => {
+      var _a, _b, _c, _d, _e, _f, _g;
+      const partId = context.part.getAttribute("id") || `P${context.partIndex + 1}`;
+      const partName = context.partNameById.get(partId) || partId;
+      const measures = Array.from(context.part.querySelectorAll(":scope > measure"));
+      const laneDefs = buildAbcExportLaneDefinitions(context.part, partId);
       for (const lane of laneDefs) {
-        appendAbcExportLane({
-          part,
+        const laneContext = {
+          part: context.part,
           partName,
           measures,
           laneDefs,
           lane,
-          fifths,
-          meterBeats,
-          meterBeatType,
-          unitLength,
-          headerLines,
-          bodyLines,
-          metaLines
+          fifths: context.fifths,
+          meterBeats: context.meterBeats,
+          meterBeatType: context.meterBeatType,
+          unitLength: context.unitLength,
+          headerLines: context.headerLines,
+          bodyLines: context.bodyLines,
+          metaLines: context.metaLines
+        };
+        const normalizedVoiceId = laneContext.lane.voiceId.replace(/[^A-Za-z0-9_.-]/g, "_");
+        const laneName = laneContext.laneDefs.length <= 1 ? laneContext.partName : laneContext.lane.staff && laneContext.lane.voice ? `${laneContext.partName} (Staff ${laneContext.lane.staff} Voice ${laneContext.lane.voice})` : laneContext.lane.staff ? `${laneContext.partName} (Staff ${laneContext.lane.staff})` : laneContext.lane.voice ? `${laneContext.partName} (Voice ${laneContext.lane.voice})` : `${laneContext.partName} (Lane)`;
+        const abcClef = resolveAbcExportLaneClef(laneContext.part, laneContext.measures, laneContext.lane.staff);
+        const clefSuffix = abcClef ? ` clef=${abcClef}` : "";
+        laneContext.headerLines.push(`V:${normalizedVoiceId} name="${laneName}"${clefSuffix}`);
+        const transposeNode = (_a = laneContext.measures[0]) === null || _a === void 0 ? void 0 : _a.querySelector(":scope > attributes > transpose");
+        if (transposeNode) {
+          const chromatic = Number((_d = (_c = (_b = transposeNode.querySelector(":scope > chromatic")) === null || _b === void 0 ? void 0 : _b.textContent) === null || _c === void 0 ? void 0 : _c.trim()) !== null && _d !== void 0 ? _d : "");
+          const diatonic = Number((_g = (_f = (_e = transposeNode.querySelector(":scope > diatonic")) === null || _e === void 0 ? void 0 : _e.textContent) === null || _f === void 0 ? void 0 : _f.trim()) !== null && _g !== void 0 ? _g : "");
+          if (Number.isFinite(chromatic) || Number.isFinite(diatonic)) {
+            laneContext.metaLines.push([
+              `%@mks transpose voice=${normalizedVoiceId}`,
+              ...Number.isFinite(chromatic) ? [`chromatic=${Math.round(chromatic)}`] : [],
+              ...Number.isFinite(diatonic) ? [`diatonic=${Math.round(diatonic)}`] : []
+            ].join(" "));
+          }
+        }
+        const state = createAbcExportLaneBodyStateFromPart(laneContext.part, laneContext.fifths, laneContext.meterBeats, laneContext.meterBeatType);
+        for (const measure of laneContext.measures) {
+          appendAbcExportLaneBodyMeasure(state, measure, laneContext.lane, laneContext.unitLength, laneContext.metaLines, normalizedVoiceId);
+        }
+        laneContext.bodyLines.push(`V:${normalizedVoiceId}`, state.measureTexts.join(" "));
+        if (state.lyricTokens.some((token) => token !== "*")) {
+          laneContext.bodyLines.push(`w: ${state.lyricTokens.join(" ")}`);
+        }
+      }
+    };
+    const appendAbcExportParts = (parts, exportContext) => {
+      for (const [partIndex, part] of parts.entries()) {
+        appendAbcExportPartFromRenderContext({
+          part,
+          partIndex,
+          partNameById: exportContext.partNameById,
+          fifths: exportContext.fifths,
+          meterBeats: exportContext.meterBeats,
+          meterBeatType: exportContext.meterBeatType,
+          unitLength: exportContext.unitLength,
+          headerLines: exportContext.headerLines,
+          bodyLines: exportContext.bodyLines,
+          metaLines: exportContext.metaLines
         });
       }
     };
-    const appendAbcExportPart = (context) => {
-      const { part, partIndex, partNameById } = context;
-      appendAbcExportPartLanes(context, createAbcExportPartRenderInfo(part, partIndex, partNameById));
-    };
-    const hasAbcExportUnitTempoHeader = (initialTempo) => Boolean(initialTempo.unit && Number.isFinite(initialTempo.bpm) && initialTempo.bpm > 0);
-    const buildAbcExportUnitTempoHeader = (initialTempo) => {
-      if (hasAbcExportUnitTempoHeader(initialTempo)) {
-        return `Q:${fractionToAbcTempoUnit(initialTempo.unit)}=${Math.round(initialTempo.bpm)}`;
-      }
-      return "";
-    };
-    const buildAbcExportFallbackTempoHeader = (tempoBpm) => Number.isFinite(tempoBpm) ? `Q:1/4=${Math.round(tempoBpm)}` : "";
-    const buildAbcExportTempoHeaderFromInitialTempo = (initialTempo) => {
-      var _a;
-      const tempoBpm = (_a = initialTempo === null || initialTempo === void 0 ? void 0 : initialTempo.bpm) !== null && _a !== void 0 ? _a : NaN;
-      if (initialTempo) {
-        const unitTempoHeader = buildAbcExportUnitTempoHeader(initialTempo);
-        if (unitTempoHeader)
-          return unitTempoHeader;
-      }
-      return buildAbcExportFallbackTempoHeader(tempoBpm);
-    };
-    const buildAbcExportTempoHeader = (doc) => buildAbcExportTempoHeaderFromInitialTempo(readInitialTempoFromMusicXml(doc));
-    const readAbcExportTitle = (doc) => {
-      var _a, _b, _c, _d;
-      return ((_b = (_a = doc.querySelector("work > work-title")) === null || _a === void 0 ? void 0 : _a.textContent) === null || _b === void 0 ? void 0 : _b.trim()) || ((_d = (_c = doc.querySelector("movement-title")) === null || _c === void 0 ? void 0 : _c.textContent) === null || _d === void 0 ? void 0 : _d.trim()) || "mikuscore";
-    };
-    const readAbcExportComposer = (doc) => {
-      var _a, _b;
-      return ((_b = (_a = doc.querySelector('identification > creator[type="composer"]')) === null || _a === void 0 ? void 0 : _a.textContent) === null || _b === void 0 ? void 0 : _b.trim()) || "";
-    };
-    const readAbcExportDocumentCredits = (doc) => ({
-      title: readAbcExportTitle(doc),
-      composer: readAbcExportComposer(doc)
-    });
-    const readAbcExportMeterBeats = (firstMeasure) => {
-      var _a, _b;
-      return ((_b = (_a = firstMeasure === null || firstMeasure === void 0 ? void 0 : firstMeasure.querySelector("attributes > time > beats")) === null || _a === void 0 ? void 0 : _a.textContent) === null || _b === void 0 ? void 0 : _b.trim()) || "4";
-    };
-    const readAbcExportMeterBeatType = (firstMeasure) => {
-      var _a, _b;
-      return ((_b = (_a = firstMeasure === null || firstMeasure === void 0 ? void 0 : firstMeasure.querySelector("attributes > time > beat-type")) === null || _a === void 0 ? void 0 : _a.textContent) === null || _b === void 0 ? void 0 : _b.trim()) || "4";
-    };
-    const readAbcExportDocumentMeterInfo = (firstMeasure) => ({
-      meterBeats: readAbcExportMeterBeats(firstMeasure),
-      meterBeatType: readAbcExportMeterBeatType(firstMeasure)
-    });
-    const buildAbcExportKeyFromFifthsMode = (fifths, mode) => exports.AbcCommon.keyFromFifthsMode(Number.isFinite(fifths) ? fifths : 0, mode);
-    const readAbcExportKeyFifths = (firstMeasure) => {
-      var _a, _b;
-      return Number(((_b = (_a = firstMeasure === null || firstMeasure === void 0 ? void 0 : firstMeasure.querySelector("attributes > key > fifths")) === null || _a === void 0 ? void 0 : _a.textContent) === null || _b === void 0 ? void 0 : _b.trim()) || "0");
-    };
-    const readAbcExportKeyMode = (firstMeasure) => {
-      var _a, _b;
-      return ((_b = (_a = firstMeasure === null || firstMeasure === void 0 ? void 0 : firstMeasure.querySelector("attributes > key > mode")) === null || _a === void 0 ? void 0 : _a.textContent) === null || _b === void 0 ? void 0 : _b.trim()) || "major";
-    };
-    const readAbcExportDocumentKeyInfo = (firstMeasure) => {
-      const fifths = readAbcExportKeyFifths(firstMeasure);
-      const mode = readAbcExportKeyMode(firstMeasure);
-      return {
+    const exportMusicXmlDomToAbc = (doc) => {
+      var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p, _q, _r, _s, _t, _u, _v, _w;
+      const title = (_f = (_c = (_b = (_a = doc.querySelector("work > work-title")) === null || _a === void 0 ? void 0 : _a.textContent) === null || _b === void 0 ? void 0 : _b.trim()) !== null && _c !== void 0 ? _c : (_e = (_d = doc.querySelector("movement-title")) === null || _d === void 0 ? void 0 : _d.textContent) === null || _e === void 0 ? void 0 : _e.trim()) !== null && _f !== void 0 ? _f : "mikuscore";
+      const composer = (_j = (_h = (_g = doc.querySelector('identification > creator[type="composer"]')) === null || _g === void 0 ? void 0 : _g.textContent) === null || _h === void 0 ? void 0 : _h.trim()) !== null && _j !== void 0 ? _j : "";
+      const firstMeasure = doc.querySelector("score-partwise > part > measure");
+      const meterBeats = (_m = (_l = (_k = firstMeasure === null || firstMeasure === void 0 ? void 0 : firstMeasure.querySelector("attributes > time > beats")) === null || _k === void 0 ? void 0 : _k.textContent) === null || _l === void 0 ? void 0 : _l.trim()) !== null && _m !== void 0 ? _m : "4";
+      const meterBeatType = (_q = (_p = (_o = firstMeasure === null || firstMeasure === void 0 ? void 0 : firstMeasure.querySelector("attributes > time > beat-type")) === null || _o === void 0 ? void 0 : _o.textContent) === null || _p === void 0 ? void 0 : _p.trim()) !== null && _q !== void 0 ? _q : "4";
+      const fifths = Number((_t = (_s = (_r = firstMeasure === null || firstMeasure === void 0 ? void 0 : firstMeasure.querySelector("attributes > key > fifths")) === null || _r === void 0 ? void 0 : _r.textContent) === null || _s === void 0 ? void 0 : _s.trim()) !== null && _t !== void 0 ? _t : "0");
+      const mode = (_w = (_v = (_u = firstMeasure === null || firstMeasure === void 0 ? void 0 : firstMeasure.querySelector("attributes > key > mode")) === null || _u === void 0 ? void 0 : _u.textContent) === null || _v === void 0 ? void 0 : _v.trim()) !== null && _w !== void 0 ? _w : "major";
+      const initialTempo = readInitialTempoFromMusicXml(doc);
+      const abcTempoHeader = initialTempo ? initialTempo.unit && Number.isFinite(initialTempo.bpm) && initialTempo.bpm > 0 ? `Q:${fractionToAbcTempoUnit(initialTempo.unit)}=${Math.round(initialTempo.bpm)}` : Number.isFinite(initialTempo.bpm) ? `Q:1/4=${Math.round(initialTempo.bpm)}` : "" : "";
+      const exportContext = {
+        headerLines: [
+          "X:1",
+          `T:${title}`,
+          composer ? `C:${composer}` : "",
+          `M:${meterBeats}/${meterBeatType}`,
+          `L:${fractionToAbcTempoUnit(DEFAULT_UNIT)}`,
+          abcTempoHeader,
+          `K:${exports.AbcCommon.keyFromFifthsMode(Number.isFinite(fifths) ? fifths : 0, mode)}`
+        ].filter((line) => line.length > 0),
+        bodyLines: [],
+        metaLines: [],
+        partNameById: new Map(Array.from(doc.querySelectorAll("part-list > score-part")).map((scorePart) => {
+          var _a2, _b2, _c2;
+          const id = (_a2 = scorePart.getAttribute("id")) !== null && _a2 !== void 0 ? _a2 : "";
+          return id ? [id, ((_c2 = (_b2 = scorePart.querySelector("part-name")) === null || _b2 === void 0 ? void 0 : _b2.textContent) === null || _c2 === void 0 ? void 0 : _c2.trim()) || id] : null;
+        }).filter((entry) => entry !== null)),
         fifths,
-        key: buildAbcExportKeyFromFifthsMode(fifths, mode)
+        meterBeats,
+        meterBeatType,
+        unitLength: DEFAULT_UNIT
       };
-    };
-    const createAbcExportDocumentMeterKeyInfoFromParts = (meterInfo, keyInfo) => ({
-      meterBeats: meterInfo.meterBeats,
-      meterBeatType: meterInfo.meterBeatType,
-      fifths: keyInfo.fifths,
-      key: keyInfo.key
-    });
-    const readAbcExportDocumentMeterKeyInfo = (firstMeasure) => {
-      const meterInfo = readAbcExportDocumentMeterInfo(firstMeasure);
-      const keyInfo = readAbcExportDocumentKeyInfo(firstMeasure);
-      return createAbcExportDocumentMeterKeyInfoFromParts(meterInfo, keyInfo);
-    };
-    const readAbcExportFirstMeasure = (doc) => doc.querySelector("score-partwise > part > measure");
-    const createAbcExportDocumentHeaderInfoFromParts = (credits, meterKeyInfo, abcTempoHeader) => ({
-      title: credits.title,
-      composer: credits.composer,
-      meterBeats: meterKeyInfo.meterBeats,
-      meterBeatType: meterKeyInfo.meterBeatType,
-      fifths: meterKeyInfo.fifths,
-      key: meterKeyInfo.key,
-      abcTempoHeader
-    });
-    const createAbcExportDocumentHeaderInfo = (doc) => createAbcExportDocumentHeaderInfoFromParts(readAbcExportDocumentCredits(doc), readAbcExportDocumentMeterKeyInfo(readAbcExportFirstMeasure(doc)), buildAbcExportTempoHeader(doc));
-    const buildAbcExportRawHeaderLines = (headerInfo) => {
-      const { title, composer, meterBeats, meterBeatType, key, abcTempoHeader } = headerInfo;
-      return [
-        "X:1",
-        `T:${title}`,
-        composer ? `C:${composer}` : "",
-        `M:${meterBeats}/${meterBeatType}`,
-        `L:${fractionToAbcTempoUnit(DEFAULT_UNIT)}`,
-        abcTempoHeader,
-        `K:${key}`
-      ];
-    };
-    const buildAbcExportHeaderLines = (headerInfo) => buildAbcExportRawHeaderLines(headerInfo).filter(Boolean);
-    const createAbcExportInitialDocumentContext = (headerInfo, partNameById) => ({
-      headerLines: buildAbcExportHeaderLines(headerInfo),
-      bodyLines: [],
-      metaLines: [],
-      partNameById,
-      fifths: headerInfo.fifths,
-      meterBeats: headerInfo.meterBeats,
-      meterBeatType: headerInfo.meterBeatType,
-      unitLength: DEFAULT_UNIT
-    });
-    const createAbcExportDocumentContext = (doc) => createAbcExportInitialDocumentContext(createAbcExportDocumentHeaderInfo(doc), buildAbcExportPartNameById(doc));
-    const buildAbcExportMetaBlock = (metaLines) => metaLines.length > 0 ? `
-${metaLines.join("\n")}
-` : "\n";
-    const buildAbcExportDocumentTextFromLines = (headerLines, bodyLines, metaLines) => {
-      const metaBlock = buildAbcExportMetaBlock(metaLines);
-      return `${headerLines.join("\n")}
+      appendAbcExportParts(Array.from(doc.querySelectorAll("score-partwise > part")), exportContext);
+      return `${exportContext.headerLines.join("\n")}
 
-${bodyLines.join("\n")}${metaBlock}`;
+${exportContext.bodyLines.join("\n")}${exportContext.metaLines.length > 0 ? `
+${exportContext.metaLines.join("\n")}
+` : "\n"}`;
     };
-    const buildAbcExportDocumentText = (exportContext) => buildAbcExportDocumentTextFromLines(exportContext.headerLines, exportContext.bodyLines, exportContext.metaLines);
-    const createAbcExportPartRenderContext = (part, partIndex, exportContext) => ({
-      part,
-      partIndex,
-      partNameById: exportContext.partNameById,
-      fifths: exportContext.fifths,
-      meterBeats: exportContext.meterBeats,
-      meterBeatType: exportContext.meterBeatType,
-      unitLength: exportContext.unitLength,
-      headerLines: exportContext.headerLines,
-      bodyLines: exportContext.bodyLines,
-      metaLines: exportContext.metaLines
-    });
-    const readAbcExportParts = (doc) => Array.from(doc.querySelectorAll("score-partwise > part"));
-    const appendAbcExportParts = (parts, exportContext) => {
-      parts.forEach((part, partIndex) => {
-        appendAbcExportPart(createAbcExportPartRenderContext(part, partIndex, exportContext));
-      });
-    };
-    const renderAbcExportDocumentContext = (doc) => {
-      const exportContext = createAbcExportDocumentContext(doc);
-      appendAbcExportParts(readAbcExportParts(doc), exportContext);
-      return exportContext;
-    };
-    const exportMusicXmlDomToAbc = (doc) => buildAbcExportDocumentText(renderAbcExportDocumentContext(doc));
     exports.exportMusicXmlDomToAbc = exportMusicXmlDomToAbc;
     const xmlEscape = (text) => text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&apos;");
-    const abcQuotedTextEscape = (text) => String(text || "").replace(/"/g, "'").replace(/\s+/g, " ").trim();
-    const normalizeChordToken = (raw) => String(raw || "").trim().replace(/♯/g, "#").replace(/♭/g, "b").replace(/\s+/g, "");
+    const abcQuotedTextEscape = (text) => String(text !== null && text !== void 0 ? text : "").replace(/"/g, "'").replace(/\s+/g, " ").trim();
+    const normalizeChordToken = (raw) => String(raw !== null && raw !== void 0 ? raw : "").trim().replace(/♯/g, "#").replace(/♭/g, "b").replace(/\s+/g, "");
     const ABC_CHORD_SYMBOL_PATTERN = /^([A-G](?:#|b)?)([^/\s"]*)?(?:\/([A-G](?:#|b)?))?$/;
-    const isLikelyAbcChordSymbol = (raw) => {
-      const text = normalizeChordToken(raw);
-      return ABC_CHORD_SYMBOL_PATTERN.test(text);
+    const isLikelyAbcChordSymbol = (raw) => ABC_CHORD_SYMBOL_PATTERN.test(normalizeChordToken(raw));
+    const normalizeHarmonyChordSuffix = (suffixRaw) => String(suffixRaw !== null && suffixRaw !== void 0 ? suffixRaw : "").trim().toLowerCase();
+    const abcHarmonyKindBySuffix = {
+      "": "major",
+      m: "minor",
+      min: "minor",
+      "6": "major-sixth",
+      m6: "minor-sixth",
+      min6: "minor-sixth",
+      "7": "dominant",
+      "7sus4": "suspended-fourth",
+      "9": "dominant-ninth",
+      "11": "dominant-11th",
+      "13": "dominant-13th",
+      maj7: "major-seventh",
+      maj9: "major-ninth",
+      m9: "minor-ninth",
+      min9: "minor-ninth",
+      m7: "minor-seventh",
+      min7: "minor-seventh",
+      dim: "diminished",
+      dim7: "diminished-seventh",
+      aug: "augmented",
+      "+": "augmented",
+      sus4: "suspended-fourth",
+      sus2: "suspended-second",
+      "m7b5": "half-diminished",
+      min7b5: "half-diminished",
+      "\xF8": "half-diminished"
     };
-    const normalizeHarmonyChordSuffix = (suffixRaw) => String(suffixRaw || "").trim().toLowerCase();
     const xmlHarmonyKindFromChordSuffix = (suffixRaw) => {
+      var _a;
       const suffix = normalizeHarmonyChordSuffix(suffixRaw);
-      if (!suffix)
-        return "major";
-      if (suffix === "m" || suffix === "min")
-        return "minor";
-      if (suffix === "6")
-        return "major-sixth";
-      if (suffix === "m6" || suffix === "min6")
-        return "minor-sixth";
-      if (suffix === "7")
-        return "dominant";
-      if (suffix === "7sus4")
-        return "suspended-fourth";
-      if (suffix === "9")
-        return "dominant-ninth";
-      if (suffix === "11")
-        return "dominant-11th";
-      if (suffix === "13")
-        return "dominant-13th";
-      if (suffix === "maj7")
-        return "major-seventh";
-      if (suffix === "maj9")
-        return "major-ninth";
-      if (suffix === "m9" || suffix === "min9")
-        return "minor-ninth";
-      if (suffix === "m7" || suffix === "min7")
-        return "minor-seventh";
-      if (suffix === "dim")
-        return "diminished";
-      if (suffix === "dim7")
-        return "diminished-seventh";
-      if (suffix === "aug" || suffix === "+")
-        return "augmented";
-      if (suffix === "sus4")
-        return "suspended-fourth";
-      if (suffix === "sus2")
-        return "suspended-second";
-      if (suffix === "m7b5" || suffix === "min7b5" || suffix === "\xF8")
-        return "half-diminished";
-      return null;
+      return (_a = abcHarmonyKindBySuffix[suffix]) !== null && _a !== void 0 ? _a : null;
     };
     const xmlHarmonyRootFromChordToken = (token) => {
-      const m = String(token || "").match(/^([A-G])(#|b)?$/);
-      if (!m)
-        return null;
-      return {
+      const m = String(token !== null && token !== void 0 ? token : "").match(/^([A-G])(#|b)?$/);
+      return m ? {
         step: m[1],
         alter: m[2] === "#" ? 1 : m[2] === "b" ? -1 : 0
-      };
+      } : null;
     };
     const parseAbcChordSymbolParts = (raw) => {
+      var _a, _b;
       const normalized = normalizeChordToken(raw);
       const match = normalized.match(ABC_CHORD_SYMBOL_PATTERN);
       if (!match)
         return null;
-      const root = xmlHarmonyRootFromChordToken(match[1] || "");
+      const root = xmlHarmonyRootFromChordToken((_a = match[1]) !== null && _a !== void 0 ? _a : "");
       if (!root)
         return null;
       const bass = match[3] ? xmlHarmonyRootFromChordToken(match[3]) : null;
       return {
         normalized,
         root,
-        suffix: String(match[2] || ""),
+        suffix: String((_b = match[2]) !== null && _b !== void 0 ? _b : ""),
         bass
       };
     };
-    const buildHarmonyPitchXml = (tagName, pitch) => {
-      const childPrefix = tagName === "root" ? "root" : "bass";
-      return [
-        `<${tagName}>`,
-        `<${childPrefix}-step>${xmlEscape(pitch.step)}</${childPrefix}-step>`,
-        pitch.alter !== 0 ? `<${childPrefix}-alter>${pitch.alter}</${childPrefix}-alter>` : "",
-        `</${tagName}>`
-      ].join("");
-    };
-    const buildHarmonyKindXml = (normalized, kind) => `<kind text="${xmlEscape(normalized)}">${kind}</kind>`;
-    const buildHarmonyXmlFromParts = (parts, kind) => [
-      "<harmony>",
-      buildHarmonyPitchXml("root", parts.root),
-      parts.bass ? buildHarmonyPitchXml("bass", parts.bass) : "",
-      buildHarmonyKindXml(parts.normalized, kind),
-      "</harmony>"
+    const buildHarmonyPitchXml = (tagName, pitch) => [
+      `<${tagName}>`,
+      `<${tagName}-step>${xmlEscape(pitch.step)}</${tagName}-step>`,
+      pitch.alter !== 0 ? `<${tagName}-alter>${pitch.alter}</${tagName}-alter>` : "",
+      `</${tagName}>`
     ].join("");
     const buildHarmonyXmlFromChordSymbol = (raw) => {
       const parts = parseAbcChordSymbolParts(raw);
       if (!parts)
         return "";
       const kind = xmlHarmonyKindFromChordSuffix(parts.suffix);
-      if (!kind)
-        return "";
-      return buildHarmonyXmlFromParts(parts, kind);
+      return kind ? [
+        "<harmony>",
+        buildHarmonyPitchXml("root", parts.root),
+        parts.bass ? buildHarmonyPitchXml("bass", parts.bass) : "",
+        `<kind text="${xmlEscape(parts.normalized)}">${kind}</kind>`,
+        "</harmony>"
+      ].join("") : "";
     };
-    const abcHarmonyPitchTokenFromStepAlter = (step, alter) => {
-      const normalizedStep = String(step || "").trim().toUpperCase();
-      if (!/^[A-G]$/.test(normalizedStep))
-        return "";
-      return `${normalizedStep}${alter === 1 ? "#" : alter === -1 ? "b" : ""}`;
+    const abcHarmonySuffixByKindValue = {
+      major: "",
+      minor: "m",
+      "major-sixth": "6",
+      "minor-sixth": "m6",
+      dominant: "7",
+      "dominant-11th": "11",
+      "dominant-13th": "13",
+      "dominant-ninth": "9",
+      "major-seventh": "maj7",
+      "major-ninth": "maj9",
+      "minor-ninth": "m9",
+      "minor-seventh": "m7",
+      diminished: "dim",
+      "diminished-seventh": "dim7",
+      augmented: "aug",
+      "suspended-fourth": "sus4",
+      "suspended-second": "sus2",
+      "half-diminished": "m7b5"
     };
-    const abcHarmonyPitchFromNode = (node, prefix) => {
-      var _a, _b;
-      if (!node)
-        return null;
-      const step = (((_a = node.querySelector(`:scope > ${prefix}-step`)) === null || _a === void 0 ? void 0 : _a.textContent) || "").trim();
-      const alter = Number(((_b = node.querySelector(`:scope > ${prefix}-alter`)) === null || _b === void 0 ? void 0 : _b.textContent) || "0");
-      return { step, alter };
-    };
-    const abcHarmonyPitchTokenFromNode = (node, prefix) => {
-      const pitch = abcHarmonyPitchFromNode(node, prefix);
-      return pitch ? abcHarmonyPitchTokenFromStepAlter(pitch.step, pitch.alter) : "";
-    };
-    const abcHarmonySuffixFromKindValue = (kindValue) => kindValue === "major" ? "" : kindValue === "minor" ? "m" : kindValue === "major-sixth" ? "6" : kindValue === "minor-sixth" ? "m6" : kindValue === "dominant" ? "7" : kindValue === "dominant-11th" ? "11" : kindValue === "dominant-13th" ? "13" : kindValue === "dominant-ninth" ? "9" : kindValue === "major-seventh" ? "maj7" : kindValue === "major-ninth" ? "maj9" : kindValue === "minor-ninth" ? "m9" : kindValue === "minor-seventh" ? "m7" : kindValue === "diminished" ? "dim" : kindValue === "diminished-seventh" ? "dim7" : kindValue === "augmented" ? "aug" : kindValue === "suspended-fourth" ? "sus4" : kindValue === "suspended-second" ? "sus2" : kindValue === "half-diminished" ? "m7b5" : "";
-    const abcHarmonyKindTextOverride = (kindNode) => {
-      const kindTextAttr = ((kindNode === null || kindNode === void 0 ? void 0 : kindNode.getAttribute("text")) || "").trim();
-      return kindTextAttr ? abcQuotedTextEscape(kindTextAttr) : "";
-    };
-    const normalizeHarmonyKindValue = (kindValue) => String(kindValue || "").trim().toLowerCase();
-    const abcHarmonyKindValueFromNode = (kindNode) => normalizeHarmonyKindValue((kindNode === null || kindNode === void 0 ? void 0 : kindNode.textContent) || "");
-    const abcHarmonySuffixFromKindNode = (kindNode) => abcHarmonySuffixFromKindValue(abcHarmonyKindValueFromNode(kindNode));
-    const abcHarmonyBassTokenFromNode = (node) => {
-      const bassPitchToken = abcHarmonyPitchTokenFromNode(node, "bass");
-      return bassPitchToken ? `/${bassPitchToken}` : "";
-    };
-    const buildAbcHarmonyChordSymbol = (rootToken, suffix, bassToken) => `${rootToken}${suffix}${bassToken}`;
     const abcChordSymbolFromHarmony = (harmony) => {
+      var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m;
       if (!harmony)
         return "";
-      const rootToken = abcHarmonyPitchTokenFromNode(harmony.querySelector(":scope > root"), "root");
+      const rootNode = harmony.querySelector(":scope > root");
+      const rootStep = rootNode ? ((_b = (_a = rootNode.querySelector(":scope > root-step")) === null || _a === void 0 ? void 0 : _a.textContent) !== null && _b !== void 0 ? _b : "").trim() : "";
+      const rootAlter = rootNode ? Number((_d = (_c = rootNode.querySelector(":scope > root-alter")) === null || _c === void 0 ? void 0 : _c.textContent) !== null && _d !== void 0 ? _d : "0") : 0;
+      const rootNormalizedStep = String(rootStep !== null && rootStep !== void 0 ? rootStep : "").trim().toUpperCase();
+      const rootToken = /^[A-G]$/.test(rootNormalizedStep) ? `${rootNormalizedStep}${rootAlter === 1 ? "#" : rootAlter === -1 ? "b" : ""}` : "";
       if (!rootToken)
         return "";
       const kindNode = harmony.querySelector(":scope > kind");
-      const kindTextOverride = abcHarmonyKindTextOverride(kindNode);
-      if (kindTextOverride)
-        return kindTextOverride;
-      const suffix = abcHarmonySuffixFromKindNode(kindNode);
-      const bassToken = abcHarmonyBassTokenFromNode(harmony.querySelector(":scope > bass"));
-      return buildAbcHarmonyChordSymbol(rootToken, suffix, bassToken);
+      const kindTextAttr = (_f = (_e = kindNode === null || kindNode === void 0 ? void 0 : kindNode.getAttribute("text")) === null || _e === void 0 ? void 0 : _e.trim()) !== null && _f !== void 0 ? _f : "";
+      if (kindTextAttr)
+        return abcQuotedTextEscape(kindTextAttr);
+      const bassNode = harmony.querySelector(":scope > bass");
+      const bassStep = bassNode ? ((_h = (_g = bassNode.querySelector(":scope > bass-step")) === null || _g === void 0 ? void 0 : _g.textContent) !== null && _h !== void 0 ? _h : "").trim() : "";
+      const bassAlter = bassNode ? Number((_k = (_j = bassNode.querySelector(":scope > bass-alter")) === null || _j === void 0 ? void 0 : _j.textContent) !== null && _k !== void 0 ? _k : "0") : 0;
+      const bassNormalizedStep = String(bassStep !== null && bassStep !== void 0 ? bassStep : "").trim().toUpperCase();
+      const bassPitchToken = /^[A-G]$/.test(bassNormalizedStep) ? `${bassNormalizedStep}${bassAlter === 1 ? "#" : bassAlter === -1 ? "b" : ""}` : "";
+      const kindValue = String((_l = kindNode === null || kindNode === void 0 ? void 0 : kindNode.textContent) !== null && _l !== void 0 ? _l : "").trim().toLowerCase();
+      const suffix = (_m = abcHarmonySuffixByKindValue[kindValue]) !== null && _m !== void 0 ? _m : "";
+      return `${rootToken}${suffix}${bassPitchToken ? `/${bassPitchToken}` : ""}`;
     };
-    const normalizeAbcLyricText = (text) => String(text || "").trim().replace(/\s+/g, "~");
-    const normalizeAbcLyricSyllabicMode = (syllabic) => String(syllabic || "single").trim().toLowerCase();
+    const normalizeAbcLyricText = (text) => String(text !== null && text !== void 0 ? text : "").trim().replace(/\s+/g, "~");
+    const normalizeAbcLyricSyllabicMode = (syllabic) => String(syllabic !== null && syllabic !== void 0 ? syllabic : "single").trim().toLowerCase();
     const shouldAppendAbcLyricHyphen = (syllabicMode) => syllabicMode === "begin" || syllabicMode === "middle";
-    const buildAbcLyricTextToken = (normalizedText, syllabicMode) => shouldAppendAbcLyricHyphen(syllabicMode) ? `${normalizedText}-` : normalizedText;
     const abcLyricTokenFromMusicXml = (text, syllabic) => {
       const normalized = normalizeAbcLyricText(text);
       const mode = normalizeAbcLyricSyllabicMode(syllabic);
       if (!normalized)
         return "*";
-      return buildAbcLyricTextToken(normalized, mode);
+      return shouldAppendAbcLyricHyphen(mode) ? `${normalized}-` : normalized;
     };
-    const normalizeMusicXmlTypeName = (t) => String(t || "").trim();
+    const normalizeMusicXmlTypeName = (t) => String(t !== null && t !== void 0 ? t : "").trim();
     const isSupportedMusicXmlTypeName = (typeName) => typeName === "16th" || typeName === "32nd" || typeName === "64th" || typeName === "128th" || typeName === "whole" || typeName === "half" || typeName === "quarter" || typeName === "eighth";
     const normalizeTypeForMusicXml = (t) => {
       const raw = normalizeMusicXmlTypeName(t);
-      if (!raw)
-        return "quarter";
-      if (isSupportedMusicXmlTypeName(raw))
-        return raw;
-      return "quarter";
+      return raw && isSupportedMusicXmlTypeName(raw) ? raw : "quarter";
     };
-    const normalizeMusicXmlVoiceText = (voice) => String(voice || "").trim();
+    const normalizeMusicXmlVoiceText = (voice) => String(voice !== null && voice !== void 0 ? voice : "").trim();
     const isPositiveIntegerVoiceText = (voiceText) => /^[1-9]\d*$/.test(voiceText);
     const extractFirstVoiceNumberText = (voiceText) => {
-      var _a;
-      return ((_a = voiceText.match(/\d+/)) === null || _a === void 0 ? void 0 : _a[0]) || "";
+      var _a, _b;
+      return (_b = (_a = voiceText.match(/\d+/)) === null || _a === void 0 ? void 0 : _a[0]) !== null && _b !== void 0 ? _b : "";
     };
     const normalizeMusicXmlVoiceNumberText = (voiceNumberText) => {
       const n = Number(voiceNumberText);
-      if (!Number.isFinite(n) || n <= 0)
-        return "1";
-      return String(Math.round(n));
+      return Number.isFinite(n) && n > 0 ? String(Math.round(n)) : "1";
     };
     const normalizeVoiceForMusicXml = (voice) => {
       const raw = normalizeMusicXmlVoiceText(voice);
@@ -156983,9 +156611,7 @@ ${bodyLines.join("\n")}${metaBlock}`;
       if (isPositiveIntegerVoiceText(raw))
         return raw;
       const numberText = extractFirstVoiceNumberText(raw);
-      if (!numberText)
-        return "1";
-      return normalizeMusicXmlVoiceNumberText(numberText);
+      return numberText ? normalizeMusicXmlVoiceNumberText(numberText) : "1";
     };
     const midiByStepForAbcImport = {
       C: 0,
@@ -156996,30 +156622,23 @@ ${bodyLines.join("\n")}${metaBlock}`;
       A: 9,
       B: 11
     };
-    const normalizeAbcImportStep = (step) => String(step || "").trim().toUpperCase();
-    const normalizeAbcImportOctave = (octave) => Number.isFinite(octave) ? Math.round(Number(octave)) : 4;
-    const normalizeAbcImportAlter = (alter) => Number.isFinite(alter) ? Math.round(Number(alter)) : 0;
-    const abcImportPitchToMidi = (step, octave, alter) => (octave + 1) * 12 + midiByStepForAbcImport[step] + alter;
-    const noteToMidiForAbcClefInference = (note) => {
-      if (!note || note.isRest)
-        return null;
-      const step = normalizeAbcImportStep(note.step);
-      if (!Object.prototype.hasOwnProperty.call(midiByStepForAbcImport, step)) {
-        return null;
-      }
-      const octave = normalizeAbcImportOctave(note.octave);
-      const alter = normalizeAbcImportAlter(note.alter);
-      return abcImportPitchToMidi(step, octave, alter);
-    };
-    const normalizeAbcImportClefName = (clef) => String(clef || "").trim().toLowerCase();
+    const normalizeAbcImportStep = (step) => String(step !== null && step !== void 0 ? step : "").trim().toUpperCase();
+    const normalizeAbcImportClefName = (clef) => String(clef !== null && clef !== void 0 ? clef : "").trim().toLowerCase();
     const collectAbcImportClefMidiKeys = (part) => {
+      var _a;
       const keys = [];
-      for (const measure of (part === null || part === void 0 ? void 0 : part.measures) || []) {
-        for (const note of measure || []) {
-          const midi = noteToMidiForAbcClefInference(note);
-          if (Number.isFinite(midi)) {
-            keys.push(midi);
+      for (const measure of (_a = part === null || part === void 0 ? void 0 : part.measures) !== null && _a !== void 0 ? _a : []) {
+        for (const note of measure !== null && measure !== void 0 ? measure : []) {
+          if (!note || note.isRest) {
+            continue;
           }
+          const step = normalizeAbcImportStep(note.step);
+          if (!Object.prototype.hasOwnProperty.call(midiByStepForAbcImport, step)) {
+            continue;
+          }
+          const octave = Number.isFinite(Number(note.octave)) ? Math.round(Number(note.octave)) : 4;
+          const alter = Number.isFinite(Number(note.alter)) ? Math.round(Number(note.alter)) : 0;
+          keys.push((octave + 1) * 12 + midiByStepForAbcImport[step] + alter);
         }
       }
       return keys;
@@ -157027,160 +156646,32 @@ ${bodyLines.join("\n")}${metaBlock}`;
     const abcImportClefNameFromMidiKeys = (keys) => (0, staffClefPolicy_1.chooseSingleClefByKeys)(keys) === "F" ? "bass" : "treble";
     const resolveAbcImportClef = (part) => {
       const explicit = normalizeAbcImportClefName(part === null || part === void 0 ? void 0 : part.clef);
+      const keys = collectAbcImportClefMidiKeys(part);
       if (explicit)
         return explicit;
-      const keys = collectAbcImportClefMidiKeys(part);
       if (!keys.length)
-        return "";
+        return explicit;
       return abcImportClefNameFromMidiKeys(keys);
     };
+    const clefFeatureByAbcClefName = {
+      bass: { sign: "F", line: 4 },
+      f: { sign: "F", line: 4 },
+      alto: { sign: "C", line: 3 },
+      c3: { sign: "C", line: 3 },
+      tenor: { sign: "C", line: 4 },
+      c4: { sign: "C", line: 4 },
+      treble: { sign: "G", line: 2 },
+      g: { sign: "G", line: 2 }
+    };
     const clefFeatureFromAbcClefName = (clef) => {
-      if (clef === "bass" || clef === "f") {
-        return { sign: "F", line: 4 };
-      }
-      if (clef === "alto" || clef === "c3") {
-        return { sign: "C", line: 3 };
-      }
-      if (clef === "tenor" || clef === "c4") {
-        return { sign: "C", line: 4 };
-      }
-      return { sign: "G", line: 2 };
+      var _a;
+      return (_a = clefFeatureByAbcClefName[clef]) !== null && _a !== void 0 ? _a : { sign: "G", line: 2 };
     };
-    const clefXmlFromAbcClef = (rawClef) => {
-      const clef = normalizeAbcImportClefName(rawClef);
-      return (0, clefs_1.buildMusicXmlClefXml)(clefFeatureFromAbcClefName(clef));
-    };
+    const clefXmlFromAbcClef = (rawClef) => (0, clefs_1.buildMusicXmlClefXml)(clefFeatureFromAbcClefName(normalizeAbcImportClefName(rawClef)));
     exports.clefXmlFromAbcClef = clefXmlFromAbcClef;
     const toHex = (value, width = 2) => {
-      const safe = Math.max(0, Math.round(Number(value) || 0));
+      const safe = Math.max(0, Math.round(Number(value !== null && value !== void 0 ? value : 0)));
       return `0x${safe.toString(16).toUpperCase().padStart(width, "0")}`;
-    };
-    const normalizeAbcDebugStep = (note) => note.isRest ? "R" : /^[A-G]$/.test(String(note.step || "").toUpperCase()) ? String(note.step).toUpperCase() : "C";
-    const normalizeAbcDebugOctave = (octave) => Number.isFinite(octave) ? Math.max(0, Math.min(9, Math.round(Number(octave)))) : 4;
-    const normalizeAbcDebugAlter = (alter) => Number.isFinite(alter) ? Math.round(Number(alter)) : 0;
-    const buildAbcMeasureDebugMiscXmlCoreFields = (index, measureNo, voice, note) => [`idx=${toHex(index, 4)}`, `m=${toHex(measureNo, 4)}`, `v=${xmlEscape(voice)}`].join(";");
-    const buildAbcMeasureDebugMiscXmlNoteFields = (note, step, octave, alter, dur) => [
-      `r=${note.isRest ? "1" : "0"}`,
-      `g=${note.grace ? "1" : "0"}`,
-      `ch=${note.chord ? "1" : "0"}`,
-      `st=${step}`,
-      `al=${String(alter)}`,
-      `oc=${toHex(octave, 2)}`,
-      `dd=${toHex(dur, 4)}`,
-      `tp=${xmlEscape(normalizeTypeForMusicXml(note.type))}`
-    ].join(";");
-    const buildAbcMeasureDebugMiscXmlCountField = (noteCount) => `<miscellaneous-field name="mks:dbg:abc:meta:count">${toHex(noteCount, 4)}</miscellaneous-field>`;
-    const buildAbcMeasureDebugMiscXmlEntry = (note, index, measureNo) => `<miscellaneous-field name="mks:dbg:abc:meta:${String(index + 1).padStart(4, "0")}">${buildAbcMeasureDebugMiscXmlPayload(note, index, measureNo)}</miscellaneous-field>`;
-    const buildAbcMeasureDebugMiscXmlPayload = (note, index, measureNo) => {
-      const voice = normalizeVoiceForMusicXml(note.voice);
-      const step = normalizeAbcDebugStep(note);
-      const octave = normalizeAbcDebugOctave(note.octave);
-      const alter = normalizeAbcDebugAlter(note.alter);
-      const dur = note.grace ? 0 : Math.max(1, Math.round(Number(note.duration) || 1));
-      return [buildAbcMeasureDebugMiscXmlCoreFields(index, measureNo, voice, note), buildAbcMeasureDebugMiscXmlNoteFields(note, step, octave, alter, dur)].join(";");
-    };
-    const buildAbcMeasureDebugMiscXml = (notes, measureNo) => {
-      if (!notes.length)
-        return "";
-      let xml = "<attributes><miscellaneous>";
-      xml += buildAbcMeasureDebugMiscXmlCountField(notes.length);
-      xml += buildAbcMeasureDebugMiscXmlEntryParts(notes, measureNo).join("");
-      xml += "</miscellaneous></attributes>";
-      return xml;
-    };
-    const buildAbcMeasureDebugMiscXmlEntryParts = (notes, measureNo) => notes.map((note, index) => buildAbcMeasureDebugMiscXmlEntry(note, index, measureNo));
-    const encodeAbcSourceForMiscXml = (abcSource) => String(abcSource !== null && abcSource !== void 0 ? abcSource : "").replace(/\\/g, "\\\\").replace(/\r/g, "\\r").replace(/\n/g, "\\n");
-    const buildAbcSourceMiscXmlEncodingField = () => `<miscellaneous-field name="mks:src:abc:raw-encoding">escape-v1</miscellaneous-field>`;
-    const buildAbcSourceMiscXmlLengthFields = (source, encoded) => buildAbcSourceMiscXmlLengthFieldParts(source, encoded).join("");
-    const buildAbcSourceMiscXmlLengthFieldParts = (source, encoded) => [
-      buildAbcSourceMiscXmlRawLengthField(source),
-      buildAbcSourceMiscXmlRawEncodedLengthField(encoded)
-    ];
-    const buildAbcSourceMiscXmlRawLengthField = (source) => `<miscellaneous-field name="mks:src:abc:raw-length">${xmlEscape(String(source.length))}</miscellaneous-field>`;
-    const buildAbcSourceMiscXmlRawEncodedLengthField = (encoded) => `<miscellaneous-field name="mks:src:abc:raw-encoded-length">${xmlEscape(String(encoded.length))}</miscellaneous-field>`;
-    const buildAbcSourceMiscXmlStateFields = (chunks, truncated) => buildAbcSourceMiscXmlStateFieldParts(chunks, truncated).join("");
-    const buildAbcSourceMiscXmlStateFieldParts = (chunks, truncated) => [
-      buildAbcSourceMiscXmlChunkCountField(chunks),
-      buildAbcSourceMiscXmlTruncatedField(truncated)
-    ];
-    const buildAbcSourceMiscXmlChunkCountField = (chunks) => `<miscellaneous-field name="mks:src:abc:raw-chunks">${xmlEscape(String(chunks.length))}</miscellaneous-field>`;
-    const buildAbcSourceMiscXmlTruncatedField = (truncated) => `<miscellaneous-field name="mks:src:abc:raw-truncated">${truncated ? "1" : "0"}</miscellaneous-field>`;
-    const buildAbcSourceMiscXmlChunkFields = (chunks) => {
-      return buildAbcSourceMiscXmlChunkFieldsXml(chunks);
-    };
-    const buildAbcSourceMiscXmlChunkFieldsXml = (chunks) => buildAbcSourceMiscXmlChunkEntryParts(chunks).join("");
-    const buildAbcSourceMiscXmlChunkEntryParts = (chunks) => {
-      const chunkParts = [];
-      for (let i = 0; i < chunks.length; i += 1) {
-        chunkParts.push(buildAbcSourceMiscXmlChunkEntry(chunks[i], i));
-      }
-      return chunkParts;
-    };
-    const buildAbcSourceMiscXmlChunkEntry = (chunk, index) => `<miscellaneous-field name="mks:src:abc:raw-${String(index + 1).padStart(4, "0")}">${xmlEscape(chunk)}</miscellaneous-field>`;
-    const buildAbcSourceMiscXmlChunks = (encoded) => {
-      const CHUNK_SIZE = 240;
-      const MAX_CHUNKS = 512;
-      const chunks = [];
-      for (let i = 0; i < encoded.length && chunks.length < MAX_CHUNKS; i += CHUNK_SIZE) {
-        chunks.push(encoded.slice(i, i + CHUNK_SIZE));
-      }
-      return chunks;
-    };
-    const buildAbcSourceMiscXmlBody = (source, encoded, chunks, truncated) => buildAbcSourceMiscXmlBodyFields(source, encoded, chunks, truncated).join("");
-    const buildAbcSourceMiscXmlBodyFields = (source, encoded, chunks, truncated) => [...buildAbcSourceMiscXmlBodyHeaderFieldItems(source, encoded, chunks, truncated), ...buildAbcSourceMiscXmlBodyChunkFieldParts(chunks)];
-    const buildAbcSourceMiscXmlBodyHeaderFieldItems = (source, encoded, chunks, truncated) => [
-      buildAbcSourceMiscXmlEncodingField(),
-      buildAbcSourceMiscXmlLengthFields(source, encoded),
-      buildAbcSourceMiscXmlStateFields(chunks, truncated)
-    ];
-    const buildAbcSourceMiscXmlBodyChunkFieldParts = (chunks) => [buildAbcSourceMiscXmlChunkFields(chunks)];
-    const buildAbcSourceMiscXml = (abcSource) => {
-      const source = String(abcSource !== null && abcSource !== void 0 ? abcSource : "");
-      if (!source.length)
-        return "";
-      const encoded = encodeAbcSourceForMiscXml(source);
-      const chunks = buildAbcSourceMiscXmlChunks(encoded);
-      const truncated = chunks.join("").length < encoded.length;
-      return `<attributes><miscellaneous>${buildAbcSourceMiscXmlBody(source, encoded, chunks, truncated)}</miscellaneous></attributes>`;
-    };
-    const buildAbcDiagMiscXmlPayload = (item) => {
-      return [...buildAbcDiagMiscXmlCoreFieldParts(item), ...buildAbcDiagMiscXmlOptionalFields(item)].join(";");
-    };
-    const buildAbcDiagMiscXmlCoreFieldParts = (item) => [`level=${item.level}`, `code=${item.code}`, `fmt=${item.fmt}`];
-    const buildAbcDiagMiscXmlNumericOptionalFields = (item) => buildAbcDiagMiscXmlNumericOptionalFieldParts(item);
-    const buildAbcDiagMiscXmlNumericOptionalFieldParts = (item) => [...buildAbcDiagMiscXmlMeasureOptionalParts(item.measure), ...buildAbcDiagMiscXmlMovedEventsOptionalParts(item.movedEvents)];
-    const buildAbcDiagMiscXmlMeasureOptionalParts = (measure) => [Number.isFinite(measure) ? `measure=${Math.max(1, Math.round(Number(measure)))}` : ""].filter(Boolean);
-    const buildAbcDiagMiscXmlMovedEventsOptionalParts = (movedEvents) => [Number.isFinite(movedEvents) ? `movedEvents=${Math.max(0, Math.round(Number(movedEvents)))}` : ""].filter(Boolean);
-    const buildAbcDiagMiscXmlTextOptionalFields = (item) => buildAbcDiagMiscXmlTextOptionalFieldParts(item);
-    const buildAbcDiagMiscXmlTextOptionalFieldParts = (item) => [
-      item.voiceId ? `voice=${xmlEscape(item.voiceId)}` : "",
-      item.action ? `action=${xmlEscape(item.action)}` : "",
-      item.message ? `message=${xmlEscape(item.message)}` : ""
-    ].filter(Boolean);
-    const buildAbcDiagMiscXmlOptionalFields = (item) => buildAbcDiagMiscXmlOptionalFieldParts(item);
-    const buildAbcDiagMiscXmlOptionalFieldParts = (item) => [...buildAbcDiagMiscXmlNumericOptionalFields(item), ...buildAbcDiagMiscXmlTextOptionalFields(item)];
-    const buildAbcDiagMiscXmlEntry = (item, index) => `<miscellaneous-field name="${buildAbcDiagMiscXmlEntryName(index)}">${buildAbcDiagMiscXmlEntryPayload(item)}</miscellaneous-field>`;
-    const buildAbcDiagMiscXmlEntryName = (index) => `mks:diag:${String(index + 1).padStart(4, "0")}`;
-    const buildAbcDiagMiscXmlEntryPayload = (item) => buildAbcDiagMiscXmlPayload(item);
-    const buildAbcDiagMiscXmlCountField = (maxEntries) => `<miscellaneous-field name="mks:diag:count">${maxEntries}</miscellaneous-field>`;
-    const buildAbcDiagMiscXmlEntries = (diagnostics, maxEntries) => buildAbcDiagMiscXmlEntryList(diagnostics, maxEntries);
-    const buildAbcDiagMiscXmlEntryList = (diagnostics, maxEntries) => buildAbcDiagMiscXmlEntryParts(diagnostics, maxEntries).join("");
-    const buildAbcDiagMiscXmlEntryParts = (diagnostics, maxEntries) => {
-      const entryParts = [];
-      for (let i = 0; i < maxEntries; i += 1) {
-        entryParts.push(buildAbcDiagMiscXmlEntry(diagnostics[i], i));
-      }
-      return entryParts;
-    };
-    const buildAbcDiagMiscXml = (diagnostics) => {
-      if (!diagnostics.length)
-        return "";
-      const maxEntries = Math.min(256, diagnostics.length);
-      let xml = "<attributes><miscellaneous>";
-      xml += buildAbcDiagMiscXmlCountField(maxEntries);
-      xml += buildAbcDiagMiscXmlEntries(diagnostics, maxEntries);
-      xml += "</miscellaneous></attributes>";
-      return xml;
     };
     const prettyPrintXml = (xml) => {
       const compact = xml.replace(/>\s+</g, "><").trim();
@@ -157201,13 +156692,10 @@ ${bodyLines.join("\n")}${metaBlock}`;
       }
       return lines.join("\n");
     };
-    const resolveAbcParsedPartsForExport = (parts) => {
-      const safeParts = parts && parts.length > 0 ? parts : [{ partId: "P1", partName: "Voice 1", measures: [[]] }];
-      return safeParts.map((part) => ({
-        ...part,
-        clef: resolveAbcImportClef(part)
-      }));
-    };
+    const resolveAbcParsedPartsForExport = (parts) => (parts && parts.length > 0 ? parts : [{ partId: "P1", partName: "Voice 1", measures: [[]] }]).map((part) => ({
+      ...part,
+      clef: resolveAbcImportClef(part)
+    }));
     const buildAbcMusicXmlExportContext = (parsed) => {
       var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l;
       const resolvedParts = resolveAbcParsedPartsForExport(parsed.parts);
@@ -157237,37 +156725,39 @@ ${bodyLines.join("\n")}${metaBlock}`;
         tempoBpm
       };
     };
-    const buildAbcScorePartwiseXmlDocument = (title, composer, partListXml, partBodyXml) => {
-      return [
-        '<?xml version="1.0" encoding="UTF-8"?>',
-        '<score-partwise version="4.0">',
-        `<work><work-title>${xmlEscape(title)}</work-title></work>`,
-        `<identification><creator type="composer">${xmlEscape(composer)}</creator></identification>`,
-        `<part-list>${partListXml}</part-list>`,
-        partBodyXml,
-        "</score-partwise>"
-      ].join("");
-    };
-    const buildMusicXmlFromAbcParsed = (parsed, abcSource, options = {}) => {
-      var _a, _b, _c;
-      const debugMetadata = (_a = options.debugMetadata) !== null && _a !== void 0 ? _a : true;
-      const sourceMetadata = (_b = options.sourceMetadata) !== null && _b !== void 0 ? _b : true;
-      const debugPrettyPrint = (_c = options.debugPrettyPrint) !== null && _c !== void 0 ? _c : debugMetadata;
-      const exportContext = buildAbcMusicXmlExportContext(parsed);
-      const buildMeasureNotesXml = (notes, staffOverride = null) => buildAbcMeasureNotesXml(notes, exportContext.measureDurationDiv, exportContext.emptyMeasureRestType, exportContext.beatDiv, staffOverride);
-      const partListXml = buildAbcPartListXml(exportContext.resolvedParts);
-      const partBodyXml = buildAbcPartBodyXml(exportContext.resolvedParts, exportContext.measureCount, exportContext.defaultFifths, exportContext.beats, exportContext.beatType, exportContext.tempoBpm, debugMetadata, sourceMetadata, parsed.diagnostics, abcSource, buildMeasureNotesXml);
-      const xml = buildAbcScorePartwiseXmlDocument(exportContext.title, exportContext.composer, partListXml, partBodyXml);
-      return debugPrettyPrint ? prettyPrintXml(xml) : xml;
-    };
+    const buildAbcScorePartwiseXmlDocument = (title, composer, partListXml, partBodyXml) => [
+      '<?xml version="1.0" encoding="UTF-8"?>',
+      '<score-partwise version="4.0">',
+      `<work><work-title>${xmlEscape(title)}</work-title></work>`,
+      `<identification><creator type="composer">${xmlEscape(composer)}</creator></identification>`,
+      `<part-list>${partListXml}</part-list>`,
+      partBodyXml,
+      "</score-partwise>"
+    ].join("");
     const convertAbcToMusicXml = (abcSource, options = {}) => {
+      var _a, _b, _c;
       const parsed = exports.AbcCompatParser.parseForMusicXml(abcSource, {
         defaultTitle: "mikuscore",
         defaultComposer: "Unknown",
         inferTransposeFromPartName: true,
         overfullCompatibilityMode: options.overfullCompatibilityMode !== false
       });
-      return buildMusicXmlFromAbcParsed(parsed, abcSource, options);
+      const debugMetadata = (_a = options.debugMetadata) !== null && _a !== void 0 ? _a : true;
+      const sourceMetadata = (_b = options.sourceMetadata) !== null && _b !== void 0 ? _b : true;
+      const debugPrettyPrint = (_c = options.debugPrettyPrint) !== null && _c !== void 0 ? _c : debugMetadata;
+      const exportContext = buildAbcMusicXmlExportContext(parsed);
+      const buildMeasureNotesXml = (notes, staffOverride = null) => buildAbcMeasureNotesXml(notes, exportContext.measureDurationDiv, exportContext.emptyMeasureRestType, exportContext.beatDiv, staffOverride);
+      const partBodyXml = exportContext.resolvedParts.map((part, partIndex) => buildAbcPartXml(part, partIndex, exportContext.measureCount, exportContext.defaultFifths, exportContext.beats, exportContext.beatType, exportContext.tempoBpm, debugMetadata, sourceMetadata, parsed.diagnostics, abcSource, buildMeasureNotesXml)).join("");
+      const xml = buildAbcScorePartwiseXmlDocument(exportContext.title, exportContext.composer, exportContext.resolvedParts.map((part, index) => [
+        `<score-part id="${xmlEscape(part.partId)}">`,
+        `<part-name>${xmlEscape(part.partName || part.partId)}</part-name>`,
+        `<midi-instrument id="${xmlEscape(part.partId)}-I1">`,
+        `<midi-channel>${index % 16 + 1 === 10 ? 11 : index % 16 + 1}</midi-channel>`,
+        `<midi-program>6</midi-program>`,
+        "</midi-instrument>",
+        "</score-part>"
+      ].join("")).join(""), partBodyXml);
+      return debugPrettyPrint ? prettyPrintXml(xml) : xml;
     };
     exports.convertAbcToMusicXml = convertAbcToMusicXml;
   },

--- a/index.html
+++ b/index.html
@@ -125,7 +125,7 @@
 <body>
   <main class="card">
     <h1>mikuscore</h1>
-    <p class="sub">Updated: 2026-05-26</p>
+    <p class="sub">Updated: 2026-05-28</p>
     <section class="lang-block" aria-label="English">
       <h2>English</h2>
       <p>

--- a/mikuscore.html
+++ b/mikuscore.html
@@ -33070,7 +33070,7 @@ const divideFractions = (a, b, fallback = DEFAULT_RATIO) => {
     return reduceFraction(a.num * b.den, a.den * b.num, fallback);
 };
 const parseFractionText = (text, fallback = DEFAULT_UNIT) => {
-    const m = String(text || "").match(/^\s*(\d+)\/(\d+)\s*$/);
+    const m = String(text !== null && text !== void 0 ? text : "").match(/^\s*(\d+)\/(\d+)\s*$/);
     if (!m) {
         return { num: fallback.num, den: fallback.den };
     }
@@ -33081,21 +33081,21 @@ const parseFractionText = (text, fallback = DEFAULT_UNIT) => {
     }
     return reduceFraction(num, den, fallback);
 };
-const isAbcjsWrapperLine = (text) => /^\[\s*\/?\s*abcjs(?:-[A-Za-z0-9_-]+)?(?:\s+[^\]]*)?\]$/i.test(String(text || "").trim());
+const isAbcjsWrapperLine = (text) => /^\[\s*\/?\s*abcjs(?:-[A-Za-z0-9_-]+)?(?:\s+[^\]]*)?\]$/i.test(String(text !== null && text !== void 0 ? text : "").trim());
 const estimateAbcMeasureContentDiv = (notes) => {
-    var _a, _b;
+    var _a, _b, _c, _d;
     const byVoice = new Map();
     const lastStartByVoice = new Map();
     for (const note of Array.isArray(notes) ? notes : []) {
         if (!note || note.grace)
             continue;
-        const voice = String(note.voice || "1");
-        const durationDiv = Math.max(0, Math.round(Number(note.duration) || 0));
+        const voice = String((_a = note.voice) !== null && _a !== void 0 ? _a : "1");
+        const durationDiv = Math.max(0, Math.round(Number((_b = note.duration) !== null && _b !== void 0 ? _b : 0)));
         if (durationDiv <= 0)
             continue;
-        const current = (_a = byVoice.get(voice)) !== null && _a !== void 0 ? _a : 0;
+        const current = (_c = byVoice.get(voice)) !== null && _c !== void 0 ? _c : 0;
         if (note.chord) {
-            const startDiv = (_b = lastStartByVoice.get(voice)) !== null && _b !== void 0 ? _b : current;
+            const startDiv = (_d = lastStartByVoice.get(voice)) !== null && _d !== void 0 ? _d : current;
             byVoice.set(voice, Math.max(current, startDiv + durationDiv));
             continue;
         }
@@ -33146,7 +33146,7 @@ const abcLengthTokenFromFraction = (ratio) => {
     return `${reduced.num}/${reduced.den}`;
 };
 const abcPitchFromStepOctave = (step, octave) => {
-    const upperStep = String(step || "").toUpperCase();
+    const upperStep = String(step !== null && step !== void 0 ? step : "").toUpperCase();
     if (!/^[A-G]$/.test(upperStep)) {
         return "C";
     }
@@ -33169,7 +33169,7 @@ const keyFromFifthsMode = (fifths, mode) => {
     if (idx < 0 || idx >= major.length) {
         return "C";
     }
-    const lowerMode = String(mode || "").toLowerCase();
+    const lowerMode = String(mode !== null && mode !== void 0 ? mode : "").toLowerCase();
     if (lowerMode === "minor") {
         return minor[idx];
     }
@@ -33250,9 +33250,10 @@ const ensureAbcDeclaredVoice = (registry, voiceId) => {
     }
 };
 const appendAbcBodyTextEntries = (rawBodyText, lineNo, voiceId, registry, bodyEntries, splitBodyTextByInlineVoice, splitBodyTextByOverlay) => {
-    const normalizedBodyText = String(rawBodyText || "").replace(/\\\s*$/, "");
+    var _a;
+    const normalizedBodyText = String(rawBodyText !== null && rawBodyText !== void 0 ? rawBodyText : "").replace(/\\\s*$/, "");
     if (!normalizedBodyText.trim()) {
-        return { appended: false, finalVoiceId: String(voiceId || "1").trim() || "1" };
+        return { appended: false, finalVoiceId: String(voiceId !== null && voiceId !== void 0 ? voiceId : "1").trim() || "1" };
     }
     const { segments: inlineVoiceSegments, finalVoiceId } = splitBodyTextByInlineVoice(normalizedBodyText, voiceId);
     for (const segment of inlineVoiceSegments) {
@@ -33274,15 +33275,16 @@ const appendAbcBodyTextEntries = (rawBodyText, lineNo, voiceId, registry, bodyEn
             bodyEntries.push({ text: overlaySegment.text, lineNo, voiceId: overlaySegment.voiceId });
         }
     }
-    return { appended: true, finalVoiceId: String(finalVoiceId || voiceId || "1").trim() || "1" };
+    return { appended: true, finalVoiceId: String((_a = finalVoiceId !== null && finalVoiceId !== void 0 ? finalVoiceId : voiceId) !== null && _a !== void 0 ? _a : "1").trim() || "1" };
 };
 const applyAbcVoiceDirective = (value, lineNo, lineState, voiceRegistry, warnings, userDefinedDecorationBySymbol, parseVoiceDirectiveTail, expandUserDefinedDecorationSymbols, pushBodyText) => {
+    var _a, _b, _c;
     const m = value.match(/^(\S+)\s*(.*)$/);
     if (!m)
         return;
     lineState.currentVoiceId = m[1];
     ensureAbcDeclaredVoice(voiceRegistry, lineState.currentVoiceId);
-    const rest = m[2].trim();
+    const rest = (_b = (_a = m[2]) === null || _a === void 0 ? void 0 : _a.trim()) !== null && _b !== void 0 ? _b : "";
     const parsedVoice = parseVoiceDirectiveTail(rest);
     if (parsedVoice.name) {
         voiceRegistry.voiceNameById[lineState.currentVoiceId] = parsedVoice.name;
@@ -33299,7 +33301,7 @@ const applyAbcVoiceDirective = (value, lineNo, lineState, voiceRegistry, warning
             ": Skipped unsupported V: directive tail token: " +
             parsedVoice.skippedText);
     }
-    for (const unsupportedKey of parsedVoice.unsupportedKeys || []) {
+    for (const unsupportedKey of (_c = parsedVoice.unsupportedKeys) !== null && _c !== void 0 ? _c : []) {
         warnings.push("line " +
             lineNo +
             ": Skipped unsupported V: property: " +
@@ -33359,10 +33361,11 @@ const parseAbcMetaParams = (raw) => {
     return params;
 };
 const applyAbcTrillMeta = (params, trillWidthHintByKey) => {
-    const voiceId = String(params.voice || "").trim();
-    const measureNo = Number.parseInt(String(params.measure || ""), 10);
-    const eventNo = Number.parseInt(String(params.event || ""), 10);
-    const upper = String(params.upper || "").trim();
+    var _a, _b, _c, _d;
+    const voiceId = String((_a = params.voice) !== null && _a !== void 0 ? _a : "").trim();
+    const measureNo = Number.parseInt(String((_b = params.measure) !== null && _b !== void 0 ? _b : ""), 10);
+    const eventNo = Number.parseInt(String((_c = params.event) !== null && _c !== void 0 ? _c : ""), 10);
+    const upper = String((_d = params.upper) !== null && _d !== void 0 ? _d : "").trim();
     if (voiceId && Number.isFinite(measureNo) && measureNo > 0 && Number.isFinite(eventNo) && eventNo > 0 && upper) {
         trillWidthHintByKey.set(`${voiceId}#${measureNo}#${eventNo}`, upper);
         return true;
@@ -33370,9 +33373,10 @@ const applyAbcTrillMeta = (params, trillWidthHintByKey) => {
     return false;
 };
 const applyAbcKeyMeta = (params, keyHintFifthsByKey) => {
-    const voiceId = String(params.voice || "").trim();
-    const measureNo = Number.parseInt(String(params.measure || ""), 10);
-    const fifths = Number.parseInt(String(params.fifths || ""), 10);
+    var _a, _b, _c;
+    const voiceId = String((_a = params.voice) !== null && _a !== void 0 ? _a : "").trim();
+    const measureNo = Number.parseInt(String((_b = params.measure) !== null && _b !== void 0 ? _b : ""), 10);
+    const fifths = Number.parseInt(String((_c = params.fifths) !== null && _c !== void 0 ? _c : ""), 10);
     if (voiceId && Number.isFinite(measureNo) && measureNo > 0 && Number.isFinite(fifths)) {
         const key = `${voiceId}#${measureNo}`;
         if (!keyHintFifthsByKey.has(key)) {
@@ -33383,19 +33387,20 @@ const applyAbcKeyMeta = (params, keyHintFifthsByKey) => {
     return false;
 };
 const applyAbcMeasureMeta = (params, measureMetaByKey) => {
-    const voiceId = String(params.voice || "").trim();
-    const measureNo = Number.parseInt(String(params.measure || ""), 10);
+    var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l;
+    const voiceId = String((_a = params.voice) !== null && _a !== void 0 ? _a : "").trim();
+    const measureNo = Number.parseInt(String((_b = params.measure) !== null && _b !== void 0 ? _b : ""), 10);
     if (!(voiceId && Number.isFinite(measureNo) && measureNo > 0))
         return false;
-    const measureNumberText = String(params.number || "").trim();
-    const implicitRaw = String(params.implicit || "").trim().toLowerCase();
-    const repeatRaw = String(params.repeat || "").trim().toLowerCase();
-    const leftRepeatRaw = String(params["left-repeat"] || "").trim().toLowerCase();
-    const rightRepeatRaw = String(params["right-repeat"] || "").trim().toLowerCase();
-    const repeatTimesRaw = Number.parseInt(String(params.times || ""), 10);
-    const endingStart = String(params["ending-start"] || "").trim();
-    const endingStop = String(params["ending-stop"] || "").trim();
-    const endingStopTypeRaw = String(params["ending-type"] || "").trim().toLowerCase();
+    const measureNumberText = String((_c = params.number) !== null && _c !== void 0 ? _c : "").trim();
+    const implicitRaw = String((_d = params.implicit) !== null && _d !== void 0 ? _d : "").trim().toLowerCase();
+    const repeatRaw = String((_e = params.repeat) !== null && _e !== void 0 ? _e : "").trim().toLowerCase();
+    const leftRepeatRaw = String((_f = params["left-repeat"]) !== null && _f !== void 0 ? _f : "").trim().toLowerCase();
+    const rightRepeatRaw = String((_g = params["right-repeat"]) !== null && _g !== void 0 ? _g : "").trim().toLowerCase();
+    const repeatTimesRaw = Number.parseInt(String((_h = params.times) !== null && _h !== void 0 ? _h : ""), 10);
+    const endingStart = String((_j = params["ending-start"]) !== null && _j !== void 0 ? _j : "").trim();
+    const endingStop = String((_k = params["ending-stop"]) !== null && _k !== void 0 ? _k : "").trim();
+    const endingStopTypeRaw = String((_l = params["ending-type"]) !== null && _l !== void 0 ? _l : "").trim().toLowerCase();
     measureMetaByKey.set(`${voiceId}#${measureNo}`, {
         number: measureNumberText || String(measureNo),
         implicit: implicitRaw === "1" || implicitRaw === "true" || implicitRaw === "yes",
@@ -33411,9 +33416,10 @@ const applyAbcMeasureMeta = (params, measureMetaByKey) => {
     return true;
 };
 const applyAbcTransposeMeta = (params, transposeHintByVoiceId) => {
-    const voiceId = String(params.voice || "").trim();
-    const chromatic = Number.parseInt(String(params.chromatic || ""), 10);
-    const diatonic = Number.parseInt(String(params.diatonic || ""), 10);
+    var _a, _b, _c;
+    const voiceId = String((_a = params.voice) !== null && _a !== void 0 ? _a : "").trim();
+    const chromatic = Number.parseInt(String((_b = params.chromatic) !== null && _b !== void 0 ? _b : ""), 10);
+    const diatonic = Number.parseInt(String((_c = params.diatonic) !== null && _c !== void 0 ? _c : ""), 10);
     if (!(voiceId && (Number.isFinite(chromatic) || Number.isFinite(diatonic))))
         return false;
     const metaTranspose = {};
@@ -33428,11 +33434,12 @@ const applyAbcTransposeMeta = (params, transposeHintByVoiceId) => {
     return false;
 };
 const handleAbcMetaDirectiveLine = (rawTrimmed, trillWidthHintByKey, keyHintFifthsByKey, measureMetaByKey, transposeHintByVoiceId) => {
+    var _a, _b;
     const metaMatch = rawTrimmed.match(/^%@mks\s+(trill|key|measure|transpose)\s+(.+)$/i);
     if (!metaMatch)
         return false;
-    const kind = String(metaMatch[1] || "").toLowerCase();
-    const params = parseAbcMetaParams(String(metaMatch[2] || ""));
+    const kind = String((_a = metaMatch[1]) !== null && _a !== void 0 ? _a : "").toLowerCase();
+    const params = parseAbcMetaParams(String((_b = metaMatch[2]) !== null && _b !== void 0 ? _b : ""));
     if (kind === "trill")
         return applyAbcTrillMeta(params, trillWidthHintByKey);
     if (kind === "key")
@@ -33511,7 +33518,7 @@ const processAbcImportLine = (raw, lineNo, context) => {
     context.pushBodyText(expandedBodyText, lineNo, context.lineState.currentVoiceId);
 };
 const buildAbcVoiceMeasureMetaByIndex = (voiceId, normalizedMeasures, keyHintFifthsByKey, notationMeasureMetaByVoice, measureMetaByKey, meterByMeasureByVoice, tempoByMeasureByVoice) => {
-    var _a, _b, _c, _d, _e, _f, _g;
+    var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p, _q, _r, _s;
     const keyByMeasure = {};
     const meterByMeasure = {};
     const tempoByMeasure = {};
@@ -33521,20 +33528,20 @@ const buildAbcVoiceMeasureMetaByIndex = (voiceId, normalizedMeasures, keyHintFif
         if (Number.isFinite(hinted)) {
             keyByMeasure[m] = Number(hinted);
         }
-        const notationMeta = ((_a = notationMeasureMetaByVoice[voiceId]) === null || _a === void 0 ? void 0 : _a[m]) || null;
-        const hintedMeta = measureMetaByKey.get(`${voiceId}#${m}`) || null;
-        const meterHint = ((_b = meterByMeasureByVoice[voiceId]) === null || _b === void 0 ? void 0 : _b[m]) || null;
-        const tempoHint = ((_c = tempoByMeasureByVoice[voiceId]) === null || _c === void 0 ? void 0 : _c[m]) || null;
+        const notationMeta = (_b = (_a = notationMeasureMetaByVoice[voiceId]) === null || _a === void 0 ? void 0 : _a[m]) !== null && _b !== void 0 ? _b : null;
+        const hintedMeta = (_c = measureMetaByKey.get(`${voiceId}#${m}`)) !== null && _c !== void 0 ? _c : null;
+        const meterHint = (_e = (_d = meterByMeasureByVoice[voiceId]) === null || _d === void 0 ? void 0 : _d[m]) !== null && _e !== void 0 ? _e : null;
+        const tempoHint = (_g = (_f = tempoByMeasureByVoice[voiceId]) === null || _f === void 0 ? void 0 : _f[m]) !== null && _g !== void 0 ? _g : null;
         if (notationMeta || hintedMeta) {
             measureMetaByIndex[m] = {
                 number: (hintedMeta === null || hintedMeta === void 0 ? void 0 : hintedMeta.number) || (notationMeta === null || notationMeta === void 0 ? void 0 : notationMeta.number) || String(m),
-                implicit: (_e = (_d = hintedMeta === null || hintedMeta === void 0 ? void 0 : hintedMeta.implicit) !== null && _d !== void 0 ? _d : notationMeta === null || notationMeta === void 0 ? void 0 : notationMeta.implicit) !== null && _e !== void 0 ? _e : false,
-                repeatStart: Boolean((notationMeta === null || notationMeta === void 0 ? void 0 : notationMeta.repeatStart) || (hintedMeta === null || hintedMeta === void 0 ? void 0 : hintedMeta.repeatStart)),
-                repeatEnd: Boolean((notationMeta === null || notationMeta === void 0 ? void 0 : notationMeta.repeatEnd) || (hintedMeta === null || hintedMeta === void 0 ? void 0 : hintedMeta.repeatEnd)),
-                repeatTimes: (_g = (_f = hintedMeta === null || hintedMeta === void 0 ? void 0 : hintedMeta.repeatTimes) !== null && _f !== void 0 ? _f : notationMeta === null || notationMeta === void 0 ? void 0 : notationMeta.repeatTimes) !== null && _g !== void 0 ? _g : null,
-                endingStart: String((notationMeta === null || notationMeta === void 0 ? void 0 : notationMeta.endingStart) || (hintedMeta === null || hintedMeta === void 0 ? void 0 : hintedMeta.endingStart) || ""),
-                endingStop: String((notationMeta === null || notationMeta === void 0 ? void 0 : notationMeta.endingStop) || (hintedMeta === null || hintedMeta === void 0 ? void 0 : hintedMeta.endingStop) || ""),
-                endingStopType: (hintedMeta === null || hintedMeta === void 0 ? void 0 : hintedMeta.endingStopType) || (notationMeta === null || notationMeta === void 0 ? void 0 : notationMeta.endingStopType) || "",
+                implicit: (_j = (_h = hintedMeta === null || hintedMeta === void 0 ? void 0 : hintedMeta.implicit) !== null && _h !== void 0 ? _h : notationMeta === null || notationMeta === void 0 ? void 0 : notationMeta.implicit) !== null && _j !== void 0 ? _j : false,
+                repeatStart: !!((notationMeta === null || notationMeta === void 0 ? void 0 : notationMeta.repeatStart) || (hintedMeta === null || hintedMeta === void 0 ? void 0 : hintedMeta.repeatStart)),
+                repeatEnd: !!((notationMeta === null || notationMeta === void 0 ? void 0 : notationMeta.repeatEnd) || (hintedMeta === null || hintedMeta === void 0 ? void 0 : hintedMeta.repeatEnd)),
+                repeatTimes: (_l = (_k = hintedMeta === null || hintedMeta === void 0 ? void 0 : hintedMeta.repeatTimes) !== null && _k !== void 0 ? _k : notationMeta === null || notationMeta === void 0 ? void 0 : notationMeta.repeatTimes) !== null && _l !== void 0 ? _l : null,
+                endingStart: String((_o = (_m = notationMeta === null || notationMeta === void 0 ? void 0 : notationMeta.endingStart) !== null && _m !== void 0 ? _m : hintedMeta === null || hintedMeta === void 0 ? void 0 : hintedMeta.endingStart) !== null && _o !== void 0 ? _o : ""),
+                endingStop: String((_q = (_p = notationMeta === null || notationMeta === void 0 ? void 0 : notationMeta.endingStop) !== null && _p !== void 0 ? _p : hintedMeta === null || hintedMeta === void 0 ? void 0 : hintedMeta.endingStop) !== null && _q !== void 0 ? _q : ""),
+                endingStopType: (_s = (_r = hintedMeta === null || hintedMeta === void 0 ? void 0 : hintedMeta.endingStopType) !== null && _r !== void 0 ? _r : notationMeta === null || notationMeta === void 0 ? void 0 : notationMeta.endingStopType) !== null && _s !== void 0 ? _s : "",
             };
         }
         if (meterHint) {
@@ -33550,6 +33557,7 @@ const buildAbcVoiceMeasureMetaByIndex = (voiceId, normalizedMeasures, keyHintFif
     return { keyByMeasure, meterByMeasure, tempoByMeasure, measureMetaByIndex };
 };
 const buildAbcNormalizedVoiceDataById = (orderedVoiceIds, voiceRegistry, measuresByVoice, measureCapacity, overfullCompatibilityMode, settings, transposeHintByVoiceId, keyHintFifthsByKey, notationMeasureMetaByVoice, measureMetaByKey, meterByMeasureByVoice, tempoByMeasureByVoice, importDiagnostics) => {
+    var _a;
     const normalizedVoiceDataById = new Map();
     for (const voiceId of orderedVoiceIds) {
         const partName = voiceRegistry.voiceNameById[voiceId] || ("Voice " + voiceId);
@@ -33576,7 +33584,7 @@ const buildAbcNormalizedVoiceDataById = (orderedVoiceIds, voiceRegistry, measure
         const measureData = buildAbcVoiceMeasureMetaByIndex(voiceId, normalizedMeasures, keyHintFifthsByKey, notationMeasureMetaByVoice, measureMetaByKey, meterByMeasureByVoice, tempoByMeasureByVoice);
         normalizedVoiceDataById.set(voiceId, {
             partName,
-            clef: voiceRegistry.voiceClefById[voiceId] || "",
+            clef: (_a = voiceRegistry.voiceClefById[voiceId]) !== null && _a !== void 0 ? _a : "",
             transpose,
             voiceId,
             keyByMeasure: measureData.keyByMeasure,
@@ -33588,37 +33596,13 @@ const buildAbcNormalizedVoiceDataById = (orderedVoiceIds, voiceRegistry, measure
     }
     return normalizedVoiceDataById;
 };
-const buildAbcGroupedStaffClefXml = (staffVoices) => {
-    return staffVoices
-        .map((staffVoice) => {
-        const clefXml = (0, exports.clefXmlFromAbcClef)(staffVoice.clef || "");
-        return clefXml.replace("<clef>", `<clef number="${staffVoice.staff}">`);
-    })
-        .join("");
-};
-const buildAbcPartTransposeXml = (transpose) => {
-    return (0, transposition_1.buildMusicXmlTransposeXml)(transpose);
-};
-const buildAbcTempoDirectionXml = (tempo, include) => {
-    if (!(include && tempo !== null)) {
-        return "";
-    }
-    return (0, direction_text_1.buildMusicXmlTempoDirectionXml)({ bpm: tempo, includeQuarterMetronome: true });
-};
-const buildAbcMeasureHeaderXml = (part, partIndex, measureIndex, currentPartFifths, currentPartMeter, currentPartTempo, hintedFifths, hintedMeter) => {
-    if (measureIndex === 0) {
-        const headerXml = buildAbcMeasureHeaderInitialParts(part, currentPartFifths, currentPartMeter).join("");
-        const tempoDirectionXml = buildAbcTempoDirectionXml(currentPartTempo, partIndex === 0);
-        return { headerXml, tempoDirectionXml };
-    }
-    const headerXml = hintedFifths !== null || hintedMeter
-        ? buildAbcMeasureHeaderUpdateParts(currentPartFifths, currentPartMeter, hintedFifths, hintedMeter).join("")
-        : "";
-    return {
-        headerXml,
-        tempoDirectionXml: "",
-    };
-};
+const buildAbcGroupedStaffClefXml = (staffVoices) => staffVoices
+    .map((staffVoice) => {
+    var _a;
+    const clefXml = (0, exports.clefXmlFromAbcClef)((_a = staffVoice.clef) !== null && _a !== void 0 ? _a : "");
+    return clefXml.replace("<clef>", `<clef number="${staffVoice.staff}">`);
+})
+    .join("");
 const buildAbcMeasureHeaderInitialParts = (part, currentPartFifths, currentPartMeter) => [
     "<attributes>",
     "<divisions>960</divisions>",
@@ -33628,57 +33612,16 @@ const buildAbcMeasureHeaderInitialParts = (part, currentPartFifths, currentPartM
         beatType: currentPartMeter.beatType,
     }),
     (0, abc_layout_1.hasAbcGroupedStaffVoices)(part) ? `<staves>${part.staffVoices.length}</staves>` : "",
-    buildAbcPartTransposeXml(part.transpose),
+    (0, transposition_1.buildMusicXmlTransposeXml)(part.transpose),
     (0, abc_layout_1.hasAbcGroupedStaffVoices)(part) ? buildAbcGroupedStaffClefXml(part.staffVoices) : (0, exports.clefXmlFromAbcClef)(part.clef),
     "</attributes>",
 ];
 const buildAbcMeasureHeaderUpdateParts = (currentPartFifths, currentPartMeter, hintedFifths, hintedMeter) => [
     "<attributes>",
-    buildAbcMeasureHeaderUpdateKeyPart(currentPartFifths, hintedFifths),
-    buildAbcMeasureHeaderUpdateTimePart(currentPartMeter, hintedMeter),
+    hintedFifths !== null ? (0, key_signatures_1.buildMusicXmlKeySignatureXml)({ fifths: currentPartFifths }) : "",
+    hintedMeter ? (0, time_signatures_1.buildMusicXmlTimeSignatureXml)({ beats: currentPartMeter.beats, beatType: currentPartMeter.beatType }) : "",
     "</attributes>",
 ];
-const buildAbcMeasureHeaderUpdateKeyPart = (currentPartFifths, hintedFifths) => buildAbcMeasureHeaderUpdateKeyPartXml(currentPartFifths, hintedFifths);
-const buildAbcMeasureHeaderUpdateKeyPartXml = (currentPartFifths, hintedFifths) => hintedFifths !== null ? buildAbcMeasureHeaderUpdateKeySignatureXml(currentPartFifths) : "";
-const buildAbcMeasureHeaderUpdateKeySignatureXml = (currentPartFifths) => (0, key_signatures_1.buildMusicXmlKeySignatureXml)({ fifths: currentPartFifths });
-const buildAbcMeasureHeaderUpdateTimePart = (currentPartMeter, hintedMeter) => buildAbcMeasureHeaderUpdateTimePartXml(currentPartMeter, hintedMeter);
-const buildAbcMeasureHeaderUpdateTimePartXml = (currentPartMeter, hintedMeter) => hintedMeter ? buildAbcMeasureHeaderUpdateTimeSignatureXml(currentPartMeter) : "";
-const buildAbcMeasureHeaderUpdateTimeSignatureXml = (currentPartMeter) => (0, time_signatures_1.buildMusicXmlTimeSignatureXml)({
-    beats: currentPartMeter.beats,
-    beatType: currentPartMeter.beatType,
-});
-const buildAbcMeasureTempoDirectionXml = (hintedTempo, partIndex, measureIndex) => {
-    return buildAbcTempoDirectionXml(hintedTempo, measureIndex > 0 && partIndex === 0);
-};
-const buildAbcMeasureRepeatStartXml = (measureMeta) => {
-    const leftBarlineChunks = buildAbcMeasureRepeatStartChunks(measureMeta);
-    return leftBarlineChunks.length > 0 ? `<barline location="left">${leftBarlineChunks.join("")}</barline>` : "";
-};
-const buildAbcMeasureRepeatStartChunks = (measureMeta) => [
-    (measureMeta === null || measureMeta === void 0 ? void 0 : measureMeta.endingStart)
-        ? `<ending number="${xmlEscape(String(measureMeta.endingStart))}" type="start"/>`
-        : "",
-    (measureMeta === null || measureMeta === void 0 ? void 0 : measureMeta.repeatStart) ? '<repeat direction="forward" winged="none"/>' : "",
-].filter(Boolean);
-const buildAbcMeasureRepeatEndXml = (measureMeta) => {
-    const rightBarlineChunks = buildAbcMeasureRepeatEndChunks(measureMeta);
-    return rightBarlineChunks.length > 0 ? `<barline location="right">${rightBarlineChunks.join("")}</barline>` : "";
-};
-const buildAbcMeasureRepeatEndChunks = (measureMeta) => [
-    (measureMeta === null || measureMeta === void 0 ? void 0 : measureMeta.endingStop)
-        ? `<ending number="${xmlEscape(String(measureMeta.endingStop))}" type="${measureMeta.endingStopType || "stop"}"/>`
-        : "",
-    (measureMeta === null || measureMeta === void 0 ? void 0 : measureMeta.repeatEnd)
-        ? `<repeat direction="backward" winged="none"${Number.isFinite(measureMeta.repeatTimes) && Number(measureMeta.repeatTimes) > 1
-            ? ` times="${Math.round(Number(measureMeta.repeatTimes))}"`
-            : ""}/>`
-        : "",
-].filter(Boolean);
-const buildAbcMeasureXml = (measureNo, measureNumberText, implicit, repeatStartXml, headerXml, tempoDirectionXml, debugMiscXml, diagMiscXml, sourceMiscXml, notesXml, repeatEndXml) => {
-    const xmlMeasureNumber = xmlEscape(String(measureNumberText || measureNo));
-    const implicitAttr = implicit ? ' implicit="yes"' : "";
-    return `<measure number="${xmlMeasureNumber}"${implicitAttr}>${repeatStartXml}${headerXml}${tempoDirectionXml}${debugMiscXml}${diagMiscXml}${sourceMiscXml}${notesXml}${repeatEndXml}</measure>`;
-};
 const buildAbcPartMeasureRenderContext = (part, measureIndex, state, beats, beatType) => {
     var _a, _b, _c, _d, _e, _f, _g, _h, _j;
     const measureNo = measureIndex + 1;
@@ -33720,54 +33663,130 @@ const buildAbcPartMeasureRenderContext = (part, measureIndex, state, beats, beat
 };
 const buildAbcRenderedPartMeasureXml = (context) => {
     const { part, partIndex, measureIndex, measureNo, notes, measureMeta, hintedFifths, hintedMeter, hintedTempo, currentPartFifths, currentPartMeter, currentPartTempo, currentMeasureDurationDiv, inferredImplicitPickup, debugMetadata, sourceMetadata, diagnostics, abcSource, buildMeasureNotesXml, } = context;
-    const { headerXml, tempoDirectionXml: headerTempoDirectionXml } = buildAbcMeasureHeaderXml(part, partIndex, measureIndex, currentPartFifths, currentPartMeter, currentPartTempo, hintedFifths, hintedMeter);
-    const tempoDirectionXml = headerTempoDirectionXml || buildAbcMeasureTempoDirectionXml(hintedTempo, partIndex, measureIndex);
+    const headerXml = measureIndex === 0
+        ? buildAbcMeasureHeaderInitialParts(part, currentPartFifths, currentPartMeter).join("")
+        : hintedFifths !== null || hintedMeter !== null
+            ? buildAbcMeasureHeaderUpdateParts(currentPartFifths, currentPartMeter, hintedFifths, hintedMeter).join("")
+            : "";
+    const headerTempoDirectionXml = measureIndex === 0 && partIndex === 0 && currentPartTempo !== null
+        ? (0, direction_text_1.buildMusicXmlTempoDirectionXml)({ bpm: currentPartTempo, includeQuarterMetronome: true })
+        : "";
+    const tempoDirectionXml = headerTempoDirectionXml ||
+        (measureIndex > 0 && partIndex === 0 && hintedTempo !== null
+            ? (0, direction_text_1.buildMusicXmlTempoDirectionXml)({ bpm: hintedTempo, includeQuarterMetronome: true })
+            : "");
     const notesXml = (0, abc_layout_1.hasAbcGroupedStaffVoices)(part)
         ? (0, abc_layout_1.buildAbcGroupedStaffMeasureNotesXml)(part.staffVoices, measureIndex, currentMeasureDurationDiv, buildMeasureNotesXml)
         : buildMeasureNotesXml(notes);
-    const repeatStartXml = buildAbcMeasureRepeatStartXml(measureMeta);
-    const repeatEndXml = buildAbcMeasureRepeatEndXml(measureMeta);
-    const { debugMiscXml, diagMiscXml, sourceMiscXml } = buildAbcRenderedMeasureMiscXml({
-        part,
-        partIndex,
-        measureNo,
-        notes,
-        debugMetadata,
-        sourceMetadata,
-        diagnostics,
-        abcSource,
-    });
-    return buildAbcMeasureXml(measureNo, String((measureMeta === null || measureMeta === void 0 ? void 0 : measureMeta.number) || measureNo), Boolean((measureMeta === null || measureMeta === void 0 ? void 0 : measureMeta.implicit) || inferredImplicitPickup), repeatStartXml, headerXml, tempoDirectionXml, debugMiscXml, diagMiscXml, sourceMiscXml, notesXml, repeatEndXml);
+    const repeatStartXml = measureMeta
+        ? (() => {
+            const chunks = [
+                ...(measureMeta.endingStart
+                    ? [`<ending number="${xmlEscape(String(measureMeta.endingStart))}" type="start"/>`]
+                    : []),
+                ...(measureMeta.repeatStart ? ['<repeat direction="forward" winged="none"/>'] : []),
+            ];
+            return chunks.length > 0 ? `<barline location="left">${chunks.join("")}</barline>` : "";
+        })()
+        : "";
+    const repeatEndXml = measureMeta
+        ? (() => {
+            const chunks = [
+                ...(measureMeta.endingStop
+                    ? [
+                        `<ending number="${xmlEscape(String(measureMeta.endingStop))}" type="${measureMeta.endingStopType || "stop"}"/>`,
+                    ]
+                    : []),
+                ...(measureMeta.repeatEnd
+                    ? [
+                        `<repeat direction="backward" winged="none"${Number.isFinite(measureMeta.repeatTimes) && Number(measureMeta.repeatTimes) > 1
+                            ? ` times="${Math.round(Number(measureMeta.repeatTimes))}"`
+                            : ""}/>`,
+                    ]
+                    : []),
+            ];
+            return chunks.length > 0 ? `<barline location="right">${chunks.join("")}</barline>` : "";
+        })()
+        : "";
+    const debugMiscXml = debugMetadata
+        ? `<attributes><miscellaneous><miscellaneous-field name="mks:dbg:abc:meta:count">${toHex(notes.length, 4)}</miscellaneous-field>${notes
+            .map((note, index) => {
+            var _a;
+            return `<miscellaneous-field name="mks:dbg:abc:meta:${String(index + 1).padStart(4, "0")}">${[
+                [
+                    `idx=${toHex(index, 4)}`,
+                    `m=${toHex(measureNo, 4)}`,
+                    `v=${xmlEscape(normalizeVoiceForMusicXml(note.voice))}`,
+                ].join(";"),
+                [
+                    `r=${note.isRest ? "1" : "0"}`,
+                    `g=${note.grace ? "1" : "0"}`,
+                    `ch=${note.chord ? "1" : "0"}`,
+                    `st=${note.isRest ? "R" : (/^[A-G]$/.test(String((_a = note.step) !== null && _a !== void 0 ? _a : "").toUpperCase()) ? String(note.step).toUpperCase() : "C")}`,
+                    `al=${String(Number.isFinite(Number(note.alter)) ? Math.round(Number(note.alter)) : 0)}`,
+                    `oc=${toHex(Number.isFinite(Number(note.octave)) ? Math.max(0, Math.min(9, Math.round(Number(note.octave)))) : 4, 2)}`,
+                    `dd=${toHex(note.grace ? 0 : Math.max(1, Math.round(Number(note.duration) || 1)), 4)}`,
+                    `tp=${xmlEscape(normalizeTypeForMusicXml(note.type))}`,
+                ].join(";"),
+            ].join(";")}</miscellaneous-field>`;
+        })
+            .join("")}</miscellaneous></attributes>`
+        : "";
+    const diagMiscNotes = partIndex === 0 && measureNo === 1
+        ? (diagnostics !== null && diagnostics !== void 0 ? diagnostics : []).filter((diag) => { var _a; return !diag.voiceId || diag.voiceId === ((_a = part.voiceId) !== null && _a !== void 0 ? _a : ""); })
+        : [];
+    const diagMiscXml = diagMiscNotes.length
+        ? `<attributes><miscellaneous><miscellaneous-field name="mks:diag:count">${Math.min(256, diagMiscNotes.length)}</miscellaneous-field>${Array.from({ length: Math.min(256, diagMiscNotes.length) }, (_, i) => `<miscellaneous-field name="mks:diag:${String(i + 1).padStart(4, "0")}">${[
+            `level=${diagMiscNotes[i].level}`,
+            `code=${diagMiscNotes[i].code}`,
+            `fmt=${diagMiscNotes[i].fmt}`,
+            ...(diagMiscNotes[i].measure !== undefined && Number.isFinite(diagMiscNotes[i].measure)
+                ? [`measure=${Math.max(1, Math.round(Number(diagMiscNotes[i].measure)))}`]
+                : []),
+            ...(diagMiscNotes[i].movedEvents !== undefined && Number.isFinite(diagMiscNotes[i].movedEvents)
+                ? [`movedEvents=${Math.max(0, Math.round(Number(diagMiscNotes[i].movedEvents)))}`]
+                : []),
+            ...(diagMiscNotes[i].voiceId ? [`voice=${xmlEscape(diagMiscNotes[i].voiceId)}`] : []),
+            ...(diagMiscNotes[i].action ? [`action=${xmlEscape(diagMiscNotes[i].action)}`] : []),
+            ...(diagMiscNotes[i].message ? [`message=${xmlEscape(diagMiscNotes[i].message)}`] : []),
+        ].join(";")}</miscellaneous-field>`).join("")}</miscellaneous></attributes>`
+        : "";
+    const sourceMiscXml = sourceMetadata && partIndex === 0 && measureNo === 1
+        ? (() => {
+            const source = String(abcSource !== null && abcSource !== void 0 ? abcSource : "");
+            if (!source.length)
+                return "";
+            const encoded = source
+                .replace(/\\/g, "\\\\")
+                .replace(/\r/g, "\\r")
+                .replace(/\n/g, "\\n");
+            const CHUNK_SIZE = 240;
+            const MAX_CHUNKS = 512;
+            const chunks = [];
+            for (let i = 0; i < encoded.length && chunks.length < MAX_CHUNKS; i += CHUNK_SIZE) {
+                chunks.push(encoded.slice(i, i + CHUNK_SIZE));
+            }
+            const truncated = chunks.join("").length < encoded.length;
+            return `<attributes><miscellaneous>${[
+                `<miscellaneous-field name="mks:src:abc:raw-encoding">escape-v1</miscellaneous-field>`,
+                `<miscellaneous-field name="mks:src:abc:raw-length">${xmlEscape(String(source.length))}</miscellaneous-field>`,
+                `<miscellaneous-field name="mks:src:abc:raw-encoded-length">${xmlEscape(String(encoded.length))}</miscellaneous-field>`,
+                `<miscellaneous-field name="mks:src:abc:raw-chunks">${xmlEscape(String(chunks.length))}</miscellaneous-field>`,
+                `<miscellaneous-field name="mks:src:abc:raw-truncated">${truncated ? "1" : "0"}</miscellaneous-field>`,
+                ...chunks.map((chunk, index) => `<miscellaneous-field name="mks:src:abc:raw-${String(index + 1).padStart(4, "0")}">${xmlEscape(chunk)}</miscellaneous-field>`),
+            ].join("")}</miscellaneous></attributes>`;
+        })()
+        : "";
+    const xmlMeasureNumber = xmlEscape(String((measureMeta === null || measureMeta === void 0 ? void 0 : measureMeta.number) || measureNo));
+    const implicitAttr = (measureMeta === null || measureMeta === void 0 ? void 0 : measureMeta.implicit) || inferredImplicitPickup ? ' implicit="yes"' : "";
+    return `<measure number="${xmlMeasureNumber}"${implicitAttr}>${repeatStartXml}${headerXml}${tempoDirectionXml}${debugMiscXml}${diagMiscXml}${sourceMiscXml}${notesXml}${repeatEndXml}</measure>`;
 };
-const buildAbcRenderedMeasureMiscXml = (context) => {
-    const { part, partIndex, measureNo, notes, debugMetadata, sourceMetadata, diagnostics, abcSource, } = context;
-    return {
-        debugMiscXml: buildAbcRenderedMeasureDebugMiscXml(debugMetadata, notes, measureNo),
-        diagMiscXml: buildAbcRenderedMeasureDiagMiscXml(part, partIndex, measureNo, diagnostics),
-        sourceMiscXml: buildAbcRenderedMeasureSourceMiscXml(sourceMetadata, partIndex, measureNo, abcSource),
-    };
-};
-const buildAbcRenderedMeasureDebugMiscXml = (debugMetadata, notes, measureNo) => debugMetadata ? buildAbcMeasureDebugMiscXml(notes, measureNo) : "";
-const buildAbcRenderedMeasureDiagMiscXml = (part, partIndex, measureNo, diagnostics) => {
-    const filteredDiagnostics = buildAbcRenderedMeasureDiagMiscDiagnostics(part, partIndex, measureNo, diagnostics);
-    return filteredDiagnostics.length > 0 ? buildAbcDiagMiscXml(filteredDiagnostics) : "";
-};
-const buildAbcRenderedMeasureDiagMiscDiagnostics = (part, partIndex, measureNo, diagnostics) => partIndex === 0 && measureNo === 1
-    ? (diagnostics !== null && diagnostics !== void 0 ? diagnostics : []).filter((diag) => !diag.voiceId || diag.voiceId === (part.voiceId || ""))
-    : [];
-const buildAbcRenderedMeasureSourceMiscXml = (sourceMetadata, partIndex, measureNo, abcSource) => (sourceMetadata && partIndex === 0 && measureNo === 1 ? buildAbcSourceMiscXml(abcSource) : "");
 const createInitialAbcPartRenderState = (defaultFifths, beats, beatType, tempoBpm) => ({
     currentPartFifths: Math.max(-7, Math.min(7, Math.round(defaultFifths))),
     currentPartMeter: { beats: Math.round(beats), beatType: Math.round(beatType) },
     currentPartTempo: tempoBpm,
 });
 const buildAbcPartXml = (part, partIndex, measureCount, defaultFifths, beats, beatType, tempoBpm, debugMetadata, sourceMetadata, diagnostics, abcSource, buildMeasureNotesXml) => {
-    return buildAbcPartXmlWrapper(part.partId, buildAbcPartXmlMeasures(part, partIndex, measureCount, defaultFifths, beats, beatType, tempoBpm, debugMetadata, sourceMetadata, diagnostics, abcSource, buildMeasureNotesXml));
-};
-const buildAbcPartXmlWrapper = (partId, measuresXml) => `<part id="${xmlEscape(partId)}">${measuresXml}</part>`;
-const buildAbcPartXmlMeasures = (part, partIndex, measureCount, defaultFifths, beats, beatType, tempoBpm, debugMetadata, sourceMetadata, diagnostics, abcSource, buildMeasureNotesXml) => buildAbcPartXmlMeasureEntries(part, partIndex, measureCount, defaultFifths, beats, beatType, tempoBpm, debugMetadata, sourceMetadata, diagnostics, abcSource, buildMeasureNotesXml);
-const buildAbcPartXmlMeasureEntries = (part, partIndex, measureCount, defaultFifths, beats, beatType, tempoBpm, debugMetadata, sourceMetadata, diagnostics, abcSource, buildMeasureNotesXml) => buildAbcPartXmlMeasureEntryParts(part, partIndex, measureCount, defaultFifths, beats, beatType, tempoBpm, debugMetadata, sourceMetadata, diagnostics, abcSource, buildMeasureNotesXml).join("");
-const buildAbcPartXmlMeasureEntryParts = (part, partIndex, measureCount, defaultFifths, beats, beatType, tempoBpm, debugMetadata, sourceMetadata, diagnostics, abcSource, buildMeasureNotesXml) => {
     const measureParts = [];
     let state = createInitialAbcPartRenderState(defaultFifths, beats, beatType, tempoBpm);
     for (let i = 0; i < measureCount; i += 1) {
@@ -33797,335 +33816,33 @@ const buildAbcPartXmlMeasureEntryParts = (part, partIndex, measureCount, default
             buildMeasureNotesXml,
         }));
     }
-    return measureParts;
+    return `<part id="${xmlEscape(part.partId)}">${measureParts.join("")}</part>`;
 };
-const buildAbcPartListXml = (resolvedParts) => {
-    return resolvedParts.map((part, index) => buildAbcPartListEntryXml(part, index)).join("");
-};
-const buildAbcPartListEntryXml = (part, index) => {
-    const midiChannel = ((index % 16) + 1 === 10) ? 11 : ((index % 16) + 1);
-    return [
-        `<score-part id="${xmlEscape(part.partId)}">`,
-        `<part-name>${xmlEscape(part.partName || part.partId)}</part-name>`,
-        `<midi-instrument id="${xmlEscape(part.partId)}-I1">`,
-        `<midi-channel>${midiChannel}</midi-channel>`,
-        `<midi-program>6</midi-program>`,
-        "</midi-instrument>",
-        "</score-part>",
-    ].join("");
-};
-const buildAbcPartBodyXml = (resolvedParts, measureCount, defaultFifths, beats, beatType, tempoBpm, debugMetadata, sourceMetadata, diagnostics, abcSource, buildMeasureNotesXml) => {
-    return buildAbcPartBodyParts(resolvedParts, measureCount, defaultFifths, beats, beatType, tempoBpm, debugMetadata, sourceMetadata, diagnostics, abcSource, buildMeasureNotesXml);
-};
-const buildAbcPartBodyParts = (resolvedParts, measureCount, defaultFifths, beats, beatType, tempoBpm, debugMetadata, sourceMetadata, diagnostics, abcSource, buildMeasureNotesXml) => buildAbcPartBodyPartEntries(resolvedParts, measureCount, defaultFifths, beats, beatType, tempoBpm, debugMetadata, sourceMetadata, diagnostics, abcSource, buildMeasureNotesXml);
-const buildAbcPartBodyPartEntries = (resolvedParts, measureCount, defaultFifths, beats, beatType, tempoBpm, debugMetadata, sourceMetadata, diagnostics, abcSource, buildMeasureNotesXml) => buildAbcPartBodyPartItems(resolvedParts, measureCount, defaultFifths, beats, beatType, tempoBpm, debugMetadata, sourceMetadata, diagnostics, abcSource, buildMeasureNotesXml).join("");
-const buildAbcPartBodyPartItems = (resolvedParts, measureCount, defaultFifths, beats, beatType, tempoBpm, debugMetadata, sourceMetadata, diagnostics, abcSource, buildMeasureNotesXml) => resolvedParts.map((part, partIndex) => buildAbcPartXml(part, partIndex, measureCount, defaultFifths, beats, beatType, tempoBpm, debugMetadata, sourceMetadata, diagnostics, abcSource, buildMeasureNotesXml));
-const buildAbcNoteHarmonyAndWordsDirectionXml = (note) => {
-    const chunks = [];
-    if (!note.chord && Array.isArray(note.chordSymbols) && note.chordSymbols.length > 0) {
-        for (const chordSymbol of note.chordSymbols) {
-            const harmonyXml = buildHarmonyXmlFromChordSymbol(chordSymbol);
-            if (harmonyXml) {
-                chunks.push(harmonyXml);
-            }
-            else {
-                chunks.push((0, direction_text_1.buildMusicXmlWordsDirectionXml)({ text: String(chordSymbol) }));
-            }
-        }
-    }
-    if (!note.chord && Array.isArray(note.annotations) && note.annotations.length > 0) {
-        for (const annotation of note.annotations) {
-            if (!annotation)
-                continue;
-            chunks.push((0, direction_text_1.buildMusicXmlWordsDirectionXml)({ text: String(annotation) }));
-        }
-    }
-    return chunks.join("");
-};
-const buildAbcNoteControlDirectionXml = (note) => {
-    const chunks = [];
-    if (!note.chord && note.segno)
-        chunks.push("<direction><direction-type><segno/></direction-type></direction>");
-    if (!note.chord && note.coda)
-        chunks.push("<direction><direction-type><coda/></direction-type></direction>");
-    if (!note.chord && note.rehearsalMark) {
-        chunks.push(`<direction><direction-type><rehearsal>${xmlEscape(String(note.rehearsalMark))}</rehearsal></direction-type></direction>`);
-    }
-    if (!note.chord && note.fine)
-        chunks.push('<direction><sound fine="yes"/></direction>');
-    if (!note.chord && note.daCapo)
-        chunks.push('<direction><sound dacapo="yes"/></direction>');
-    if (!note.chord && note.dalSegno)
-        chunks.push('<direction><sound dalsegno="segno"/></direction>');
-    if (!note.chord && note.toCoda)
-        chunks.push('<direction><sound tocoda="coda"/></direction>');
-    if (!note.chord && note.crescendoStart)
-        chunks.push((0, dynamics_1.buildMusicXmlDirectionFeatureXml)({ kind: "wedge", wedgeType: "crescendo" }));
-    if (!note.chord && note.diminuendoStart)
-        chunks.push((0, dynamics_1.buildMusicXmlDirectionFeatureXml)({ kind: "wedge", wedgeType: "diminuendo" }));
-    if (!note.chord && (note.crescendoStop || note.diminuendoStop)) {
-        chunks.push((0, dynamics_1.buildMusicXmlDirectionFeatureXml)({ kind: "wedge", wedgeType: "stop" }));
-    }
-    if (!note.chord && note.dynamicMark) {
-        const dynamicMark = (0, dynamics_1.normalizeDynamicMark)(String(note.dynamicMark));
-        if (dynamicMark)
-            chunks.push((0, dynamics_1.buildMusicXmlDirectionFeatureXml)({ kind: "dynamic", mark: dynamicMark }));
-    }
-    if (!note.chord && note.sfz) {
-        chunks.push((0, dynamics_1.buildMusicXmlDirectionFeatureXml)({ kind: "dynamic", mark: "sfz" }));
-    }
-    return chunks.join("");
-};
-const buildAbcNoteLeadingDirectionXml = (note) => {
-    const chunks = [];
-    chunks.push(buildAbcNoteHarmonyAndWordsDirectionXml(note));
-    chunks.push(buildAbcNoteControlDirectionXml(note));
-    return chunks.join("");
-};
-const buildAbcNotePitchOrRestXml = (note) => {
-    if (note.isRest) {
-        return "<rest/>";
-    }
-    return (0, pitches_1.buildMusicXmlPitchXml)({
-        step: note.step,
-        alter: note.alter,
-        octave: note.octave,
-    });
-};
-const buildAbcNoteLyricXml = (note) => {
-    return (0, note_elements_1.buildMusicXmlLyricXml)({
-        text: note.lyricText,
-        syllabic: note.lyricSyllabic || "single",
-        extend: note.lyricExtend,
-    });
-};
-const buildAbcNoteTimeModificationXml = (note) => {
-    var _a, _b;
-    return (0, tuplets_1.buildMusicXmlTimeModificationXml)({
-        actualNotes: (_a = note.timeModification) === null || _a === void 0 ? void 0 : _a.actual,
-        normalNotes: (_b = note.timeModification) === null || _b === void 0 ? void 0 : _b.normal,
-    });
-};
-const buildAbcNoteAccidentalXml = (note) => {
-    return (0, note_elements_1.buildMusicXmlAccidentalXml)({
-        text: note.accidentalText,
-        editorial: note.accidentalEditorial,
-        cautionary: note.accidentalCautionary,
-    });
-};
-const buildAbcNoteCoreXml = (note, noteIndex, staffOverride, beamXmlByNoteIndex) => {
-    const chunks = [];
-    chunks.push(...buildAbcNoteCoreOpenParts(note, staffOverride));
-    if (!note.chord && beamXmlByNoteIndex.has(noteIndex))
-        chunks.push(String(beamXmlByNoteIndex.get(noteIndex)));
-    chunks.push(...buildAbcNoteCoreTailParts(note));
-    return chunks.join("");
-};
-const buildAbcNoteCoreOpenParts = (note, staffOverride) => {
-    const chunks = ["<note>"];
-    if (note.chord)
-        chunks.push("<chord/>");
-    if (note.grace)
-        chunks.push((0, note_elements_1.buildMusicXmlGraceXml)({ slash: note.graceSlash }));
-    chunks.push(buildAbcNotePitchOrRestXml(note));
-    if (!note.grace) {
-        const duration = Math.max(1, Math.round(Number(note.duration) || 1));
-        chunks.push(`<duration>${duration}</duration>`);
-    }
-    chunks.push(`<voice>${xmlEscape(normalizeVoiceForMusicXml(note.voice))}</voice>`);
-    if (staffOverride !== null || Number.isFinite(note.staff)) {
-        const staffNumber = staffOverride !== null ? staffOverride : Math.max(1, Math.round(Number(note.staff) || 1));
-        chunks.push(`<staff>${staffNumber}</staff>`);
-    }
-    chunks.push(buildAbcNoteLyricXml(note));
-    chunks.push(`<type>${normalizeTypeForMusicXml(note.type)}</type>`);
-    return chunks;
-};
-const buildAbcNoteCoreTailParts = (note) => [...buildAbcNoteCoreModifierTailParts(note), buildAbcNoteCoreTieTailPart(note)];
-const buildAbcNoteCoreModifierTailParts = (note) => [
-    buildAbcNoteTimeModificationXml(note),
-    buildAbcNoteAccidentalXml(note),
-];
-const buildAbcNoteCoreTieTailPart = (note) => (0, ties_1.buildMusicXmlTieItemsXml)({
-    tieStart: Boolean(note.tieStart),
-    tieStop: Boolean(note.tieStop),
-});
-const buildAbcNoteOrnamentsXml = (note) => {
-    return [buildAbcNoteOrnamentsFeatureParts(note), buildAbcNoteOrnamentsMotionParts(note)].join("");
-};
-const buildAbcNoteOrnamentsFeatureParts = (note) => [
-    buildAbcNoteOrnamentsWavyLinePart(note),
-    buildAbcNoteOrnamentsTurnPart(note),
-    buildAbcNoteOrnamentsMordentPart(note),
-    buildAbcNoteOrnamentsTremoloPart(note),
-    buildAbcNoteOrnamentsSchleiferPart(note),
-    buildAbcNoteOrnamentsShakePart(note),
-].join("");
-const buildAbcNoteOrnamentsMotionParts = (note) => buildAbcNoteOrnamentsMotionItemParts(note).join("");
-const buildAbcNoteOrnamentsMotionItemParts = (note) => [
-    note.glissandoStart ? '<glissando type="start" number="1">wavy</glissando>' : "",
-    note.glissandoStop ? '<glissando type="stop" number="1">wavy</glissando>' : "",
-    note.slideStart ? '<slide type="start" number="1"/>' : "",
-    note.slideStop ? '<slide type="stop" number="1"/>' : "",
-    note.arpeggiate ? "<arpeggiate/>" : "",
-].filter(Boolean);
-const buildAbcNoteOrnamentsWavyLinePart = (note) => {
-    if (!note.trill && !note.trillLineStop)
-        return "";
-    const trillParts = note.trill ? [(0, ornaments_1.buildMusicXmlOrnamentItemsXml)([{ kind: "trill-mark" }])] : [];
-    if (note.trillLineStop) {
-        trillParts.push('<wavy-line type="stop"/>');
-    }
-    else if (note.trillLineStart) {
-        trillParts.push('<wavy-line type="start"/>');
-    }
-    if (note.trillAccidentalText)
-        trillParts.push(`<accidental-mark>${xmlEscape(String(note.trillAccidentalText))}</accidental-mark>`);
-    return `<ornaments>${trillParts.join("")}</ornaments>`;
-};
-const buildAbcNoteOrnamentsTurnPart = (note) => {
-    if (!note.turnType)
-        return "";
-    return (0, ornaments_1.buildMusicXmlOrnamentsXml)([
-        { kind: note.turnType === "inverted-turn" ? "inverted-turn" : "turn", ...(note.turnSlash ? { slash: true } : {}) },
-        ...(note.delayedTurn ? [{ kind: "delayed-turn" }] : []),
-    ]);
-};
-const buildAbcNoteOrnamentsMordentPart = (note) => {
-    if (!note.mordentType)
-        return "";
-    return (0, ornaments_1.buildMusicXmlOrnamentsXml)([
-        { kind: note.mordentType === "inverted-mordent" ? "inverted-mordent" : "mordent" },
-    ]);
-};
-const buildAbcNoteOrnamentsTremoloPart = (note) => {
-    if (!note.tremoloType)
-        return "";
-    return (0, ornaments_1.buildMusicXmlOrnamentsXml)([
-        { kind: "tremolo", tremoloType: note.tremoloType, marks: note.tremoloMarks },
-    ]);
-};
-const buildAbcNoteOrnamentsSchleiferPart = (note) => note.schleifer ? (0, ornaments_1.buildMusicXmlOrnamentsXml)([{ kind: "schleifer" }]) : "";
-const buildAbcNoteOrnamentsShakePart = (note) => note.shake ? (0, ornaments_1.buildMusicXmlOrnamentsXml)([{ kind: "shake" }]) : "";
-const buildAbcNoteArticulationsXml = (note) => {
-    const featureItemsXml = buildAbcNoteArticulationFeatureItemsXml(note);
-    const decorativeParts = buildAbcNoteArticulationDecorativeParts(note);
-    if (featureItemsXml && decorativeParts.length === 0)
-        return `<articulations>${featureItemsXml}</articulations>`;
-    if (featureItemsXml)
-        decorativeParts.unshift(featureItemsXml);
-    return decorativeParts.length > 0 ? `<articulations>${decorativeParts.join("")}</articulations>` : "";
-};
-const buildAbcNoteArticulationDecorativeParts = (note) => {
-    const articulationParts = [];
-    if (note.stress)
-        articulationParts.push("<stress/>");
-    if (note.unstress)
-        articulationParts.push("<unstress/>");
-    if (note.phraseMark)
-        articulationParts.push(`<other-articulation>${xmlEscape(String(note.phraseMark))}</other-articulation>`);
-    return articulationParts;
-};
-const buildAbcNoteArticulationFeatureItemsXml = (note) => (0, articulations_1.buildMusicXmlArticulationItemsXml)(buildAbcNoteArticulationFeatureKinds(note));
-const buildAbcNoteArticulationFeatureKinds = (note) => {
-    const articulationKinds = [];
-    if (note.staccato)
-        articulationKinds.push("staccato");
-    if (note.staccatissimo)
-        articulationKinds.push("staccatissimo");
-    if (note.accent)
-        articulationKinds.push("accent");
-    if (note.tenuto)
-        articulationKinds.push("tenuto");
-    if (note.strongAccent)
-        articulationKinds.push("strong-accent");
-    if (note.breathMark)
-        articulationKinds.push("breath-mark");
-    if (note.caesura)
-        articulationKinds.push("caesura");
-    return articulationKinds;
-};
-const buildAbcNoteTechnicalXml = (note) => {
-    const technicalParts = [];
-    technicalParts.push(...buildAbcNoteTechnicalPlainParts(note));
-    technicalParts.push(...buildAbcNoteTechnicalCollectionParts(note));
-    technicalParts.push(...buildAbcNoteTechnicalFlagParts(note));
-    return (0, note_elements_1.buildMusicXmlTechnicalXml)(technicalParts);
-};
-const buildAbcNoteTechnicalPlainParts = (note) => [
-    note.upBow ? "<up-bow/>" : "",
-    note.downBow ? "<down-bow/>" : "",
-    note.doubleTongue ? "<double-tongue/>" : "",
-    note.tripleTongue ? "<triple-tongue/>" : "",
-    note.heel ? "<heel/>" : "",
-    note.toe ? "<toe/>" : "",
-].filter(Boolean);
-const buildAbcNoteTechnicalCollectionParts = (note) => {
-    return buildAbcNoteTechnicalCollectionItemParts(note);
-};
-const buildAbcNoteTechnicalCollectionItemParts = (note) => {
-    const collectionParts = [];
-    if (Array.isArray(note.fingerings) && note.fingerings.length > 0) {
-        for (const fingering of note.fingerings)
-            collectionParts.push((0, note_elements_1.buildMusicXmlFingeringXml)(fingering));
-    }
-    if (Array.isArray(note.strings) && note.strings.length > 0) {
-        for (const stringText of note.strings)
-            collectionParts.push((0, note_elements_1.buildMusicXmlStringNumberXml)(stringText));
-    }
-    if (Array.isArray(note.plucks) && note.plucks.length > 0) {
-        for (const pluckText of note.plucks)
-            if (pluckText)
-                collectionParts.push(`<pluck>${xmlEscape(String(pluckText))}</pluck>`);
-    }
-    return collectionParts;
-};
-const buildAbcNoteTechnicalFlagParts = (note) => [
-    note.openString ? "<open-string/>" : "",
-    note.snapPizzicato ? "<snap-pizzicato/>" : "",
-    note.harmonic ? "<harmonic/>" : "",
-    note.stopped ? "<stopped/>" : "",
-    note.thumbPosition ? "<thumb-position/>" : "",
-].filter(Boolean);
-const hasAbcNoteNotations = (note) => Boolean(note.tieStart || note.tieStop || note.slurStart || note.slurStop || note.trill || note.trillLineStop || note.turnType ||
-    note.delayedTurn || note.mordentType || note.tremoloType || note.glissandoStart || note.glissandoStop ||
-    note.slideStart || note.slideStop || note.schleifer || note.shake || note.arpeggiate || note.staccato ||
-    note.staccatissimo || note.accent || note.tenuto || note.stress || note.unstress || note.fermataType ||
-    note.strongAccent || note.breathMark || note.caesura || note.phraseMark || note.upBow || note.downBow ||
-    note.doubleTongue || note.tripleTongue || note.heel || note.toe ||
-    (Array.isArray(note.fingerings) && note.fingerings.length > 0) ||
-    (Array.isArray(note.strings) && note.strings.length > 0) ||
-    (Array.isArray(note.plucks) && note.plucks.length > 0) || note.openString || note.snapPizzicato ||
-    note.harmonic || note.stopped || note.thumbPosition || note.tupletStart || note.tupletStop);
-const buildAbcNoteNotationsXml = (note) => {
-    if (!hasAbcNoteNotations(note))
-        return "";
-    return `<notations>${buildAbcNoteNotationsFeatureChunks(note)}</notations>`;
-};
-const buildAbcNoteNotationsFeatureChunks = (note) => [
-    (0, ties_1.buildMusicXmlTiedItemsXml)({
-        tiedStart: Boolean(note.tieStart),
-        tiedStop: Boolean(note.tieStop),
-    }),
-    (0, slurs_1.buildMusicXmlSlursXml)([
-        ...(note.slurStart ? [{ type: "start" }] : []),
-        ...(note.slurStop ? [{ type: "stop" }] : []),
-    ]),
-    note.tupletStart ? '<tuplet type="start"/>' : "",
-    note.tupletStop ? '<tuplet type="stop"/>' : "",
-    buildAbcNoteOrnamentsXml(note),
-    buildAbcNoteArticulationsXml(note),
-    buildAbcNoteTechnicalXml(note),
-    note.fermataType ? `<fermata>${note.fermataType === "inverted" ? "inverted" : "normal"}</fermata>` : "",
-].join("");
-const buildAbcEmptyMeasureNotesXml = (measureDurationDiv, emptyMeasureRestType, staffOverride) => {
-    return `<note><rest/><duration>${measureDurationDiv}</duration><voice>1</voice><type>${emptyMeasureRestType}</type>${staffOverride !== null ? `<staff>${staffOverride}</staff>` : ""}</note>`;
-};
+const hasAbcNoteNotations = (note) => hasAbcNoteTieOrSlurNotations(note) ||
+    hasAbcNoteOrnaments(note) ||
+    hasAbcNoteArticulations(note) ||
+    hasAbcNoteTechnicalNotations(note) ||
+    hasAbcNoteFermataNotation(note) ||
+    hasAbcNoteTupletNotations(note);
+const hasAbcNoteTieOrSlurNotations = (note) => note.tieStart || note.tieStop || note.slurStart || note.slurStop;
+const hasAbcNoteOrnaments = (note) => hasAbcNoteOrnamentFeatureNotations(note) || hasAbcNoteOrnamentMotionNotations(note);
+const hasAbcNoteOrnamentFeatureNotations = (note) => note.trill || note.trillLineStop || note.turnType || note.delayedTurn || note.mordentType || note.tremoloType ||
+    note.schleifer || note.shake;
+const hasAbcNoteOrnamentMotionNotations = (note) => note.glissandoStart || note.glissandoStop || note.slideStart || note.slideStop || note.arpeggiate;
+const hasAbcNoteArticulations = (note) => hasAbcNoteArticulationFeatureNotations(note) || hasAbcNoteArticulationDecorativeNotations(note);
+const hasAbcNoteArticulationFeatureNotations = (note) => note.staccato || note.staccatissimo || note.accent || note.tenuto || note.strongAccent || note.breathMark || note.caesura;
+const hasAbcNoteArticulationDecorativeNotations = (note) => note.stress || note.unstress || note.phraseMark;
+const hasAbcNoteTechnicalNotations = (note) => hasAbcNoteTechnicalPlainNotations(note) || hasAbcNoteTechnicalCollectionNotations(note) || hasAbcNoteTechnicalFlagNotations(note);
+const hasAbcNoteTechnicalPlainNotations = (note) => !!(note.upBow || note.downBow || note.doubleTongue || note.tripleTongue || note.heel || note.toe);
+const hasAbcNoteTechnicalCollectionNotations = (note) => { var _a, _b, _c; return !!(((_a = note.fingerings) === null || _a === void 0 ? void 0 : _a.length) || ((_b = note.strings) === null || _b === void 0 ? void 0 : _b.length) || ((_c = note.plucks) === null || _c === void 0 ? void 0 : _c.length)); };
+const hasAbcNoteTechnicalFlagNotations = (note) => note.openString || note.snapPizzicato || note.harmonic || note.stopped || note.thumbPosition;
+const hasAbcNoteFermataNotation = (note) => !!note.fermataType;
+const hasAbcNoteTupletNotations = (note) => !!(note.tupletStart || note.tupletStop);
 const buildAbcBeamXmlByNoteIndex = (notes, beatDiv) => {
     var _a;
     const out = new Map();
     const levelFromType = (typeText) => {
-        switch (String(typeText || "").trim().toLowerCase()) {
+        switch (String(typeText !== null && typeText !== void 0 ? typeText : "").trim().toLowerCase()) {
             case "eighth":
                 return 1;
             case "16th":
@@ -34155,8 +33872,8 @@ const buildAbcBeamXmlByNoteIndex = (notes, beatDiv) => {
             const type = normalizeTypeForMusicXml((_a = ev.note) === null || _a === void 0 ? void 0 : _a.type);
             return {
                 timed: true,
-                chord: !Boolean((_b = ev.note) === null || _b === void 0 ? void 0 : _b.isRest),
-                grace: Boolean((_c = ev.note) === null || _c === void 0 ? void 0 : _c.grace),
+                chord: !((_b = ev.note) === null || _b === void 0 ? void 0 : _b.isRest),
+                grace: !!((_c = ev.note) === null || _c === void 0 ? void 0 : _c.grace),
                 durationDiv: ((_d = ev.note) === null || _d === void 0 ? void 0 : _d.grace) ? 0 : Math.max(1, Math.round(Number((_e = ev.note) === null || _e === void 0 ? void 0 : _e.duration) || 1)),
                 levels: levelFromType(type),
                 explicitMode: (_f = ev.note) === null || _f === void 0 ? void 0 : _f.beamMode,
@@ -34175,16 +33892,187 @@ const buildAbcBeamXmlByNoteIndex = (notes, beatDiv) => {
     return out;
 };
 const buildAbcNoteXml = (note, noteIndex, staffOverride, beamXmlByNoteIndex) => {
+    var _a, _b, _c, _d, _e, _f;
+    const voice = normalizeVoiceForMusicXml(note.voice);
+    const staff = Number(note.staff);
+    const staffValue = staffOverride !== null && staffOverride !== void 0 ? staffOverride : (Number.isFinite(staff) ? Math.max(1, Math.round(staff || 1)) : null);
     const chunks = [];
-    chunks.push(buildAbcNoteLeadingDirectionXml(note));
-    chunks.push(buildAbcNoteCoreXml(note, noteIndex, staffOverride, beamXmlByNoteIndex));
-    chunks.push(buildAbcNoteNotationsXml(note));
+    chunks.push(note.chord
+        ? ""
+        : [
+            (_b = (_a = note.chordSymbols) === null || _a === void 0 ? void 0 : _a.map((chordSymbol) => buildHarmonyXmlFromChordSymbol(chordSymbol) || (0, direction_text_1.buildMusicXmlWordsDirectionXml)({ text: String(chordSymbol) })).join("")) !== null && _b !== void 0 ? _b : "",
+            (_d = (_c = note.annotations) === null || _c === void 0 ? void 0 : _c.filter((annotation) => annotation.trim().length > 0).map((annotation) => (0, direction_text_1.buildMusicXmlWordsDirectionXml)({ text: String(annotation) })).join("")) !== null && _d !== void 0 ? _d : "",
+            [
+                note.segno ? "<direction><direction-type><segno/></direction-type></direction>" : "",
+                note.coda ? "<direction><direction-type><coda/></direction-type></direction>" : "",
+                note.rehearsalMark
+                    ? `<direction><direction-type><rehearsal>${xmlEscape(String(note.rehearsalMark))}</rehearsal></direction-type></direction>`
+                    : "",
+                note.fine ? '<direction><sound fine="yes"/></direction>' : "",
+                note.daCapo ? '<direction><sound dacapo="yes"/></direction>' : "",
+                note.dalSegno ? '<direction><sound dalsegno="segno"/></direction>' : "",
+                note.toCoda ? '<direction><sound tocoda="coda"/></direction>' : "",
+                note.crescendoStart
+                    ? (0, dynamics_1.buildMusicXmlDirectionFeatureXml)({ kind: "wedge", wedgeType: "crescendo" })
+                    : note.diminuendoStart
+                        ? (0, dynamics_1.buildMusicXmlDirectionFeatureXml)({ kind: "wedge", wedgeType: "diminuendo" })
+                        : note.crescendoStop || note.diminuendoStop
+                            ? (0, dynamics_1.buildMusicXmlDirectionFeatureXml)({ kind: "wedge", wedgeType: "stop" })
+                            : "",
+                note.dynamicMark ? (0, dynamics_1.buildMusicXmlDirectionFeatureXml)({ kind: "dynamic", mark: (0, dynamics_1.normalizeDynamicMark)(String(note.dynamicMark)) }) : "",
+                note.sfz ? (0, dynamics_1.buildMusicXmlDirectionFeatureXml)({ kind: "dynamic", mark: "sfz" }) : "",
+            ]
+                .filter((part) => part.length > 0)
+                .join(""),
+        ]
+            .filter((part) => part.length > 0)
+            .join(""));
+    chunks.push([
+        "<note>",
+        ...(note.chord ? ["<chord/>"] : []),
+        ...(note.grace ? [(0, note_elements_1.buildMusicXmlGraceXml)({ slash: note.graceSlash })] : []),
+        note.isRest
+            ? "<rest/>"
+            : (0, pitches_1.buildMusicXmlPitchXml)({
+                step: note.step,
+                alter: note.alter,
+                octave: note.octave,
+            }),
+        ...(note.grace ? [] : [`<duration>${Math.max(1, Math.round(Number(note.duration) || 1))}</duration>`]),
+        `<voice>${xmlEscape(voice)}</voice>`,
+        ...(staffValue ? [`<staff>${staffValue}</staff>`] : []),
+        (0, note_elements_1.buildMusicXmlLyricXml)({
+            text: note.lyricText,
+            syllabic: note.lyricSyllabic || "single",
+            extend: note.lyricExtend,
+        }),
+        `<type>${normalizeTypeForMusicXml(note.type)}</type>`,
+        !note.chord && beamXmlByNoteIndex.has(noteIndex) ? String(beamXmlByNoteIndex.get(noteIndex)) : "",
+        (0, tuplets_1.buildMusicXmlTimeModificationXml)({
+            actualNotes: (_e = note.timeModification) === null || _e === void 0 ? void 0 : _e.actual,
+            normalNotes: (_f = note.timeModification) === null || _f === void 0 ? void 0 : _f.normal,
+        }),
+        (0, note_elements_1.buildMusicXmlAccidentalXml)({
+            text: note.accidentalText,
+            editorial: note.accidentalEditorial,
+            cautionary: note.accidentalCautionary,
+        }),
+        (0, ties_1.buildMusicXmlTieItemsXml)({
+            tieStart: !!note.tieStart,
+            tieStop: !!note.tieStop,
+        }),
+    ].join(""));
+    chunks.push(hasAbcNoteNotations(note)
+        ? [
+            (0, ties_1.buildMusicXmlTiedItemsXml)({
+                tiedStart: !!note.tieStart,
+                tiedStop: !!note.tieStop,
+            }),
+            (0, slurs_1.buildMusicXmlSlursXml)([
+                ...(note.slurStart ? [{ type: "start" }] : []),
+                ...(note.slurStop ? [{ type: "stop" }] : []),
+            ]),
+            `${note.tupletStart ? '<tuplet type="start"/>' : ""}${note.tupletStop ? '<tuplet type="stop"/>' : ""}`,
+            [
+                [
+                    note.trill ? (0, ornaments_1.buildMusicXmlOrnamentItemsXml)([{ kind: "trill-mark" }]) : "",
+                    note.trillLineStop ? '<wavy-line type="stop"/>' : note.trillLineStart ? '<wavy-line type="start"/>' : "",
+                    note.trillAccidentalText ? `<accidental-mark>${xmlEscape(String(note.trillAccidentalText))}</accidental-mark>` : "",
+                ]
+                    .filter((part) => part.length > 0)
+                    .join("")
+                    .replace(/^/, "<ornaments>")
+                    .concat("</ornaments>"),
+                note.turnType
+                    ? (0, ornaments_1.buildMusicXmlOrnamentsXml)([
+                        {
+                            kind: note.turnType === "inverted-turn" ? "inverted-turn" : "turn",
+                            ...(note.turnSlash ? { slash: true } : {}),
+                        },
+                        ...(note.delayedTurn ? [{ kind: "delayed-turn" }] : []),
+                    ])
+                    : "",
+                note.mordentType
+                    ? (0, ornaments_1.buildMusicXmlOrnamentsXml)([
+                        {
+                            kind: note.mordentType === "inverted-mordent" ? "inverted-mordent" : "mordent",
+                        },
+                    ])
+                    : "",
+                note.tremoloType
+                    ? (0, ornaments_1.buildMusicXmlOrnamentsXml)([
+                        {
+                            kind: "tremolo",
+                            tremoloType: note.tremoloType,
+                            marks: note.tremoloMarks,
+                        },
+                    ])
+                    : "",
+                note.schleifer ? (0, ornaments_1.buildMusicXmlOrnamentsXml)([{ kind: "schleifer" }]) : "",
+                note.shake ? (0, ornaments_1.buildMusicXmlOrnamentsXml)([{ kind: "shake" }]) : "",
+                `${note.glissandoStart ? '<glissando type="start" number="1">wavy</glissando>' : ""}${note.glissandoStop ? '<glissando type="stop" number="1">wavy</glissando>' : ""}`,
+                `${note.slideStart ? '<slide type="start" number="1"/>' : ""}${note.slideStop ? '<slide type="stop" number="1"/>' : ""}`,
+                note.arpeggiate ? "<arpeggiate/>" : "",
+            ]
+                .filter((part) => part.length > 0)
+                .join(""),
+            [
+                (0, articulations_1.buildMusicXmlArticulationItemsXml)([
+                    ...[
+                        note.staccato ? "staccato" : "",
+                        note.staccatissimo ? "staccatissimo" : "",
+                        note.accent ? "accent" : "",
+                        note.tenuto ? "tenuto" : "",
+                    ].filter((part) => part.length > 0),
+                    ...[
+                        note.strongAccent ? "strong-accent" : "",
+                        note.breathMark ? "breath-mark" : "",
+                        note.caesura ? "caesura" : "",
+                    ].filter((part) => part.length > 0),
+                ]),
+                note.stress ? "<stress/>" : "",
+                note.unstress ? "<unstress/>" : "",
+                note.phraseMark ? `<other-articulation>${xmlEscape(String(note.phraseMark))}</other-articulation>` : "",
+            ]
+                .filter((part) => part.length > 0)
+                .join("")
+                .replace(/^/, "<articulations>")
+                .concat("</articulations>"),
+            (0, note_elements_1.buildMusicXmlTechnicalXml)([
+                ...[
+                    note.upBow ? "<up-bow/>" : "",
+                    note.downBow ? "<down-bow/>" : "",
+                    note.doubleTongue ? "<double-tongue/>" : "",
+                    note.tripleTongue ? "<triple-tongue/>" : "",
+                ].filter((part) => part.length > 0),
+                ...[
+                    note.heel ? "<heel/>" : "",
+                    note.toe ? "<toe/>" : "",
+                ].filter((part) => part.length > 0),
+                ...(note.fingerings ? note.fingerings.map((fingering) => (0, note_elements_1.buildMusicXmlFingeringXml)(fingering)) : []),
+                ...(note.strings ? note.strings.map((stringText) => (0, note_elements_1.buildMusicXmlStringNumberXml)(stringText)) : []),
+                ...(note.plucks ? note.plucks.map((pluckText) => (pluckText ? `<pluck>${xmlEscape(pluckText)}</pluck>` : "")) : []),
+                ...[
+                    note.openString ? "<open-string/>" : "",
+                    note.snapPizzicato ? "<snap-pizzicato/>" : "",
+                    note.harmonic ? "<harmonic/>" : "",
+                    note.stopped ? "<stopped/>" : "",
+                    note.thumbPosition ? "<thumb-position/>" : "",
+                ].filter((part) => part.length > 0),
+            ]),
+            note.fermataType ? `<fermata>${note.fermataType === "inverted" ? "inverted" : "normal"}</fermata>` : "",
+        ]
+            .filter((part) => part.length > 0)
+            .join("")
+            .replace(/^/, "<notations>")
+            .concat("</notations>")
+        : "");
     chunks.push("</note>");
     return chunks.join("");
 };
 const buildAbcMeasureNotesXml = (notes, measureDurationDiv, emptyMeasureRestType, beatDiv, staffOverride = null) => {
     if (!notes.length) {
-        return buildAbcEmptyMeasureNotesXml(measureDurationDiv, emptyMeasureRestType, staffOverride);
+        return `<note><rest/><duration>${measureDurationDiv}</duration><voice>1</voice><type>${emptyMeasureRestType}</type>${staffOverride !== null ? `<staff>${staffOverride}</staff>` : ""}</note>`;
     }
     const beamXmlByNoteIndex = buildAbcBeamXmlByNoteIndex(notes, beatDiv);
     return notes
@@ -34238,12 +34126,13 @@ const ensureAbcTempoByMeasure = (stores, voiceId) => {
     return stores.tempoByMeasureByVoice[voiceId];
 };
 const finalizeAbcActiveEndings = (stores) => {
+    var _a;
     for (const voiceId of Object.keys(stores.measuresByVoice)) {
         const measures = stores.measuresByVoice[voiceId];
         while (measures.length > 1 && measures[measures.length - 1].length === 0) {
             measures.pop();
         }
-        const activeEndingMarker = String(stores.activeEndingByVoice[voiceId] || "");
+        const activeEndingMarker = String((_a = stores.activeEndingByVoice[voiceId]) !== null && _a !== void 0 ? _a : "");
         if (activeEndingMarker) {
             const lastMeasureNo = measures.length;
             if (lastMeasureNo >= 1) {
@@ -34327,7 +34216,7 @@ const applyAbcBodyField = (fieldName, fieldValue, context) => {
         return { handled: true, activeKeyFifths, activeKeySignatureAccidentals, activeUnitLength, activeMeter, activeTempoBpm, measureAccidentals };
     }
     if (fieldName === "Q") {
-        activeTempoBpm = parseTempoFromQ(fieldValue || "", context.warnings);
+        activeTempoBpm = parseTempoFromQ(fieldValue !== null && fieldValue !== void 0 ? fieldValue : "", context.warnings);
         if (Number.isFinite(activeTempoBpm)) {
             ensureAbcTempoByMeasure(context.voiceStores, context.entryVoiceId)[context.currentMeasureNo] =
                 Math.max(20, Math.min(300, Math.round(Number(activeTempoBpm))));
@@ -34405,24 +34294,6 @@ const processAbcPlayableEvent = (playableEvent, context) => {
     }
     context.commitPlayableEvent(eventNotes, context.resolution.commitOptions);
     return true;
-};
-const buildAbcPlayableEventNotes = (context) => {
-    const notes = [];
-    for (let pitchIndex = 0; pitchIndex < context.pitchSources.length; pitchIndex += 1) {
-        const note = context.buildPlayableNoteForBody(context.pitchSources[pitchIndex], context.timing.absoluteLength, context.timing.dur, context.octaveWarningMessage);
-        if (!note) {
-            notes.length = 0;
-            break;
-        }
-        if (pitchIndex === 0) {
-            context.finalizePlayableEventStart(note, context.timing.dur, context.timing.activeTuplet, context.firstNoteOptions);
-        }
-        else {
-            note.chord = true;
-        }
-        notes.push(note);
-    }
-    return notes;
 };
 const processAbcSimpleBodyToken = (bodyToken, context) => {
     if (!bodyToken) {
@@ -34548,7 +34419,7 @@ const fifthsFromAbcKey = (raw) => {
         Ebm: -6,
         Abm: -7,
     };
-    const normalized = String(raw || "").trim().replace(/\s+/g, "");
+    const normalized = String(raw !== null && raw !== void 0 ? raw : "").trim().replace(/\s+/g, "");
     if (Object.prototype.hasOwnProperty.call(table, normalized)) {
         return table[normalized];
     }
@@ -34613,14 +34484,14 @@ const SNAP_PIZZICATO_DECORATIONS = new Set(["snap", "snap-pizzicato", "snappizzi
 const STOPPED_DECORATIONS = new Set(["stopped", "+", "plus", "stopped horn", "stopped-horn"]);
 const THUMB_POSITION_DECORATIONS = new Set(["thumb", "thumbposition", "thumb-position", "thumbpos", "thumb pos", "thumb position"]);
 function tokenizeAbcLyricLine(text) {
-    const raw = String(text || "").trim();
+    const raw = String(text !== null && text !== void 0 ? text : "").trim();
     if (!raw)
         return [];
     const chunks = raw
         .replace(/\|/g, " ")
         .split(/\s+/)
         .map((token) => token.trim())
-        .filter(Boolean);
+        .filter((token) => token.length > 0);
     const tokens = [];
     let pendingHyphenWord = false;
     for (const chunk of chunks) {
@@ -34663,10 +34534,11 @@ function tokenizeAbcLyricLine(text) {
     return tokens;
 }
 function splitBodyTextByInlineVoice(text, initialVoiceId) {
+    var _a;
     const segments = [];
-    let activeVoiceId = String(initialVoiceId || "1").trim() || "1";
+    let activeVoiceId = String(initialVoiceId !== null && initialVoiceId !== void 0 ? initialVoiceId : "1").trim() || "1";
     let buffer = "";
-    const raw = String(text || "");
+    const raw = String(text !== null && text !== void 0 ? text : "");
     let idx = 0;
     while (idx < raw.length) {
         if (raw[idx] === "[") {
@@ -34677,7 +34549,7 @@ function splitBodyTextByInlineVoice(text, initialVoiceId) {
                     segments.push({ voiceId: activeVoiceId, text: buffer });
                 }
                 buffer = "";
-                const voiceMatch = String(inlineField.fieldValue || "").match(/^(\S+)/);
+                const voiceMatch = String((_a = inlineField.fieldValue) !== null && _a !== void 0 ? _a : "").match(/^(\S+)/);
                 if (voiceMatch) {
                     activeVoiceId = voiceMatch[1];
                 }
@@ -34700,8 +34572,8 @@ function splitBodyTextByInlineVoice(text, initialVoiceId) {
     };
 }
 function splitBodyTextByOverlay(text, baseVoiceId) {
-    const raw = String(text || "");
-    const normalizedBaseVoiceId = String(baseVoiceId || "1").trim() || "1";
+    const raw = String(text !== null && text !== void 0 ? text : "");
+    const normalizedBaseVoiceId = String(baseVoiceId !== null && baseVoiceId !== void 0 ? baseVoiceId : "1").trim() || "1";
     const overlayBuffers = [""];
     let completedMeasureSkeleton = "";
     let activeOverlayIndex = 0;
@@ -34772,12 +34644,13 @@ function splitBodyTextByOverlay(text, baseVoiceId) {
         .filter((segment) => segment.text.trim().length > 0);
 }
 function parseUserDefinedDecoration(rawValue) {
-    const text = String(rawValue || "").trim();
+    var _a, _b;
+    const text = String(rawValue !== null && rawValue !== void 0 ? rawValue : "").trim();
     const match = text.match(/^(\S)(?:\s*=\s*|\s+)(.+)$/);
     if (!match)
         return null;
-    const symbol = String(match[1] || "");
-    const rhs = String(match[2] || "").trim();
+    const symbol = String((_a = match[1]) !== null && _a !== void 0 ? _a : "");
+    const rhs = String((_b = match[2]) !== null && _b !== void 0 ? _b : "").trim();
     if (!symbol || !rhs)
         return null;
     const wrapped = rhs.match(/^[!+](.+)[!+]$/);
@@ -34787,8 +34660,8 @@ function parseUserDefinedDecoration(rawValue) {
     return { symbol, decoration };
 }
 function expandUserDefinedDecorationSymbols(text, userDefinedDecorationBySymbol) {
-    const raw = String(text || "");
-    const symbolMap = userDefinedDecorationBySymbol || {};
+    const raw = String(text !== null && text !== void 0 ? text : "");
+    const symbolMap = userDefinedDecorationBySymbol !== null && userDefinedDecorationBySymbol !== void 0 ? userDefinedDecorationBySymbol : {};
     if (!raw || Object.keys(symbolMap).length === 0) {
         return raw;
     }
@@ -34818,7 +34691,7 @@ function expandUserDefinedDecorationSymbols(text, userDefinedDecorationBySymbol)
     return out;
 }
 function parseTempoFromQ(rawQ, warnings) {
-    const raw = String(rawQ || "").trim();
+    const raw = String(rawQ !== null && rawQ !== void 0 ? rawQ : "").trim();
     if (!raw) {
         return null;
     }
@@ -34851,8 +34724,9 @@ function parseTempoFromQ(rawQ, warnings) {
     return null;
 }
 function parseForMusicXml(source, settings) {
+    var _a, _b, _c;
     const warnings = [];
-    const lines = String(source || "").split("\n");
+    const lines = String(source !== null && source !== void 0 ? source : "").split("\n");
     const trillWidthHintByKey = new Map();
     const keyHintFifthsByKey = new Map();
     const measureMetaByKey = new Map();
@@ -34907,7 +34781,7 @@ function parseForMusicXml(source, settings) {
     const meter = parseMeter(headers.M || "4/4", warnings);
     const unitLength = parseFraction(headers.L || "1/8", "L", warnings);
     const keyInfo = parseKey(headers.K || "C", warnings);
-    const tempoBpm = parseTempoFromQ(headers.Q || "", warnings);
+    const tempoBpm = parseTempoFromQ((_a = headers.Q) !== null && _a !== void 0 ? _a : "", warnings);
     const keySignatureAccidentals = keySignatureAlterByStep(keyInfo.fifths);
     const voiceStores = createAbcVoiceStores();
     let noteCount = 0;
@@ -34917,7 +34791,7 @@ function parseForMusicXml(source, settings) {
         let measureAccidentals = {};
         let activeUnitLength = unitLength;
         let activeMeter = meter;
-        let activeTempoBpm = Number.isFinite(tempoBpm) ? Number(tempoBpm) : null;
+        let activeTempoBpm = tempoBpm !== null && tempoBpm !== void 0 ? tempoBpm : null;
         let activeKeyFifths = Number.isFinite(voiceStores.currentKeyFifthsByVoice[entry.voiceId])
             ? Number(voiceStores.currentKeyFifthsByVoice[entry.voiceId])
             : keyInfo.fifths;
@@ -34992,9 +34866,9 @@ function parseForMusicXml(source, settings) {
         let beamRunActive = false;
         let sawInterEventWhitespace = false;
         let beamCursorDiv = 0;
-        let activeEndingMarker = String(voiceStores.activeEndingByVoice[entry.voiceId] || "");
+        let activeEndingMarker = String((_b = voiceStores.activeEndingByVoice[entry.voiceId]) !== null && _b !== void 0 ? _b : "");
         let idx = 0;
-        const text = entry.text;
+        const text = (_c = entry.text) !== null && _c !== void 0 ? _c : "";
         const warnBody = (message) => {
             warnings.push("line " + entry.lineNo + ": " + message);
         };
@@ -35510,21 +35384,23 @@ function parseForMusicXml(source, settings) {
             }
         };
         const finalizePlayableEventStart = (note, dur, activeTuplet, options = {}) => {
+            var _a;
             const applyTieStop = options.applyTieStop !== false;
             applyBeamModeForEvent(note, dur);
             currentEventNo += 1;
-            const trillHint = trillWidthHintByKey.get(`${entry.voiceId}#${currentMeasureNo}#${currentEventNo}`) || "";
+            const trillHint = (_a = trillWidthHintByKey.get(`${entry.voiceId}#${currentMeasureNo}#${currentEventNo}`)) !== null && _a !== void 0 ? _a : "";
             applyPendingToPlayableNote(note, { applySlurStart: true, applyTieStop, trillHint });
             applyTupletToEventStart(note, activeTuplet);
             note.voice = entry.voiceId;
         };
         const buildPlayableNoteForBody = (pitchSource, absoluteLength, dur, octaveWarningMessage) => {
+            var _a;
             let note;
             try {
                 note = buildNoteData(pitchSource.pitchChar, pitchSource.accidentalText, pitchSource.octaveShift, absoluteLength, dur, entry.lineNo, activeKeySignatureAccidentals, measureAccidentals);
             }
             catch (error) {
-                if (error instanceof Error && /Octave out of range/i.test(error.message || "")) {
+                if (error instanceof Error && /Octave out of range/i.test((_a = error.message) !== null && _a !== void 0 ? _a : "")) {
                     warnBody(octaveWarningMessage);
                     return null;
                 }
@@ -35541,6 +35417,7 @@ function parseForMusicXml(source, settings) {
             lastEventNotes = [];
         };
         const commitPlayableEvent = (notes, options = {}) => {
+            var _a;
             const applyChordTieStop = options.applyChordTieStop === true;
             if (applyChordTieStop && pendingTieToNext && notes.length > 0) {
                 for (const note of notes) {
@@ -35557,22 +35434,31 @@ function parseForMusicXml(source, settings) {
                 clearLastEventState();
                 return false;
             }
-            lastNote = notes[0] || null;
+            lastNote = (_a = notes[0]) !== null && _a !== void 0 ? _a : null;
             lastEventNotes = notes;
             noteCount += notes.length;
             return true;
         };
         const buildPlayableEventFromPitches = (pitchSources, timing, options = {}) => {
-            const octaveWarningMessage = options.octaveWarningMessage || "Skipped note with unsupported octave range.";
-            const firstNoteOptions = options.firstNoteOptions || {};
-            return buildAbcPlayableEventNotes({
-                pitchSources,
-                timing,
-                octaveWarningMessage,
-                firstNoteOptions,
-                buildPlayableNoteForBody,
-                finalizePlayableEventStart,
-            });
+            var _a, _b;
+            const octaveWarningMessage = (_a = options.octaveWarningMessage) !== null && _a !== void 0 ? _a : "Skipped note with unsupported octave range.";
+            const firstNoteOptions = (_b = options.firstNoteOptions) !== null && _b !== void 0 ? _b : {};
+            const notes = [];
+            for (let pitchIndex = 0; pitchIndex < pitchSources.length; pitchIndex += 1) {
+                const note = buildPlayableNoteForBody(pitchSources[pitchIndex], timing.absoluteLength, timing.dur, octaveWarningMessage);
+                if (!note) {
+                    notes.length = 0;
+                    break;
+                }
+                if (pitchIndex === 0) {
+                    finalizePlayableEventStart(note, timing.dur, timing.activeTuplet, firstNoteOptions);
+                }
+                else {
+                    note.chord = true;
+                }
+                notes.push(note);
+            }
+            return notes;
         };
         const playableEventOptionsForSource = (source) => ({
             invalidLengthMessage: source === "chord" ? "Skipped chord with invalid length." : "Skipped note with invalid length.",
@@ -35931,10 +35817,13 @@ function parseForMusicXml(source, settings) {
             }
             return false;
         };
-        const isBeamableAbcNote = (note) => Boolean(note &&
-            !note.isRest &&
-            !note.grace &&
-            ["eighth", "16th", "32nd", "64th"].includes(String(note.type || "").trim().toLowerCase()));
+        const isBeamableAbcNote = (note) => {
+            var _a;
+            return !!(note &&
+                !note.isRest &&
+                !note.grace &&
+                ["eighth", "16th", "32nd", "64th"].includes(String((_a = note.type) !== null && _a !== void 0 ? _a : "").trim().toLowerCase()));
+        };
         const applyBeamModeForEvent = (note, durationDiv) => {
             const resolvedDurationDiv = Math.max(0, Math.round(Number(durationDiv) || 0));
             const beatDiv = Math.max(1, Math.round((960 * 4) / Math.max(1, Math.round(Number(activeMeter === null || activeMeter === void 0 ? void 0 : activeMeter.beatType) || 4))));
@@ -36027,30 +35916,32 @@ function parseForMusicXml(source, settings) {
     };
 }
 function parseVoiceDirectiveTail(raw) {
+    var _a, _b;
     if (!raw) {
         return { name: "", clef: "", transpose: null, bodyText: "", skippedText: "", unsupportedKeys: [] };
     }
-    let bodyText = String(raw);
+    let bodyText = String(raw !== null && raw !== void 0 ? raw : "");
     let name = "";
     let clef = "";
     let transpose = null;
     const unsupportedKeys = [];
     const bareClefMatch = bodyText.match(/^\s*(bass|treble|alto|tenor|c3|c4)(?=\s|$)/i);
     if (bareClefMatch) {
-        clef = String(bareClefMatch[1] || "").trim().toLowerCase();
+        clef = String((_a = bareClefMatch[1]) !== null && _a !== void 0 ? _a : "").trim().toLowerCase();
         bodyText = bodyText.slice(bareClefMatch[0].length);
     }
     const attrRegex = /([A-Za-z][A-Za-z0-9_-]*)\s*=\s*("([^"]*)"|(\S+))/g;
     bodyText = bodyText.replace(attrRegex, (_full, key, _quotedValue, quotedInner, bareValue) => {
+        var _a, _b, _c;
         const lowerKey = String(key).toLowerCase();
         if (lowerKey === "name") {
-            name = quotedInner || bareValue || "";
+            name = (_a = quotedInner !== null && quotedInner !== void 0 ? quotedInner : bareValue) !== null && _a !== void 0 ? _a : "";
         }
         else if (lowerKey === "clef") {
-            clef = String(quotedInner || bareValue || "").trim().toLowerCase();
+            clef = String((_b = quotedInner !== null && quotedInner !== void 0 ? quotedInner : bareValue) !== null && _b !== void 0 ? _b : "").trim().toLowerCase();
         }
         else if (lowerKey === "transpose") {
-            const parsed = Number.parseInt(String(quotedInner || bareValue || "").trim(), 10);
+            const parsed = Number.parseInt(String((_c = quotedInner !== null && quotedInner !== void 0 ? quotedInner : bareValue) !== null && _c !== void 0 ? _c : "").trim(), 10);
             if (Number.isFinite(parsed) && parsed >= -24 && parsed <= 24) {
                 transpose = { chromatic: parsed };
             }
@@ -36063,7 +35954,7 @@ function parseVoiceDirectiveTail(raw) {
     bodyText = bodyText.trim();
     let skippedText = "";
     const firstTokenMatch = bodyText.match(/^(\S+)/);
-    const firstToken = firstTokenMatch ? firstTokenMatch[1] : "";
+    const firstToken = firstTokenMatch ? (_b = firstTokenMatch[1]) !== null && _b !== void 0 ? _b : "" : "";
     if (firstToken && /^[A-Za-z][A-Za-z0-9_-]*$/.test(firstToken) && /[^A-Ga-gzZxX]/.test(firstToken)) {
         skippedText = firstToken;
         bodyText = bodyText.slice(firstToken.length).trim();
@@ -36078,6 +35969,7 @@ function parseVoiceDirectiveTail(raw) {
     };
 }
 function inferTransposeFromPartName(partName) {
+    var _a;
     if (!partName) {
         return null;
     }
@@ -36086,7 +35978,7 @@ function inferTransposeFromPartName(partName) {
     if (!m) {
         return null;
     }
-    const tonic = String(m[1]).toUpperCase() + (m[2] || "");
+    const tonic = String(m[1]).toUpperCase() + ((_a = m[2]) !== null && _a !== void 0 ? _a : "");
     const semitoneByTonic = {
         C: 0,
         "C#": 1,
@@ -36119,7 +36011,7 @@ function inferTransposeFromPartName(partName) {
     return { chromatic };
 }
 function parseMeter(raw, warnings) {
-    const normalized = String(raw || "").trim();
+    const normalized = String(raw !== null && raw !== void 0 ? raw : "").trim();
     if (normalized === "C") {
         return { beats: 4, beatType: 4 };
     }
@@ -36135,11 +36027,11 @@ function parseMeter(raw, warnings) {
 }
 function parseFraction(raw, fieldName, warnings) {
     const parsed = abcCommon.parseFractionText(raw, { num: 1, den: 8 });
-    if (parsed.num === 1 && parsed.den === 8 && !/^\s*\d+\/\d+\s*$/.test(String(raw || ""))) {
+    if (parsed.num === 1 && parsed.den === 8 && !/^\s*\d+\/\d+\s*$/.test(String(raw !== null && raw !== void 0 ? raw : ""))) {
         warnings.push(fieldName + " has invalid format; defaulted to 1/8: " + raw);
         return parsed;
     }
-    const m = String(raw || "").match(/^\s*(\d+)\/(\d+)\s*$/);
+    const m = String(raw !== null && raw !== void 0 ? raw : "").match(/^\s*(\d+)\/(\d+)\s*$/);
     if (!m || !Number(m[1]) || !Number(m[2])) {
         warnings.push(fieldName + " has invalid value; defaulted to 1/8: " + raw);
         return { num: 1, den: 8 };
@@ -36159,6 +36051,7 @@ function parseLengthToken(token, lineNo) {
     return abcCommon.parseAbcLengthToken(token, lineNo);
 }
 function parseGraceGroupAt(text, startIdx, lineNo, unitLength, keySignatureAccidentals, measureAccidentals, voiceId, warnings) {
+    var _a;
     const parsedGrace = (0, abc_parser_1.parseAbcGraceGroupAt)(text, startIdx, lineNo, warnings);
     if (!parsedGrace)
         return null;
@@ -36178,7 +36071,7 @@ function parseGraceGroupAt(text, startIdx, lineNo, unitLength, keySignatureAccid
             note = buildNoteData(pitchChar, accidentalText, octaveShift, absoluteLength, dur, lineNo, keySignatureAccidentals, graceAccidentals);
         }
         catch (error) {
-            if (error instanceof Error && /Octave out of range/i.test(error.message || "")) {
+            if (error instanceof Error && /Octave out of range/i.test((_a = error.message) !== null && _a !== void 0 ? _a : "")) {
                 warnings.push("line " + lineNo + ": Skipped grace note with unsupported octave range.");
                 continue;
             }
@@ -36461,18 +36354,6 @@ const parseOptionalMusicXmlNumber = (text) => {
     const parsed = Number(raw);
     return Number.isFinite(parsed) ? parsed : null;
 };
-const buildAbcExportPartNameById = (doc) => {
-    var _a, _b, _c;
-    const partNameById = new Map();
-    for (const scorePart of Array.from(doc.querySelectorAll("part-list > score-part"))) {
-        const id = (_a = scorePart.getAttribute("id")) !== null && _a !== void 0 ? _a : "";
-        if (!id)
-            continue;
-        const name = ((_c = (_b = scorePart.querySelector("part-name")) === null || _b === void 0 ? void 0 : _b.textContent) === null || _c === void 0 ? void 0 : _c.trim()) || id;
-        partNameById.set(id, name);
-    }
-    return partNameById;
-};
 const compareAbcExportLanes = (a, b) => {
     var _a, _b;
     const staffA = a.staff === null ? Number.POSITIVE_INFINITY : Number(a.staff);
@@ -36513,140 +36394,108 @@ const buildAbcExportLaneDefinitions = (part, partId) => {
         return { ...lane, voiceId: `${partId}${staffSuffix}${voiceSuffix || `_l${laneIndex + 1}`}` };
     });
 };
-const buildAbcExportLaneName = (partName, laneCount, lane) => {
-    if (laneCount <= 1)
-        return partName;
-    if (lane.staff && lane.voice)
-        return `${partName} (Staff ${lane.staff} Voice ${lane.voice})`;
-    if (lane.staff)
-        return `${partName} (Staff ${lane.staff})`;
-    if (lane.voice)
-        return `${partName} (Voice ${lane.voice})`;
-    return `${partName} (Lane)`;
-};
-const buildAbcExportTransposeMetaLine = (normalizedVoiceId, measure) => {
-    var _a, _b, _c, _d;
-    const transposeNode = measure.querySelector(":scope > attributes > transpose");
-    if (!transposeNode)
-        return null;
-    const chromatic = Number(((_b = (_a = transposeNode.querySelector(":scope > chromatic")) === null || _a === void 0 ? void 0 : _a.textContent) === null || _b === void 0 ? void 0 : _b.trim()) || "");
-    const diatonic = Number(((_d = (_c = transposeNode.querySelector(":scope > diatonic")) === null || _c === void 0 ? void 0 : _c.textContent) === null || _d === void 0 ? void 0 : _d.trim()) || "");
-    if (!Number.isFinite(chromatic) && !Number.isFinite(diatonic))
-        return null;
-    const parts = [`%@mks transpose voice=${normalizedVoiceId}`];
-    if (Number.isFinite(chromatic))
-        parts.push(`chromatic=${Math.round(chromatic)}`);
-    if (Number.isFinite(diatonic))
-        parts.push(`diatonic=${Math.round(diatonic)}`);
-    return parts.join(" ");
-};
-const buildAbcExportDiagMetaLines = (normalizedVoiceId, measure, safeMeasureNumber) => {
-    const fields = Array.from(measure.querySelectorAll(':scope > attributes > miscellaneous > miscellaneous-field[name^="mks:diag:"]'));
-    if (!fields.length)
-        return [];
-    const byName = new Map();
-    for (const field of fields) {
-        const name = (field.getAttribute("name") || "").trim();
-        if (!name)
-            continue;
-        const value = (field.textContent || "").trim();
-        byName.set(name, value);
-    }
-    const orderedNames = Array.from(byName.keys()).sort((a, b) => {
-        const isCountA = a === "mks:diag:count";
-        const isCountB = b === "mks:diag:count";
-        if (isCountA && !isCountB)
-            return -1;
-        if (!isCountA && isCountB)
-            return 1;
-        return a.localeCompare(b);
-    });
-    return orderedNames.map((name) => {
-        const value = byName.get(name) || "";
-        return `%@mks diag voice=${normalizedVoiceId} measure=${safeMeasureNumber} name=${name} enc=uri-v1 value=${encodeURIComponent(value)}`;
-    });
-};
-const buildAbcExportMeasureMetaLine = (normalizedVoiceId, measure, safeMeasureNumber, hasRightRepeat, rightEndingNumber, rightEndingType) => {
-    const rawMeasureNumber = (measure.getAttribute("number") || "").trim() || String(safeMeasureNumber);
-    const implicitAttr = (measure.getAttribute("implicit") || "").trim().toLowerCase();
-    const isImplicit = implicitAttr === "yes" || implicitAttr === "true" || implicitAttr === "1";
-    const rightRepeatNode = measure.querySelector(':scope > barline[location="right"] > repeat');
-    const repeatTimes = Number.parseInt(String((rightRepeatNode === null || rightRepeatNode === void 0 ? void 0 : rightRepeatNode.getAttribute("times")) || ""), 10);
-    if (!isImplicit &&
-        rawMeasureNumber === String(safeMeasureNumber) &&
-        (!hasRightRepeat || !Number.isFinite(repeatTimes) || repeatTimes <= 2) &&
-        (!rightEndingNumber || rightEndingType !== "discontinue")) {
-        return null;
-    }
-    const metaChunks = [
-        `%@mks measure voice=${normalizedVoiceId} measure=${safeMeasureNumber}`,
-        `number=${rawMeasureNumber}`,
-        `implicit=${isImplicit ? 1 : 0}`,
-    ];
-    if (hasRightRepeat && Number.isFinite(repeatTimes) && repeatTimes > 2) {
-        metaChunks.push(`times=${Math.round(repeatTimes)}`);
-    }
-    if (rightEndingNumber && rightEndingType === "discontinue") {
-        metaChunks.push(`ending-stop=${rightEndingNumber}`);
-        metaChunks.push(`ending-type=${rightEndingType}`);
-    }
-    return metaChunks.join(" ");
-};
 const applyAbcExportDirectionToPending = (direction, pendingDirectionWords, pendingDirectionDecorations, activeWedgeType) => {
-    const rehearsalTexts = Array.from(direction.querySelectorAll(":scope > direction-type > rehearsal"))
-        .map((node) => abcQuotedTextEscape(node.textContent || ""))
-        .filter(Boolean);
-    for (const rehearsalText of rehearsalTexts) {
-        pendingDirectionDecorations.push(`!rehearsal:${rehearsalText}!`);
-    }
-    const words = (0, direction_text_1.extractMusicXmlDirectionWords)(direction)
+    appendAbcExportDirectionWords(direction, pendingDirectionWords);
+    appendAbcExportDirectionTextDecorations(direction, pendingDirectionDecorations);
+    appendAbcExportDirectionSoundDecorations(direction, pendingDirectionDecorations);
+    return appendAbcExportDirectionFeatureDecorations(direction, pendingDirectionDecorations, activeWedgeType);
+};
+const appendAbcExportDirectionWords = (direction, pendingDirectionWords) => {
+    pendingDirectionWords.push(...(0, direction_text_1.extractMusicXmlDirectionWords)(direction)
         .map((feature) => abcQuotedTextEscape(feature.text))
-        .filter(Boolean);
-    pendingDirectionWords.push(...words);
-    if (direction.querySelector(":scope > direction-type > segno")) {
-        pendingDirectionDecorations.push("!segno!");
+        .filter((word) => word.length > 0));
+};
+const appendAbcExportDirectionTextDecorations = (direction, pendingDirectionDecorations) => {
+    for (const rehearsalText of Array.from(direction.querySelectorAll(":scope > direction-type > rehearsal"))
+        .map((node) => { var _a; return abcQuotedTextEscape((_a = node.textContent) !== null && _a !== void 0 ? _a : ""); })
+        .filter((text) => text.length > 0)) {
+        appendAbcExportDirectionPresenceDecoration(pendingDirectionDecorations, true, `!rehearsal:${rehearsalText}!`);
     }
-    if (direction.querySelector(":scope > direction-type > coda")) {
-        pendingDirectionDecorations.push("!coda!");
-    }
-    if (direction.querySelector(':scope > sound[fine="yes"]')) {
-        pendingDirectionDecorations.push("!fine!");
-    }
-    const hasDaCapo = Boolean(direction.querySelector(':scope > sound[dacapo="yes"]'));
-    const hasToCoda = Boolean(direction.querySelector(":scope > sound[tocoda]"));
-    if (hasDaCapo && hasToCoda) {
-        pendingDirectionDecorations.push("!dacoda!");
-    }
-    else if (hasDaCapo) {
-        pendingDirectionDecorations.push("!dacapo!");
-    }
-    if (direction.querySelector(":scope > sound[dalsegno]")) {
-        pendingDirectionDecorations.push("!dalsegno!");
-    }
-    if (hasToCoda && !hasDaCapo) {
-        pendingDirectionDecorations.push("!tocoda!");
-    }
+};
+const appendAbcExportDirectionSoundDecorations = (direction, pendingDirectionDecorations) => {
+    appendAbcExportDirectionMarkerDecorations(direction, pendingDirectionDecorations);
+    appendAbcExportDirectionJumpDecorations(direction, pendingDirectionDecorations);
+};
+const appendAbcExportDirectionMarkerDecorations = (direction, pendingDirectionDecorations) => {
+    appendAbcExportDirectionPresenceDecorations(pendingDirectionDecorations, [
+        [direction.querySelector(":scope > direction-type > segno") !== null, "!segno!"],
+        [direction.querySelector(":scope > direction-type > coda") !== null, "!coda!"],
+        [direction.querySelector(':scope > sound[fine="yes"]') !== null, "!fine!"],
+    ]);
+};
+const appendAbcExportDirectionJumpDecorations = (direction, pendingDirectionDecorations) => {
+    appendAbcExportDirectionDaCapoDecorations(direction, pendingDirectionDecorations);
+    appendAbcExportDirectionDalSegnoDecorations(direction, pendingDirectionDecorations);
+    appendAbcExportDirectionToCodaDecorations(direction, pendingDirectionDecorations);
+};
+const appendAbcExportDirectionDaCapoDecorations = (direction, pendingDirectionDecorations) => {
+    const hasDaCapo = direction.querySelector(':scope > sound[dacapo="yes"]') !== null;
+    const hasToCoda = direction.querySelector(":scope > sound[tocoda]") !== null;
+    appendAbcExportDirectionPresenceDecoration(pendingDirectionDecorations, hasDaCapo && hasToCoda, "!dacoda!");
+    appendAbcExportDirectionPresenceDecoration(pendingDirectionDecorations, hasDaCapo && !hasToCoda, "!dacapo!");
+};
+const appendAbcExportDirectionDalSegnoDecorations = (direction, pendingDirectionDecorations) => {
+    appendAbcExportDirectionPresenceDecoration(pendingDirectionDecorations, direction.querySelector(":scope > sound[dalsegno]") !== null, "!dalsegno!");
+};
+const appendAbcExportDirectionToCodaDecorations = (direction, pendingDirectionDecorations) => {
+    appendAbcExportDirectionPresenceDecoration(pendingDirectionDecorations, direction.querySelector(":scope > sound[tocoda]") !== null && direction.querySelector(':scope > sound[dacapo="yes"]') === null, "!tocoda!");
+};
+const appendAbcExportDirectionFeatureDecorations = (direction, pendingDirectionDecorations, activeWedgeType) => {
     const directionFeatures = (0, dynamics_1.extractMusicXmlDirectionFeatures)(direction);
+    appendAbcExportDirectionDynamicDecorations(directionFeatures, pendingDirectionDecorations);
+    return appendAbcExportDirectionWedgeDecorations(directionFeatures, pendingDirectionDecorations, activeWedgeType);
+};
+const appendAbcExportDirectionWedgeDecorations = (directionFeatures, pendingDirectionDecorations, activeWedgeType) => appendAbcExportDirectionWedgeStopDecorations(directionFeatures, pendingDirectionDecorations, appendAbcExportDirectionWedgeStartDecorations(directionFeatures, pendingDirectionDecorations, activeWedgeType));
+const appendAbcExportDirectionWedgeStartDecorations = (directionFeatures, pendingDirectionDecorations, activeWedgeType) => {
+    const crescendoWedgeType = appendAbcExportDirectionWedgeMatch(directionFeatures, pendingDirectionDecorations, activeWedgeType, (feature) => feature.kind === "wedge" && feature.wedgeType === "crescendo", "!crescendo(!", "crescendo");
+    return appendAbcExportDirectionWedgeMatch(directionFeatures, pendingDirectionDecorations, crescendoWedgeType, (feature) => feature.kind === "wedge" && feature.wedgeType === "diminuendo", "!diminuendo(!", "diminuendo");
+};
+const appendAbcExportDirectionWedgeStopDecorations = (directionFeatures, pendingDirectionDecorations, activeWedgeType) => {
     let nextWedgeType = activeWedgeType;
     for (const feature of directionFeatures) {
-        if (feature.kind === "wedge" && feature.wedgeType === "crescendo") {
-            pendingDirectionDecorations.push("!crescendo(!");
-            nextWedgeType = "crescendo";
-        }
-        else if (feature.kind === "wedge" && feature.wedgeType === "diminuendo") {
-            pendingDirectionDecorations.push("!diminuendo(!");
-            nextWedgeType = "diminuendo";
-        }
-        else if (feature.kind === "wedge" && feature.wedgeType === "stop") {
+        if (feature.kind === "wedge" && feature.wedgeType === "stop") {
             pendingDirectionDecorations.push(nextWedgeType === "diminuendo" ? "!diminuendo)!" : "!crescendo)!");
             nextWedgeType = "";
         }
     }
-    for (const feature of directionFeatures) {
-        if (feature.kind === "dynamic")
-            pendingDirectionDecorations.push(`!${feature.mark}!`);
-    }
     return nextWedgeType;
+};
+const appendAbcExportDirectionWedgeMatch = (directionFeatures, pendingDirectionDecorations, activeWedgeType, predicate, decoration, nextWedgeType) => {
+    let result = activeWedgeType;
+    for (const feature of directionFeatures) {
+        if (predicate(feature)) {
+            pendingDirectionDecorations.push(decoration);
+            result = nextWedgeType;
+        }
+    }
+    return result;
+};
+const appendAbcExportDirectionDynamicDecorations = (directionFeatures, pendingDirectionDecorations) => {
+    appendAbcExportDirectionSfzDecorations(directionFeatures, pendingDirectionDecorations);
+    appendAbcExportDirectionStandardDynamicDecorations(directionFeatures, pendingDirectionDecorations);
+};
+const appendAbcExportDirectionSfzDecorations = (directionFeatures, pendingDirectionDecorations) => {
+    appendAbcExportDirectionFeatureMatches(directionFeatures, pendingDirectionDecorations, (feature) => feature.kind === "dynamic" && feature.mark === "sfz", () => "!sfz!");
+};
+const appendAbcExportDirectionStandardDynamicDecorations = (directionFeatures, pendingDirectionDecorations) => {
+    appendAbcExportDirectionFeatureMatches(directionFeatures, pendingDirectionDecorations, (feature) => feature.kind === "dynamic" && feature.mark !== "sfz", (feature) => `!${feature.mark}!`);
+};
+const appendAbcExportDirectionPresenceDecoration = (pendingDirectionDecorations, hasDecoration, decoration) => {
+    if (hasDecoration) {
+        pendingDirectionDecorations.push(decoration);
+    }
+};
+const appendAbcExportDirectionPresenceDecorations = (pendingDirectionDecorations, entries) => {
+    for (const [hasDecoration, decoration] of entries) {
+        appendAbcExportDirectionPresenceDecoration(pendingDirectionDecorations, hasDecoration, decoration);
+    }
+};
+const appendAbcExportDirectionFeatureMatches = (directionFeatures, pendingDirectionDecorations, predicate, decorationFromFeature) => {
+    for (const feature of directionFeatures) {
+        if (predicate(feature)) {
+            pendingDirectionDecorations.push(decorationFromFeature(feature));
+        }
+    }
 };
 const isMusicXmlNoteInAbcExportLane = (note, lane) => {
     var _a, _b, _c, _d, _e, _f;
@@ -36664,7 +36513,7 @@ const isMusicXmlNoteInAbcExportLane = (note, lane) => {
     return true;
 };
 const buildAbcExportPitchToken = (note, keyAlterMap, measureAccidentalByStepOctave) => {
-    var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l;
+    var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o;
     if (note.querySelector(":scope > rest"))
         return "z";
     const step = ((_b = (_a = note.querySelector(":scope > pitch > step")) === null || _a === void 0 ? void 0 : _a.textContent) === null || _b === void 0 ? void 0 : _b.trim()) || "C";
@@ -36677,11 +36526,11 @@ const buildAbcExportPitchToken = (note, keyAlterMap, measureAccidentalByStepOcta
     const accidentalNode = note.querySelector(":scope > accidental");
     const accidentalText = (_j = (_h = accidentalNode === null || accidentalNode === void 0 ? void 0 : accidentalNode.textContent) === null || _h === void 0 ? void 0 : _h.trim()) !== null && _j !== void 0 ? _j : "";
     const accidentalAlter = musicXmlAccidentalTextToAlter(accidentalText);
-    const accidentalEditorial = (((accidentalNode === null || accidentalNode === void 0 ? void 0 : accidentalNode.getAttribute("editorial")) || "").trim().toLowerCase() === "yes");
-    const accidentalCautionary = (((accidentalNode === null || accidentalNode === void 0 ? void 0 : accidentalNode.getAttribute("cautionary")) || "").trim().toLowerCase() === "yes");
-    const keyAlter = (_k = keyAlterMap[upperStep]) !== null && _k !== void 0 ? _k : 0;
+    const accidentalEditorial = (((_k = accidentalNode === null || accidentalNode === void 0 ? void 0 : accidentalNode.getAttribute("editorial")) !== null && _k !== void 0 ? _k : "").trim().toLowerCase() === "yes");
+    const accidentalCautionary = (((_l = accidentalNode === null || accidentalNode === void 0 ? void 0 : accidentalNode.getAttribute("cautionary")) !== null && _l !== void 0 ? _l : "").trim().toLowerCase() === "yes");
+    const keyAlter = (_m = keyAlterMap[upperStep]) !== null && _m !== void 0 ? _m : 0;
     const currentAlter = measureAccidentalByStepOctave.has(stepOctaveKey)
-        ? (_l = measureAccidentalByStepOctave.get(stepOctaveKey)) !== null && _l !== void 0 ? _l : 0
+        ? (_o = measureAccidentalByStepOctave.get(stepOctaveKey)) !== null && _o !== void 0 ? _o : 0
         : keyAlter;
     // In MusicXML pitch, omitted <alter> means natural (0), not "follow key accidental".
     // Key signature context is only used to decide whether an explicit accidental token is needed.
@@ -36718,14 +36567,6 @@ const appendAbcExportGraceToken = (pendingGraceTokens, pitchToken, len, hasTieSt
         : `[${last}${graceSlashPrefix}${pitchToken}]`;
     pendingGraceTokens.push(merged);
 };
-const readAbcExportTimeModification = (note) => {
-    var _a, _b, _c, _d;
-    const actual = Number(((_b = (_a = note.querySelector(":scope > time-modification > actual-notes")) === null || _a === void 0 ? void 0 : _a.textContent) === null || _b === void 0 ? void 0 : _b.trim()) || "");
-    const normal = Number(((_d = (_c = note.querySelector(":scope > time-modification > normal-notes")) === null || _c === void 0 ? void 0 : _c.textContent) === null || _d === void 0 ? void 0 : _d.trim()) || "");
-    if (!Number.isFinite(actual) || actual <= 0 || !Number.isFinite(normal) || normal <= 0)
-        return null;
-    return { actual: Math.round(actual), normal: Math.round(normal) };
-};
 const buildAbcExportLengthToken = (noteDuration, currentDivisions, unitLength, timeModification) => {
     const rawWholeFraction = exports.AbcCommon.reduceFraction(noteDuration, currentDivisions * 4, { num: 1, den: 4 });
     const abcBaseWholeFraction = timeModification
@@ -36749,11 +36590,6 @@ const updateAbcExportActiveTupletBeforeEvent = (activeTuplet, hasTupletStart, ti
     }
     return activeTuplet;
 };
-const buildAbcExportTupletPrefix = (activeTuplet, isChord) => {
-    if (isChord || !activeTuplet || activeTuplet.remaining !== activeTuplet.actual)
-        return "";
-    return `(${activeTuplet.actual}:${activeTuplet.normal}:${activeTuplet.actual}`;
-};
 const advanceAbcExportActiveTupletAfterEvent = (activeTuplet, isChord) => {
     if (isChord || !activeTuplet)
         return activeTuplet;
@@ -36761,165 +36597,26 @@ const advanceAbcExportActiveTupletAfterEvent = (activeTuplet, isChord) => {
     return activeTuplet.remaining <= 0 ? null : activeTuplet;
 };
 const takeAbcExportQueuedEventPrefix = (isChord, pendingHarmonySymbols, pendingDirectionWords, pendingDirectionDecorations, pendingGraceTokens) => {
-    const harmonyPrefix = !isChord && pendingHarmonySymbols.length > 0
-        ? `${pendingHarmonySymbols.map((symbol) => `"${abcQuotedTextEscape(symbol)}"`).join("")}`
-        : "";
-    const wordsPrefix = !isChord && pendingDirectionWords.length > 0
-        ? `${pendingDirectionWords.map((word) => `"${word}"`).join("")}`
-        : "";
-    const directionDecorationPrefix = !isChord && pendingDirectionDecorations.length > 0 ? pendingDirectionDecorations.join("") : "";
+    const harmonyPrefix = !isChord && pendingHarmonySymbols.length > 0 ? pendingHarmonySymbols.map((item) => `"${abcQuotedTextEscape(item)}"`).join("") : "";
+    const wordsPrefix = !isChord && pendingDirectionWords.length > 0 ? pendingDirectionWords.map((item) => `"${item}"`).join("") : "";
+    const decorationPrefix = !isChord && pendingDirectionDecorations.length > 0 ? pendingDirectionDecorations.join("") : "";
     const gracePrefix = pendingGraceTokens.length > 0 ? `{${pendingGraceTokens.join("")}}` : "";
-    if (!isChord && pendingHarmonySymbols.length > 0) {
+    if (!isChord) {
         pendingHarmonySymbols.length = 0;
-    }
-    if (!isChord && pendingDirectionWords.length > 0) {
         pendingDirectionWords.length = 0;
-    }
-    if (!isChord && pendingDirectionDecorations.length > 0) {
         pendingDirectionDecorations.length = 0;
-    }
-    if (pendingGraceTokens.length > 0) {
         pendingGraceTokens.length = 0;
     }
-    return `${harmonyPrefix}${wordsPrefix}${directionDecorationPrefix}${gracePrefix}`;
-};
-const buildAbcExportTrillMetaLine = (normalizedVoiceId, measure, fallbackMeasureNumber, eventNo, trillAccidentalText) => {
-    const measureNumber = measure.getAttribute("number") || fallbackMeasureNumber;
-    return `%@mks trill voice=${normalizedVoiceId} measure=${measureNumber} event=${eventNo} upper=${trillAccidentalText}`;
-};
-const buildAbcExportOrnamentPrefixInfo = (note) => {
-    var _a, _b;
-    const ornamentFeatures = (0, ornaments_1.extractMusicXmlOrnamentFeatures)(note);
-    const ornamentKinds = new Set(ornamentFeatures.map((feature) => feature.kind));
-    const hasTrillMark = ornamentKinds.has("trill-mark");
-    const hasTurn = ornamentKinds.has("turn");
-    const hasInvertedTurn = ornamentKinds.has("inverted-turn");
-    const hasTurnSlash = ornamentFeatures.some((feature) => (feature.kind === "turn" || feature.kind === "inverted-turn") && feature.slash);
-    const hasDelayedTurn = ornamentKinds.has("delayed-turn");
-    const hasMordent = ornamentKinds.has("mordent");
-    const hasInvertedMordent = ornamentKinds.has("inverted-mordent");
-    const tremoloFeature = ornamentFeatures.find((feature) => feature.kind === "tremolo");
-    const hasSchleifer = ornamentKinds.has("schleifer");
-    const hasShake = ornamentKinds.has("shake");
-    const hasGlissandoStart = Boolean(note.querySelector(':scope > notations > glissando[type="start"]'));
-    const hasGlissandoStop = Boolean(note.querySelector(':scope > notations > glissando[type="stop"]'));
-    const hasSlideStart = Boolean(note.querySelector(':scope > notations > slide[type="start"]'));
-    const hasSlideStop = Boolean(note.querySelector(':scope > notations > slide[type="stop"]'));
-    const hasArpeggiate = Boolean(note.querySelector(":scope > notations > arpeggiate"));
-    const hasWavyLineStart = Array.from(note.querySelectorAll(":scope > notations > ornaments > wavy-line")).some((node) => {
-        var _a;
-        const type = ((_a = node.getAttribute("type")) !== null && _a !== void 0 ? _a : "").trim().toLowerCase();
-        return type === "" || type === "start";
-    });
-    const hasWavyLineStop = Array.from(note.querySelectorAll(":scope > notations > ornaments > wavy-line")).some((node) => {
-        var _a;
-        const type = ((_a = node.getAttribute("type")) !== null && _a !== void 0 ? _a : "").trim().toLowerCase();
-        return type === "stop";
-    });
-    const hasTrill = hasTrillMark || hasWavyLineStart;
-    const turnType = hasInvertedTurn ? "inverted-turn" : (hasTurn ? "turn" : "");
-    const mordentType = hasInvertedMordent ? "inverted-mordent" : (hasMordent ? "mordent" : "");
-    const tremoloType = (tremoloFeature === null || tremoloFeature === void 0 ? void 0 : tremoloFeature.kind) === "tremolo" && tremoloFeature.tremoloType
-        ? tremoloFeature.tremoloType
-        : "";
-    const tremoloMarks = (tremoloFeature === null || tremoloFeature === void 0 ? void 0 : tremoloFeature.kind) === "tremolo" && tremoloFeature.marks ? tremoloFeature.marks : 1;
-    const trillAccidentalText = ((_b = (_a = note.querySelector(":scope > notations > ornaments > accidental-mark")) === null || _a === void 0 ? void 0 : _a.textContent) === null || _b === void 0 ? void 0 : _b.trim()) || "";
-    const trillPrefix = hasWavyLineStop
-        ? "!trill)!"
-        : (hasWavyLineStart && !hasTrillMark ? "!trill!" : (hasWavyLineStart ? "!trill(!" : (hasTrill ? "!trill!" : "")));
-    const turnPrefix = turnType === "inverted-turn"
-        ? (hasDelayedTurn ? "!delayedinvertedturn!" : (hasTurnSlash ? "!invertedturnx!" : "!invertedturn!"))
-        : (turnType === "turn" ? (hasDelayedTurn ? "!delayedturn!" : (hasTurnSlash ? "!turnx!" : "!turn!")) : "");
-    const mordentPrefix = mordentType === "inverted-mordent" ? "!pralltriller!" : (mordentType === "mordent" ? "!mordent!" : "");
-    const tremoloPrefix = tremoloType ? `!tremolo-${tremoloType}-${tremoloMarks}!` : "";
-    const glissandoPrefix = hasGlissandoStart ? "!gliss-start!" : (hasGlissandoStop ? "!gliss-stop!" : "");
-    const slidePrefix = hasSlideStart ? "!slide!" : (hasSlideStop ? "!slide-stop!" : "");
-    const schleiferPrefix = hasSchleifer ? "!schleifer!" : "";
-    const shakePrefix = hasShake ? "!shake!" : "";
-    const arpeggiatePrefix = hasArpeggiate ? "!arpeggio!" : "";
-    return {
-        prefix: `${trillPrefix}${turnPrefix}${mordentPrefix}${tremoloPrefix}${glissandoPrefix}${slidePrefix}${schleiferPrefix}${shakePrefix}${arpeggiatePrefix}`,
-        hasTrill,
-        trillAccidentalText,
-    };
-};
-const buildAbcExportTechnicalPrefix = (note) => {
-    const hasUpBow = Boolean(note.querySelector(":scope > notations > technical > up-bow"));
-    const hasDownBow = Boolean(note.querySelector(":scope > notations > technical > down-bow"));
-    const hasDoubleTongue = Boolean(note.querySelector(":scope > notations > technical > double-tongue"));
-    const hasTripleTongue = Boolean(note.querySelector(":scope > notations > technical > triple-tongue"));
-    const hasHeel = Boolean(note.querySelector(":scope > notations > technical > heel"));
-    const hasToe = Boolean(note.querySelector(":scope > notations > technical > toe"));
-    const fingeringTexts = Array.from(note.querySelectorAll(":scope > notations > technical > fingering"))
-        .map((node) => (node.textContent || "").trim())
-        .filter(Boolean);
-    const stringTexts = Array.from(note.querySelectorAll(":scope > notations > technical > string"))
-        .map((node) => (node.textContent || "").trim())
-        .filter(Boolean);
-    const pluckTexts = Array.from(note.querySelectorAll(":scope > notations > technical > pluck"))
-        .map((node) => (node.textContent || "").trim())
-        .filter(Boolean);
-    const hasOpenString = Boolean(note.querySelector(":scope > notations > technical > open-string"));
-    const hasSnapPizzicato = Boolean(note.querySelector(":scope > notations > technical > snap-pizzicato"));
-    const hasHarmonic = Boolean(note.querySelector(":scope > notations > technical > harmonic"));
-    const hasStopped = Boolean(note.querySelector(":scope > notations > technical > stopped"));
-    const hasThumbPosition = Boolean(note.querySelector(":scope > notations > technical > thumb-position"));
-    const fingeringPrefix = fingeringTexts
-        .map((value) => (/^[0-5]$/.test(value) ? `!${value}!` : `!fingering:${value}!`))
-        .join("");
-    return [
-        hasUpBow ? "!upbow!" : "",
-        hasDownBow ? "!downbow!" : "",
-        hasDoubleTongue ? "!doubletongue!" : "",
-        hasTripleTongue ? "!tripletongue!" : "",
-        hasHeel ? "!heel!" : "",
-        hasToe ? "!toe!" : "",
-        fingeringPrefix,
-        stringTexts.map((value) => `!string:${value}!`).join(""),
-        pluckTexts.map((value) => `!pluck:${value}!`).join(""),
-        hasOpenString ? "!open!" : "",
-        hasSnapPizzicato ? "!snap!" : "",
-        hasHarmonic ? "!harmonic!" : "",
-        hasStopped ? "!stopped!" : "",
-        hasThumbPosition ? "!thumb!" : "",
-    ].join("");
-};
-const buildAbcExportFermataPrefix = (note) => {
-    var _a, _b;
-    const fermata = note.querySelector(":scope > notations > fermata");
-    if (!fermata)
-        return "";
-    const type = ((_a = fermata.getAttribute("type")) === null || _a === void 0 ? void 0 : _a.trim().toLowerCase()) || "";
-    const shape = ((_b = fermata.textContent) === null || _b === void 0 ? void 0 : _b.trim().toLowerCase()) || "";
-    return type === "inverted" || shape === "inverted" ? "!invertedfermata!" : "!fermata!";
-};
-const buildAbcExportArticulationPrefix = (note) => {
-    const articulationKinds = new Set((0, articulations_1.extractMusicXmlArticulationKinds)(note));
-    const phraseMarkText = Array.from(note.querySelectorAll(":scope > notations > articulations > other-articulation"))
-        .map((node) => (node.textContent || "").trim().toLowerCase())
-        .find((text) => text === "shortphrase" || text === "mediumphrase" || text === "longphrase") || "";
-    return [
-        articulationKinds.has("staccatissimo") ? "!wedge!" : (articulationKinds.has("staccato") ? "!staccato!" : ""),
-        articulationKinds.has("accent") ? "!accent!" : "",
-        articulationKinds.has("tenuto") ? "!tenuto!" : "",
-        note.querySelector(":scope > notations > articulations > stress") ? "!stress!" : "",
-        note.querySelector(":scope > notations > articulations > unstress") ? "!unstress!" : "",
-        articulationKinds.has("strong-accent") ? "!marcato!" : "",
-        articulationKinds.has("breath-mark") ? "!breath!" : "",
-        articulationKinds.has("caesura") ? "!caesura!" : "",
-        phraseMarkText === "shortphrase" || phraseMarkText === "mediumphrase" || phraseMarkText === "longphrase"
-            ? `!${phraseMarkText}!`
-            : "",
-    ].join("");
+    return `${harmonyPrefix}${wordsPrefix}${decorationPrefix}${gracePrefix}`;
 };
 const appendAbcExportLyricToken = (note, lyricTokens, pendingLyricExtension) => {
-    var _a, _b, _c, _d;
+    var _a, _b, _c, _d, _e, _f;
     if (note.querySelector(":scope > rest"))
         return pendingLyricExtension;
     const lyric = note.querySelector(":scope > lyric");
-    const lyricText = ((_b = (_a = lyric === null || lyric === void 0 ? void 0 : lyric.querySelector(":scope > text")) === null || _a === void 0 ? void 0 : _a.textContent) === null || _b === void 0 ? void 0 : _b.trim()) || "";
-    const lyricSyllabic = ((_d = (_c = lyric === null || lyric === void 0 ? void 0 : lyric.querySelector(":scope > syllabic")) === null || _c === void 0 ? void 0 : _c.textContent) === null || _d === void 0 ? void 0 : _d.trim()) || "single";
-    const lyricExtend = Boolean(lyric === null || lyric === void 0 ? void 0 : lyric.querySelector(":scope > extend"));
+    const lyricText = (_c = (_b = (_a = lyric === null || lyric === void 0 ? void 0 : lyric.querySelector(":scope > text")) === null || _a === void 0 ? void 0 : _a.textContent) === null || _b === void 0 ? void 0 : _b.trim()) !== null && _c !== void 0 ? _c : "";
+    const lyricSyllabic = (_f = (_e = (_d = lyric === null || lyric === void 0 ? void 0 : lyric.querySelector(":scope > syllabic")) === null || _d === void 0 ? void 0 : _d.textContent) === null || _e === void 0 ? void 0 : _e.trim()) !== null && _f !== void 0 ? _f : "single";
+    const lyricExtend = (lyric === null || lyric === void 0 ? void 0 : lyric.querySelector(":scope > extend")) !== null;
     if (lyricText) {
         lyricTokens.push(abcLyricTokenFromMusicXml(lyricText, lyricSyllabic));
         return lyricExtend;
@@ -36931,71 +36628,65 @@ const appendAbcExportLyricToken = (note, lyricTokens, pendingLyricExtension) => 
     lyricTokens.push("*");
     return false;
 };
-const buildAbcExportPendingEventToken = (pending) => {
-    const tieSuffix = pending.tie ? "-" : "";
-    const slurStopSuffix = pending.slurStop ? ")" : "";
-    if (pending.pitches.length === 1) {
-        return `${pending.prefix}${pending.pitches[0]}${pending.len}${tieSuffix}${slurStopSuffix}`;
-    }
-    return `${pending.prefix}[${pending.pitches.join("")}]${pending.len}${tieSuffix}${slurStopSuffix}`;
-};
 const flushAbcExportPendingEvent = (pending, tokens) => {
     if (pending) {
-        tokens.push(buildAbcExportPendingEventToken(pending));
+        const tieSuffix = pending.tie ? "-" : "";
+        const slurStopSuffix = pending.slurStop ? ")" : "";
+        tokens.push(pending.pitches.length === 1
+            ? `${pending.prefix}${pending.pitches[0]}${pending.len}${tieSuffix}${slurStopSuffix}`
+            : `${pending.prefix}[${pending.pitches.join("")}]${pending.len}${tieSuffix}${slurStopSuffix}`);
     }
     return null;
 };
-const createAbcExportPendingEvent = (pitchToken, len, hasTieStart, hasSlurStop, eventPrefix) => ({
-    pitches: [pitchToken],
-    len,
-    tie: hasTieStart,
-    slurStop: hasSlurStop,
-    prefix: eventPrefix,
-});
 const appendAbcExportChordPitchToPendingEvent = (pending, pitchToken, hasTieStart, hasSlurStop) => {
     pending.pitches.push(pitchToken);
     pending.tie = pending.tie || hasTieStart;
     pending.slurStop = pending.slurStop || hasSlurStop;
 };
-const appendAbcExportTrillMetaLineIfNeeded = (metaLines, normalizedVoiceId, measure, fallbackMeasureNumber, eventNo, ornamentPrefixInfo) => {
-    if (!ornamentPrefixInfo.hasTrill || !ornamentPrefixInfo.trillAccidentalText)
-        return;
-    metaLines.push(buildAbcExportTrillMetaLine(normalizedVoiceId, measure, fallbackMeasureNumber, eventNo, ornamentPrefixInfo.trillAccidentalText));
-};
-const readAbcExportNoteEventInfo = (note, currentDivisions, unitLength) => {
-    var _a, _b, _c, _d;
-    const isChord = Boolean(note.querySelector(":scope > chord"));
-    const isGrace = Boolean(note.querySelector(":scope > grace"));
-    const duration = Number(((_b = (_a = note.querySelector(":scope > duration")) === null || _a === void 0 ? void 0 : _a.textContent) === null || _b === void 0 ? void 0 : _b.trim()) || "0");
-    if (!isGrace && (!Number.isFinite(duration) || duration <= 0))
-        return null;
-    const noteDuration = isGrace
-        ? (Number.isFinite(duration) && duration > 0 ? duration : Math.round(currentDivisions / 2))
-        : duration;
-    const tieState = (0, ties_1.extractMusicXmlTieState)(note);
-    const slurFeatures = (0, slurs_1.extractMusicXmlSlurFeatures)(note);
-    const timeModification = readAbcExportTimeModification(note);
+const startAbcExportPendingEventForNote = (flushPending, pending, tokens, metaLines, normalizedVoiceId, measure, fallbackMeasureNumber, ornamentPrefixInfo, pitchToken, len, hasTieStart, hasSlurStop, eventPrefix, eventNo) => {
+    const nextEventNo = eventNo + 1;
+    const trillMetaLine = ornamentPrefixInfo.hasTrill && ornamentPrefixInfo.trillAccidentalText
+        ? `%@mks trill voice=${normalizedVoiceId} measure=${measure.getAttribute("number") || fallbackMeasureNumber} event=${nextEventNo} upper=${ornamentPrefixInfo.trillAccidentalText}`
+        : "";
+    if (trillMetaLine)
+        metaLines.push(trillMetaLine);
+    if (flushPending)
+        flushAbcExportPendingEvent(pending, tokens);
     return {
-        isChord,
-        isGrace,
-        hasTieStart: tieState.tieStart,
-        ornamentPrefixInfo: buildAbcExportOrnamentPrefixInfo(note),
-        hasSlurStart: slurFeatures.some((slur) => slur.type === "start"),
-        hasSlurStop: slurFeatures.some((slur) => slur.type === "stop"),
-        hasGraceSlash: ((_d = (_c = note.querySelector(":scope > grace")) === null || _c === void 0 ? void 0 : _c.getAttribute("slash")) !== null && _d !== void 0 ? _d : "").trim().toLowerCase() === "yes",
-        hasTupletStart: Boolean(note.querySelector(':scope > notations > tuplet[type="start"]')),
-        timeModification,
-        len: buildAbcExportLengthToken(noteDuration, currentDivisions, unitLength, timeModification),
+        pending: {
+            pitches: [pitchToken],
+            len,
+            tie: hasTieStart,
+            slurStop: hasSlurStop,
+            prefix: eventPrefix,
+        },
+        eventNo: nextEventNo,
     };
 };
 const buildAbcExportEventPrefix = (note, noteEventInfo, activeTuplet, pendingHarmonySymbols, pendingDirectionWords, pendingDirectionDecorations, pendingGraceTokens) => {
-    const tupletPrefix = buildAbcExportTupletPrefix(activeTuplet, noteEventInfo.isChord);
-    const articulationPrefix = buildAbcExportArticulationPrefix(note);
-    const technicalPrefix = buildAbcExportTechnicalPrefix(note);
-    const fermataPrefix = buildAbcExportFermataPrefix(note);
+    var _a, _b, _c;
+    const tupletPrefix = noteEventInfo.isChord || !activeTuplet || activeTuplet.remaining !== activeTuplet.actual
+        ? ""
+        : `(${activeTuplet.actual}:${activeTuplet.normal}:${activeTuplet.actual}`;
+    const articulationKinds = new Set((0, articulations_1.extractMusicXmlArticulationKinds)(note));
+    const otherPhrase = (_a = Array.from(note.querySelectorAll(":scope > notations > articulations > other-articulation"))
+        .map((node) => { var _a; return ((_a = node.textContent) !== null && _a !== void 0 ? _a : "").trim().toLowerCase(); })
+        .find((text) => text === "shortphrase" || text === "mediumphrase" || text === "longphrase")) !== null && _a !== void 0 ? _a : "";
+    const articulationPrefix = `${articulationKinds.has("staccatissimo") ? "!wedge!" : (articulationKinds.has("staccato") ? "!staccato!" : "")}${articulationKinds.has("accent") ? "!accent!" : ""}${articulationKinds.has("tenuto") ? "!tenuto!" : ""}${note.querySelector(":scope > notations > articulations > stress") !== null ? "!stress!" : ""}${note.querySelector(":scope > notations > articulations > unstress") !== null ? "!unstress!" : ""}${articulationKinds.has("strong-accent") ? "!marcato!" : ""}${articulationKinds.has("breath-mark") ? "!breath!" : ""}${articulationKinds.has("caesura") ? "!caesura!" : ""}${otherPhrase ? `!${otherPhrase}!` : ""}`;
+    const technicalPrefix = `${`${note.querySelector(":scope > notations > technical > up-bow") ? "!upbow!" : ""}${note.querySelector(":scope > notations > technical > down-bow") ? "!downbow!" : ""}`}${`${note.querySelector(":scope > notations > technical > double-tongue") ? "!doubletongue!" : ""}${note.querySelector(":scope > notations > technical > triple-tongue") ? "!tripletongue!" : ""}${note.querySelector(":scope > notations > technical > heel") ? "!heel!" : ""}${note.querySelector(":scope > notations > technical > toe") ? "!toe!" : ""}`}${Array.from(note.querySelectorAll(":scope > notations > technical > fingering")).map((node) => { var _a; return ((_a = node.textContent) !== null && _a !== void 0 ? _a : "").trim(); }).filter((text) => text.length > 0).map((value) => (/^[0-5]$/.test(value) ? `!${value}!` : `!fingering:${value}!`)).join("")}${Array.from(note.querySelectorAll(":scope > notations > technical > string")).map((node) => { var _a; return ((_a = node.textContent) !== null && _a !== void 0 ? _a : "").trim(); }).filter((text) => text.length > 0).map((value) => `!string:${value}!`).join("")}${Array.from(note.querySelectorAll(":scope > notations > technical > pluck")).map((node) => { var _a; return ((_a = node.textContent) !== null && _a !== void 0 ? _a : "").trim(); }).filter((text) => text.length > 0).map((value) => `!pluck:${value}!`).join("")}${`${note.querySelector(":scope > notations > technical > open-string") ? "!open!" : ""}${note.querySelector(":scope > notations > technical > snap-pizzicato") ? "!snap!" : ""}${note.querySelector(":scope > notations > technical > harmonic") ? "!harmonic!" : ""}${note.querySelector(":scope > notations > technical > stopped") ? "!stopped!" : ""}${note.querySelector(":scope > notations > technical > thumb-position") ? "!thumb!" : ""}`}`;
+    const fermata = note.querySelector(":scope > notations > fermata");
+    const fermataPrefix = fermata ? (((_b = fermata.getAttribute("type")) === null || _b === void 0 ? void 0 : _b.trim().toLowerCase()) === "inverted" || ((_c = fermata.textContent) === null || _c === void 0 ? void 0 : _c.trim().toLowerCase()) === "inverted" ? "!invertedfermata!" : "!fermata!") : "";
     const slurStartPrefix = noteEventInfo.hasSlurStart ? "(" : "";
-    const queuedPrefix = takeAbcExportQueuedEventPrefix(noteEventInfo.isChord, pendingHarmonySymbols, pendingDirectionWords, pendingDirectionDecorations, pendingGraceTokens);
-    return `${queuedPrefix}${tupletPrefix}${slurStartPrefix}${noteEventInfo.ornamentPrefixInfo.prefix}${articulationPrefix}${technicalPrefix}${fermataPrefix}`;
+    const parts = [
+        takeAbcExportQueuedEventPrefix(noteEventInfo.isChord, pendingHarmonySymbols, pendingDirectionWords, pendingDirectionDecorations, pendingGraceTokens),
+        tupletPrefix,
+        slurStartPrefix,
+        noteEventInfo.ornamentPrefixInfo.prefix,
+        articulationPrefix,
+        technicalPrefix,
+        fermataPrefix,
+    ];
+    return parts.join("");
 };
 const flushAbcExportPendingGraceTokens = (pendingGraceTokens, tokens) => {
     if (pendingGraceTokens.length === 0)
@@ -37011,39 +36702,6 @@ const appendAbcExportEmptyMeasureRestTokenIfNeeded = (tokens, currentDivisions, 
     const lenRatio = exports.AbcCommon.divideFractions(wholeFraction, unitLength, { num: 1, den: 1 });
     tokens.push(`z${exports.AbcCommon.abcLengthTokenFromFraction(lenRatio)}`);
 };
-const buildAbcExportMeasureText = (tokens, needsInlineKeyChange, currentFifths, boundaryInfo) => {
-    const measureTokenText = tokens.join(" ");
-    const keyPrefix = needsInlineKeyChange
-        ? `[K:${exports.AbcCommon.keyFromFifthsMode(Math.max(-7, Math.min(7, Math.round(currentFifths))), "major")}]`
-        : "";
-    const leftPrefix = `${boundaryInfo.hasLeftRepeat ? "|:" : ""}${boundaryInfo.leftEndingNumber ? `[${boundaryInfo.leftEndingNumber}` : ""}`;
-    let rightSuffix = "|";
-    if (boundaryInfo.hasRightRepeat && boundaryInfo.rightEndingNumber) {
-        rightSuffix = `:|]`;
-    }
-    else if (boundaryInfo.hasRightRepeat) {
-        rightSuffix = ":|";
-    }
-    else if (boundaryInfo.rightEndingNumber) {
-        rightSuffix = "]|";
-    }
-    return `${leftPrefix}${leftPrefix ? " " : ""}${keyPrefix}${keyPrefix ? " " : ""}${measureTokenText} ${rightSuffix}`.trim();
-};
-const readAbcExportMeasureBoundaryInfo = (measure) => {
-    const leftRepeatNode = measure.querySelector(':scope > barline[location="left"] > repeat');
-    const rightRepeatNode = measure.querySelector(':scope > barline[location="right"] > repeat');
-    const leftEndingNode = measure.querySelector(':scope > barline[location="left"] > ending');
-    const rightEndingNode = measure.querySelector(':scope > barline[location="right"] > ending');
-    const leftRepeatDir = ((leftRepeatNode === null || leftRepeatNode === void 0 ? void 0 : leftRepeatNode.getAttribute("direction")) || "").trim().toLowerCase();
-    const rightRepeatDir = ((rightRepeatNode === null || rightRepeatNode === void 0 ? void 0 : rightRepeatNode.getAttribute("direction")) || "").trim().toLowerCase();
-    return {
-        hasLeftRepeat: leftRepeatDir === "forward",
-        hasRightRepeat: rightRepeatDir === "backward",
-        leftEndingNumber: ((leftEndingNode === null || leftEndingNode === void 0 ? void 0 : leftEndingNode.getAttribute("number")) || "").trim(),
-        rightEndingNumber: ((rightEndingNode === null || rightEndingNode === void 0 ? void 0 : rightEndingNode.getAttribute("number")) || "").trim(),
-        rightEndingType: ((rightEndingNode === null || rightEndingNode === void 0 ? void 0 : rightEndingNode.getAttribute("type")) || "").trim().toLowerCase(),
-    };
-};
 const applyAbcExportMeasureAttributesToState = (measure, state) => {
     var _a, _b, _c, _d;
     const parsedDiv = parseOptionalMusicXmlNumber((_a = measure.querySelector("attributes > divisions")) === null || _a === void 0 ? void 0 : _a.textContent);
@@ -37058,10 +36716,51 @@ const applyAbcExportMeasureAttributesToState = (measure, state) => {
     };
 };
 const appendAbcExportMeasureMetaLines = (metaLines, normalizedVoiceId, measure, safeMeasureNumber, boundaryInfo) => {
-    const measureMetaLine = buildAbcExportMeasureMetaLine(normalizedVoiceId, measure, safeMeasureNumber, boundaryInfo.hasRightRepeat, boundaryInfo.rightEndingNumber, boundaryInfo.rightEndingType);
+    var _a, _b, _c, _d, _e;
+    const rawMeasureNumber = ((_a = measure.getAttribute("number")) !== null && _a !== void 0 ? _a : "").trim() || String(safeMeasureNumber);
+    const implicitAttr = ((_b = measure.getAttribute("implicit")) !== null && _b !== void 0 ? _b : "").trim().toLowerCase();
+    const isImplicit = implicitAttr === "yes" || implicitAttr === "true" || implicitAttr === "1";
+    const rightRepeatNode = measure.querySelector(':scope > barline[location="right"] > repeat');
+    const repeatTimes = Number.parseInt(String((_c = rightRepeatNode === null || rightRepeatNode === void 0 ? void 0 : rightRepeatNode.getAttribute("times")) !== null && _c !== void 0 ? _c : ""), 10);
+    const measureMetaLine = !isImplicit &&
+        rawMeasureNumber === String(safeMeasureNumber) &&
+        (!boundaryInfo.hasRightRepeat || !Number.isFinite(repeatTimes) || repeatTimes <= 2) &&
+        (!boundaryInfo.rightEndingNumber || boundaryInfo.rightEndingType !== "discontinue")
+        ? null
+        : [
+            `%@mks measure voice=${normalizedVoiceId} measure=${safeMeasureNumber}`,
+            `number=${rawMeasureNumber}`,
+            `implicit=${isImplicit ? 1 : 0}`,
+            ...(boundaryInfo.hasRightRepeat && Number.isFinite(repeatTimes) && repeatTimes > 2 ? [`times=${Math.round(repeatTimes)}`] : []),
+            ...(boundaryInfo.rightEndingNumber && boundaryInfo.rightEndingType === "discontinue"
+                ? [`ending-stop=${boundaryInfo.rightEndingNumber}`, `ending-type=${boundaryInfo.rightEndingType}`]
+                : []),
+        ].join(" ");
     if (measureMetaLine)
         metaLines.push(measureMetaLine);
-    metaLines.push(...buildAbcExportDiagMetaLines(normalizedVoiceId, measure, safeMeasureNumber));
+    const diagFields = Array.from(measure.querySelectorAll(':scope > attributes > miscellaneous > miscellaneous-field[name^="mks:diag:"]'));
+    if (diagFields.length > 0) {
+        const byName = new Map();
+        for (const field of diagFields) {
+            const name = ((_d = field.getAttribute("name")) !== null && _d !== void 0 ? _d : "").trim();
+            if (!name)
+                continue;
+            byName.set(name, ((_e = field.textContent) !== null && _e !== void 0 ? _e : "").trim());
+        }
+        const orderedNames = Array.from(byName.keys()).sort((a, b) => {
+            const isCountA = a === "mks:diag:count";
+            const isCountB = b === "mks:diag:count";
+            if (isCountA && !isCountB)
+                return -1;
+            if (!isCountA && isCountB)
+                return 1;
+            return a.localeCompare(b);
+        });
+        metaLines.push(...orderedNames.map((name) => {
+            var _a;
+            return `%@mks diag voice=${normalizedVoiceId} measure=${safeMeasureNumber} name=${name} enc=uri-v1 value=${encodeURIComponent((_a = byName.get(name)) !== null && _a !== void 0 ? _a : "")}`;
+        }));
+    }
 };
 const applyAbcExportNonNoteChildToPending = (child, pendingHarmonySymbols, pendingDirectionWords, pendingDirectionDecorations, activeWedgeType) => {
     if (child.tagName === "harmony") {
@@ -37089,35 +36788,39 @@ const updateAbcExportActiveTupletBeforeNoteEvent = (activeTuplet, noteEventInfo)
 const updateAbcExportPendingEventForNote = (pending, tokens, eventNo, metaLines, normalizedVoiceId, measure, fallbackMeasureNumber, noteEventInfo, pitchToken, eventPrefix) => {
     const { isChord, hasTieStart, ornamentPrefixInfo, hasSlurStop, len, } = noteEventInfo;
     if (!isChord) {
-        const nextEventNo = eventNo + 1;
-        appendAbcExportTrillMetaLineIfNeeded(metaLines, normalizedVoiceId, measure, fallbackMeasureNumber, nextEventNo, ornamentPrefixInfo);
-        flushAbcExportPendingEvent(pending, tokens);
-        return {
-            pending: createAbcExportPendingEvent(pitchToken, len, hasTieStart, hasSlurStop, eventPrefix),
-            eventNo: nextEventNo,
-        };
+        return startAbcExportPendingEventForNote(true, pending, tokens, metaLines, normalizedVoiceId, measure, fallbackMeasureNumber, ornamentPrefixInfo, pitchToken, len, hasTieStart, hasSlurStop, eventPrefix, eventNo);
     }
     if (!pending) {
-        const nextEventNo = eventNo + 1;
-        appendAbcExportTrillMetaLineIfNeeded(metaLines, normalizedVoiceId, measure, fallbackMeasureNumber, nextEventNo, ornamentPrefixInfo);
-        return {
-            pending: createAbcExportPendingEvent(pitchToken, len, hasTieStart, hasSlurStop, eventPrefix),
-            eventNo: nextEventNo,
-        };
+        return startAbcExportPendingEventForNote(false, pending, tokens, metaLines, normalizedVoiceId, measure, fallbackMeasureNumber, ornamentPrefixInfo, pitchToken, len, hasTieStart, hasSlurStop, eventPrefix, eventNo);
     }
     appendAbcExportChordPitchToPendingEvent(pending, pitchToken, hasTieStart, hasSlurStop);
     return { pending, eventNo };
 };
 const updateAbcExportStateAfterNoteEvent = (note, noteEventInfo, activeTuplet, lyricTokens, pendingLyricExtension) => {
-    const nextActiveTuplet = advanceAbcExportActiveTupletAfterEvent(activeTuplet, noteEventInfo.isChord);
     return {
-        activeTuplet: nextActiveTuplet,
-        pendingLyricExtension: noteEventInfo.isChord
-            ? pendingLyricExtension
-            : appendAbcExportLyricToken(note, lyricTokens, pendingLyricExtension),
+        activeTuplet: advanceAbcExportActiveTupletAfterEvent(activeTuplet, noteEventInfo.isChord),
+        pendingLyricExtension: noteEventInfo.isChord ? pendingLyricExtension : appendAbcExportLyricToken(note, lyricTokens, pendingLyricExtension),
+    };
+};
+const applyAbcExportNoteEvent = (child, noteEventInfo, activeTuplet, pending, eventNo, pendingGraceTokens, pendingHarmonySymbols, pendingDirectionWords, pendingDirectionDecorations, tokens, metaLines, normalizedVoiceId, measure, fallbackMeasureNumber, keyAlterMap, measureAccidentalByStepOctave, lyricTokens, pendingLyricExtension) => {
+    const pitchToken = buildAbcExportPitchToken(child, keyAlterMap, measureAccidentalByStepOctave);
+    if (applyAbcExportGraceNoteToPending(noteEventInfo, pendingGraceTokens, pitchToken)) {
+        return { handled: true, pending, eventNo, activeTuplet, pendingLyricExtension };
+    }
+    const nextActiveTuplet = updateAbcExportActiveTupletBeforeNoteEvent(activeTuplet, noteEventInfo);
+    const eventPrefix = buildAbcExportEventPrefix(child, noteEventInfo, nextActiveTuplet, pendingHarmonySymbols, pendingDirectionWords, pendingDirectionDecorations, pendingGraceTokens);
+    const pendingEventUpdate = updateAbcExportPendingEventForNote(pending, tokens, eventNo, metaLines, normalizedVoiceId, measure, fallbackMeasureNumber, noteEventInfo, pitchToken, eventPrefix);
+    const postNoteEventState = updateAbcExportStateAfterNoteEvent(child, noteEventInfo, nextActiveTuplet, lyricTokens, pendingLyricExtension);
+    return {
+        handled: true,
+        pending: pendingEventUpdate.pending,
+        eventNo: pendingEventUpdate.eventNo,
+        activeTuplet: postNoteEventState.activeTuplet,
+        pendingLyricExtension: postNoteEventState.pendingLyricExtension,
     };
 };
 const processAbcExportNoteChild = (context) => {
+    var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p;
     const { child, lane, currentDivisions, unitLength, keyAlterMap, measureAccidentalByStepOctave, pendingGraceTokens, pendingHarmonySymbols, pendingDirectionWords, pendingDirectionDecorations, tokens, metaLines, normalizedVoiceId, measure, fallbackMeasureNumber, lyricTokens, } = context;
     let { activeTuplet, pending, eventNo, pendingLyricExtension, } = context;
     if (child.tagName !== "note") {
@@ -37126,28 +36829,121 @@ const processAbcExportNoteChild = (context) => {
     if (!isMusicXmlNoteInAbcExportLane(child, lane)) {
         return { handled: true, pending, eventNo, activeTuplet, pendingLyricExtension };
     }
-    const noteEventInfo = readAbcExportNoteEventInfo(child, currentDivisions, unitLength);
-    if (!noteEventInfo) {
+    const isChord = child.querySelector(":scope > chord") !== null;
+    const isGrace = child.querySelector(":scope > grace") !== null;
+    const duration = Number((_c = (_b = (_a = child.querySelector(":scope > duration")) === null || _a === void 0 ? void 0 : _a.textContent) === null || _b === void 0 ? void 0 : _b.trim()) !== null && _c !== void 0 ? _c : "0");
+    if (!isGrace && (!Number.isFinite(duration) || duration <= 0)) {
         return { handled: true, pending, eventNo, activeTuplet, pendingLyricExtension };
     }
-    const pitchToken = buildAbcExportPitchToken(child, keyAlterMap, measureAccidentalByStepOctave);
-    if (applyAbcExportGraceNoteToPending(noteEventInfo, pendingGraceTokens, pitchToken)) {
-        return { handled: true, pending, eventNo, activeTuplet, pendingLyricExtension };
-    }
-    activeTuplet = updateAbcExportActiveTupletBeforeNoteEvent(activeTuplet, noteEventInfo);
-    const eventPrefix = buildAbcExportEventPrefix(child, noteEventInfo, activeTuplet, pendingHarmonySymbols, pendingDirectionWords, pendingDirectionDecorations, pendingGraceTokens);
-    const pendingEventUpdate = updateAbcExportPendingEventForNote(pending, tokens, eventNo, metaLines, normalizedVoiceId, measure, fallbackMeasureNumber, noteEventInfo, pitchToken, eventPrefix);
-    pending = pendingEventUpdate.pending;
-    eventNo = pendingEventUpdate.eventNo;
-    const postNoteEventState = updateAbcExportStateAfterNoteEvent(child, noteEventInfo, activeTuplet, lyricTokens, pendingLyricExtension);
-    return {
-        handled: true,
-        pending,
-        eventNo,
-        activeTuplet: postNoteEventState.activeTuplet,
-        pendingLyricExtension: postNoteEventState.pendingLyricExtension,
+    const noteDuration = isGrace
+        ? (Number.isFinite(duration) && duration > 0 ? duration : Math.round(currentDivisions / 2))
+        : duration;
+    const tieState = (0, ties_1.extractMusicXmlTieState)(child);
+    const slurFeatures = (0, slurs_1.extractMusicXmlSlurFeatures)(child);
+    const actualNotes = Number((_f = (_e = (_d = child.querySelector(":scope > time-modification > actual-notes")) === null || _d === void 0 ? void 0 : _d.textContent) === null || _e === void 0 ? void 0 : _e.trim()) !== null && _f !== void 0 ? _f : "");
+    const normalNotes = Number((_j = (_h = (_g = child.querySelector(":scope > time-modification > normal-notes")) === null || _g === void 0 ? void 0 : _g.textContent) === null || _h === void 0 ? void 0 : _h.trim()) !== null && _j !== void 0 ? _j : "");
+    const timeModification = Number.isFinite(actualNotes) && actualNotes > 0 && Number.isFinite(normalNotes) && normalNotes > 0
+        ? { actual: Math.round(actualNotes), normal: Math.round(normalNotes) }
+        : null;
+    const ornamentFeatures = (0, ornaments_1.extractMusicXmlOrnamentFeatures)(child);
+    const ornamentKinds = new Set(ornamentFeatures.map((feature) => feature.kind));
+    const hasTrillMark = ornamentKinds.has("trill-mark");
+    const hasWavyLineStart = Array.from(child.querySelectorAll(":scope > notations > ornaments > wavy-line")).some((node) => { var _a, _b; return ((_a = node.getAttribute("type")) !== null && _a !== void 0 ? _a : "").trim().toLowerCase() === "" || ((_b = node.getAttribute("type")) !== null && _b !== void 0 ? _b : "").trim().toLowerCase() === "start"; });
+    const hasWavyLineStop = Array.from(child.querySelectorAll(":scope > notations > ornaments > wavy-line")).some((node) => { var _a; return ((_a = node.getAttribute("type")) !== null && _a !== void 0 ? _a : "").trim().toLowerCase() === "stop"; });
+    const ornamentTrillPrefix = hasWavyLineStop
+        ? "!trill)!"
+        : hasWavyLineStart && !hasTrillMark
+            ? "!trill!"
+            : hasWavyLineStart
+                ? "!trill(!"
+                : hasTrillMark
+                    ? "!trill!"
+                    : "";
+    const noteEventInfo = {
+        isChord,
+        isGrace,
+        hasTieStart: tieState.tieStart,
+        ornamentPrefixInfo: {
+            prefix: `${ornamentTrillPrefix}${`${ornamentKinds.has("inverted-turn") ? (ornamentKinds.has("delayed-turn") ? "!delayedinvertedturn!" : (ornamentFeatures.some((feature) => feature.kind === "inverted-turn" && feature.slash) ? "!invertedturnx!" : "!invertedturn!")) : ""}${ornamentKinds.has("turn") ? (ornamentKinds.has("delayed-turn") ? "!delayedturn!" : (ornamentFeatures.some((feature) => feature.kind === "turn" && feature.slash) ? "!turnx!" : "!turn!")) : ""}`}${`${ornamentKinds.has("inverted-mordent") ? "!pralltriller!" : ""}${ornamentKinds.has("mordent") ? "!mordent!" : ""}`}${["single", "start", "stop"].map((tremoloType) => {
+                const tremoloFeature = ornamentFeatures.find((feature) => feature.kind === "tremolo" && feature.tremoloType === tremoloType);
+                return tremoloFeature ? `!tremolo-${tremoloType}-${tremoloFeature.marks ? tremoloFeature.marks : 1}!` : "";
+            }).join("")}${`${child.querySelector(':scope > notations > glissando[type="start"]') ? "!gliss-start!" : ""}${child.querySelector(':scope > notations > glissando[type="stop"]') ? "!gliss-stop!" : ""}${child.querySelector(':scope > notations > slide[type="start"]') ? "!slide!" : ""}${child.querySelector(':scope > notations > slide[type="stop"]') ? "!slide-stop!" : ""}${ornamentKinds.has("schleifer") ? "!schleifer!" : ""}${ornamentKinds.has("shake") ? "!shake!" : ""}${child.querySelector(":scope > notations > arpeggiate") ? "!arpeggio!" : ""}`}`,
+            hasTrill: hasTrillMark || hasWavyLineStart,
+            trillAccidentalText: (_m = (_l = (_k = child.querySelector(":scope > notations > ornaments > accidental-mark")) === null || _k === void 0 ? void 0 : _k.textContent) === null || _l === void 0 ? void 0 : _l.trim()) !== null && _m !== void 0 ? _m : "",
+        },
+        hasSlurStart: slurFeatures.some((slur) => slur.type === "start"),
+        hasSlurStop: slurFeatures.some((slur) => slur.type === "stop"),
+        hasGraceSlash: ((_p = (_o = child.querySelector(":scope > grace")) === null || _o === void 0 ? void 0 : _o.getAttribute("slash")) !== null && _p !== void 0 ? _p : "").trim().toLowerCase() === "yes",
+        hasTupletStart: child.querySelector(':scope > notations > tuplet[type="start"]') !== null,
+        timeModification,
+        len: buildAbcExportLengthToken(noteDuration, currentDivisions, unitLength, timeModification),
     };
+    return applyAbcExportNoteEvent(child, noteEventInfo, activeTuplet, pending, eventNo, pendingGraceTokens, pendingHarmonySymbols, pendingDirectionWords, pendingDirectionDecorations, tokens, metaLines, normalizedVoiceId, measure, fallbackMeasureNumber, keyAlterMap, measureAccidentalByStepOctave, lyricTokens, pendingLyricExtension);
 };
+const processAbcExportMeasureChild = (child, state) => {
+    if (processAbcExportMeasureNonNoteChild(child, state)) {
+        return;
+    }
+    processAbcExportMeasureNoteChild(child, state);
+};
+const processAbcExportMeasureNonNoteChild = (child, state) => {
+    const nonNoteDispatch = applyAbcExportNonNoteChildToPending(child, state.pendingHarmonySymbols, state.pendingDirectionWords, state.pendingDirectionDecorations, state.activeWedgeType);
+    state.activeWedgeType = nonNoteDispatch.activeWedgeType;
+    return nonNoteDispatch.handled;
+};
+const processAbcExportMeasureNoteChild = (child, state) => {
+    const noteChildProcess = processAbcExportNoteChild({
+        child,
+        lane: state.lane,
+        currentDivisions: state.currentDivisions,
+        unitLength: state.unitLength,
+        keyAlterMap: state.keyAlterMap,
+        measureAccidentalByStepOctave: state.measureAccidentalByStepOctave,
+        pendingGraceTokens: state.pendingGraceTokens,
+        activeTuplet: state.activeTuplet,
+        pendingHarmonySymbols: state.pendingHarmonySymbols,
+        pendingDirectionWords: state.pendingDirectionWords,
+        pendingDirectionDecorations: state.pendingDirectionDecorations,
+        pending: state.pending,
+        tokens: state.tokens,
+        eventNo: state.eventNo,
+        metaLines: state.metaLines,
+        normalizedVoiceId: state.normalizedVoiceId,
+        measure: state.measure,
+        fallbackMeasureNumber: state.fallbackMeasureNumber,
+        lyricTokens: state.lyricTokens,
+        pendingLyricExtension: state.pendingLyricExtension,
+    });
+    if (!noteChildProcess.handled) {
+        return;
+    }
+    state.pending = noteChildProcess.pending;
+    state.eventNo = noteChildProcess.eventNo;
+    state.activeTuplet = noteChildProcess.activeTuplet;
+    state.pendingLyricExtension = noteChildProcess.pendingLyricExtension;
+};
+const createAbcExportMeasureChildProcessingState = (context, pendingGraceTokens, pendingHarmonySymbols, pendingDirectionWords, pendingDirectionDecorations) => ({
+    lane: context.lane,
+    currentDivisions: context.currentDivisions,
+    unitLength: context.unitLength,
+    keyAlterMap: context.keyAlterMap,
+    measureAccidentalByStepOctave: context.measureAccidentalByStepOctave,
+    pendingGraceTokens,
+    pendingHarmonySymbols,
+    pendingDirectionWords,
+    pendingDirectionDecorations,
+    tokens: context.tokens,
+    metaLines: context.metaLines,
+    normalizedVoiceId: context.normalizedVoiceId,
+    measure: context.measure,
+    fallbackMeasureNumber: context.fallbackMeasureNumber,
+    lyricTokens: context.lyricTokens,
+    pending: null,
+    eventNo: 0,
+    activeTuplet: null,
+    pendingLyricExtension: context.pendingLyricExtension,
+    activeWedgeType: "",
+});
 const processAbcExportMeasureChildren = (context) => {
     const { measure, lane, currentDivisions, unitLength, keyAlterMap, measureAccidentalByStepOctave, tokens, metaLines, normalizedVoiceId, fallbackMeasureNumber, lyricTokens, } = context;
     let { pendingLyricExtension } = context;
@@ -37156,55 +36952,32 @@ const processAbcExportMeasureChildren = (context) => {
     const pendingHarmonySymbols = [];
     const pendingDirectionWords = [];
     const pendingDirectionDecorations = [];
-    let activeWedgeType = "";
-    let activeTuplet = null;
-    let eventNo = 0;
+    const state = createAbcExportMeasureChildProcessingState(context, pendingGraceTokens, pendingHarmonySymbols, pendingDirectionWords, pendingDirectionDecorations);
     for (const child of Array.from(measure.children)) {
-        const nonNoteDispatch = applyAbcExportNonNoteChildToPending(child, pendingHarmonySymbols, pendingDirectionWords, pendingDirectionDecorations, activeWedgeType);
-        activeWedgeType = nonNoteDispatch.activeWedgeType;
-        if (nonNoteDispatch.handled) {
-            continue;
-        }
-        const noteChildProcess = processAbcExportNoteChild({
-            child,
-            lane,
-            currentDivisions,
-            unitLength,
-            keyAlterMap,
-            measureAccidentalByStepOctave,
-            pendingGraceTokens,
-            activeTuplet,
-            pendingHarmonySymbols,
-            pendingDirectionWords,
-            pendingDirectionDecorations,
-            pending,
-            tokens,
-            eventNo,
-            metaLines,
-            normalizedVoiceId,
-            measure,
-            fallbackMeasureNumber,
-            lyricTokens,
-            pendingLyricExtension,
-        });
-        if (!noteChildProcess.handled)
-            continue;
-        pending = noteChildProcess.pending;
-        eventNo = noteChildProcess.eventNo;
-        activeTuplet = noteChildProcess.activeTuplet;
-        pendingLyricExtension = noteChildProcess.pendingLyricExtension;
+        processAbcExportMeasureChild(child, state);
     }
     return {
-        pending,
+        pending: state.pending,
         pendingGraceTokens,
-        pendingLyricExtension,
+        pendingLyricExtension: state.pendingLyricExtension,
     };
 };
 const renderAbcExportMeasureText = (context) => {
+    var _a, _b, _c, _d, _e;
     const { measure, lane, lastEmittedKeyFifths, unitLength, metaLines, normalizedVoiceId, fallbackMeasureNumber, lyricTokens, } = context;
     let { pendingLyricExtension } = context;
     const measureState = applyAbcExportMeasureAttributesToState(measure, context.measureState);
-    const boundaryInfo = readAbcExportMeasureBoundaryInfo(measure);
+    const leftRepeatNode = measure.querySelector(':scope > barline[location="left"] > repeat');
+    const rightRepeatNode = measure.querySelector(':scope > barline[location="right"] > repeat');
+    const leftEndingNode = measure.querySelector(':scope > barline[location="left"] > ending');
+    const rightEndingNode = measure.querySelector(':scope > barline[location="right"] > ending');
+    const boundaryInfo = {
+        hasLeftRepeat: ((_a = leftRepeatNode === null || leftRepeatNode === void 0 ? void 0 : leftRepeatNode.getAttribute("direction")) !== null && _a !== void 0 ? _a : "").trim().toLowerCase() === "forward",
+        hasRightRepeat: ((_b = rightRepeatNode === null || rightRepeatNode === void 0 ? void 0 : rightRepeatNode.getAttribute("direction")) !== null && _b !== void 0 ? _b : "").trim().toLowerCase() === "backward",
+        leftEndingNumber: ((_c = leftEndingNode === null || leftEndingNode === void 0 ? void 0 : leftEndingNode.getAttribute("number")) !== null && _c !== void 0 ? _c : "").trim(),
+        rightEndingNumber: ((_d = rightEndingNode === null || rightEndingNode === void 0 ? void 0 : rightEndingNode.getAttribute("number")) !== null && _d !== void 0 ? _d : "").trim(),
+        rightEndingType: ((_e = rightEndingNode === null || rightEndingNode === void 0 ? void 0 : rightEndingNode.getAttribute("type")) !== null && _e !== void 0 ? _e : "").trim().toLowerCase(),
+    };
     appendAbcExportMeasureMetaLines(metaLines, normalizedVoiceId, measure, fallbackMeasureNumber, boundaryInfo);
     const { currentDivisions, currentFifths, currentBeats, currentBeatType } = measureState;
     const needsInlineKeyChange = lastEmittedKeyFifths === null || lastEmittedKeyFifths !== currentFifths;
@@ -37229,27 +37002,26 @@ const renderAbcExportMeasureText = (context) => {
     flushAbcExportPendingGraceTokens(measureChildren.pendingGraceTokens, tokens);
     flushAbcExportPendingEvent(measureChildren.pending, tokens);
     appendAbcExportEmptyMeasureRestTokenIfNeeded(tokens, currentDivisions, currentBeats, currentBeatType, unitLength);
+    const boundaryPrefix = `${boundaryInfo.hasLeftRepeat ? "|:" : ""}${boundaryInfo.leftEndingNumber ? `[${boundaryInfo.leftEndingNumber}` : ""}`;
+    const keyPrefix = needsInlineKeyChange
+        ? `[K:${exports.AbcCommon.keyFromFifthsMode(Math.max(-7, Math.min(7, Math.round(currentFifths))), "major")}]`
+        : "";
+    const boundarySuffix = boundaryInfo.hasRightRepeat
+        ? (boundaryInfo.rightEndingNumber ? ":|]" : ":|")
+        : (boundaryInfo.rightEndingNumber ? "]|" : "|");
     return {
-        measureText: buildAbcExportMeasureText(tokens, needsInlineKeyChange, currentFifths, boundaryInfo),
+        measureText: [
+            ...(boundaryPrefix ? [boundaryPrefix] : []),
+            ...(keyPrefix ? [keyPrefix] : []),
+            tokens.join(" "),
+            ...(boundarySuffix ? [boundarySuffix] : []),
+        ]
+            .join(" ")
+            .trim(),
         measureState,
         lastEmittedKeyFifths: currentFifths,
         pendingLyricExtension,
     };
-};
-const appendAbcExportLaneHeader = (context) => {
-    const { part, partName, measures, laneDefs, lane, headerLines, metaLines, } = context;
-    const normalizedVoiceId = lane.voiceId.replace(/[^A-Za-z0-9_.-]/g, "_");
-    const laneName = buildAbcExportLaneName(partName, laneDefs.length, lane);
-    const abcClef = resolveAbcExportLaneClef(part, measures, lane.staff);
-    const clefSuffix = abcClef ? ` clef=${abcClef}` : "";
-    headerLines.push(`V:${normalizedVoiceId} name="${laneName}"${clefSuffix}`);
-    for (const measure of measures) {
-        const transposeMetaLine = buildAbcExportTransposeMetaLine(normalizedVoiceId, measure);
-        if (transposeMetaLine)
-            metaLines.push(transposeMetaLine);
-        break;
-    }
-    return normalizedVoiceId;
 };
 const readAbcExportPartInitialFifths = (part, fallbackFifths) => {
     var _a;
@@ -37258,211 +37030,151 @@ const readAbcExportPartInitialFifths = (part, fallbackFifths) => {
         ? Math.round(partInitialFifthsRaw)
         : (Number.isFinite(fallbackFifths) ? Math.round(fallbackFifths) : 0);
 };
-const createAbcExportInitialMeasureState = (part, fifths, meterBeats, meterBeatType) => ({
+const createAbcExportInitialMeasureStateFromPart = (part, fifths, meterBeats, meterBeatType) => ({
     currentDivisions: 480,
     currentFifths: readAbcExportPartInitialFifths(part, fifths),
     currentBeats: Number(meterBeats) || 4,
     currentBeatType: Number(meterBeatType) || 4,
 });
-const renderAbcExportLaneBody = (context, normalizedVoiceId) => {
-    const { part, measures, lane, fifths, meterBeats, meterBeatType, unitLength, metaLines, } = context;
-    let measureState = createAbcExportInitialMeasureState(part, fifths, meterBeats, meterBeatType);
-    let lastEmittedKeyFifths = Number.isFinite(fifths) ? Math.round(fifths) : 0;
-    const measureTexts = [];
-    const lyricTokens = [];
-    let pendingLyricExtension = false;
-    for (const measure of measures) {
-        const safeMeasureNumber = measureTexts.length + 1;
-        const renderedMeasure = renderAbcExportMeasureText({
-            measure,
-            lane,
-            measureState,
-            lastEmittedKeyFifths,
-            unitLength,
-            metaLines,
-            normalizedVoiceId,
-            fallbackMeasureNumber: safeMeasureNumber,
-            lyricTokens,
-            pendingLyricExtension,
-        });
-        measureState = renderedMeasure.measureState;
-        lastEmittedKeyFifths = renderedMeasure.lastEmittedKeyFifths;
-        pendingLyricExtension = renderedMeasure.pendingLyricExtension;
-        measureTexts.push(renderedMeasure.measureText);
-    }
-    return { measureTexts, lyricTokens };
+const createAbcExportLaneBodyStateFromPart = (part, fifths, meterBeats, meterBeatType) => ({
+    measureState: createAbcExportInitialMeasureStateFromPart(part, fifths, meterBeats, meterBeatType),
+    lastEmittedKeyFifths: Number.isFinite(fifths) ? Math.round(fifths) : 0,
+    measureTexts: [],
+    lyricTokens: [],
+    pendingLyricExtension: false,
+});
+const appendAbcExportLaneBodyMeasure = (state, measure, lane, unitLength, metaLines, normalizedVoiceId) => {
+    const renderedMeasure = renderAbcExportMeasureText({
+        measure,
+        lane,
+        measureState: state.measureState,
+        lastEmittedKeyFifths: state.lastEmittedKeyFifths,
+        unitLength,
+        metaLines,
+        normalizedVoiceId,
+        fallbackMeasureNumber: state.measureTexts.length + 1,
+        lyricTokens: state.lyricTokens,
+        pendingLyricExtension: state.pendingLyricExtension,
+    });
+    state.measureState = renderedMeasure.measureState;
+    state.lastEmittedKeyFifths = renderedMeasure.lastEmittedKeyFifths;
+    state.pendingLyricExtension = renderedMeasure.pendingLyricExtension;
+    state.measureTexts.push(renderedMeasure.measureText);
 };
-const appendAbcExportRenderedLaneBody = (bodyLines, normalizedVoiceId, renderedLaneBody) => {
-    const { measureTexts, lyricTokens } = renderedLaneBody;
-    bodyLines.push(`V:${normalizedVoiceId}`);
-    bodyLines.push(measureTexts.join(" "));
-    if (lyricTokens.some((token) => token !== "*")) {
-        bodyLines.push(`w: ${lyricTokens.join(" ")}`);
-    }
-};
-const appendAbcExportLaneBody = (context, normalizedVoiceId) => {
-    const { bodyLines } = context;
-    appendAbcExportRenderedLaneBody(bodyLines, normalizedVoiceId, renderAbcExportLaneBody(context, normalizedVoiceId));
-};
-const appendAbcExportLane = (context) => {
-    const normalizedVoiceId = appendAbcExportLaneHeader(context);
-    appendAbcExportLaneBody(context, normalizedVoiceId);
-};
-const createAbcExportPartRenderInfo = (part, partIndex, partNameById) => {
-    const partId = part.getAttribute("id") || `P${partIndex + 1}`;
-    return {
-        partName: partNameById.get(partId) || partId,
-        measures: Array.from(part.querySelectorAll(":scope > measure")),
-        laneDefs: buildAbcExportLaneDefinitions(part, partId),
-    };
-};
-const appendAbcExportPartLanes = (context, partRenderInfo) => {
-    const { part, fifths, meterBeats, meterBeatType, unitLength, headerLines, bodyLines, metaLines, } = context;
-    const { partName, measures, laneDefs } = partRenderInfo;
+const appendAbcExportPartFromRenderContext = (context) => {
+    var _a, _b, _c, _d, _e, _f, _g;
+    const partId = context.part.getAttribute("id") || `P${context.partIndex + 1}`;
+    const partName = context.partNameById.get(partId) || partId;
+    const measures = Array.from(context.part.querySelectorAll(":scope > measure"));
+    const laneDefs = buildAbcExportLaneDefinitions(context.part, partId);
     for (const lane of laneDefs) {
-        appendAbcExportLane({
-            part,
+        const laneContext = {
+            part: context.part,
             partName,
             measures,
             laneDefs,
             lane,
-            fifths,
-            meterBeats,
-            meterBeatType,
-            unitLength,
-            headerLines,
-            bodyLines,
-            metaLines,
+            fifths: context.fifths,
+            meterBeats: context.meterBeats,
+            meterBeatType: context.meterBeatType,
+            unitLength: context.unitLength,
+            headerLines: context.headerLines,
+            bodyLines: context.bodyLines,
+            metaLines: context.metaLines,
+        };
+        const normalizedVoiceId = laneContext.lane.voiceId.replace(/[^A-Za-z0-9_.-]/g, "_");
+        const laneName = laneContext.laneDefs.length <= 1
+            ? laneContext.partName
+            : laneContext.lane.staff && laneContext.lane.voice
+                ? `${laneContext.partName} (Staff ${laneContext.lane.staff} Voice ${laneContext.lane.voice})`
+                : laneContext.lane.staff
+                    ? `${laneContext.partName} (Staff ${laneContext.lane.staff})`
+                    : laneContext.lane.voice
+                        ? `${laneContext.partName} (Voice ${laneContext.lane.voice})`
+                        : `${laneContext.partName} (Lane)`;
+        const abcClef = resolveAbcExportLaneClef(laneContext.part, laneContext.measures, laneContext.lane.staff);
+        const clefSuffix = abcClef ? ` clef=${abcClef}` : "";
+        laneContext.headerLines.push(`V:${normalizedVoiceId} name="${laneName}"${clefSuffix}`);
+        const transposeNode = (_a = laneContext.measures[0]) === null || _a === void 0 ? void 0 : _a.querySelector(":scope > attributes > transpose");
+        if (transposeNode) {
+            const chromatic = Number((_d = (_c = (_b = transposeNode.querySelector(":scope > chromatic")) === null || _b === void 0 ? void 0 : _b.textContent) === null || _c === void 0 ? void 0 : _c.trim()) !== null && _d !== void 0 ? _d : "");
+            const diatonic = Number((_g = (_f = (_e = transposeNode.querySelector(":scope > diatonic")) === null || _e === void 0 ? void 0 : _e.textContent) === null || _f === void 0 ? void 0 : _f.trim()) !== null && _g !== void 0 ? _g : "");
+            if (Number.isFinite(chromatic) || Number.isFinite(diatonic)) {
+                laneContext.metaLines.push([
+                    `%@mks transpose voice=${normalizedVoiceId}`,
+                    ...(Number.isFinite(chromatic) ? [`chromatic=${Math.round(chromatic)}`] : []),
+                    ...(Number.isFinite(diatonic) ? [`diatonic=${Math.round(diatonic)}`] : []),
+                ].join(" "));
+            }
+        }
+        const state = createAbcExportLaneBodyStateFromPart(laneContext.part, laneContext.fifths, laneContext.meterBeats, laneContext.meterBeatType);
+        for (const measure of laneContext.measures) {
+            appendAbcExportLaneBodyMeasure(state, measure, laneContext.lane, laneContext.unitLength, laneContext.metaLines, normalizedVoiceId);
+        }
+        laneContext.bodyLines.push(`V:${normalizedVoiceId}`, state.measureTexts.join(" "));
+        if (state.lyricTokens.some((token) => token !== "*")) {
+            laneContext.bodyLines.push(`w: ${state.lyricTokens.join(" ")}`);
+        }
+    }
+};
+const appendAbcExportParts = (parts, exportContext) => {
+    for (const [partIndex, part] of parts.entries()) {
+        appendAbcExportPartFromRenderContext({
+            part,
+            partIndex,
+            partNameById: exportContext.partNameById,
+            fifths: exportContext.fifths,
+            meterBeats: exportContext.meterBeats,
+            meterBeatType: exportContext.meterBeatType,
+            unitLength: exportContext.unitLength,
+            headerLines: exportContext.headerLines,
+            bodyLines: exportContext.bodyLines,
+            metaLines: exportContext.metaLines,
         });
     }
 };
-const appendAbcExportPart = (context) => {
-    const { part, partIndex, partNameById, } = context;
-    appendAbcExportPartLanes(context, createAbcExportPartRenderInfo(part, partIndex, partNameById));
-};
-const hasAbcExportUnitTempoHeader = (initialTempo) => Boolean(initialTempo.unit && Number.isFinite(initialTempo.bpm) && initialTempo.bpm > 0);
-const buildAbcExportUnitTempoHeader = (initialTempo) => {
-    if (hasAbcExportUnitTempoHeader(initialTempo)) {
-        return `Q:${fractionToAbcTempoUnit(initialTempo.unit)}=${Math.round(initialTempo.bpm)}`;
-    }
-    return "";
-};
-const buildAbcExportFallbackTempoHeader = (tempoBpm) => Number.isFinite(tempoBpm) ? `Q:1/4=${Math.round(tempoBpm)}` : "";
-const buildAbcExportTempoHeaderFromInitialTempo = (initialTempo) => {
-    var _a;
-    const tempoBpm = (_a = initialTempo === null || initialTempo === void 0 ? void 0 : initialTempo.bpm) !== null && _a !== void 0 ? _a : NaN;
-    if (initialTempo) {
-        const unitTempoHeader = buildAbcExportUnitTempoHeader(initialTempo);
-        if (unitTempoHeader)
-            return unitTempoHeader;
-    }
-    return buildAbcExportFallbackTempoHeader(tempoBpm);
-};
-const buildAbcExportTempoHeader = (doc) => buildAbcExportTempoHeaderFromInitialTempo(readInitialTempoFromMusicXml(doc));
-const readAbcExportTitle = (doc) => {
-    var _a, _b, _c, _d;
-    return ((_b = (_a = doc.querySelector("work > work-title")) === null || _a === void 0 ? void 0 : _a.textContent) === null || _b === void 0 ? void 0 : _b.trim()) ||
-        ((_d = (_c = doc.querySelector("movement-title")) === null || _c === void 0 ? void 0 : _c.textContent) === null || _d === void 0 ? void 0 : _d.trim()) ||
-        "mikuscore";
-};
-const readAbcExportComposer = (doc) => { var _a, _b; return ((_b = (_a = doc.querySelector('identification > creator[type="composer"]')) === null || _a === void 0 ? void 0 : _a.textContent) === null || _b === void 0 ? void 0 : _b.trim()) || ""; };
-const readAbcExportDocumentCredits = (doc) => ({
-    title: readAbcExportTitle(doc),
-    composer: readAbcExportComposer(doc),
-});
-const readAbcExportMeterBeats = (firstMeasure) => { var _a, _b; return ((_b = (_a = firstMeasure === null || firstMeasure === void 0 ? void 0 : firstMeasure.querySelector("attributes > time > beats")) === null || _a === void 0 ? void 0 : _a.textContent) === null || _b === void 0 ? void 0 : _b.trim()) || "4"; };
-const readAbcExportMeterBeatType = (firstMeasure) => { var _a, _b; return ((_b = (_a = firstMeasure === null || firstMeasure === void 0 ? void 0 : firstMeasure.querySelector("attributes > time > beat-type")) === null || _a === void 0 ? void 0 : _a.textContent) === null || _b === void 0 ? void 0 : _b.trim()) || "4"; };
-const readAbcExportDocumentMeterInfo = (firstMeasure) => ({
-    meterBeats: readAbcExportMeterBeats(firstMeasure),
-    meterBeatType: readAbcExportMeterBeatType(firstMeasure),
-});
-const buildAbcExportKeyFromFifthsMode = (fifths, mode) => exports.AbcCommon.keyFromFifthsMode(Number.isFinite(fifths) ? fifths : 0, mode);
-const readAbcExportKeyFifths = (firstMeasure) => { var _a, _b; return Number(((_b = (_a = firstMeasure === null || firstMeasure === void 0 ? void 0 : firstMeasure.querySelector("attributes > key > fifths")) === null || _a === void 0 ? void 0 : _a.textContent) === null || _b === void 0 ? void 0 : _b.trim()) || "0"); };
-const readAbcExportKeyMode = (firstMeasure) => { var _a, _b; return ((_b = (_a = firstMeasure === null || firstMeasure === void 0 ? void 0 : firstMeasure.querySelector("attributes > key > mode")) === null || _a === void 0 ? void 0 : _a.textContent) === null || _b === void 0 ? void 0 : _b.trim()) || "major"; };
-const readAbcExportDocumentKeyInfo = (firstMeasure) => {
-    const fifths = readAbcExportKeyFifths(firstMeasure);
-    const mode = readAbcExportKeyMode(firstMeasure);
-    return {
+const exportMusicXmlDomToAbc = (doc) => {
+    var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p, _q, _r, _s, _t, _u, _v, _w;
+    const title = (_f = (_c = (_b = (_a = doc.querySelector("work > work-title")) === null || _a === void 0 ? void 0 : _a.textContent) === null || _b === void 0 ? void 0 : _b.trim()) !== null && _c !== void 0 ? _c : (_e = (_d = doc.querySelector("movement-title")) === null || _d === void 0 ? void 0 : _d.textContent) === null || _e === void 0 ? void 0 : _e.trim()) !== null && _f !== void 0 ? _f : "mikuscore";
+    const composer = (_j = (_h = (_g = doc.querySelector('identification > creator[type="composer"]')) === null || _g === void 0 ? void 0 : _g.textContent) === null || _h === void 0 ? void 0 : _h.trim()) !== null && _j !== void 0 ? _j : "";
+    const firstMeasure = doc.querySelector("score-partwise > part > measure");
+    const meterBeats = (_m = (_l = (_k = firstMeasure === null || firstMeasure === void 0 ? void 0 : firstMeasure.querySelector("attributes > time > beats")) === null || _k === void 0 ? void 0 : _k.textContent) === null || _l === void 0 ? void 0 : _l.trim()) !== null && _m !== void 0 ? _m : "4";
+    const meterBeatType = (_q = (_p = (_o = firstMeasure === null || firstMeasure === void 0 ? void 0 : firstMeasure.querySelector("attributes > time > beat-type")) === null || _o === void 0 ? void 0 : _o.textContent) === null || _p === void 0 ? void 0 : _p.trim()) !== null && _q !== void 0 ? _q : "4";
+    const fifths = Number((_t = (_s = (_r = firstMeasure === null || firstMeasure === void 0 ? void 0 : firstMeasure.querySelector("attributes > key > fifths")) === null || _r === void 0 ? void 0 : _r.textContent) === null || _s === void 0 ? void 0 : _s.trim()) !== null && _t !== void 0 ? _t : "0");
+    const mode = (_w = (_v = (_u = firstMeasure === null || firstMeasure === void 0 ? void 0 : firstMeasure.querySelector("attributes > key > mode")) === null || _u === void 0 ? void 0 : _u.textContent) === null || _v === void 0 ? void 0 : _v.trim()) !== null && _w !== void 0 ? _w : "major";
+    const initialTempo = readInitialTempoFromMusicXml(doc);
+    const abcTempoHeader = initialTempo
+        ? (initialTempo.unit && Number.isFinite(initialTempo.bpm) && initialTempo.bpm > 0
+            ? `Q:${fractionToAbcTempoUnit(initialTempo.unit)}=${Math.round(initialTempo.bpm)}`
+            : (Number.isFinite(initialTempo.bpm) ? `Q:1/4=${Math.round(initialTempo.bpm)}` : ""))
+        : "";
+    const exportContext = {
+        headerLines: [
+            "X:1",
+            `T:${title}`,
+            composer ? `C:${composer}` : "",
+            `M:${meterBeats}/${meterBeatType}`,
+            `L:${fractionToAbcTempoUnit(DEFAULT_UNIT)}`,
+            abcTempoHeader,
+            `K:${exports.AbcCommon.keyFromFifthsMode(Number.isFinite(fifths) ? fifths : 0, mode)}`,
+        ].filter((line) => line.length > 0),
+        bodyLines: [],
+        metaLines: [],
+        partNameById: new Map(Array.from(doc.querySelectorAll("part-list > score-part"))
+            .map((scorePart) => {
+            var _a, _b, _c;
+            const id = (_a = scorePart.getAttribute("id")) !== null && _a !== void 0 ? _a : "";
+            return id ? [id, ((_c = (_b = scorePart.querySelector("part-name")) === null || _b === void 0 ? void 0 : _b.textContent) === null || _c === void 0 ? void 0 : _c.trim()) || id] : null;
+        })
+            .filter((entry) => entry !== null)),
         fifths,
-        key: buildAbcExportKeyFromFifthsMode(fifths, mode),
+        meterBeats,
+        meterBeatType,
+        unitLength: DEFAULT_UNIT,
     };
+    appendAbcExportParts(Array.from(doc.querySelectorAll("score-partwise > part")), exportContext);
+    return `${exportContext.headerLines.join("\n")}\n\n${exportContext.bodyLines.join("\n")}${exportContext.metaLines.length > 0 ? `\n${exportContext.metaLines.join("\n")}\n` : "\n"}`;
 };
-const createAbcExportDocumentMeterKeyInfoFromParts = (meterInfo, keyInfo) => ({
-    meterBeats: meterInfo.meterBeats,
-    meterBeatType: meterInfo.meterBeatType,
-    fifths: keyInfo.fifths,
-    key: keyInfo.key,
-});
-const readAbcExportDocumentMeterKeyInfo = (firstMeasure) => {
-    const meterInfo = readAbcExportDocumentMeterInfo(firstMeasure);
-    const keyInfo = readAbcExportDocumentKeyInfo(firstMeasure);
-    return createAbcExportDocumentMeterKeyInfoFromParts(meterInfo, keyInfo);
-};
-const readAbcExportFirstMeasure = (doc) => doc.querySelector("score-partwise > part > measure");
-const createAbcExportDocumentHeaderInfoFromParts = (credits, meterKeyInfo, abcTempoHeader) => ({
-    title: credits.title,
-    composer: credits.composer,
-    meterBeats: meterKeyInfo.meterBeats,
-    meterBeatType: meterKeyInfo.meterBeatType,
-    fifths: meterKeyInfo.fifths,
-    key: meterKeyInfo.key,
-    abcTempoHeader,
-});
-const createAbcExportDocumentHeaderInfo = (doc) => createAbcExportDocumentHeaderInfoFromParts(readAbcExportDocumentCredits(doc), readAbcExportDocumentMeterKeyInfo(readAbcExportFirstMeasure(doc)), buildAbcExportTempoHeader(doc));
-const buildAbcExportRawHeaderLines = (headerInfo) => {
-    const { title, composer, meterBeats, meterBeatType, key, abcTempoHeader } = headerInfo;
-    return [
-        "X:1",
-        `T:${title}`,
-        composer ? `C:${composer}` : "",
-        `M:${meterBeats}/${meterBeatType}`,
-        `L:${fractionToAbcTempoUnit(DEFAULT_UNIT)}`,
-        abcTempoHeader,
-        `K:${key}`,
-    ];
-};
-const buildAbcExportHeaderLines = (headerInfo) => buildAbcExportRawHeaderLines(headerInfo).filter(Boolean);
-const createAbcExportInitialDocumentContext = (headerInfo, partNameById) => ({
-    headerLines: buildAbcExportHeaderLines(headerInfo),
-    bodyLines: [],
-    metaLines: [],
-    partNameById,
-    fifths: headerInfo.fifths,
-    meterBeats: headerInfo.meterBeats,
-    meterBeatType: headerInfo.meterBeatType,
-    unitLength: DEFAULT_UNIT,
-});
-const createAbcExportDocumentContext = (doc) => createAbcExportInitialDocumentContext(createAbcExportDocumentHeaderInfo(doc), buildAbcExportPartNameById(doc));
-const buildAbcExportMetaBlock = (metaLines) => metaLines.length > 0 ? `\n${metaLines.join("\n")}\n` : "\n";
-const buildAbcExportDocumentTextFromLines = (headerLines, bodyLines, metaLines) => {
-    const metaBlock = buildAbcExportMetaBlock(metaLines);
-    return `${headerLines.join("\n")}\n\n${bodyLines.join("\n")}${metaBlock}`;
-};
-const buildAbcExportDocumentText = (exportContext) => buildAbcExportDocumentTextFromLines(exportContext.headerLines, exportContext.bodyLines, exportContext.metaLines);
-const createAbcExportPartRenderContext = (part, partIndex, exportContext) => ({
-    part,
-    partIndex,
-    partNameById: exportContext.partNameById,
-    fifths: exportContext.fifths,
-    meterBeats: exportContext.meterBeats,
-    meterBeatType: exportContext.meterBeatType,
-    unitLength: exportContext.unitLength,
-    headerLines: exportContext.headerLines,
-    bodyLines: exportContext.bodyLines,
-    metaLines: exportContext.metaLines,
-});
-const readAbcExportParts = (doc) => Array.from(doc.querySelectorAll("score-partwise > part"));
-const appendAbcExportParts = (parts, exportContext) => {
-    parts.forEach((part, partIndex) => {
-        appendAbcExportPart(createAbcExportPartRenderContext(part, partIndex, exportContext));
-    });
-};
-const renderAbcExportDocumentContext = (doc) => {
-    const exportContext = createAbcExportDocumentContext(doc);
-    appendAbcExportParts(readAbcExportParts(doc), exportContext);
-    return exportContext;
-};
-const exportMusicXmlDomToAbc = (doc) => buildAbcExportDocumentText(renderAbcExportDocumentContext(doc));
 exports.exportMusicXmlDomToAbc = exportMusicXmlDomToAbc;
 const xmlEscape = (text) => text
     .replace(/&/g, "&amp;")
@@ -37470,189 +37182,157 @@ const xmlEscape = (text) => text
     .replace(/>/g, "&gt;")
     .replace(/"/g, "&quot;")
     .replace(/'/g, "&apos;");
-const abcQuotedTextEscape = (text) => String(text || "")
+const abcQuotedTextEscape = (text) => String(text !== null && text !== void 0 ? text : "")
     .replace(/"/g, "'")
     .replace(/\s+/g, " ")
     .trim();
-const normalizeChordToken = (raw) => String(raw || "")
+const normalizeChordToken = (raw) => String(raw !== null && raw !== void 0 ? raw : "")
     .trim()
     .replace(/♯/g, "#")
     .replace(/♭/g, "b")
     .replace(/\s+/g, "");
 const ABC_CHORD_SYMBOL_PATTERN = /^([A-G](?:#|b)?)([^/\s"]*)?(?:\/([A-G](?:#|b)?))?$/;
-const isLikelyAbcChordSymbol = (raw) => {
-    const text = normalizeChordToken(raw);
-    return ABC_CHORD_SYMBOL_PATTERN.test(text);
+const isLikelyAbcChordSymbol = (raw) => ABC_CHORD_SYMBOL_PATTERN.test(normalizeChordToken(raw));
+const normalizeHarmonyChordSuffix = (suffixRaw) => String(suffixRaw !== null && suffixRaw !== void 0 ? suffixRaw : "").trim().toLowerCase();
+const abcHarmonyKindBySuffix = {
+    "": "major",
+    m: "minor",
+    min: "minor",
+    "6": "major-sixth",
+    m6: "minor-sixth",
+    min6: "minor-sixth",
+    "7": "dominant",
+    "7sus4": "suspended-fourth",
+    "9": "dominant-ninth",
+    "11": "dominant-11th",
+    "13": "dominant-13th",
+    maj7: "major-seventh",
+    maj9: "major-ninth",
+    m9: "minor-ninth",
+    min9: "minor-ninth",
+    m7: "minor-seventh",
+    min7: "minor-seventh",
+    dim: "diminished",
+    dim7: "diminished-seventh",
+    aug: "augmented",
+    "+": "augmented",
+    sus4: "suspended-fourth",
+    sus2: "suspended-second",
+    "m7b5": "half-diminished",
+    min7b5: "half-diminished",
+    "ø": "half-diminished",
 };
-const normalizeHarmonyChordSuffix = (suffixRaw) => String(suffixRaw || "").trim().toLowerCase();
 const xmlHarmonyKindFromChordSuffix = (suffixRaw) => {
+    var _a;
     const suffix = normalizeHarmonyChordSuffix(suffixRaw);
-    if (!suffix)
-        return "major";
-    if (suffix === "m" || suffix === "min")
-        return "minor";
-    if (suffix === "6")
-        return "major-sixth";
-    if (suffix === "m6" || suffix === "min6")
-        return "minor-sixth";
-    if (suffix === "7")
-        return "dominant";
-    if (suffix === "7sus4")
-        return "suspended-fourth";
-    if (suffix === "9")
-        return "dominant-ninth";
-    if (suffix === "11")
-        return "dominant-11th";
-    if (suffix === "13")
-        return "dominant-13th";
-    if (suffix === "maj7")
-        return "major-seventh";
-    if (suffix === "maj9")
-        return "major-ninth";
-    if (suffix === "m9" || suffix === "min9")
-        return "minor-ninth";
-    if (suffix === "m7" || suffix === "min7")
-        return "minor-seventh";
-    if (suffix === "dim")
-        return "diminished";
-    if (suffix === "dim7")
-        return "diminished-seventh";
-    if (suffix === "aug" || suffix === "+")
-        return "augmented";
-    if (suffix === "sus4")
-        return "suspended-fourth";
-    if (suffix === "sus2")
-        return "suspended-second";
-    if (suffix === "m7b5" || suffix === "min7b5" || suffix === "ø")
-        return "half-diminished";
-    return null;
+    return (_a = abcHarmonyKindBySuffix[suffix]) !== null && _a !== void 0 ? _a : null;
 };
 const xmlHarmonyRootFromChordToken = (token) => {
-    const m = String(token || "").match(/^([A-G])(#|b)?$/);
-    if (!m)
-        return null;
-    return {
-        step: m[1],
-        alter: m[2] === "#" ? 1 : (m[2] === "b" ? -1 : 0),
-    };
+    const m = String(token !== null && token !== void 0 ? token : "").match(/^([A-G])(#|b)?$/);
+    return m
+        ? {
+            step: m[1],
+            alter: m[2] === "#" ? 1 : (m[2] === "b" ? -1 : 0),
+        }
+        : null;
 };
 const parseAbcChordSymbolParts = (raw) => {
+    var _a, _b;
     const normalized = normalizeChordToken(raw);
     const match = normalized.match(ABC_CHORD_SYMBOL_PATTERN);
     if (!match)
         return null;
-    const root = xmlHarmonyRootFromChordToken(match[1] || "");
+    const root = xmlHarmonyRootFromChordToken((_a = match[1]) !== null && _a !== void 0 ? _a : "");
     if (!root)
         return null;
     const bass = match[3] ? xmlHarmonyRootFromChordToken(match[3]) : null;
     return {
         normalized,
         root,
-        suffix: String(match[2] || ""),
+        suffix: String((_b = match[2]) !== null && _b !== void 0 ? _b : ""),
         bass,
     };
 };
-const buildHarmonyPitchXml = (tagName, pitch) => {
-    const childPrefix = tagName === "root" ? "root" : "bass";
-    return [
-        `<${tagName}>`,
-        `<${childPrefix}-step>${xmlEscape(pitch.step)}</${childPrefix}-step>`,
-        pitch.alter !== 0 ? `<${childPrefix}-alter>${pitch.alter}</${childPrefix}-alter>` : "",
-        `</${tagName}>`,
-    ].join("");
-};
-const buildHarmonyKindXml = (normalized, kind) => `<kind text="${xmlEscape(normalized)}">${kind}</kind>`;
-const buildHarmonyXmlFromParts = (parts, kind) => [
-    "<harmony>",
-    buildHarmonyPitchXml("root", parts.root),
-    parts.bass ? buildHarmonyPitchXml("bass", parts.bass) : "",
-    buildHarmonyKindXml(parts.normalized, kind),
-    "</harmony>",
+const buildHarmonyPitchXml = (tagName, pitch) => [
+    `<${tagName}>`,
+    `<${tagName}-step>${xmlEscape(pitch.step)}</${tagName}-step>`,
+    pitch.alter !== 0 ? `<${tagName}-alter>${pitch.alter}</${tagName}-alter>` : "",
+    `</${tagName}>`,
 ].join("");
 const buildHarmonyXmlFromChordSymbol = (raw) => {
     const parts = parseAbcChordSymbolParts(raw);
     if (!parts)
         return "";
     const kind = xmlHarmonyKindFromChordSuffix(parts.suffix);
-    if (!kind)
-        return "";
-    return buildHarmonyXmlFromParts(parts, kind);
+    return kind
+        ? [
+            "<harmony>",
+            buildHarmonyPitchXml("root", parts.root),
+            parts.bass ? buildHarmonyPitchXml("bass", parts.bass) : "",
+            `<kind text="${xmlEscape(parts.normalized)}">${kind}</kind>`,
+            "</harmony>",
+        ].join("")
+        : "";
 };
-const abcHarmonyPitchTokenFromStepAlter = (step, alter) => {
-    const normalizedStep = String(step || "").trim().toUpperCase();
-    if (!/^[A-G]$/.test(normalizedStep))
-        return "";
-    return `${normalizedStep}${alter === 1 ? "#" : (alter === -1 ? "b" : "")}`;
+const abcHarmonySuffixByKindValue = {
+    major: "",
+    minor: "m",
+    "major-sixth": "6",
+    "minor-sixth": "m6",
+    dominant: "7",
+    "dominant-11th": "11",
+    "dominant-13th": "13",
+    "dominant-ninth": "9",
+    "major-seventh": "maj7",
+    "major-ninth": "maj9",
+    "minor-ninth": "m9",
+    "minor-seventh": "m7",
+    diminished: "dim",
+    "diminished-seventh": "dim7",
+    augmented: "aug",
+    "suspended-fourth": "sus4",
+    "suspended-second": "sus2",
+    "half-diminished": "m7b5",
 };
-const abcHarmonyPitchFromNode = (node, prefix) => {
-    var _a, _b;
-    if (!node)
-        return null;
-    const step = (((_a = node.querySelector(`:scope > ${prefix}-step`)) === null || _a === void 0 ? void 0 : _a.textContent) || "").trim();
-    const alter = Number(((_b = node.querySelector(`:scope > ${prefix}-alter`)) === null || _b === void 0 ? void 0 : _b.textContent) || "0");
-    return { step, alter };
-};
-const abcHarmonyPitchTokenFromNode = (node, prefix) => {
-    const pitch = abcHarmonyPitchFromNode(node, prefix);
-    return pitch ? abcHarmonyPitchTokenFromStepAlter(pitch.step, pitch.alter) : "";
-};
-const abcHarmonySuffixFromKindValue = (kindValue) => kindValue === "major" ? "" :
-    kindValue === "minor" ? "m" :
-        kindValue === "major-sixth" ? "6" :
-            kindValue === "minor-sixth" ? "m6" :
-                kindValue === "dominant" ? "7" :
-                    kindValue === "dominant-11th" ? "11" :
-                        kindValue === "dominant-13th" ? "13" :
-                            kindValue === "dominant-ninth" ? "9" :
-                                kindValue === "major-seventh" ? "maj7" :
-                                    kindValue === "major-ninth" ? "maj9" :
-                                        kindValue === "minor-ninth" ? "m9" :
-                                            kindValue === "minor-seventh" ? "m7" :
-                                                kindValue === "diminished" ? "dim" :
-                                                    kindValue === "diminished-seventh" ? "dim7" :
-                                                        kindValue === "augmented" ? "aug" :
-                                                            kindValue === "suspended-fourth" ? "sus4" :
-                                                                kindValue === "suspended-second" ? "sus2" :
-                                                                    kindValue === "half-diminished" ? "m7b5" :
-                                                                        "";
-const abcHarmonyKindTextOverride = (kindNode) => {
-    const kindTextAttr = ((kindNode === null || kindNode === void 0 ? void 0 : kindNode.getAttribute("text")) || "").trim();
-    return kindTextAttr ? abcQuotedTextEscape(kindTextAttr) : "";
-};
-const normalizeHarmonyKindValue = (kindValue) => String(kindValue || "").trim().toLowerCase();
-const abcHarmonyKindValueFromNode = (kindNode) => normalizeHarmonyKindValue((kindNode === null || kindNode === void 0 ? void 0 : kindNode.textContent) || "");
-const abcHarmonySuffixFromKindNode = (kindNode) => abcHarmonySuffixFromKindValue(abcHarmonyKindValueFromNode(kindNode));
-const abcHarmonyBassTokenFromNode = (node) => {
-    const bassPitchToken = abcHarmonyPitchTokenFromNode(node, "bass");
-    return bassPitchToken ? `/${bassPitchToken}` : "";
-};
-const buildAbcHarmonyChordSymbol = (rootToken, suffix, bassToken) => `${rootToken}${suffix}${bassToken}`;
 const abcChordSymbolFromHarmony = (harmony) => {
+    var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m;
     if (!harmony)
         return "";
-    const rootToken = abcHarmonyPitchTokenFromNode(harmony.querySelector(":scope > root"), "root");
+    const rootNode = harmony.querySelector(":scope > root");
+    const rootStep = rootNode ? ((_b = (_a = rootNode.querySelector(":scope > root-step")) === null || _a === void 0 ? void 0 : _a.textContent) !== null && _b !== void 0 ? _b : "").trim() : "";
+    const rootAlter = rootNode ? Number((_d = (_c = rootNode.querySelector(":scope > root-alter")) === null || _c === void 0 ? void 0 : _c.textContent) !== null && _d !== void 0 ? _d : "0") : 0;
+    const rootNormalizedStep = String(rootStep !== null && rootStep !== void 0 ? rootStep : "").trim().toUpperCase();
+    const rootToken = /^[A-G]$/.test(rootNormalizedStep)
+        ? `${rootNormalizedStep}${rootAlter === 1 ? "#" : (rootAlter === -1 ? "b" : "")}`
+        : "";
     if (!rootToken)
         return "";
     const kindNode = harmony.querySelector(":scope > kind");
-    const kindTextOverride = abcHarmonyKindTextOverride(kindNode);
-    if (kindTextOverride)
-        return kindTextOverride;
-    const suffix = abcHarmonySuffixFromKindNode(kindNode);
-    const bassToken = abcHarmonyBassTokenFromNode(harmony.querySelector(":scope > bass"));
-    return buildAbcHarmonyChordSymbol(rootToken, suffix, bassToken);
+    const kindTextAttr = (_f = (_e = kindNode === null || kindNode === void 0 ? void 0 : kindNode.getAttribute("text")) === null || _e === void 0 ? void 0 : _e.trim()) !== null && _f !== void 0 ? _f : "";
+    if (kindTextAttr)
+        return abcQuotedTextEscape(kindTextAttr);
+    const bassNode = harmony.querySelector(":scope > bass");
+    const bassStep = bassNode ? ((_h = (_g = bassNode.querySelector(":scope > bass-step")) === null || _g === void 0 ? void 0 : _g.textContent) !== null && _h !== void 0 ? _h : "").trim() : "";
+    const bassAlter = bassNode ? Number((_k = (_j = bassNode.querySelector(":scope > bass-alter")) === null || _j === void 0 ? void 0 : _j.textContent) !== null && _k !== void 0 ? _k : "0") : 0;
+    const bassNormalizedStep = String(bassStep !== null && bassStep !== void 0 ? bassStep : "").trim().toUpperCase();
+    const bassPitchToken = /^[A-G]$/.test(bassNormalizedStep)
+        ? `${bassNormalizedStep}${bassAlter === 1 ? "#" : (bassAlter === -1 ? "b" : "")}`
+        : "";
+    const kindValue = String((_l = kindNode === null || kindNode === void 0 ? void 0 : kindNode.textContent) !== null && _l !== void 0 ? _l : "").trim().toLowerCase();
+    const suffix = (_m = abcHarmonySuffixByKindValue[kindValue]) !== null && _m !== void 0 ? _m : "";
+    return `${rootToken}${suffix}${bassPitchToken ? `/${bassPitchToken}` : ""}`;
 };
-const normalizeAbcLyricText = (text) => String(text || "").trim().replace(/\s+/g, "~");
-const normalizeAbcLyricSyllabicMode = (syllabic) => String(syllabic || "single").trim().toLowerCase();
+const normalizeAbcLyricText = (text) => String(text !== null && text !== void 0 ? text : "").trim().replace(/\s+/g, "~");
+const normalizeAbcLyricSyllabicMode = (syllabic) => String(syllabic !== null && syllabic !== void 0 ? syllabic : "single").trim().toLowerCase();
 const shouldAppendAbcLyricHyphen = (syllabicMode) => syllabicMode === "begin" || syllabicMode === "middle";
-const buildAbcLyricTextToken = (normalizedText, syllabicMode) => shouldAppendAbcLyricHyphen(syllabicMode) ? `${normalizedText}-` : normalizedText;
 const abcLyricTokenFromMusicXml = (text, syllabic) => {
     const normalized = normalizeAbcLyricText(text);
     const mode = normalizeAbcLyricSyllabicMode(syllabic);
     if (!normalized)
         return "*";
-    return buildAbcLyricTextToken(normalized, mode);
+    return shouldAppendAbcLyricHyphen(mode) ? `${normalized}-` : normalized;
 };
-const normalizeMusicXmlTypeName = (t) => String(t || "").trim();
+const normalizeMusicXmlTypeName = (t) => String(t !== null && t !== void 0 ? t : "").trim();
 const isSupportedMusicXmlTypeName = (typeName) => typeName === "16th" ||
     typeName === "32nd" ||
     typeName === "64th" ||
@@ -37663,20 +37343,14 @@ const isSupportedMusicXmlTypeName = (typeName) => typeName === "16th" ||
     typeName === "eighth";
 const normalizeTypeForMusicXml = (t) => {
     const raw = normalizeMusicXmlTypeName(t);
-    if (!raw)
-        return "quarter";
-    if (isSupportedMusicXmlTypeName(raw))
-        return raw;
-    return "quarter";
+    return raw && isSupportedMusicXmlTypeName(raw) ? raw : "quarter";
 };
-const normalizeMusicXmlVoiceText = (voice) => String(voice || "").trim();
+const normalizeMusicXmlVoiceText = (voice) => String(voice !== null && voice !== void 0 ? voice : "").trim();
 const isPositiveIntegerVoiceText = (voiceText) => /^[1-9]\d*$/.test(voiceText);
-const extractFirstVoiceNumberText = (voiceText) => { var _a; return ((_a = voiceText.match(/\d+/)) === null || _a === void 0 ? void 0 : _a[0]) || ""; };
+const extractFirstVoiceNumberText = (voiceText) => { var _a, _b; return (_b = (_a = voiceText.match(/\d+/)) === null || _a === void 0 ? void 0 : _a[0]) !== null && _b !== void 0 ? _b : ""; };
 const normalizeMusicXmlVoiceNumberText = (voiceNumberText) => {
     const n = Number(voiceNumberText);
-    if (!Number.isFinite(n) || n <= 0)
-        return "1";
-    return String(Math.round(n));
+    return Number.isFinite(n) && n > 0 ? String(Math.round(n)) : "1";
 };
 const normalizeVoiceForMusicXml = (voice) => {
     const raw = normalizeMusicXmlVoiceText(voice);
@@ -37685,9 +37359,7 @@ const normalizeVoiceForMusicXml = (voice) => {
     if (isPositiveIntegerVoiceText(raw))
         return raw;
     const numberText = extractFirstVoiceNumberText(raw);
-    if (!numberText)
-        return "1";
-    return normalizeMusicXmlVoiceNumberText(numberText);
+    return numberText ? normalizeMusicXmlVoiceNumberText(numberText) : "1";
 };
 const midiByStepForAbcImport = {
     C: 0,
@@ -37698,30 +37370,23 @@ const midiByStepForAbcImport = {
     A: 9,
     B: 11,
 };
-const normalizeAbcImportStep = (step) => String(step || "").trim().toUpperCase();
-const normalizeAbcImportOctave = (octave) => Number.isFinite(octave) ? Math.round(Number(octave)) : 4;
-const normalizeAbcImportAlter = (alter) => Number.isFinite(alter) ? Math.round(Number(alter)) : 0;
-const abcImportPitchToMidi = (step, octave, alter) => (octave + 1) * 12 + midiByStepForAbcImport[step] + alter;
-const noteToMidiForAbcClefInference = (note) => {
-    if (!note || note.isRest)
-        return null;
-    const step = normalizeAbcImportStep(note.step);
-    if (!Object.prototype.hasOwnProperty.call(midiByStepForAbcImport, step)) {
-        return null;
-    }
-    const octave = normalizeAbcImportOctave(note.octave);
-    const alter = normalizeAbcImportAlter(note.alter);
-    return abcImportPitchToMidi(step, octave, alter);
-};
-const normalizeAbcImportClefName = (clef) => String(clef || "").trim().toLowerCase();
+const normalizeAbcImportStep = (step) => String(step !== null && step !== void 0 ? step : "").trim().toUpperCase();
+const normalizeAbcImportClefName = (clef) => String(clef !== null && clef !== void 0 ? clef : "").trim().toLowerCase();
 const collectAbcImportClefMidiKeys = (part) => {
+    var _a;
     const keys = [];
-    for (const measure of (part === null || part === void 0 ? void 0 : part.measures) || []) {
-        for (const note of measure || []) {
-            const midi = noteToMidiForAbcClefInference(note);
-            if (Number.isFinite(midi)) {
-                keys.push(midi);
+    for (const measure of (_a = part === null || part === void 0 ? void 0 : part.measures) !== null && _a !== void 0 ? _a : []) {
+        for (const note of measure !== null && measure !== void 0 ? measure : []) {
+            if (!note || note.isRest) {
+                continue;
             }
+            const step = normalizeAbcImportStep(note.step);
+            if (!Object.prototype.hasOwnProperty.call(midiByStepForAbcImport, step)) {
+                continue;
+            }
+            const octave = Number.isFinite(Number(note.octave)) ? Math.round(Number(note.octave)) : 4;
+            const alter = Number.isFinite(Number(note.alter)) ? Math.round(Number(note.alter)) : 0;
+            keys.push((octave + 1) * 12 + midiByStepForAbcImport[step] + alter);
         }
     }
     return keys;
@@ -37729,163 +37394,29 @@ const collectAbcImportClefMidiKeys = (part) => {
 const abcImportClefNameFromMidiKeys = (keys) => (0, staffClefPolicy_1.chooseSingleClefByKeys)(keys) === "F" ? "bass" : "treble";
 const resolveAbcImportClef = (part) => {
     const explicit = normalizeAbcImportClefName(part === null || part === void 0 ? void 0 : part.clef);
+    const keys = collectAbcImportClefMidiKeys(part);
     if (explicit)
         return explicit;
-    const keys = collectAbcImportClefMidiKeys(part);
     if (!keys.length)
-        return "";
+        return explicit;
     return abcImportClefNameFromMidiKeys(keys);
 };
-const clefFeatureFromAbcClefName = (clef) => {
-    if (clef === "bass" || clef === "f") {
-        return { sign: "F", line: 4 };
-    }
-    if (clef === "alto" || clef === "c3") {
-        return { sign: "C", line: 3 };
-    }
-    if (clef === "tenor" || clef === "c4") {
-        return { sign: "C", line: 4 };
-    }
-    return { sign: "G", line: 2 };
+const clefFeatureByAbcClefName = {
+    bass: { sign: "F", line: 4 },
+    f: { sign: "F", line: 4 },
+    alto: { sign: "C", line: 3 },
+    c3: { sign: "C", line: 3 },
+    tenor: { sign: "C", line: 4 },
+    c4: { sign: "C", line: 4 },
+    treble: { sign: "G", line: 2 },
+    g: { sign: "G", line: 2 },
 };
-const clefXmlFromAbcClef = (rawClef) => {
-    const clef = normalizeAbcImportClefName(rawClef);
-    return (0, clefs_1.buildMusicXmlClefXml)(clefFeatureFromAbcClefName(clef));
-};
+const clefFeatureFromAbcClefName = (clef) => { var _a; return (_a = clefFeatureByAbcClefName[clef]) !== null && _a !== void 0 ? _a : { sign: "G", line: 2 }; };
+const clefXmlFromAbcClef = (rawClef) => (0, clefs_1.buildMusicXmlClefXml)(clefFeatureFromAbcClefName(normalizeAbcImportClefName(rawClef)));
 exports.clefXmlFromAbcClef = clefXmlFromAbcClef;
 const toHex = (value, width = 2) => {
-    const safe = Math.max(0, Math.round(Number(value) || 0));
+    const safe = Math.max(0, Math.round(Number(value !== null && value !== void 0 ? value : 0)));
     return `0x${safe.toString(16).toUpperCase().padStart(width, "0")}`;
-};
-const normalizeAbcDebugStep = (note) => note.isRest ? "R" : (/^[A-G]$/.test(String(note.step || "").toUpperCase()) ? String(note.step).toUpperCase() : "C");
-const normalizeAbcDebugOctave = (octave) => Number.isFinite(octave) ? Math.max(0, Math.min(9, Math.round(Number(octave)))) : 4;
-const normalizeAbcDebugAlter = (alter) => Number.isFinite(alter) ? Math.round(Number(alter)) : 0;
-const buildAbcMeasureDebugMiscXmlCoreFields = (index, measureNo, voice, note) => [`idx=${toHex(index, 4)}`, `m=${toHex(measureNo, 4)}`, `v=${xmlEscape(voice)}`].join(";");
-const buildAbcMeasureDebugMiscXmlNoteFields = (note, step, octave, alter, dur) => [
-    `r=${note.isRest ? "1" : "0"}`,
-    `g=${note.grace ? "1" : "0"}`,
-    `ch=${note.chord ? "1" : "0"}`,
-    `st=${step}`,
-    `al=${String(alter)}`,
-    `oc=${toHex(octave, 2)}`,
-    `dd=${toHex(dur, 4)}`,
-    `tp=${xmlEscape(normalizeTypeForMusicXml(note.type))}`,
-].join(";");
-const buildAbcMeasureDebugMiscXmlCountField = (noteCount) => `<miscellaneous-field name="mks:dbg:abc:meta:count">${toHex(noteCount, 4)}</miscellaneous-field>`;
-const buildAbcMeasureDebugMiscXmlEntry = (note, index, measureNo) => `<miscellaneous-field name="mks:dbg:abc:meta:${String(index + 1).padStart(4, "0")}">${buildAbcMeasureDebugMiscXmlPayload(note, index, measureNo)}</miscellaneous-field>`;
-const buildAbcMeasureDebugMiscXmlPayload = (note, index, measureNo) => {
-    const voice = normalizeVoiceForMusicXml(note.voice);
-    const step = normalizeAbcDebugStep(note);
-    const octave = normalizeAbcDebugOctave(note.octave);
-    const alter = normalizeAbcDebugAlter(note.alter);
-    const dur = note.grace ? 0 : Math.max(1, Math.round(Number(note.duration) || 1));
-    return [buildAbcMeasureDebugMiscXmlCoreFields(index, measureNo, voice, note), buildAbcMeasureDebugMiscXmlNoteFields(note, step, octave, alter, dur)].join(";");
-};
-const buildAbcMeasureDebugMiscXml = (notes, measureNo) => {
-    if (!notes.length)
-        return "";
-    let xml = "<attributes><miscellaneous>";
-    xml += buildAbcMeasureDebugMiscXmlCountField(notes.length);
-    xml += buildAbcMeasureDebugMiscXmlEntryParts(notes, measureNo).join("");
-    xml += "</miscellaneous></attributes>";
-    return xml;
-};
-const buildAbcMeasureDebugMiscXmlEntryParts = (notes, measureNo) => notes.map((note, index) => buildAbcMeasureDebugMiscXmlEntry(note, index, measureNo));
-const encodeAbcSourceForMiscXml = (abcSource) => String(abcSource !== null && abcSource !== void 0 ? abcSource : "")
-    .replace(/\\/g, "\\\\")
-    .replace(/\r/g, "\\r")
-    .replace(/\n/g, "\\n");
-const buildAbcSourceMiscXmlEncodingField = () => `<miscellaneous-field name="mks:src:abc:raw-encoding">escape-v1</miscellaneous-field>`;
-const buildAbcSourceMiscXmlLengthFields = (source, encoded) => buildAbcSourceMiscXmlLengthFieldParts(source, encoded).join("");
-const buildAbcSourceMiscXmlLengthFieldParts = (source, encoded) => [
-    buildAbcSourceMiscXmlRawLengthField(source),
-    buildAbcSourceMiscXmlRawEncodedLengthField(encoded),
-];
-const buildAbcSourceMiscXmlRawLengthField = (source) => `<miscellaneous-field name="mks:src:abc:raw-length">${xmlEscape(String(source.length))}</miscellaneous-field>`;
-const buildAbcSourceMiscXmlRawEncodedLengthField = (encoded) => `<miscellaneous-field name="mks:src:abc:raw-encoded-length">${xmlEscape(String(encoded.length))}</miscellaneous-field>`;
-const buildAbcSourceMiscXmlStateFields = (chunks, truncated) => buildAbcSourceMiscXmlStateFieldParts(chunks, truncated).join("");
-const buildAbcSourceMiscXmlStateFieldParts = (chunks, truncated) => [
-    buildAbcSourceMiscXmlChunkCountField(chunks),
-    buildAbcSourceMiscXmlTruncatedField(truncated),
-];
-const buildAbcSourceMiscXmlChunkCountField = (chunks) => `<miscellaneous-field name="mks:src:abc:raw-chunks">${xmlEscape(String(chunks.length))}</miscellaneous-field>`;
-const buildAbcSourceMiscXmlTruncatedField = (truncated) => `<miscellaneous-field name="mks:src:abc:raw-truncated">${truncated ? "1" : "0"}</miscellaneous-field>`;
-const buildAbcSourceMiscXmlChunkFields = (chunks) => {
-    return buildAbcSourceMiscXmlChunkFieldsXml(chunks);
-};
-const buildAbcSourceMiscXmlChunkFieldsXml = (chunks) => buildAbcSourceMiscXmlChunkEntryParts(chunks).join("");
-const buildAbcSourceMiscXmlChunkEntryParts = (chunks) => {
-    const chunkParts = [];
-    for (let i = 0; i < chunks.length; i += 1) {
-        chunkParts.push(buildAbcSourceMiscXmlChunkEntry(chunks[i], i));
-    }
-    return chunkParts;
-};
-const buildAbcSourceMiscXmlChunkEntry = (chunk, index) => `<miscellaneous-field name="mks:src:abc:raw-${String(index + 1).padStart(4, "0")}">${xmlEscape(chunk)}</miscellaneous-field>`;
-const buildAbcSourceMiscXmlChunks = (encoded) => {
-    const CHUNK_SIZE = 240;
-    const MAX_CHUNKS = 512;
-    const chunks = [];
-    for (let i = 0; i < encoded.length && chunks.length < MAX_CHUNKS; i += CHUNK_SIZE) {
-        chunks.push(encoded.slice(i, i + CHUNK_SIZE));
-    }
-    return chunks;
-};
-const buildAbcSourceMiscXmlBody = (source, encoded, chunks, truncated) => buildAbcSourceMiscXmlBodyFields(source, encoded, chunks, truncated).join("");
-const buildAbcSourceMiscXmlBodyFields = (source, encoded, chunks, truncated) => [...buildAbcSourceMiscXmlBodyHeaderFieldItems(source, encoded, chunks, truncated), ...buildAbcSourceMiscXmlBodyChunkFieldParts(chunks)];
-const buildAbcSourceMiscXmlBodyHeaderFieldItems = (source, encoded, chunks, truncated) => [
-    buildAbcSourceMiscXmlEncodingField(),
-    buildAbcSourceMiscXmlLengthFields(source, encoded),
-    buildAbcSourceMiscXmlStateFields(chunks, truncated),
-];
-const buildAbcSourceMiscXmlBodyChunkFieldParts = (chunks) => [buildAbcSourceMiscXmlChunkFields(chunks)];
-const buildAbcSourceMiscXml = (abcSource) => {
-    const source = String(abcSource !== null && abcSource !== void 0 ? abcSource : "");
-    if (!source.length)
-        return "";
-    const encoded = encodeAbcSourceForMiscXml(source);
-    const chunks = buildAbcSourceMiscXmlChunks(encoded);
-    const truncated = chunks.join("").length < encoded.length;
-    return `<attributes><miscellaneous>${buildAbcSourceMiscXmlBody(source, encoded, chunks, truncated)}</miscellaneous></attributes>`;
-};
-const buildAbcDiagMiscXmlPayload = (item) => {
-    return [...buildAbcDiagMiscXmlCoreFieldParts(item), ...buildAbcDiagMiscXmlOptionalFields(item)].join(";");
-};
-const buildAbcDiagMiscXmlCoreFieldParts = (item) => [`level=${item.level}`, `code=${item.code}`, `fmt=${item.fmt}`];
-const buildAbcDiagMiscXmlNumericOptionalFields = (item) => buildAbcDiagMiscXmlNumericOptionalFieldParts(item);
-const buildAbcDiagMiscXmlNumericOptionalFieldParts = (item) => [...buildAbcDiagMiscXmlMeasureOptionalParts(item.measure), ...buildAbcDiagMiscXmlMovedEventsOptionalParts(item.movedEvents)];
-const buildAbcDiagMiscXmlMeasureOptionalParts = (measure) => [Number.isFinite(measure) ? `measure=${Math.max(1, Math.round(Number(measure)))}` : ""].filter(Boolean);
-const buildAbcDiagMiscXmlMovedEventsOptionalParts = (movedEvents) => [Number.isFinite(movedEvents) ? `movedEvents=${Math.max(0, Math.round(Number(movedEvents)))}` : ""].filter(Boolean);
-const buildAbcDiagMiscXmlTextOptionalFields = (item) => buildAbcDiagMiscXmlTextOptionalFieldParts(item);
-const buildAbcDiagMiscXmlTextOptionalFieldParts = (item) => [
-    item.voiceId ? `voice=${xmlEscape(item.voiceId)}` : "",
-    item.action ? `action=${xmlEscape(item.action)}` : "",
-    item.message ? `message=${xmlEscape(item.message)}` : "",
-].filter(Boolean);
-const buildAbcDiagMiscXmlOptionalFields = (item) => buildAbcDiagMiscXmlOptionalFieldParts(item);
-const buildAbcDiagMiscXmlOptionalFieldParts = (item) => [...buildAbcDiagMiscXmlNumericOptionalFields(item), ...buildAbcDiagMiscXmlTextOptionalFields(item)];
-const buildAbcDiagMiscXmlEntry = (item, index) => `<miscellaneous-field name="${buildAbcDiagMiscXmlEntryName(index)}">${buildAbcDiagMiscXmlEntryPayload(item)}</miscellaneous-field>`;
-const buildAbcDiagMiscXmlEntryName = (index) => `mks:diag:${String(index + 1).padStart(4, "0")}`;
-const buildAbcDiagMiscXmlEntryPayload = (item) => buildAbcDiagMiscXmlPayload(item);
-const buildAbcDiagMiscXmlCountField = (maxEntries) => `<miscellaneous-field name="mks:diag:count">${maxEntries}</miscellaneous-field>`;
-const buildAbcDiagMiscXmlEntries = (diagnostics, maxEntries) => buildAbcDiagMiscXmlEntryList(diagnostics, maxEntries);
-const buildAbcDiagMiscXmlEntryList = (diagnostics, maxEntries) => buildAbcDiagMiscXmlEntryParts(diagnostics, maxEntries).join("");
-const buildAbcDiagMiscXmlEntryParts = (diagnostics, maxEntries) => {
-    const entryParts = [];
-    for (let i = 0; i < maxEntries; i += 1) {
-        entryParts.push(buildAbcDiagMiscXmlEntry(diagnostics[i], i));
-    }
-    return entryParts;
-};
-const buildAbcDiagMiscXml = (diagnostics) => {
-    if (!diagnostics.length)
-        return "";
-    const maxEntries = Math.min(256, diagnostics.length);
-    let xml = "<attributes><miscellaneous>";
-    xml += buildAbcDiagMiscXmlCountField(maxEntries);
-    xml += buildAbcDiagMiscXmlEntries(diagnostics, maxEntries);
-    xml += "</miscellaneous></attributes>";
-    return xml;
 };
 const prettyPrintXml = (xml) => {
     const compact = xml.replace(/>\s+</g, "><").trim();
@@ -37906,15 +37437,10 @@ const prettyPrintXml = (xml) => {
     }
     return lines.join("\n");
 };
-const resolveAbcParsedPartsForExport = (parts) => {
-    const safeParts = parts && parts.length > 0
-        ? parts
-        : [{ partId: "P1", partName: "Voice 1", measures: [[]] }];
-    return safeParts.map((part) => ({
-        ...part,
-        clef: resolveAbcImportClef(part),
-    }));
-};
+const resolveAbcParsedPartsForExport = (parts) => (parts && parts.length > 0 ? parts : [{ partId: "P1", partName: "Voice 1", measures: [[]] }]).map((part) => ({
+    ...part,
+    clef: resolveAbcImportClef(part),
+}));
 const buildAbcMusicXmlExportContext = (parsed) => {
     var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l;
     const resolvedParts = resolveAbcParsedPartsForExport(parsed.parts);
@@ -37946,37 +37472,43 @@ const buildAbcMusicXmlExportContext = (parsed) => {
         tempoBpm,
     };
 };
-const buildAbcScorePartwiseXmlDocument = (title, composer, partListXml, partBodyXml) => {
-    return [
-        '<?xml version="1.0" encoding="UTF-8"?>',
-        '<score-partwise version="4.0">',
-        `<work><work-title>${xmlEscape(title)}</work-title></work>`,
-        `<identification><creator type="composer">${xmlEscape(composer)}</creator></identification>`,
-        `<part-list>${partListXml}</part-list>`,
-        partBodyXml,
-        "</score-partwise>",
-    ].join("");
-};
-const buildMusicXmlFromAbcParsed = (parsed, abcSource, options = {}) => {
-    var _a, _b, _c;
-    const debugMetadata = (_a = options.debugMetadata) !== null && _a !== void 0 ? _a : true;
-    const sourceMetadata = (_b = options.sourceMetadata) !== null && _b !== void 0 ? _b : true;
-    const debugPrettyPrint = (_c = options.debugPrettyPrint) !== null && _c !== void 0 ? _c : debugMetadata;
-    const exportContext = buildAbcMusicXmlExportContext(parsed);
-    const buildMeasureNotesXml = (notes, staffOverride = null) => buildAbcMeasureNotesXml(notes, exportContext.measureDurationDiv, exportContext.emptyMeasureRestType, exportContext.beatDiv, staffOverride);
-    const partListXml = buildAbcPartListXml(exportContext.resolvedParts);
-    const partBodyXml = buildAbcPartBodyXml(exportContext.resolvedParts, exportContext.measureCount, exportContext.defaultFifths, exportContext.beats, exportContext.beatType, exportContext.tempoBpm, debugMetadata, sourceMetadata, parsed.diagnostics, abcSource, buildMeasureNotesXml);
-    const xml = buildAbcScorePartwiseXmlDocument(exportContext.title, exportContext.composer, partListXml, partBodyXml);
-    return debugPrettyPrint ? prettyPrintXml(xml) : xml;
-};
+const buildAbcScorePartwiseXmlDocument = (title, composer, partListXml, partBodyXml) => [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<score-partwise version="4.0">',
+    `<work><work-title>${xmlEscape(title)}</work-title></work>`,
+    `<identification><creator type="composer">${xmlEscape(composer)}</creator></identification>`,
+    `<part-list>${partListXml}</part-list>`,
+    partBodyXml,
+    "</score-partwise>",
+].join("");
 const convertAbcToMusicXml = (abcSource, options = {}) => {
+    var _a, _b, _c;
     const parsed = exports.AbcCompatParser.parseForMusicXml(abcSource, {
         defaultTitle: "mikuscore",
         defaultComposer: "Unknown",
         inferTransposeFromPartName: true,
         overfullCompatibilityMode: options.overfullCompatibilityMode !== false,
     });
-    return buildMusicXmlFromAbcParsed(parsed, abcSource, options);
+    const debugMetadata = (_a = options.debugMetadata) !== null && _a !== void 0 ? _a : true;
+    const sourceMetadata = (_b = options.sourceMetadata) !== null && _b !== void 0 ? _b : true;
+    const debugPrettyPrint = (_c = options.debugPrettyPrint) !== null && _c !== void 0 ? _c : debugMetadata;
+    const exportContext = buildAbcMusicXmlExportContext(parsed);
+    const buildMeasureNotesXml = (notes, staffOverride = null) => buildAbcMeasureNotesXml(notes, exportContext.measureDurationDiv, exportContext.emptyMeasureRestType, exportContext.beatDiv, staffOverride);
+    const partBodyXml = exportContext.resolvedParts
+        .map((part, partIndex) => buildAbcPartXml(part, partIndex, exportContext.measureCount, exportContext.defaultFifths, exportContext.beats, exportContext.beatType, exportContext.tempoBpm, debugMetadata, sourceMetadata, parsed.diagnostics, abcSource, buildMeasureNotesXml))
+        .join("");
+    const xml = buildAbcScorePartwiseXmlDocument(exportContext.title, exportContext.composer, exportContext.resolvedParts
+        .map((part, index) => [
+        `<score-part id="${xmlEscape(part.partId)}">`,
+        `<part-name>${xmlEscape(part.partName || part.partId)}</part-name>`,
+        `<midi-instrument id="${xmlEscape(part.partId)}-I1">`,
+        `<midi-channel>${((index % 16) + 1 === 10) ? 11 : ((index % 16) + 1)}</midi-channel>`,
+        `<midi-program>6</midi-program>`,
+        "</midi-instrument>",
+        "</score-part>",
+    ].join(""))
+        .join(""), partBodyXml);
+    return debugPrettyPrint ? prettyPrintXml(xml) : xml;
 };
 exports.convertAbcToMusicXml = convertAbcToMusicXml;
 

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -22746,7 +22746,7 @@ const divideFractions = (a, b, fallback = DEFAULT_RATIO) => {
     return reduceFraction(a.num * b.den, a.den * b.num, fallback);
 };
 const parseFractionText = (text, fallback = DEFAULT_UNIT) => {
-    const m = String(text || "").match(/^\s*(\d+)\/(\d+)\s*$/);
+    const m = String(text !== null && text !== void 0 ? text : "").match(/^\s*(\d+)\/(\d+)\s*$/);
     if (!m) {
         return { num: fallback.num, den: fallback.den };
     }
@@ -22757,21 +22757,21 @@ const parseFractionText = (text, fallback = DEFAULT_UNIT) => {
     }
     return reduceFraction(num, den, fallback);
 };
-const isAbcjsWrapperLine = (text) => /^\[\s*\/?\s*abcjs(?:-[A-Za-z0-9_-]+)?(?:\s+[^\]]*)?\]$/i.test(String(text || "").trim());
+const isAbcjsWrapperLine = (text) => /^\[\s*\/?\s*abcjs(?:-[A-Za-z0-9_-]+)?(?:\s+[^\]]*)?\]$/i.test(String(text !== null && text !== void 0 ? text : "").trim());
 const estimateAbcMeasureContentDiv = (notes) => {
-    var _a, _b;
+    var _a, _b, _c, _d;
     const byVoice = new Map();
     const lastStartByVoice = new Map();
     for (const note of Array.isArray(notes) ? notes : []) {
         if (!note || note.grace)
             continue;
-        const voice = String(note.voice || "1");
-        const durationDiv = Math.max(0, Math.round(Number(note.duration) || 0));
+        const voice = String((_a = note.voice) !== null && _a !== void 0 ? _a : "1");
+        const durationDiv = Math.max(0, Math.round(Number((_b = note.duration) !== null && _b !== void 0 ? _b : 0)));
         if (durationDiv <= 0)
             continue;
-        const current = (_a = byVoice.get(voice)) !== null && _a !== void 0 ? _a : 0;
+        const current = (_c = byVoice.get(voice)) !== null && _c !== void 0 ? _c : 0;
         if (note.chord) {
-            const startDiv = (_b = lastStartByVoice.get(voice)) !== null && _b !== void 0 ? _b : current;
+            const startDiv = (_d = lastStartByVoice.get(voice)) !== null && _d !== void 0 ? _d : current;
             byVoice.set(voice, Math.max(current, startDiv + durationDiv));
             continue;
         }
@@ -22822,7 +22822,7 @@ const abcLengthTokenFromFraction = (ratio) => {
     return `${reduced.num}/${reduced.den}`;
 };
 const abcPitchFromStepOctave = (step, octave) => {
-    const upperStep = String(step || "").toUpperCase();
+    const upperStep = String(step !== null && step !== void 0 ? step : "").toUpperCase();
     if (!/^[A-G]$/.test(upperStep)) {
         return "C";
     }
@@ -22845,7 +22845,7 @@ const keyFromFifthsMode = (fifths, mode) => {
     if (idx < 0 || idx >= major.length) {
         return "C";
     }
-    const lowerMode = String(mode || "").toLowerCase();
+    const lowerMode = String(mode !== null && mode !== void 0 ? mode : "").toLowerCase();
     if (lowerMode === "minor") {
         return minor[idx];
     }
@@ -22926,9 +22926,10 @@ const ensureAbcDeclaredVoice = (registry, voiceId) => {
     }
 };
 const appendAbcBodyTextEntries = (rawBodyText, lineNo, voiceId, registry, bodyEntries, splitBodyTextByInlineVoice, splitBodyTextByOverlay) => {
-    const normalizedBodyText = String(rawBodyText || "").replace(/\\\s*$/, "");
+    var _a;
+    const normalizedBodyText = String(rawBodyText !== null && rawBodyText !== void 0 ? rawBodyText : "").replace(/\\\s*$/, "");
     if (!normalizedBodyText.trim()) {
-        return { appended: false, finalVoiceId: String(voiceId || "1").trim() || "1" };
+        return { appended: false, finalVoiceId: String(voiceId !== null && voiceId !== void 0 ? voiceId : "1").trim() || "1" };
     }
     const { segments: inlineVoiceSegments, finalVoiceId } = splitBodyTextByInlineVoice(normalizedBodyText, voiceId);
     for (const segment of inlineVoiceSegments) {
@@ -22950,15 +22951,16 @@ const appendAbcBodyTextEntries = (rawBodyText, lineNo, voiceId, registry, bodyEn
             bodyEntries.push({ text: overlaySegment.text, lineNo, voiceId: overlaySegment.voiceId });
         }
     }
-    return { appended: true, finalVoiceId: String(finalVoiceId || voiceId || "1").trim() || "1" };
+    return { appended: true, finalVoiceId: String((_a = finalVoiceId !== null && finalVoiceId !== void 0 ? finalVoiceId : voiceId) !== null && _a !== void 0 ? _a : "1").trim() || "1" };
 };
 const applyAbcVoiceDirective = (value, lineNo, lineState, voiceRegistry, warnings, userDefinedDecorationBySymbol, parseVoiceDirectiveTail, expandUserDefinedDecorationSymbols, pushBodyText) => {
+    var _a, _b, _c;
     const m = value.match(/^(\S+)\s*(.*)$/);
     if (!m)
         return;
     lineState.currentVoiceId = m[1];
     ensureAbcDeclaredVoice(voiceRegistry, lineState.currentVoiceId);
-    const rest = m[2].trim();
+    const rest = (_b = (_a = m[2]) === null || _a === void 0 ? void 0 : _a.trim()) !== null && _b !== void 0 ? _b : "";
     const parsedVoice = parseVoiceDirectiveTail(rest);
     if (parsedVoice.name) {
         voiceRegistry.voiceNameById[lineState.currentVoiceId] = parsedVoice.name;
@@ -22975,7 +22977,7 @@ const applyAbcVoiceDirective = (value, lineNo, lineState, voiceRegistry, warning
             ": Skipped unsupported V: directive tail token: " +
             parsedVoice.skippedText);
     }
-    for (const unsupportedKey of parsedVoice.unsupportedKeys || []) {
+    for (const unsupportedKey of (_c = parsedVoice.unsupportedKeys) !== null && _c !== void 0 ? _c : []) {
         warnings.push("line " +
             lineNo +
             ": Skipped unsupported V: property: " +
@@ -23035,10 +23037,11 @@ const parseAbcMetaParams = (raw) => {
     return params;
 };
 const applyAbcTrillMeta = (params, trillWidthHintByKey) => {
-    const voiceId = String(params.voice || "").trim();
-    const measureNo = Number.parseInt(String(params.measure || ""), 10);
-    const eventNo = Number.parseInt(String(params.event || ""), 10);
-    const upper = String(params.upper || "").trim();
+    var _a, _b, _c, _d;
+    const voiceId = String((_a = params.voice) !== null && _a !== void 0 ? _a : "").trim();
+    const measureNo = Number.parseInt(String((_b = params.measure) !== null && _b !== void 0 ? _b : ""), 10);
+    const eventNo = Number.parseInt(String((_c = params.event) !== null && _c !== void 0 ? _c : ""), 10);
+    const upper = String((_d = params.upper) !== null && _d !== void 0 ? _d : "").trim();
     if (voiceId && Number.isFinite(measureNo) && measureNo > 0 && Number.isFinite(eventNo) && eventNo > 0 && upper) {
         trillWidthHintByKey.set(`${voiceId}#${measureNo}#${eventNo}`, upper);
         return true;
@@ -23046,9 +23049,10 @@ const applyAbcTrillMeta = (params, trillWidthHintByKey) => {
     return false;
 };
 const applyAbcKeyMeta = (params, keyHintFifthsByKey) => {
-    const voiceId = String(params.voice || "").trim();
-    const measureNo = Number.parseInt(String(params.measure || ""), 10);
-    const fifths = Number.parseInt(String(params.fifths || ""), 10);
+    var _a, _b, _c;
+    const voiceId = String((_a = params.voice) !== null && _a !== void 0 ? _a : "").trim();
+    const measureNo = Number.parseInt(String((_b = params.measure) !== null && _b !== void 0 ? _b : ""), 10);
+    const fifths = Number.parseInt(String((_c = params.fifths) !== null && _c !== void 0 ? _c : ""), 10);
     if (voiceId && Number.isFinite(measureNo) && measureNo > 0 && Number.isFinite(fifths)) {
         const key = `${voiceId}#${measureNo}`;
         if (!keyHintFifthsByKey.has(key)) {
@@ -23059,19 +23063,20 @@ const applyAbcKeyMeta = (params, keyHintFifthsByKey) => {
     return false;
 };
 const applyAbcMeasureMeta = (params, measureMetaByKey) => {
-    const voiceId = String(params.voice || "").trim();
-    const measureNo = Number.parseInt(String(params.measure || ""), 10);
+    var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l;
+    const voiceId = String((_a = params.voice) !== null && _a !== void 0 ? _a : "").trim();
+    const measureNo = Number.parseInt(String((_b = params.measure) !== null && _b !== void 0 ? _b : ""), 10);
     if (!(voiceId && Number.isFinite(measureNo) && measureNo > 0))
         return false;
-    const measureNumberText = String(params.number || "").trim();
-    const implicitRaw = String(params.implicit || "").trim().toLowerCase();
-    const repeatRaw = String(params.repeat || "").trim().toLowerCase();
-    const leftRepeatRaw = String(params["left-repeat"] || "").trim().toLowerCase();
-    const rightRepeatRaw = String(params["right-repeat"] || "").trim().toLowerCase();
-    const repeatTimesRaw = Number.parseInt(String(params.times || ""), 10);
-    const endingStart = String(params["ending-start"] || "").trim();
-    const endingStop = String(params["ending-stop"] || "").trim();
-    const endingStopTypeRaw = String(params["ending-type"] || "").trim().toLowerCase();
+    const measureNumberText = String((_c = params.number) !== null && _c !== void 0 ? _c : "").trim();
+    const implicitRaw = String((_d = params.implicit) !== null && _d !== void 0 ? _d : "").trim().toLowerCase();
+    const repeatRaw = String((_e = params.repeat) !== null && _e !== void 0 ? _e : "").trim().toLowerCase();
+    const leftRepeatRaw = String((_f = params["left-repeat"]) !== null && _f !== void 0 ? _f : "").trim().toLowerCase();
+    const rightRepeatRaw = String((_g = params["right-repeat"]) !== null && _g !== void 0 ? _g : "").trim().toLowerCase();
+    const repeatTimesRaw = Number.parseInt(String((_h = params.times) !== null && _h !== void 0 ? _h : ""), 10);
+    const endingStart = String((_j = params["ending-start"]) !== null && _j !== void 0 ? _j : "").trim();
+    const endingStop = String((_k = params["ending-stop"]) !== null && _k !== void 0 ? _k : "").trim();
+    const endingStopTypeRaw = String((_l = params["ending-type"]) !== null && _l !== void 0 ? _l : "").trim().toLowerCase();
     measureMetaByKey.set(`${voiceId}#${measureNo}`, {
         number: measureNumberText || String(measureNo),
         implicit: implicitRaw === "1" || implicitRaw === "true" || implicitRaw === "yes",
@@ -23087,9 +23092,10 @@ const applyAbcMeasureMeta = (params, measureMetaByKey) => {
     return true;
 };
 const applyAbcTransposeMeta = (params, transposeHintByVoiceId) => {
-    const voiceId = String(params.voice || "").trim();
-    const chromatic = Number.parseInt(String(params.chromatic || ""), 10);
-    const diatonic = Number.parseInt(String(params.diatonic || ""), 10);
+    var _a, _b, _c;
+    const voiceId = String((_a = params.voice) !== null && _a !== void 0 ? _a : "").trim();
+    const chromatic = Number.parseInt(String((_b = params.chromatic) !== null && _b !== void 0 ? _b : ""), 10);
+    const diatonic = Number.parseInt(String((_c = params.diatonic) !== null && _c !== void 0 ? _c : ""), 10);
     if (!(voiceId && (Number.isFinite(chromatic) || Number.isFinite(diatonic))))
         return false;
     const metaTranspose = {};
@@ -23104,11 +23110,12 @@ const applyAbcTransposeMeta = (params, transposeHintByVoiceId) => {
     return false;
 };
 const handleAbcMetaDirectiveLine = (rawTrimmed, trillWidthHintByKey, keyHintFifthsByKey, measureMetaByKey, transposeHintByVoiceId) => {
+    var _a, _b;
     const metaMatch = rawTrimmed.match(/^%@mks\s+(trill|key|measure|transpose)\s+(.+)$/i);
     if (!metaMatch)
         return false;
-    const kind = String(metaMatch[1] || "").toLowerCase();
-    const params = parseAbcMetaParams(String(metaMatch[2] || ""));
+    const kind = String((_a = metaMatch[1]) !== null && _a !== void 0 ? _a : "").toLowerCase();
+    const params = parseAbcMetaParams(String((_b = metaMatch[2]) !== null && _b !== void 0 ? _b : ""));
     if (kind === "trill")
         return applyAbcTrillMeta(params, trillWidthHintByKey);
     if (kind === "key")
@@ -23187,7 +23194,7 @@ const processAbcImportLine = (raw, lineNo, context) => {
     context.pushBodyText(expandedBodyText, lineNo, context.lineState.currentVoiceId);
 };
 const buildAbcVoiceMeasureMetaByIndex = (voiceId, normalizedMeasures, keyHintFifthsByKey, notationMeasureMetaByVoice, measureMetaByKey, meterByMeasureByVoice, tempoByMeasureByVoice) => {
-    var _a, _b, _c, _d, _e, _f, _g;
+    var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p, _q, _r, _s;
     const keyByMeasure = {};
     const meterByMeasure = {};
     const tempoByMeasure = {};
@@ -23197,20 +23204,20 @@ const buildAbcVoiceMeasureMetaByIndex = (voiceId, normalizedMeasures, keyHintFif
         if (Number.isFinite(hinted)) {
             keyByMeasure[m] = Number(hinted);
         }
-        const notationMeta = ((_a = notationMeasureMetaByVoice[voiceId]) === null || _a === void 0 ? void 0 : _a[m]) || null;
-        const hintedMeta = measureMetaByKey.get(`${voiceId}#${m}`) || null;
-        const meterHint = ((_b = meterByMeasureByVoice[voiceId]) === null || _b === void 0 ? void 0 : _b[m]) || null;
-        const tempoHint = ((_c = tempoByMeasureByVoice[voiceId]) === null || _c === void 0 ? void 0 : _c[m]) || null;
+        const notationMeta = (_b = (_a = notationMeasureMetaByVoice[voiceId]) === null || _a === void 0 ? void 0 : _a[m]) !== null && _b !== void 0 ? _b : null;
+        const hintedMeta = (_c = measureMetaByKey.get(`${voiceId}#${m}`)) !== null && _c !== void 0 ? _c : null;
+        const meterHint = (_e = (_d = meterByMeasureByVoice[voiceId]) === null || _d === void 0 ? void 0 : _d[m]) !== null && _e !== void 0 ? _e : null;
+        const tempoHint = (_g = (_f = tempoByMeasureByVoice[voiceId]) === null || _f === void 0 ? void 0 : _f[m]) !== null && _g !== void 0 ? _g : null;
         if (notationMeta || hintedMeta) {
             measureMetaByIndex[m] = {
                 number: (hintedMeta === null || hintedMeta === void 0 ? void 0 : hintedMeta.number) || (notationMeta === null || notationMeta === void 0 ? void 0 : notationMeta.number) || String(m),
-                implicit: (_e = (_d = hintedMeta === null || hintedMeta === void 0 ? void 0 : hintedMeta.implicit) !== null && _d !== void 0 ? _d : notationMeta === null || notationMeta === void 0 ? void 0 : notationMeta.implicit) !== null && _e !== void 0 ? _e : false,
-                repeatStart: Boolean((notationMeta === null || notationMeta === void 0 ? void 0 : notationMeta.repeatStart) || (hintedMeta === null || hintedMeta === void 0 ? void 0 : hintedMeta.repeatStart)),
-                repeatEnd: Boolean((notationMeta === null || notationMeta === void 0 ? void 0 : notationMeta.repeatEnd) || (hintedMeta === null || hintedMeta === void 0 ? void 0 : hintedMeta.repeatEnd)),
-                repeatTimes: (_g = (_f = hintedMeta === null || hintedMeta === void 0 ? void 0 : hintedMeta.repeatTimes) !== null && _f !== void 0 ? _f : notationMeta === null || notationMeta === void 0 ? void 0 : notationMeta.repeatTimes) !== null && _g !== void 0 ? _g : null,
-                endingStart: String((notationMeta === null || notationMeta === void 0 ? void 0 : notationMeta.endingStart) || (hintedMeta === null || hintedMeta === void 0 ? void 0 : hintedMeta.endingStart) || ""),
-                endingStop: String((notationMeta === null || notationMeta === void 0 ? void 0 : notationMeta.endingStop) || (hintedMeta === null || hintedMeta === void 0 ? void 0 : hintedMeta.endingStop) || ""),
-                endingStopType: (hintedMeta === null || hintedMeta === void 0 ? void 0 : hintedMeta.endingStopType) || (notationMeta === null || notationMeta === void 0 ? void 0 : notationMeta.endingStopType) || "",
+                implicit: (_j = (_h = hintedMeta === null || hintedMeta === void 0 ? void 0 : hintedMeta.implicit) !== null && _h !== void 0 ? _h : notationMeta === null || notationMeta === void 0 ? void 0 : notationMeta.implicit) !== null && _j !== void 0 ? _j : false,
+                repeatStart: !!((notationMeta === null || notationMeta === void 0 ? void 0 : notationMeta.repeatStart) || (hintedMeta === null || hintedMeta === void 0 ? void 0 : hintedMeta.repeatStart)),
+                repeatEnd: !!((notationMeta === null || notationMeta === void 0 ? void 0 : notationMeta.repeatEnd) || (hintedMeta === null || hintedMeta === void 0 ? void 0 : hintedMeta.repeatEnd)),
+                repeatTimes: (_l = (_k = hintedMeta === null || hintedMeta === void 0 ? void 0 : hintedMeta.repeatTimes) !== null && _k !== void 0 ? _k : notationMeta === null || notationMeta === void 0 ? void 0 : notationMeta.repeatTimes) !== null && _l !== void 0 ? _l : null,
+                endingStart: String((_o = (_m = notationMeta === null || notationMeta === void 0 ? void 0 : notationMeta.endingStart) !== null && _m !== void 0 ? _m : hintedMeta === null || hintedMeta === void 0 ? void 0 : hintedMeta.endingStart) !== null && _o !== void 0 ? _o : ""),
+                endingStop: String((_q = (_p = notationMeta === null || notationMeta === void 0 ? void 0 : notationMeta.endingStop) !== null && _p !== void 0 ? _p : hintedMeta === null || hintedMeta === void 0 ? void 0 : hintedMeta.endingStop) !== null && _q !== void 0 ? _q : ""),
+                endingStopType: (_s = (_r = hintedMeta === null || hintedMeta === void 0 ? void 0 : hintedMeta.endingStopType) !== null && _r !== void 0 ? _r : notationMeta === null || notationMeta === void 0 ? void 0 : notationMeta.endingStopType) !== null && _s !== void 0 ? _s : "",
             };
         }
         if (meterHint) {
@@ -23226,6 +23233,7 @@ const buildAbcVoiceMeasureMetaByIndex = (voiceId, normalizedMeasures, keyHintFif
     return { keyByMeasure, meterByMeasure, tempoByMeasure, measureMetaByIndex };
 };
 const buildAbcNormalizedVoiceDataById = (orderedVoiceIds, voiceRegistry, measuresByVoice, measureCapacity, overfullCompatibilityMode, settings, transposeHintByVoiceId, keyHintFifthsByKey, notationMeasureMetaByVoice, measureMetaByKey, meterByMeasureByVoice, tempoByMeasureByVoice, importDiagnostics) => {
+    var _a;
     const normalizedVoiceDataById = new Map();
     for (const voiceId of orderedVoiceIds) {
         const partName = voiceRegistry.voiceNameById[voiceId] || ("Voice " + voiceId);
@@ -23252,7 +23260,7 @@ const buildAbcNormalizedVoiceDataById = (orderedVoiceIds, voiceRegistry, measure
         const measureData = buildAbcVoiceMeasureMetaByIndex(voiceId, normalizedMeasures, keyHintFifthsByKey, notationMeasureMetaByVoice, measureMetaByKey, meterByMeasureByVoice, tempoByMeasureByVoice);
         normalizedVoiceDataById.set(voiceId, {
             partName,
-            clef: voiceRegistry.voiceClefById[voiceId] || "",
+            clef: (_a = voiceRegistry.voiceClefById[voiceId]) !== null && _a !== void 0 ? _a : "",
             transpose,
             voiceId,
             keyByMeasure: measureData.keyByMeasure,
@@ -23264,37 +23272,13 @@ const buildAbcNormalizedVoiceDataById = (orderedVoiceIds, voiceRegistry, measure
     }
     return normalizedVoiceDataById;
 };
-const buildAbcGroupedStaffClefXml = (staffVoices) => {
-    return staffVoices
-        .map((staffVoice) => {
-        const clefXml = (0, exports.clefXmlFromAbcClef)(staffVoice.clef || "");
-        return clefXml.replace("<clef>", `<clef number="${staffVoice.staff}">`);
-    })
-        .join("");
-};
-const buildAbcPartTransposeXml = (transpose) => {
-    return (0, transposition_1.buildMusicXmlTransposeXml)(transpose);
-};
-const buildAbcTempoDirectionXml = (tempo, include) => {
-    if (!(include && tempo !== null)) {
-        return "";
-    }
-    return (0, direction_text_1.buildMusicXmlTempoDirectionXml)({ bpm: tempo, includeQuarterMetronome: true });
-};
-const buildAbcMeasureHeaderXml = (part, partIndex, measureIndex, currentPartFifths, currentPartMeter, currentPartTempo, hintedFifths, hintedMeter) => {
-    if (measureIndex === 0) {
-        const headerXml = buildAbcMeasureHeaderInitialParts(part, currentPartFifths, currentPartMeter).join("");
-        const tempoDirectionXml = buildAbcTempoDirectionXml(currentPartTempo, partIndex === 0);
-        return { headerXml, tempoDirectionXml };
-    }
-    const headerXml = hintedFifths !== null || hintedMeter
-        ? buildAbcMeasureHeaderUpdateParts(currentPartFifths, currentPartMeter, hintedFifths, hintedMeter).join("")
-        : "";
-    return {
-        headerXml,
-        tempoDirectionXml: "",
-    };
-};
+const buildAbcGroupedStaffClefXml = (staffVoices) => staffVoices
+    .map((staffVoice) => {
+    var _a;
+    const clefXml = (0, exports.clefXmlFromAbcClef)((_a = staffVoice.clef) !== null && _a !== void 0 ? _a : "");
+    return clefXml.replace("<clef>", `<clef number="${staffVoice.staff}">`);
+})
+    .join("");
 const buildAbcMeasureHeaderInitialParts = (part, currentPartFifths, currentPartMeter) => [
     "<attributes>",
     "<divisions>960</divisions>",
@@ -23304,57 +23288,16 @@ const buildAbcMeasureHeaderInitialParts = (part, currentPartFifths, currentPartM
         beatType: currentPartMeter.beatType,
     }),
     (0, abc_layout_1.hasAbcGroupedStaffVoices)(part) ? `<staves>${part.staffVoices.length}</staves>` : "",
-    buildAbcPartTransposeXml(part.transpose),
+    (0, transposition_1.buildMusicXmlTransposeXml)(part.transpose),
     (0, abc_layout_1.hasAbcGroupedStaffVoices)(part) ? buildAbcGroupedStaffClefXml(part.staffVoices) : (0, exports.clefXmlFromAbcClef)(part.clef),
     "</attributes>",
 ];
 const buildAbcMeasureHeaderUpdateParts = (currentPartFifths, currentPartMeter, hintedFifths, hintedMeter) => [
     "<attributes>",
-    buildAbcMeasureHeaderUpdateKeyPart(currentPartFifths, hintedFifths),
-    buildAbcMeasureHeaderUpdateTimePart(currentPartMeter, hintedMeter),
+    hintedFifths !== null ? (0, key_signatures_1.buildMusicXmlKeySignatureXml)({ fifths: currentPartFifths }) : "",
+    hintedMeter ? (0, time_signatures_1.buildMusicXmlTimeSignatureXml)({ beats: currentPartMeter.beats, beatType: currentPartMeter.beatType }) : "",
     "</attributes>",
 ];
-const buildAbcMeasureHeaderUpdateKeyPart = (currentPartFifths, hintedFifths) => buildAbcMeasureHeaderUpdateKeyPartXml(currentPartFifths, hintedFifths);
-const buildAbcMeasureHeaderUpdateKeyPartXml = (currentPartFifths, hintedFifths) => hintedFifths !== null ? buildAbcMeasureHeaderUpdateKeySignatureXml(currentPartFifths) : "";
-const buildAbcMeasureHeaderUpdateKeySignatureXml = (currentPartFifths) => (0, key_signatures_1.buildMusicXmlKeySignatureXml)({ fifths: currentPartFifths });
-const buildAbcMeasureHeaderUpdateTimePart = (currentPartMeter, hintedMeter) => buildAbcMeasureHeaderUpdateTimePartXml(currentPartMeter, hintedMeter);
-const buildAbcMeasureHeaderUpdateTimePartXml = (currentPartMeter, hintedMeter) => hintedMeter ? buildAbcMeasureHeaderUpdateTimeSignatureXml(currentPartMeter) : "";
-const buildAbcMeasureHeaderUpdateTimeSignatureXml = (currentPartMeter) => (0, time_signatures_1.buildMusicXmlTimeSignatureXml)({
-    beats: currentPartMeter.beats,
-    beatType: currentPartMeter.beatType,
-});
-const buildAbcMeasureTempoDirectionXml = (hintedTempo, partIndex, measureIndex) => {
-    return buildAbcTempoDirectionXml(hintedTempo, measureIndex > 0 && partIndex === 0);
-};
-const buildAbcMeasureRepeatStartXml = (measureMeta) => {
-    const leftBarlineChunks = buildAbcMeasureRepeatStartChunks(measureMeta);
-    return leftBarlineChunks.length > 0 ? `<barline location="left">${leftBarlineChunks.join("")}</barline>` : "";
-};
-const buildAbcMeasureRepeatStartChunks = (measureMeta) => [
-    (measureMeta === null || measureMeta === void 0 ? void 0 : measureMeta.endingStart)
-        ? `<ending number="${xmlEscape(String(measureMeta.endingStart))}" type="start"/>`
-        : "",
-    (measureMeta === null || measureMeta === void 0 ? void 0 : measureMeta.repeatStart) ? '<repeat direction="forward" winged="none"/>' : "",
-].filter(Boolean);
-const buildAbcMeasureRepeatEndXml = (measureMeta) => {
-    const rightBarlineChunks = buildAbcMeasureRepeatEndChunks(measureMeta);
-    return rightBarlineChunks.length > 0 ? `<barline location="right">${rightBarlineChunks.join("")}</barline>` : "";
-};
-const buildAbcMeasureRepeatEndChunks = (measureMeta) => [
-    (measureMeta === null || measureMeta === void 0 ? void 0 : measureMeta.endingStop)
-        ? `<ending number="${xmlEscape(String(measureMeta.endingStop))}" type="${measureMeta.endingStopType || "stop"}"/>`
-        : "",
-    (measureMeta === null || measureMeta === void 0 ? void 0 : measureMeta.repeatEnd)
-        ? `<repeat direction="backward" winged="none"${Number.isFinite(measureMeta.repeatTimes) && Number(measureMeta.repeatTimes) > 1
-            ? ` times="${Math.round(Number(measureMeta.repeatTimes))}"`
-            : ""}/>`
-        : "",
-].filter(Boolean);
-const buildAbcMeasureXml = (measureNo, measureNumberText, implicit, repeatStartXml, headerXml, tempoDirectionXml, debugMiscXml, diagMiscXml, sourceMiscXml, notesXml, repeatEndXml) => {
-    const xmlMeasureNumber = xmlEscape(String(measureNumberText || measureNo));
-    const implicitAttr = implicit ? ' implicit="yes"' : "";
-    return `<measure number="${xmlMeasureNumber}"${implicitAttr}>${repeatStartXml}${headerXml}${tempoDirectionXml}${debugMiscXml}${diagMiscXml}${sourceMiscXml}${notesXml}${repeatEndXml}</measure>`;
-};
 const buildAbcPartMeasureRenderContext = (part, measureIndex, state, beats, beatType) => {
     var _a, _b, _c, _d, _e, _f, _g, _h, _j;
     const measureNo = measureIndex + 1;
@@ -23396,54 +23339,130 @@ const buildAbcPartMeasureRenderContext = (part, measureIndex, state, beats, beat
 };
 const buildAbcRenderedPartMeasureXml = (context) => {
     const { part, partIndex, measureIndex, measureNo, notes, measureMeta, hintedFifths, hintedMeter, hintedTempo, currentPartFifths, currentPartMeter, currentPartTempo, currentMeasureDurationDiv, inferredImplicitPickup, debugMetadata, sourceMetadata, diagnostics, abcSource, buildMeasureNotesXml, } = context;
-    const { headerXml, tempoDirectionXml: headerTempoDirectionXml } = buildAbcMeasureHeaderXml(part, partIndex, measureIndex, currentPartFifths, currentPartMeter, currentPartTempo, hintedFifths, hintedMeter);
-    const tempoDirectionXml = headerTempoDirectionXml || buildAbcMeasureTempoDirectionXml(hintedTempo, partIndex, measureIndex);
+    const headerXml = measureIndex === 0
+        ? buildAbcMeasureHeaderInitialParts(part, currentPartFifths, currentPartMeter).join("")
+        : hintedFifths !== null || hintedMeter !== null
+            ? buildAbcMeasureHeaderUpdateParts(currentPartFifths, currentPartMeter, hintedFifths, hintedMeter).join("")
+            : "";
+    const headerTempoDirectionXml = measureIndex === 0 && partIndex === 0 && currentPartTempo !== null
+        ? (0, direction_text_1.buildMusicXmlTempoDirectionXml)({ bpm: currentPartTempo, includeQuarterMetronome: true })
+        : "";
+    const tempoDirectionXml = headerTempoDirectionXml ||
+        (measureIndex > 0 && partIndex === 0 && hintedTempo !== null
+            ? (0, direction_text_1.buildMusicXmlTempoDirectionXml)({ bpm: hintedTempo, includeQuarterMetronome: true })
+            : "");
     const notesXml = (0, abc_layout_1.hasAbcGroupedStaffVoices)(part)
         ? (0, abc_layout_1.buildAbcGroupedStaffMeasureNotesXml)(part.staffVoices, measureIndex, currentMeasureDurationDiv, buildMeasureNotesXml)
         : buildMeasureNotesXml(notes);
-    const repeatStartXml = buildAbcMeasureRepeatStartXml(measureMeta);
-    const repeatEndXml = buildAbcMeasureRepeatEndXml(measureMeta);
-    const { debugMiscXml, diagMiscXml, sourceMiscXml } = buildAbcRenderedMeasureMiscXml({
-        part,
-        partIndex,
-        measureNo,
-        notes,
-        debugMetadata,
-        sourceMetadata,
-        diagnostics,
-        abcSource,
-    });
-    return buildAbcMeasureXml(measureNo, String((measureMeta === null || measureMeta === void 0 ? void 0 : measureMeta.number) || measureNo), Boolean((measureMeta === null || measureMeta === void 0 ? void 0 : measureMeta.implicit) || inferredImplicitPickup), repeatStartXml, headerXml, tempoDirectionXml, debugMiscXml, diagMiscXml, sourceMiscXml, notesXml, repeatEndXml);
+    const repeatStartXml = measureMeta
+        ? (() => {
+            const chunks = [
+                ...(measureMeta.endingStart
+                    ? [`<ending number="${xmlEscape(String(measureMeta.endingStart))}" type="start"/>`]
+                    : []),
+                ...(measureMeta.repeatStart ? ['<repeat direction="forward" winged="none"/>'] : []),
+            ];
+            return chunks.length > 0 ? `<barline location="left">${chunks.join("")}</barline>` : "";
+        })()
+        : "";
+    const repeatEndXml = measureMeta
+        ? (() => {
+            const chunks = [
+                ...(measureMeta.endingStop
+                    ? [
+                        `<ending number="${xmlEscape(String(measureMeta.endingStop))}" type="${measureMeta.endingStopType || "stop"}"/>`,
+                    ]
+                    : []),
+                ...(measureMeta.repeatEnd
+                    ? [
+                        `<repeat direction="backward" winged="none"${Number.isFinite(measureMeta.repeatTimes) && Number(measureMeta.repeatTimes) > 1
+                            ? ` times="${Math.round(Number(measureMeta.repeatTimes))}"`
+                            : ""}/>`,
+                    ]
+                    : []),
+            ];
+            return chunks.length > 0 ? `<barline location="right">${chunks.join("")}</barline>` : "";
+        })()
+        : "";
+    const debugMiscXml = debugMetadata
+        ? `<attributes><miscellaneous><miscellaneous-field name="mks:dbg:abc:meta:count">${toHex(notes.length, 4)}</miscellaneous-field>${notes
+            .map((note, index) => {
+            var _a;
+            return `<miscellaneous-field name="mks:dbg:abc:meta:${String(index + 1).padStart(4, "0")}">${[
+                [
+                    `idx=${toHex(index, 4)}`,
+                    `m=${toHex(measureNo, 4)}`,
+                    `v=${xmlEscape(normalizeVoiceForMusicXml(note.voice))}`,
+                ].join(";"),
+                [
+                    `r=${note.isRest ? "1" : "0"}`,
+                    `g=${note.grace ? "1" : "0"}`,
+                    `ch=${note.chord ? "1" : "0"}`,
+                    `st=${note.isRest ? "R" : (/^[A-G]$/.test(String((_a = note.step) !== null && _a !== void 0 ? _a : "").toUpperCase()) ? String(note.step).toUpperCase() : "C")}`,
+                    `al=${String(Number.isFinite(Number(note.alter)) ? Math.round(Number(note.alter)) : 0)}`,
+                    `oc=${toHex(Number.isFinite(Number(note.octave)) ? Math.max(0, Math.min(9, Math.round(Number(note.octave)))) : 4, 2)}`,
+                    `dd=${toHex(note.grace ? 0 : Math.max(1, Math.round(Number(note.duration) || 1)), 4)}`,
+                    `tp=${xmlEscape(normalizeTypeForMusicXml(note.type))}`,
+                ].join(";"),
+            ].join(";")}</miscellaneous-field>`;
+        })
+            .join("")}</miscellaneous></attributes>`
+        : "";
+    const diagMiscNotes = partIndex === 0 && measureNo === 1
+        ? (diagnostics !== null && diagnostics !== void 0 ? diagnostics : []).filter((diag) => { var _a; return !diag.voiceId || diag.voiceId === ((_a = part.voiceId) !== null && _a !== void 0 ? _a : ""); })
+        : [];
+    const diagMiscXml = diagMiscNotes.length
+        ? `<attributes><miscellaneous><miscellaneous-field name="mks:diag:count">${Math.min(256, diagMiscNotes.length)}</miscellaneous-field>${Array.from({ length: Math.min(256, diagMiscNotes.length) }, (_, i) => `<miscellaneous-field name="mks:diag:${String(i + 1).padStart(4, "0")}">${[
+            `level=${diagMiscNotes[i].level}`,
+            `code=${diagMiscNotes[i].code}`,
+            `fmt=${diagMiscNotes[i].fmt}`,
+            ...(diagMiscNotes[i].measure !== undefined && Number.isFinite(diagMiscNotes[i].measure)
+                ? [`measure=${Math.max(1, Math.round(Number(diagMiscNotes[i].measure)))}`]
+                : []),
+            ...(diagMiscNotes[i].movedEvents !== undefined && Number.isFinite(diagMiscNotes[i].movedEvents)
+                ? [`movedEvents=${Math.max(0, Math.round(Number(diagMiscNotes[i].movedEvents)))}`]
+                : []),
+            ...(diagMiscNotes[i].voiceId ? [`voice=${xmlEscape(diagMiscNotes[i].voiceId)}`] : []),
+            ...(diagMiscNotes[i].action ? [`action=${xmlEscape(diagMiscNotes[i].action)}`] : []),
+            ...(diagMiscNotes[i].message ? [`message=${xmlEscape(diagMiscNotes[i].message)}`] : []),
+        ].join(";")}</miscellaneous-field>`).join("")}</miscellaneous></attributes>`
+        : "";
+    const sourceMiscXml = sourceMetadata && partIndex === 0 && measureNo === 1
+        ? (() => {
+            const source = String(abcSource !== null && abcSource !== void 0 ? abcSource : "");
+            if (!source.length)
+                return "";
+            const encoded = source
+                .replace(/\\/g, "\\\\")
+                .replace(/\r/g, "\\r")
+                .replace(/\n/g, "\\n");
+            const CHUNK_SIZE = 240;
+            const MAX_CHUNKS = 512;
+            const chunks = [];
+            for (let i = 0; i < encoded.length && chunks.length < MAX_CHUNKS; i += CHUNK_SIZE) {
+                chunks.push(encoded.slice(i, i + CHUNK_SIZE));
+            }
+            const truncated = chunks.join("").length < encoded.length;
+            return `<attributes><miscellaneous>${[
+                `<miscellaneous-field name="mks:src:abc:raw-encoding">escape-v1</miscellaneous-field>`,
+                `<miscellaneous-field name="mks:src:abc:raw-length">${xmlEscape(String(source.length))}</miscellaneous-field>`,
+                `<miscellaneous-field name="mks:src:abc:raw-encoded-length">${xmlEscape(String(encoded.length))}</miscellaneous-field>`,
+                `<miscellaneous-field name="mks:src:abc:raw-chunks">${xmlEscape(String(chunks.length))}</miscellaneous-field>`,
+                `<miscellaneous-field name="mks:src:abc:raw-truncated">${truncated ? "1" : "0"}</miscellaneous-field>`,
+                ...chunks.map((chunk, index) => `<miscellaneous-field name="mks:src:abc:raw-${String(index + 1).padStart(4, "0")}">${xmlEscape(chunk)}</miscellaneous-field>`),
+            ].join("")}</miscellaneous></attributes>`;
+        })()
+        : "";
+    const xmlMeasureNumber = xmlEscape(String((measureMeta === null || measureMeta === void 0 ? void 0 : measureMeta.number) || measureNo));
+    const implicitAttr = (measureMeta === null || measureMeta === void 0 ? void 0 : measureMeta.implicit) || inferredImplicitPickup ? ' implicit="yes"' : "";
+    return `<measure number="${xmlMeasureNumber}"${implicitAttr}>${repeatStartXml}${headerXml}${tempoDirectionXml}${debugMiscXml}${diagMiscXml}${sourceMiscXml}${notesXml}${repeatEndXml}</measure>`;
 };
-const buildAbcRenderedMeasureMiscXml = (context) => {
-    const { part, partIndex, measureNo, notes, debugMetadata, sourceMetadata, diagnostics, abcSource, } = context;
-    return {
-        debugMiscXml: buildAbcRenderedMeasureDebugMiscXml(debugMetadata, notes, measureNo),
-        diagMiscXml: buildAbcRenderedMeasureDiagMiscXml(part, partIndex, measureNo, diagnostics),
-        sourceMiscXml: buildAbcRenderedMeasureSourceMiscXml(sourceMetadata, partIndex, measureNo, abcSource),
-    };
-};
-const buildAbcRenderedMeasureDebugMiscXml = (debugMetadata, notes, measureNo) => debugMetadata ? buildAbcMeasureDebugMiscXml(notes, measureNo) : "";
-const buildAbcRenderedMeasureDiagMiscXml = (part, partIndex, measureNo, diagnostics) => {
-    const filteredDiagnostics = buildAbcRenderedMeasureDiagMiscDiagnostics(part, partIndex, measureNo, diagnostics);
-    return filteredDiagnostics.length > 0 ? buildAbcDiagMiscXml(filteredDiagnostics) : "";
-};
-const buildAbcRenderedMeasureDiagMiscDiagnostics = (part, partIndex, measureNo, diagnostics) => partIndex === 0 && measureNo === 1
-    ? (diagnostics !== null && diagnostics !== void 0 ? diagnostics : []).filter((diag) => !diag.voiceId || diag.voiceId === (part.voiceId || ""))
-    : [];
-const buildAbcRenderedMeasureSourceMiscXml = (sourceMetadata, partIndex, measureNo, abcSource) => (sourceMetadata && partIndex === 0 && measureNo === 1 ? buildAbcSourceMiscXml(abcSource) : "");
 const createInitialAbcPartRenderState = (defaultFifths, beats, beatType, tempoBpm) => ({
     currentPartFifths: Math.max(-7, Math.min(7, Math.round(defaultFifths))),
     currentPartMeter: { beats: Math.round(beats), beatType: Math.round(beatType) },
     currentPartTempo: tempoBpm,
 });
 const buildAbcPartXml = (part, partIndex, measureCount, defaultFifths, beats, beatType, tempoBpm, debugMetadata, sourceMetadata, diagnostics, abcSource, buildMeasureNotesXml) => {
-    return buildAbcPartXmlWrapper(part.partId, buildAbcPartXmlMeasures(part, partIndex, measureCount, defaultFifths, beats, beatType, tempoBpm, debugMetadata, sourceMetadata, diagnostics, abcSource, buildMeasureNotesXml));
-};
-const buildAbcPartXmlWrapper = (partId, measuresXml) => `<part id="${xmlEscape(partId)}">${measuresXml}</part>`;
-const buildAbcPartXmlMeasures = (part, partIndex, measureCount, defaultFifths, beats, beatType, tempoBpm, debugMetadata, sourceMetadata, diagnostics, abcSource, buildMeasureNotesXml) => buildAbcPartXmlMeasureEntries(part, partIndex, measureCount, defaultFifths, beats, beatType, tempoBpm, debugMetadata, sourceMetadata, diagnostics, abcSource, buildMeasureNotesXml);
-const buildAbcPartXmlMeasureEntries = (part, partIndex, measureCount, defaultFifths, beats, beatType, tempoBpm, debugMetadata, sourceMetadata, diagnostics, abcSource, buildMeasureNotesXml) => buildAbcPartXmlMeasureEntryParts(part, partIndex, measureCount, defaultFifths, beats, beatType, tempoBpm, debugMetadata, sourceMetadata, diagnostics, abcSource, buildMeasureNotesXml).join("");
-const buildAbcPartXmlMeasureEntryParts = (part, partIndex, measureCount, defaultFifths, beats, beatType, tempoBpm, debugMetadata, sourceMetadata, diagnostics, abcSource, buildMeasureNotesXml) => {
     const measureParts = [];
     let state = createInitialAbcPartRenderState(defaultFifths, beats, beatType, tempoBpm);
     for (let i = 0; i < measureCount; i += 1) {
@@ -23473,335 +23492,33 @@ const buildAbcPartXmlMeasureEntryParts = (part, partIndex, measureCount, default
             buildMeasureNotesXml,
         }));
     }
-    return measureParts;
+    return `<part id="${xmlEscape(part.partId)}">${measureParts.join("")}</part>`;
 };
-const buildAbcPartListXml = (resolvedParts) => {
-    return resolvedParts.map((part, index) => buildAbcPartListEntryXml(part, index)).join("");
-};
-const buildAbcPartListEntryXml = (part, index) => {
-    const midiChannel = ((index % 16) + 1 === 10) ? 11 : ((index % 16) + 1);
-    return [
-        `<score-part id="${xmlEscape(part.partId)}">`,
-        `<part-name>${xmlEscape(part.partName || part.partId)}</part-name>`,
-        `<midi-instrument id="${xmlEscape(part.partId)}-I1">`,
-        `<midi-channel>${midiChannel}</midi-channel>`,
-        `<midi-program>6</midi-program>`,
-        "</midi-instrument>",
-        "</score-part>",
-    ].join("");
-};
-const buildAbcPartBodyXml = (resolvedParts, measureCount, defaultFifths, beats, beatType, tempoBpm, debugMetadata, sourceMetadata, diagnostics, abcSource, buildMeasureNotesXml) => {
-    return buildAbcPartBodyParts(resolvedParts, measureCount, defaultFifths, beats, beatType, tempoBpm, debugMetadata, sourceMetadata, diagnostics, abcSource, buildMeasureNotesXml);
-};
-const buildAbcPartBodyParts = (resolvedParts, measureCount, defaultFifths, beats, beatType, tempoBpm, debugMetadata, sourceMetadata, diagnostics, abcSource, buildMeasureNotesXml) => buildAbcPartBodyPartEntries(resolvedParts, measureCount, defaultFifths, beats, beatType, tempoBpm, debugMetadata, sourceMetadata, diagnostics, abcSource, buildMeasureNotesXml);
-const buildAbcPartBodyPartEntries = (resolvedParts, measureCount, defaultFifths, beats, beatType, tempoBpm, debugMetadata, sourceMetadata, diagnostics, abcSource, buildMeasureNotesXml) => buildAbcPartBodyPartItems(resolvedParts, measureCount, defaultFifths, beats, beatType, tempoBpm, debugMetadata, sourceMetadata, diagnostics, abcSource, buildMeasureNotesXml).join("");
-const buildAbcPartBodyPartItems = (resolvedParts, measureCount, defaultFifths, beats, beatType, tempoBpm, debugMetadata, sourceMetadata, diagnostics, abcSource, buildMeasureNotesXml) => resolvedParts.map((part, partIndex) => buildAbcPartXml(part, partIndex, measureCount, defaultFifths, beats, beatType, tempoBpm, debugMetadata, sourceMetadata, diagnostics, abcSource, buildMeasureNotesXml));
-const buildAbcNoteHarmonyAndWordsDirectionXml = (note) => {
-    const chunks = [];
-    if (!note.chord && Array.isArray(note.chordSymbols) && note.chordSymbols.length > 0) {
-        for (const chordSymbol of note.chordSymbols) {
-            const harmonyXml = buildHarmonyXmlFromChordSymbol(chordSymbol);
-            if (harmonyXml) {
-                chunks.push(harmonyXml);
-            }
-            else {
-                chunks.push((0, direction_text_1.buildMusicXmlWordsDirectionXml)({ text: String(chordSymbol) }));
-            }
-        }
-    }
-    if (!note.chord && Array.isArray(note.annotations) && note.annotations.length > 0) {
-        for (const annotation of note.annotations) {
-            if (!annotation)
-                continue;
-            chunks.push((0, direction_text_1.buildMusicXmlWordsDirectionXml)({ text: String(annotation) }));
-        }
-    }
-    return chunks.join("");
-};
-const buildAbcNoteControlDirectionXml = (note) => {
-    const chunks = [];
-    if (!note.chord && note.segno)
-        chunks.push("<direction><direction-type><segno/></direction-type></direction>");
-    if (!note.chord && note.coda)
-        chunks.push("<direction><direction-type><coda/></direction-type></direction>");
-    if (!note.chord && note.rehearsalMark) {
-        chunks.push(`<direction><direction-type><rehearsal>${xmlEscape(String(note.rehearsalMark))}</rehearsal></direction-type></direction>`);
-    }
-    if (!note.chord && note.fine)
-        chunks.push('<direction><sound fine="yes"/></direction>');
-    if (!note.chord && note.daCapo)
-        chunks.push('<direction><sound dacapo="yes"/></direction>');
-    if (!note.chord && note.dalSegno)
-        chunks.push('<direction><sound dalsegno="segno"/></direction>');
-    if (!note.chord && note.toCoda)
-        chunks.push('<direction><sound tocoda="coda"/></direction>');
-    if (!note.chord && note.crescendoStart)
-        chunks.push((0, dynamics_1.buildMusicXmlDirectionFeatureXml)({ kind: "wedge", wedgeType: "crescendo" }));
-    if (!note.chord && note.diminuendoStart)
-        chunks.push((0, dynamics_1.buildMusicXmlDirectionFeatureXml)({ kind: "wedge", wedgeType: "diminuendo" }));
-    if (!note.chord && (note.crescendoStop || note.diminuendoStop)) {
-        chunks.push((0, dynamics_1.buildMusicXmlDirectionFeatureXml)({ kind: "wedge", wedgeType: "stop" }));
-    }
-    if (!note.chord && note.dynamicMark) {
-        const dynamicMark = (0, dynamics_1.normalizeDynamicMark)(String(note.dynamicMark));
-        if (dynamicMark)
-            chunks.push((0, dynamics_1.buildMusicXmlDirectionFeatureXml)({ kind: "dynamic", mark: dynamicMark }));
-    }
-    if (!note.chord && note.sfz) {
-        chunks.push((0, dynamics_1.buildMusicXmlDirectionFeatureXml)({ kind: "dynamic", mark: "sfz" }));
-    }
-    return chunks.join("");
-};
-const buildAbcNoteLeadingDirectionXml = (note) => {
-    const chunks = [];
-    chunks.push(buildAbcNoteHarmonyAndWordsDirectionXml(note));
-    chunks.push(buildAbcNoteControlDirectionXml(note));
-    return chunks.join("");
-};
-const buildAbcNotePitchOrRestXml = (note) => {
-    if (note.isRest) {
-        return "<rest/>";
-    }
-    return (0, pitches_1.buildMusicXmlPitchXml)({
-        step: note.step,
-        alter: note.alter,
-        octave: note.octave,
-    });
-};
-const buildAbcNoteLyricXml = (note) => {
-    return (0, note_elements_1.buildMusicXmlLyricXml)({
-        text: note.lyricText,
-        syllabic: note.lyricSyllabic || "single",
-        extend: note.lyricExtend,
-    });
-};
-const buildAbcNoteTimeModificationXml = (note) => {
-    var _a, _b;
-    return (0, tuplets_1.buildMusicXmlTimeModificationXml)({
-        actualNotes: (_a = note.timeModification) === null || _a === void 0 ? void 0 : _a.actual,
-        normalNotes: (_b = note.timeModification) === null || _b === void 0 ? void 0 : _b.normal,
-    });
-};
-const buildAbcNoteAccidentalXml = (note) => {
-    return (0, note_elements_1.buildMusicXmlAccidentalXml)({
-        text: note.accidentalText,
-        editorial: note.accidentalEditorial,
-        cautionary: note.accidentalCautionary,
-    });
-};
-const buildAbcNoteCoreXml = (note, noteIndex, staffOverride, beamXmlByNoteIndex) => {
-    const chunks = [];
-    chunks.push(...buildAbcNoteCoreOpenParts(note, staffOverride));
-    if (!note.chord && beamXmlByNoteIndex.has(noteIndex))
-        chunks.push(String(beamXmlByNoteIndex.get(noteIndex)));
-    chunks.push(...buildAbcNoteCoreTailParts(note));
-    return chunks.join("");
-};
-const buildAbcNoteCoreOpenParts = (note, staffOverride) => {
-    const chunks = ["<note>"];
-    if (note.chord)
-        chunks.push("<chord/>");
-    if (note.grace)
-        chunks.push((0, note_elements_1.buildMusicXmlGraceXml)({ slash: note.graceSlash }));
-    chunks.push(buildAbcNotePitchOrRestXml(note));
-    if (!note.grace) {
-        const duration = Math.max(1, Math.round(Number(note.duration) || 1));
-        chunks.push(`<duration>${duration}</duration>`);
-    }
-    chunks.push(`<voice>${xmlEscape(normalizeVoiceForMusicXml(note.voice))}</voice>`);
-    if (staffOverride !== null || Number.isFinite(note.staff)) {
-        const staffNumber = staffOverride !== null ? staffOverride : Math.max(1, Math.round(Number(note.staff) || 1));
-        chunks.push(`<staff>${staffNumber}</staff>`);
-    }
-    chunks.push(buildAbcNoteLyricXml(note));
-    chunks.push(`<type>${normalizeTypeForMusicXml(note.type)}</type>`);
-    return chunks;
-};
-const buildAbcNoteCoreTailParts = (note) => [...buildAbcNoteCoreModifierTailParts(note), buildAbcNoteCoreTieTailPart(note)];
-const buildAbcNoteCoreModifierTailParts = (note) => [
-    buildAbcNoteTimeModificationXml(note),
-    buildAbcNoteAccidentalXml(note),
-];
-const buildAbcNoteCoreTieTailPart = (note) => (0, ties_1.buildMusicXmlTieItemsXml)({
-    tieStart: Boolean(note.tieStart),
-    tieStop: Boolean(note.tieStop),
-});
-const buildAbcNoteOrnamentsXml = (note) => {
-    return [buildAbcNoteOrnamentsFeatureParts(note), buildAbcNoteOrnamentsMotionParts(note)].join("");
-};
-const buildAbcNoteOrnamentsFeatureParts = (note) => [
-    buildAbcNoteOrnamentsWavyLinePart(note),
-    buildAbcNoteOrnamentsTurnPart(note),
-    buildAbcNoteOrnamentsMordentPart(note),
-    buildAbcNoteOrnamentsTremoloPart(note),
-    buildAbcNoteOrnamentsSchleiferPart(note),
-    buildAbcNoteOrnamentsShakePart(note),
-].join("");
-const buildAbcNoteOrnamentsMotionParts = (note) => buildAbcNoteOrnamentsMotionItemParts(note).join("");
-const buildAbcNoteOrnamentsMotionItemParts = (note) => [
-    note.glissandoStart ? '<glissando type="start" number="1">wavy</glissando>' : "",
-    note.glissandoStop ? '<glissando type="stop" number="1">wavy</glissando>' : "",
-    note.slideStart ? '<slide type="start" number="1"/>' : "",
-    note.slideStop ? '<slide type="stop" number="1"/>' : "",
-    note.arpeggiate ? "<arpeggiate/>" : "",
-].filter(Boolean);
-const buildAbcNoteOrnamentsWavyLinePart = (note) => {
-    if (!note.trill && !note.trillLineStop)
-        return "";
-    const trillParts = note.trill ? [(0, ornaments_1.buildMusicXmlOrnamentItemsXml)([{ kind: "trill-mark" }])] : [];
-    if (note.trillLineStop) {
-        trillParts.push('<wavy-line type="stop"/>');
-    }
-    else if (note.trillLineStart) {
-        trillParts.push('<wavy-line type="start"/>');
-    }
-    if (note.trillAccidentalText)
-        trillParts.push(`<accidental-mark>${xmlEscape(String(note.trillAccidentalText))}</accidental-mark>`);
-    return `<ornaments>${trillParts.join("")}</ornaments>`;
-};
-const buildAbcNoteOrnamentsTurnPart = (note) => {
-    if (!note.turnType)
-        return "";
-    return (0, ornaments_1.buildMusicXmlOrnamentsXml)([
-        { kind: note.turnType === "inverted-turn" ? "inverted-turn" : "turn", ...(note.turnSlash ? { slash: true } : {}) },
-        ...(note.delayedTurn ? [{ kind: "delayed-turn" }] : []),
-    ]);
-};
-const buildAbcNoteOrnamentsMordentPart = (note) => {
-    if (!note.mordentType)
-        return "";
-    return (0, ornaments_1.buildMusicXmlOrnamentsXml)([
-        { kind: note.mordentType === "inverted-mordent" ? "inverted-mordent" : "mordent" },
-    ]);
-};
-const buildAbcNoteOrnamentsTremoloPart = (note) => {
-    if (!note.tremoloType)
-        return "";
-    return (0, ornaments_1.buildMusicXmlOrnamentsXml)([
-        { kind: "tremolo", tremoloType: note.tremoloType, marks: note.tremoloMarks },
-    ]);
-};
-const buildAbcNoteOrnamentsSchleiferPart = (note) => note.schleifer ? (0, ornaments_1.buildMusicXmlOrnamentsXml)([{ kind: "schleifer" }]) : "";
-const buildAbcNoteOrnamentsShakePart = (note) => note.shake ? (0, ornaments_1.buildMusicXmlOrnamentsXml)([{ kind: "shake" }]) : "";
-const buildAbcNoteArticulationsXml = (note) => {
-    const featureItemsXml = buildAbcNoteArticulationFeatureItemsXml(note);
-    const decorativeParts = buildAbcNoteArticulationDecorativeParts(note);
-    if (featureItemsXml && decorativeParts.length === 0)
-        return `<articulations>${featureItemsXml}</articulations>`;
-    if (featureItemsXml)
-        decorativeParts.unshift(featureItemsXml);
-    return decorativeParts.length > 0 ? `<articulations>${decorativeParts.join("")}</articulations>` : "";
-};
-const buildAbcNoteArticulationDecorativeParts = (note) => {
-    const articulationParts = [];
-    if (note.stress)
-        articulationParts.push("<stress/>");
-    if (note.unstress)
-        articulationParts.push("<unstress/>");
-    if (note.phraseMark)
-        articulationParts.push(`<other-articulation>${xmlEscape(String(note.phraseMark))}</other-articulation>`);
-    return articulationParts;
-};
-const buildAbcNoteArticulationFeatureItemsXml = (note) => (0, articulations_1.buildMusicXmlArticulationItemsXml)(buildAbcNoteArticulationFeatureKinds(note));
-const buildAbcNoteArticulationFeatureKinds = (note) => {
-    const articulationKinds = [];
-    if (note.staccato)
-        articulationKinds.push("staccato");
-    if (note.staccatissimo)
-        articulationKinds.push("staccatissimo");
-    if (note.accent)
-        articulationKinds.push("accent");
-    if (note.tenuto)
-        articulationKinds.push("tenuto");
-    if (note.strongAccent)
-        articulationKinds.push("strong-accent");
-    if (note.breathMark)
-        articulationKinds.push("breath-mark");
-    if (note.caesura)
-        articulationKinds.push("caesura");
-    return articulationKinds;
-};
-const buildAbcNoteTechnicalXml = (note) => {
-    const technicalParts = [];
-    technicalParts.push(...buildAbcNoteTechnicalPlainParts(note));
-    technicalParts.push(...buildAbcNoteTechnicalCollectionParts(note));
-    technicalParts.push(...buildAbcNoteTechnicalFlagParts(note));
-    return (0, note_elements_1.buildMusicXmlTechnicalXml)(technicalParts);
-};
-const buildAbcNoteTechnicalPlainParts = (note) => [
-    note.upBow ? "<up-bow/>" : "",
-    note.downBow ? "<down-bow/>" : "",
-    note.doubleTongue ? "<double-tongue/>" : "",
-    note.tripleTongue ? "<triple-tongue/>" : "",
-    note.heel ? "<heel/>" : "",
-    note.toe ? "<toe/>" : "",
-].filter(Boolean);
-const buildAbcNoteTechnicalCollectionParts = (note) => {
-    return buildAbcNoteTechnicalCollectionItemParts(note);
-};
-const buildAbcNoteTechnicalCollectionItemParts = (note) => {
-    const collectionParts = [];
-    if (Array.isArray(note.fingerings) && note.fingerings.length > 0) {
-        for (const fingering of note.fingerings)
-            collectionParts.push((0, note_elements_1.buildMusicXmlFingeringXml)(fingering));
-    }
-    if (Array.isArray(note.strings) && note.strings.length > 0) {
-        for (const stringText of note.strings)
-            collectionParts.push((0, note_elements_1.buildMusicXmlStringNumberXml)(stringText));
-    }
-    if (Array.isArray(note.plucks) && note.plucks.length > 0) {
-        for (const pluckText of note.plucks)
-            if (pluckText)
-                collectionParts.push(`<pluck>${xmlEscape(String(pluckText))}</pluck>`);
-    }
-    return collectionParts;
-};
-const buildAbcNoteTechnicalFlagParts = (note) => [
-    note.openString ? "<open-string/>" : "",
-    note.snapPizzicato ? "<snap-pizzicato/>" : "",
-    note.harmonic ? "<harmonic/>" : "",
-    note.stopped ? "<stopped/>" : "",
-    note.thumbPosition ? "<thumb-position/>" : "",
-].filter(Boolean);
-const hasAbcNoteNotations = (note) => Boolean(note.tieStart || note.tieStop || note.slurStart || note.slurStop || note.trill || note.trillLineStop || note.turnType ||
-    note.delayedTurn || note.mordentType || note.tremoloType || note.glissandoStart || note.glissandoStop ||
-    note.slideStart || note.slideStop || note.schleifer || note.shake || note.arpeggiate || note.staccato ||
-    note.staccatissimo || note.accent || note.tenuto || note.stress || note.unstress || note.fermataType ||
-    note.strongAccent || note.breathMark || note.caesura || note.phraseMark || note.upBow || note.downBow ||
-    note.doubleTongue || note.tripleTongue || note.heel || note.toe ||
-    (Array.isArray(note.fingerings) && note.fingerings.length > 0) ||
-    (Array.isArray(note.strings) && note.strings.length > 0) ||
-    (Array.isArray(note.plucks) && note.plucks.length > 0) || note.openString || note.snapPizzicato ||
-    note.harmonic || note.stopped || note.thumbPosition || note.tupletStart || note.tupletStop);
-const buildAbcNoteNotationsXml = (note) => {
-    if (!hasAbcNoteNotations(note))
-        return "";
-    return `<notations>${buildAbcNoteNotationsFeatureChunks(note)}</notations>`;
-};
-const buildAbcNoteNotationsFeatureChunks = (note) => [
-    (0, ties_1.buildMusicXmlTiedItemsXml)({
-        tiedStart: Boolean(note.tieStart),
-        tiedStop: Boolean(note.tieStop),
-    }),
-    (0, slurs_1.buildMusicXmlSlursXml)([
-        ...(note.slurStart ? [{ type: "start" }] : []),
-        ...(note.slurStop ? [{ type: "stop" }] : []),
-    ]),
-    note.tupletStart ? '<tuplet type="start"/>' : "",
-    note.tupletStop ? '<tuplet type="stop"/>' : "",
-    buildAbcNoteOrnamentsXml(note),
-    buildAbcNoteArticulationsXml(note),
-    buildAbcNoteTechnicalXml(note),
-    note.fermataType ? `<fermata>${note.fermataType === "inverted" ? "inverted" : "normal"}</fermata>` : "",
-].join("");
-const buildAbcEmptyMeasureNotesXml = (measureDurationDiv, emptyMeasureRestType, staffOverride) => {
-    return `<note><rest/><duration>${measureDurationDiv}</duration><voice>1</voice><type>${emptyMeasureRestType}</type>${staffOverride !== null ? `<staff>${staffOverride}</staff>` : ""}</note>`;
-};
+const hasAbcNoteNotations = (note) => hasAbcNoteTieOrSlurNotations(note) ||
+    hasAbcNoteOrnaments(note) ||
+    hasAbcNoteArticulations(note) ||
+    hasAbcNoteTechnicalNotations(note) ||
+    hasAbcNoteFermataNotation(note) ||
+    hasAbcNoteTupletNotations(note);
+const hasAbcNoteTieOrSlurNotations = (note) => note.tieStart || note.tieStop || note.slurStart || note.slurStop;
+const hasAbcNoteOrnaments = (note) => hasAbcNoteOrnamentFeatureNotations(note) || hasAbcNoteOrnamentMotionNotations(note);
+const hasAbcNoteOrnamentFeatureNotations = (note) => note.trill || note.trillLineStop || note.turnType || note.delayedTurn || note.mordentType || note.tremoloType ||
+    note.schleifer || note.shake;
+const hasAbcNoteOrnamentMotionNotations = (note) => note.glissandoStart || note.glissandoStop || note.slideStart || note.slideStop || note.arpeggiate;
+const hasAbcNoteArticulations = (note) => hasAbcNoteArticulationFeatureNotations(note) || hasAbcNoteArticulationDecorativeNotations(note);
+const hasAbcNoteArticulationFeatureNotations = (note) => note.staccato || note.staccatissimo || note.accent || note.tenuto || note.strongAccent || note.breathMark || note.caesura;
+const hasAbcNoteArticulationDecorativeNotations = (note) => note.stress || note.unstress || note.phraseMark;
+const hasAbcNoteTechnicalNotations = (note) => hasAbcNoteTechnicalPlainNotations(note) || hasAbcNoteTechnicalCollectionNotations(note) || hasAbcNoteTechnicalFlagNotations(note);
+const hasAbcNoteTechnicalPlainNotations = (note) => !!(note.upBow || note.downBow || note.doubleTongue || note.tripleTongue || note.heel || note.toe);
+const hasAbcNoteTechnicalCollectionNotations = (note) => { var _a, _b, _c; return !!(((_a = note.fingerings) === null || _a === void 0 ? void 0 : _a.length) || ((_b = note.strings) === null || _b === void 0 ? void 0 : _b.length) || ((_c = note.plucks) === null || _c === void 0 ? void 0 : _c.length)); };
+const hasAbcNoteTechnicalFlagNotations = (note) => note.openString || note.snapPizzicato || note.harmonic || note.stopped || note.thumbPosition;
+const hasAbcNoteFermataNotation = (note) => !!note.fermataType;
+const hasAbcNoteTupletNotations = (note) => !!(note.tupletStart || note.tupletStop);
 const buildAbcBeamXmlByNoteIndex = (notes, beatDiv) => {
     var _a;
     const out = new Map();
     const levelFromType = (typeText) => {
-        switch (String(typeText || "").trim().toLowerCase()) {
+        switch (String(typeText !== null && typeText !== void 0 ? typeText : "").trim().toLowerCase()) {
             case "eighth":
                 return 1;
             case "16th":
@@ -23831,8 +23548,8 @@ const buildAbcBeamXmlByNoteIndex = (notes, beatDiv) => {
             const type = normalizeTypeForMusicXml((_a = ev.note) === null || _a === void 0 ? void 0 : _a.type);
             return {
                 timed: true,
-                chord: !Boolean((_b = ev.note) === null || _b === void 0 ? void 0 : _b.isRest),
-                grace: Boolean((_c = ev.note) === null || _c === void 0 ? void 0 : _c.grace),
+                chord: !((_b = ev.note) === null || _b === void 0 ? void 0 : _b.isRest),
+                grace: !!((_c = ev.note) === null || _c === void 0 ? void 0 : _c.grace),
                 durationDiv: ((_d = ev.note) === null || _d === void 0 ? void 0 : _d.grace) ? 0 : Math.max(1, Math.round(Number((_e = ev.note) === null || _e === void 0 ? void 0 : _e.duration) || 1)),
                 levels: levelFromType(type),
                 explicitMode: (_f = ev.note) === null || _f === void 0 ? void 0 : _f.beamMode,
@@ -23851,16 +23568,187 @@ const buildAbcBeamXmlByNoteIndex = (notes, beatDiv) => {
     return out;
 };
 const buildAbcNoteXml = (note, noteIndex, staffOverride, beamXmlByNoteIndex) => {
+    var _a, _b, _c, _d, _e, _f;
+    const voice = normalizeVoiceForMusicXml(note.voice);
+    const staff = Number(note.staff);
+    const staffValue = staffOverride !== null && staffOverride !== void 0 ? staffOverride : (Number.isFinite(staff) ? Math.max(1, Math.round(staff || 1)) : null);
     const chunks = [];
-    chunks.push(buildAbcNoteLeadingDirectionXml(note));
-    chunks.push(buildAbcNoteCoreXml(note, noteIndex, staffOverride, beamXmlByNoteIndex));
-    chunks.push(buildAbcNoteNotationsXml(note));
+    chunks.push(note.chord
+        ? ""
+        : [
+            (_b = (_a = note.chordSymbols) === null || _a === void 0 ? void 0 : _a.map((chordSymbol) => buildHarmonyXmlFromChordSymbol(chordSymbol) || (0, direction_text_1.buildMusicXmlWordsDirectionXml)({ text: String(chordSymbol) })).join("")) !== null && _b !== void 0 ? _b : "",
+            (_d = (_c = note.annotations) === null || _c === void 0 ? void 0 : _c.filter((annotation) => annotation.trim().length > 0).map((annotation) => (0, direction_text_1.buildMusicXmlWordsDirectionXml)({ text: String(annotation) })).join("")) !== null && _d !== void 0 ? _d : "",
+            [
+                note.segno ? "<direction><direction-type><segno/></direction-type></direction>" : "",
+                note.coda ? "<direction><direction-type><coda/></direction-type></direction>" : "",
+                note.rehearsalMark
+                    ? `<direction><direction-type><rehearsal>${xmlEscape(String(note.rehearsalMark))}</rehearsal></direction-type></direction>`
+                    : "",
+                note.fine ? '<direction><sound fine="yes"/></direction>' : "",
+                note.daCapo ? '<direction><sound dacapo="yes"/></direction>' : "",
+                note.dalSegno ? '<direction><sound dalsegno="segno"/></direction>' : "",
+                note.toCoda ? '<direction><sound tocoda="coda"/></direction>' : "",
+                note.crescendoStart
+                    ? (0, dynamics_1.buildMusicXmlDirectionFeatureXml)({ kind: "wedge", wedgeType: "crescendo" })
+                    : note.diminuendoStart
+                        ? (0, dynamics_1.buildMusicXmlDirectionFeatureXml)({ kind: "wedge", wedgeType: "diminuendo" })
+                        : note.crescendoStop || note.diminuendoStop
+                            ? (0, dynamics_1.buildMusicXmlDirectionFeatureXml)({ kind: "wedge", wedgeType: "stop" })
+                            : "",
+                note.dynamicMark ? (0, dynamics_1.buildMusicXmlDirectionFeatureXml)({ kind: "dynamic", mark: (0, dynamics_1.normalizeDynamicMark)(String(note.dynamicMark)) }) : "",
+                note.sfz ? (0, dynamics_1.buildMusicXmlDirectionFeatureXml)({ kind: "dynamic", mark: "sfz" }) : "",
+            ]
+                .filter((part) => part.length > 0)
+                .join(""),
+        ]
+            .filter((part) => part.length > 0)
+            .join(""));
+    chunks.push([
+        "<note>",
+        ...(note.chord ? ["<chord/>"] : []),
+        ...(note.grace ? [(0, note_elements_1.buildMusicXmlGraceXml)({ slash: note.graceSlash })] : []),
+        note.isRest
+            ? "<rest/>"
+            : (0, pitches_1.buildMusicXmlPitchXml)({
+                step: note.step,
+                alter: note.alter,
+                octave: note.octave,
+            }),
+        ...(note.grace ? [] : [`<duration>${Math.max(1, Math.round(Number(note.duration) || 1))}</duration>`]),
+        `<voice>${xmlEscape(voice)}</voice>`,
+        ...(staffValue ? [`<staff>${staffValue}</staff>`] : []),
+        (0, note_elements_1.buildMusicXmlLyricXml)({
+            text: note.lyricText,
+            syllabic: note.lyricSyllabic || "single",
+            extend: note.lyricExtend,
+        }),
+        `<type>${normalizeTypeForMusicXml(note.type)}</type>`,
+        !note.chord && beamXmlByNoteIndex.has(noteIndex) ? String(beamXmlByNoteIndex.get(noteIndex)) : "",
+        (0, tuplets_1.buildMusicXmlTimeModificationXml)({
+            actualNotes: (_e = note.timeModification) === null || _e === void 0 ? void 0 : _e.actual,
+            normalNotes: (_f = note.timeModification) === null || _f === void 0 ? void 0 : _f.normal,
+        }),
+        (0, note_elements_1.buildMusicXmlAccidentalXml)({
+            text: note.accidentalText,
+            editorial: note.accidentalEditorial,
+            cautionary: note.accidentalCautionary,
+        }),
+        (0, ties_1.buildMusicXmlTieItemsXml)({
+            tieStart: !!note.tieStart,
+            tieStop: !!note.tieStop,
+        }),
+    ].join(""));
+    chunks.push(hasAbcNoteNotations(note)
+        ? [
+            (0, ties_1.buildMusicXmlTiedItemsXml)({
+                tiedStart: !!note.tieStart,
+                tiedStop: !!note.tieStop,
+            }),
+            (0, slurs_1.buildMusicXmlSlursXml)([
+                ...(note.slurStart ? [{ type: "start" }] : []),
+                ...(note.slurStop ? [{ type: "stop" }] : []),
+            ]),
+            `${note.tupletStart ? '<tuplet type="start"/>' : ""}${note.tupletStop ? '<tuplet type="stop"/>' : ""}`,
+            [
+                [
+                    note.trill ? (0, ornaments_1.buildMusicXmlOrnamentItemsXml)([{ kind: "trill-mark" }]) : "",
+                    note.trillLineStop ? '<wavy-line type="stop"/>' : note.trillLineStart ? '<wavy-line type="start"/>' : "",
+                    note.trillAccidentalText ? `<accidental-mark>${xmlEscape(String(note.trillAccidentalText))}</accidental-mark>` : "",
+                ]
+                    .filter((part) => part.length > 0)
+                    .join("")
+                    .replace(/^/, "<ornaments>")
+                    .concat("</ornaments>"),
+                note.turnType
+                    ? (0, ornaments_1.buildMusicXmlOrnamentsXml)([
+                        {
+                            kind: note.turnType === "inverted-turn" ? "inverted-turn" : "turn",
+                            ...(note.turnSlash ? { slash: true } : {}),
+                        },
+                        ...(note.delayedTurn ? [{ kind: "delayed-turn" }] : []),
+                    ])
+                    : "",
+                note.mordentType
+                    ? (0, ornaments_1.buildMusicXmlOrnamentsXml)([
+                        {
+                            kind: note.mordentType === "inverted-mordent" ? "inverted-mordent" : "mordent",
+                        },
+                    ])
+                    : "",
+                note.tremoloType
+                    ? (0, ornaments_1.buildMusicXmlOrnamentsXml)([
+                        {
+                            kind: "tremolo",
+                            tremoloType: note.tremoloType,
+                            marks: note.tremoloMarks,
+                        },
+                    ])
+                    : "",
+                note.schleifer ? (0, ornaments_1.buildMusicXmlOrnamentsXml)([{ kind: "schleifer" }]) : "",
+                note.shake ? (0, ornaments_1.buildMusicXmlOrnamentsXml)([{ kind: "shake" }]) : "",
+                `${note.glissandoStart ? '<glissando type="start" number="1">wavy</glissando>' : ""}${note.glissandoStop ? '<glissando type="stop" number="1">wavy</glissando>' : ""}`,
+                `${note.slideStart ? '<slide type="start" number="1"/>' : ""}${note.slideStop ? '<slide type="stop" number="1"/>' : ""}`,
+                note.arpeggiate ? "<arpeggiate/>" : "",
+            ]
+                .filter((part) => part.length > 0)
+                .join(""),
+            [
+                (0, articulations_1.buildMusicXmlArticulationItemsXml)([
+                    ...[
+                        note.staccato ? "staccato" : "",
+                        note.staccatissimo ? "staccatissimo" : "",
+                        note.accent ? "accent" : "",
+                        note.tenuto ? "tenuto" : "",
+                    ].filter((part) => part.length > 0),
+                    ...[
+                        note.strongAccent ? "strong-accent" : "",
+                        note.breathMark ? "breath-mark" : "",
+                        note.caesura ? "caesura" : "",
+                    ].filter((part) => part.length > 0),
+                ]),
+                note.stress ? "<stress/>" : "",
+                note.unstress ? "<unstress/>" : "",
+                note.phraseMark ? `<other-articulation>${xmlEscape(String(note.phraseMark))}</other-articulation>` : "",
+            ]
+                .filter((part) => part.length > 0)
+                .join("")
+                .replace(/^/, "<articulations>")
+                .concat("</articulations>"),
+            (0, note_elements_1.buildMusicXmlTechnicalXml)([
+                ...[
+                    note.upBow ? "<up-bow/>" : "",
+                    note.downBow ? "<down-bow/>" : "",
+                    note.doubleTongue ? "<double-tongue/>" : "",
+                    note.tripleTongue ? "<triple-tongue/>" : "",
+                ].filter((part) => part.length > 0),
+                ...[
+                    note.heel ? "<heel/>" : "",
+                    note.toe ? "<toe/>" : "",
+                ].filter((part) => part.length > 0),
+                ...(note.fingerings ? note.fingerings.map((fingering) => (0, note_elements_1.buildMusicXmlFingeringXml)(fingering)) : []),
+                ...(note.strings ? note.strings.map((stringText) => (0, note_elements_1.buildMusicXmlStringNumberXml)(stringText)) : []),
+                ...(note.plucks ? note.plucks.map((pluckText) => (pluckText ? `<pluck>${xmlEscape(pluckText)}</pluck>` : "")) : []),
+                ...[
+                    note.openString ? "<open-string/>" : "",
+                    note.snapPizzicato ? "<snap-pizzicato/>" : "",
+                    note.harmonic ? "<harmonic/>" : "",
+                    note.stopped ? "<stopped/>" : "",
+                    note.thumbPosition ? "<thumb-position/>" : "",
+                ].filter((part) => part.length > 0),
+            ]),
+            note.fermataType ? `<fermata>${note.fermataType === "inverted" ? "inverted" : "normal"}</fermata>` : "",
+        ]
+            .filter((part) => part.length > 0)
+            .join("")
+            .replace(/^/, "<notations>")
+            .concat("</notations>")
+        : "");
     chunks.push("</note>");
     return chunks.join("");
 };
 const buildAbcMeasureNotesXml = (notes, measureDurationDiv, emptyMeasureRestType, beatDiv, staffOverride = null) => {
     if (!notes.length) {
-        return buildAbcEmptyMeasureNotesXml(measureDurationDiv, emptyMeasureRestType, staffOverride);
+        return `<note><rest/><duration>${measureDurationDiv}</duration><voice>1</voice><type>${emptyMeasureRestType}</type>${staffOverride !== null ? `<staff>${staffOverride}</staff>` : ""}</note>`;
     }
     const beamXmlByNoteIndex = buildAbcBeamXmlByNoteIndex(notes, beatDiv);
     return notes
@@ -23914,12 +23802,13 @@ const ensureAbcTempoByMeasure = (stores, voiceId) => {
     return stores.tempoByMeasureByVoice[voiceId];
 };
 const finalizeAbcActiveEndings = (stores) => {
+    var _a;
     for (const voiceId of Object.keys(stores.measuresByVoice)) {
         const measures = stores.measuresByVoice[voiceId];
         while (measures.length > 1 && measures[measures.length - 1].length === 0) {
             measures.pop();
         }
-        const activeEndingMarker = String(stores.activeEndingByVoice[voiceId] || "");
+        const activeEndingMarker = String((_a = stores.activeEndingByVoice[voiceId]) !== null && _a !== void 0 ? _a : "");
         if (activeEndingMarker) {
             const lastMeasureNo = measures.length;
             if (lastMeasureNo >= 1) {
@@ -24003,7 +23892,7 @@ const applyAbcBodyField = (fieldName, fieldValue, context) => {
         return { handled: true, activeKeyFifths, activeKeySignatureAccidentals, activeUnitLength, activeMeter, activeTempoBpm, measureAccidentals };
     }
     if (fieldName === "Q") {
-        activeTempoBpm = parseTempoFromQ(fieldValue || "", context.warnings);
+        activeTempoBpm = parseTempoFromQ(fieldValue !== null && fieldValue !== void 0 ? fieldValue : "", context.warnings);
         if (Number.isFinite(activeTempoBpm)) {
             ensureAbcTempoByMeasure(context.voiceStores, context.entryVoiceId)[context.currentMeasureNo] =
                 Math.max(20, Math.min(300, Math.round(Number(activeTempoBpm))));
@@ -24081,24 +23970,6 @@ const processAbcPlayableEvent = (playableEvent, context) => {
     }
     context.commitPlayableEvent(eventNotes, context.resolution.commitOptions);
     return true;
-};
-const buildAbcPlayableEventNotes = (context) => {
-    const notes = [];
-    for (let pitchIndex = 0; pitchIndex < context.pitchSources.length; pitchIndex += 1) {
-        const note = context.buildPlayableNoteForBody(context.pitchSources[pitchIndex], context.timing.absoluteLength, context.timing.dur, context.octaveWarningMessage);
-        if (!note) {
-            notes.length = 0;
-            break;
-        }
-        if (pitchIndex === 0) {
-            context.finalizePlayableEventStart(note, context.timing.dur, context.timing.activeTuplet, context.firstNoteOptions);
-        }
-        else {
-            note.chord = true;
-        }
-        notes.push(note);
-    }
-    return notes;
 };
 const processAbcSimpleBodyToken = (bodyToken, context) => {
     if (!bodyToken) {
@@ -24224,7 +24095,7 @@ const fifthsFromAbcKey = (raw) => {
         Ebm: -6,
         Abm: -7,
     };
-    const normalized = String(raw || "").trim().replace(/\s+/g, "");
+    const normalized = String(raw !== null && raw !== void 0 ? raw : "").trim().replace(/\s+/g, "");
     if (Object.prototype.hasOwnProperty.call(table, normalized)) {
         return table[normalized];
     }
@@ -24289,14 +24160,14 @@ const SNAP_PIZZICATO_DECORATIONS = new Set(["snap", "snap-pizzicato", "snappizzi
 const STOPPED_DECORATIONS = new Set(["stopped", "+", "plus", "stopped horn", "stopped-horn"]);
 const THUMB_POSITION_DECORATIONS = new Set(["thumb", "thumbposition", "thumb-position", "thumbpos", "thumb pos", "thumb position"]);
 function tokenizeAbcLyricLine(text) {
-    const raw = String(text || "").trim();
+    const raw = String(text !== null && text !== void 0 ? text : "").trim();
     if (!raw)
         return [];
     const chunks = raw
         .replace(/\|/g, " ")
         .split(/\s+/)
         .map((token) => token.trim())
-        .filter(Boolean);
+        .filter((token) => token.length > 0);
     const tokens = [];
     let pendingHyphenWord = false;
     for (const chunk of chunks) {
@@ -24339,10 +24210,11 @@ function tokenizeAbcLyricLine(text) {
     return tokens;
 }
 function splitBodyTextByInlineVoice(text, initialVoiceId) {
+    var _a;
     const segments = [];
-    let activeVoiceId = String(initialVoiceId || "1").trim() || "1";
+    let activeVoiceId = String(initialVoiceId !== null && initialVoiceId !== void 0 ? initialVoiceId : "1").trim() || "1";
     let buffer = "";
-    const raw = String(text || "");
+    const raw = String(text !== null && text !== void 0 ? text : "");
     let idx = 0;
     while (idx < raw.length) {
         if (raw[idx] === "[") {
@@ -24353,7 +24225,7 @@ function splitBodyTextByInlineVoice(text, initialVoiceId) {
                     segments.push({ voiceId: activeVoiceId, text: buffer });
                 }
                 buffer = "";
-                const voiceMatch = String(inlineField.fieldValue || "").match(/^(\S+)/);
+                const voiceMatch = String((_a = inlineField.fieldValue) !== null && _a !== void 0 ? _a : "").match(/^(\S+)/);
                 if (voiceMatch) {
                     activeVoiceId = voiceMatch[1];
                 }
@@ -24376,8 +24248,8 @@ function splitBodyTextByInlineVoice(text, initialVoiceId) {
     };
 }
 function splitBodyTextByOverlay(text, baseVoiceId) {
-    const raw = String(text || "");
-    const normalizedBaseVoiceId = String(baseVoiceId || "1").trim() || "1";
+    const raw = String(text !== null && text !== void 0 ? text : "");
+    const normalizedBaseVoiceId = String(baseVoiceId !== null && baseVoiceId !== void 0 ? baseVoiceId : "1").trim() || "1";
     const overlayBuffers = [""];
     let completedMeasureSkeleton = "";
     let activeOverlayIndex = 0;
@@ -24448,12 +24320,13 @@ function splitBodyTextByOverlay(text, baseVoiceId) {
         .filter((segment) => segment.text.trim().length > 0);
 }
 function parseUserDefinedDecoration(rawValue) {
-    const text = String(rawValue || "").trim();
+    var _a, _b;
+    const text = String(rawValue !== null && rawValue !== void 0 ? rawValue : "").trim();
     const match = text.match(/^(\S)(?:\s*=\s*|\s+)(.+)$/);
     if (!match)
         return null;
-    const symbol = String(match[1] || "");
-    const rhs = String(match[2] || "").trim();
+    const symbol = String((_a = match[1]) !== null && _a !== void 0 ? _a : "");
+    const rhs = String((_b = match[2]) !== null && _b !== void 0 ? _b : "").trim();
     if (!symbol || !rhs)
         return null;
     const wrapped = rhs.match(/^[!+](.+)[!+]$/);
@@ -24463,8 +24336,8 @@ function parseUserDefinedDecoration(rawValue) {
     return { symbol, decoration };
 }
 function expandUserDefinedDecorationSymbols(text, userDefinedDecorationBySymbol) {
-    const raw = String(text || "");
-    const symbolMap = userDefinedDecorationBySymbol || {};
+    const raw = String(text !== null && text !== void 0 ? text : "");
+    const symbolMap = userDefinedDecorationBySymbol !== null && userDefinedDecorationBySymbol !== void 0 ? userDefinedDecorationBySymbol : {};
     if (!raw || Object.keys(symbolMap).length === 0) {
         return raw;
     }
@@ -24494,7 +24367,7 @@ function expandUserDefinedDecorationSymbols(text, userDefinedDecorationBySymbol)
     return out;
 }
 function parseTempoFromQ(rawQ, warnings) {
-    const raw = String(rawQ || "").trim();
+    const raw = String(rawQ !== null && rawQ !== void 0 ? rawQ : "").trim();
     if (!raw) {
         return null;
     }
@@ -24527,8 +24400,9 @@ function parseTempoFromQ(rawQ, warnings) {
     return null;
 }
 function parseForMusicXml(source, settings) {
+    var _a, _b, _c;
     const warnings = [];
-    const lines = String(source || "").split("\n");
+    const lines = String(source !== null && source !== void 0 ? source : "").split("\n");
     const trillWidthHintByKey = new Map();
     const keyHintFifthsByKey = new Map();
     const measureMetaByKey = new Map();
@@ -24583,7 +24457,7 @@ function parseForMusicXml(source, settings) {
     const meter = parseMeter(headers.M || "4/4", warnings);
     const unitLength = parseFraction(headers.L || "1/8", "L", warnings);
     const keyInfo = parseKey(headers.K || "C", warnings);
-    const tempoBpm = parseTempoFromQ(headers.Q || "", warnings);
+    const tempoBpm = parseTempoFromQ((_a = headers.Q) !== null && _a !== void 0 ? _a : "", warnings);
     const keySignatureAccidentals = keySignatureAlterByStep(keyInfo.fifths);
     const voiceStores = createAbcVoiceStores();
     let noteCount = 0;
@@ -24593,7 +24467,7 @@ function parseForMusicXml(source, settings) {
         let measureAccidentals = {};
         let activeUnitLength = unitLength;
         let activeMeter = meter;
-        let activeTempoBpm = Number.isFinite(tempoBpm) ? Number(tempoBpm) : null;
+        let activeTempoBpm = tempoBpm !== null && tempoBpm !== void 0 ? tempoBpm : null;
         let activeKeyFifths = Number.isFinite(voiceStores.currentKeyFifthsByVoice[entry.voiceId])
             ? Number(voiceStores.currentKeyFifthsByVoice[entry.voiceId])
             : keyInfo.fifths;
@@ -24668,9 +24542,9 @@ function parseForMusicXml(source, settings) {
         let beamRunActive = false;
         let sawInterEventWhitespace = false;
         let beamCursorDiv = 0;
-        let activeEndingMarker = String(voiceStores.activeEndingByVoice[entry.voiceId] || "");
+        let activeEndingMarker = String((_b = voiceStores.activeEndingByVoice[entry.voiceId]) !== null && _b !== void 0 ? _b : "");
         let idx = 0;
-        const text = entry.text;
+        const text = (_c = entry.text) !== null && _c !== void 0 ? _c : "";
         const warnBody = (message) => {
             warnings.push("line " + entry.lineNo + ": " + message);
         };
@@ -25186,21 +25060,23 @@ function parseForMusicXml(source, settings) {
             }
         };
         const finalizePlayableEventStart = (note, dur, activeTuplet, options = {}) => {
+            var _a;
             const applyTieStop = options.applyTieStop !== false;
             applyBeamModeForEvent(note, dur);
             currentEventNo += 1;
-            const trillHint = trillWidthHintByKey.get(`${entry.voiceId}#${currentMeasureNo}#${currentEventNo}`) || "";
+            const trillHint = (_a = trillWidthHintByKey.get(`${entry.voiceId}#${currentMeasureNo}#${currentEventNo}`)) !== null && _a !== void 0 ? _a : "";
             applyPendingToPlayableNote(note, { applySlurStart: true, applyTieStop, trillHint });
             applyTupletToEventStart(note, activeTuplet);
             note.voice = entry.voiceId;
         };
         const buildPlayableNoteForBody = (pitchSource, absoluteLength, dur, octaveWarningMessage) => {
+            var _a;
             let note;
             try {
                 note = buildNoteData(pitchSource.pitchChar, pitchSource.accidentalText, pitchSource.octaveShift, absoluteLength, dur, entry.lineNo, activeKeySignatureAccidentals, measureAccidentals);
             }
             catch (error) {
-                if (error instanceof Error && /Octave out of range/i.test(error.message || "")) {
+                if (error instanceof Error && /Octave out of range/i.test((_a = error.message) !== null && _a !== void 0 ? _a : "")) {
                     warnBody(octaveWarningMessage);
                     return null;
                 }
@@ -25217,6 +25093,7 @@ function parseForMusicXml(source, settings) {
             lastEventNotes = [];
         };
         const commitPlayableEvent = (notes, options = {}) => {
+            var _a;
             const applyChordTieStop = options.applyChordTieStop === true;
             if (applyChordTieStop && pendingTieToNext && notes.length > 0) {
                 for (const note of notes) {
@@ -25233,22 +25110,31 @@ function parseForMusicXml(source, settings) {
                 clearLastEventState();
                 return false;
             }
-            lastNote = notes[0] || null;
+            lastNote = (_a = notes[0]) !== null && _a !== void 0 ? _a : null;
             lastEventNotes = notes;
             noteCount += notes.length;
             return true;
         };
         const buildPlayableEventFromPitches = (pitchSources, timing, options = {}) => {
-            const octaveWarningMessage = options.octaveWarningMessage || "Skipped note with unsupported octave range.";
-            const firstNoteOptions = options.firstNoteOptions || {};
-            return buildAbcPlayableEventNotes({
-                pitchSources,
-                timing,
-                octaveWarningMessage,
-                firstNoteOptions,
-                buildPlayableNoteForBody,
-                finalizePlayableEventStart,
-            });
+            var _a, _b;
+            const octaveWarningMessage = (_a = options.octaveWarningMessage) !== null && _a !== void 0 ? _a : "Skipped note with unsupported octave range.";
+            const firstNoteOptions = (_b = options.firstNoteOptions) !== null && _b !== void 0 ? _b : {};
+            const notes = [];
+            for (let pitchIndex = 0; pitchIndex < pitchSources.length; pitchIndex += 1) {
+                const note = buildPlayableNoteForBody(pitchSources[pitchIndex], timing.absoluteLength, timing.dur, octaveWarningMessage);
+                if (!note) {
+                    notes.length = 0;
+                    break;
+                }
+                if (pitchIndex === 0) {
+                    finalizePlayableEventStart(note, timing.dur, timing.activeTuplet, firstNoteOptions);
+                }
+                else {
+                    note.chord = true;
+                }
+                notes.push(note);
+            }
+            return notes;
         };
         const playableEventOptionsForSource = (source) => ({
             invalidLengthMessage: source === "chord" ? "Skipped chord with invalid length." : "Skipped note with invalid length.",
@@ -25607,10 +25493,13 @@ function parseForMusicXml(source, settings) {
             }
             return false;
         };
-        const isBeamableAbcNote = (note) => Boolean(note &&
-            !note.isRest &&
-            !note.grace &&
-            ["eighth", "16th", "32nd", "64th"].includes(String(note.type || "").trim().toLowerCase()));
+        const isBeamableAbcNote = (note) => {
+            var _a;
+            return !!(note &&
+                !note.isRest &&
+                !note.grace &&
+                ["eighth", "16th", "32nd", "64th"].includes(String((_a = note.type) !== null && _a !== void 0 ? _a : "").trim().toLowerCase()));
+        };
         const applyBeamModeForEvent = (note, durationDiv) => {
             const resolvedDurationDiv = Math.max(0, Math.round(Number(durationDiv) || 0));
             const beatDiv = Math.max(1, Math.round((960 * 4) / Math.max(1, Math.round(Number(activeMeter === null || activeMeter === void 0 ? void 0 : activeMeter.beatType) || 4))));
@@ -25703,30 +25592,32 @@ function parseForMusicXml(source, settings) {
     };
 }
 function parseVoiceDirectiveTail(raw) {
+    var _a, _b;
     if (!raw) {
         return { name: "", clef: "", transpose: null, bodyText: "", skippedText: "", unsupportedKeys: [] };
     }
-    let bodyText = String(raw);
+    let bodyText = String(raw !== null && raw !== void 0 ? raw : "");
     let name = "";
     let clef = "";
     let transpose = null;
     const unsupportedKeys = [];
     const bareClefMatch = bodyText.match(/^\s*(bass|treble|alto|tenor|c3|c4)(?=\s|$)/i);
     if (bareClefMatch) {
-        clef = String(bareClefMatch[1] || "").trim().toLowerCase();
+        clef = String((_a = bareClefMatch[1]) !== null && _a !== void 0 ? _a : "").trim().toLowerCase();
         bodyText = bodyText.slice(bareClefMatch[0].length);
     }
     const attrRegex = /([A-Za-z][A-Za-z0-9_-]*)\s*=\s*("([^"]*)"|(\S+))/g;
     bodyText = bodyText.replace(attrRegex, (_full, key, _quotedValue, quotedInner, bareValue) => {
+        var _a, _b, _c;
         const lowerKey = String(key).toLowerCase();
         if (lowerKey === "name") {
-            name = quotedInner || bareValue || "";
+            name = (_a = quotedInner !== null && quotedInner !== void 0 ? quotedInner : bareValue) !== null && _a !== void 0 ? _a : "";
         }
         else if (lowerKey === "clef") {
-            clef = String(quotedInner || bareValue || "").trim().toLowerCase();
+            clef = String((_b = quotedInner !== null && quotedInner !== void 0 ? quotedInner : bareValue) !== null && _b !== void 0 ? _b : "").trim().toLowerCase();
         }
         else if (lowerKey === "transpose") {
-            const parsed = Number.parseInt(String(quotedInner || bareValue || "").trim(), 10);
+            const parsed = Number.parseInt(String((_c = quotedInner !== null && quotedInner !== void 0 ? quotedInner : bareValue) !== null && _c !== void 0 ? _c : "").trim(), 10);
             if (Number.isFinite(parsed) && parsed >= -24 && parsed <= 24) {
                 transpose = { chromatic: parsed };
             }
@@ -25739,7 +25630,7 @@ function parseVoiceDirectiveTail(raw) {
     bodyText = bodyText.trim();
     let skippedText = "";
     const firstTokenMatch = bodyText.match(/^(\S+)/);
-    const firstToken = firstTokenMatch ? firstTokenMatch[1] : "";
+    const firstToken = firstTokenMatch ? (_b = firstTokenMatch[1]) !== null && _b !== void 0 ? _b : "" : "";
     if (firstToken && /^[A-Za-z][A-Za-z0-9_-]*$/.test(firstToken) && /[^A-Ga-gzZxX]/.test(firstToken)) {
         skippedText = firstToken;
         bodyText = bodyText.slice(firstToken.length).trim();
@@ -25754,6 +25645,7 @@ function parseVoiceDirectiveTail(raw) {
     };
 }
 function inferTransposeFromPartName(partName) {
+    var _a;
     if (!partName) {
         return null;
     }
@@ -25762,7 +25654,7 @@ function inferTransposeFromPartName(partName) {
     if (!m) {
         return null;
     }
-    const tonic = String(m[1]).toUpperCase() + (m[2] || "");
+    const tonic = String(m[1]).toUpperCase() + ((_a = m[2]) !== null && _a !== void 0 ? _a : "");
     const semitoneByTonic = {
         C: 0,
         "C#": 1,
@@ -25795,7 +25687,7 @@ function inferTransposeFromPartName(partName) {
     return { chromatic };
 }
 function parseMeter(raw, warnings) {
-    const normalized = String(raw || "").trim();
+    const normalized = String(raw !== null && raw !== void 0 ? raw : "").trim();
     if (normalized === "C") {
         return { beats: 4, beatType: 4 };
     }
@@ -25811,11 +25703,11 @@ function parseMeter(raw, warnings) {
 }
 function parseFraction(raw, fieldName, warnings) {
     const parsed = abcCommon.parseFractionText(raw, { num: 1, den: 8 });
-    if (parsed.num === 1 && parsed.den === 8 && !/^\s*\d+\/\d+\s*$/.test(String(raw || ""))) {
+    if (parsed.num === 1 && parsed.den === 8 && !/^\s*\d+\/\d+\s*$/.test(String(raw !== null && raw !== void 0 ? raw : ""))) {
         warnings.push(fieldName + " has invalid format; defaulted to 1/8: " + raw);
         return parsed;
     }
-    const m = String(raw || "").match(/^\s*(\d+)\/(\d+)\s*$/);
+    const m = String(raw !== null && raw !== void 0 ? raw : "").match(/^\s*(\d+)\/(\d+)\s*$/);
     if (!m || !Number(m[1]) || !Number(m[2])) {
         warnings.push(fieldName + " has invalid value; defaulted to 1/8: " + raw);
         return { num: 1, den: 8 };
@@ -25835,6 +25727,7 @@ function parseLengthToken(token, lineNo) {
     return abcCommon.parseAbcLengthToken(token, lineNo);
 }
 function parseGraceGroupAt(text, startIdx, lineNo, unitLength, keySignatureAccidentals, measureAccidentals, voiceId, warnings) {
+    var _a;
     const parsedGrace = (0, abc_parser_1.parseAbcGraceGroupAt)(text, startIdx, lineNo, warnings);
     if (!parsedGrace)
         return null;
@@ -25854,7 +25747,7 @@ function parseGraceGroupAt(text, startIdx, lineNo, unitLength, keySignatureAccid
             note = buildNoteData(pitchChar, accidentalText, octaveShift, absoluteLength, dur, lineNo, keySignatureAccidentals, graceAccidentals);
         }
         catch (error) {
-            if (error instanceof Error && /Octave out of range/i.test(error.message || "")) {
+            if (error instanceof Error && /Octave out of range/i.test((_a = error.message) !== null && _a !== void 0 ? _a : "")) {
                 warnings.push("line " + lineNo + ": Skipped grace note with unsupported octave range.");
                 continue;
             }
@@ -26137,18 +26030,6 @@ const parseOptionalMusicXmlNumber = (text) => {
     const parsed = Number(raw);
     return Number.isFinite(parsed) ? parsed : null;
 };
-const buildAbcExportPartNameById = (doc) => {
-    var _a, _b, _c;
-    const partNameById = new Map();
-    for (const scorePart of Array.from(doc.querySelectorAll("part-list > score-part"))) {
-        const id = (_a = scorePart.getAttribute("id")) !== null && _a !== void 0 ? _a : "";
-        if (!id)
-            continue;
-        const name = ((_c = (_b = scorePart.querySelector("part-name")) === null || _b === void 0 ? void 0 : _b.textContent) === null || _c === void 0 ? void 0 : _c.trim()) || id;
-        partNameById.set(id, name);
-    }
-    return partNameById;
-};
 const compareAbcExportLanes = (a, b) => {
     var _a, _b;
     const staffA = a.staff === null ? Number.POSITIVE_INFINITY : Number(a.staff);
@@ -26189,140 +26070,108 @@ const buildAbcExportLaneDefinitions = (part, partId) => {
         return { ...lane, voiceId: `${partId}${staffSuffix}${voiceSuffix || `_l${laneIndex + 1}`}` };
     });
 };
-const buildAbcExportLaneName = (partName, laneCount, lane) => {
-    if (laneCount <= 1)
-        return partName;
-    if (lane.staff && lane.voice)
-        return `${partName} (Staff ${lane.staff} Voice ${lane.voice})`;
-    if (lane.staff)
-        return `${partName} (Staff ${lane.staff})`;
-    if (lane.voice)
-        return `${partName} (Voice ${lane.voice})`;
-    return `${partName} (Lane)`;
-};
-const buildAbcExportTransposeMetaLine = (normalizedVoiceId, measure) => {
-    var _a, _b, _c, _d;
-    const transposeNode = measure.querySelector(":scope > attributes > transpose");
-    if (!transposeNode)
-        return null;
-    const chromatic = Number(((_b = (_a = transposeNode.querySelector(":scope > chromatic")) === null || _a === void 0 ? void 0 : _a.textContent) === null || _b === void 0 ? void 0 : _b.trim()) || "");
-    const diatonic = Number(((_d = (_c = transposeNode.querySelector(":scope > diatonic")) === null || _c === void 0 ? void 0 : _c.textContent) === null || _d === void 0 ? void 0 : _d.trim()) || "");
-    if (!Number.isFinite(chromatic) && !Number.isFinite(diatonic))
-        return null;
-    const parts = [`%@mks transpose voice=${normalizedVoiceId}`];
-    if (Number.isFinite(chromatic))
-        parts.push(`chromatic=${Math.round(chromatic)}`);
-    if (Number.isFinite(diatonic))
-        parts.push(`diatonic=${Math.round(diatonic)}`);
-    return parts.join(" ");
-};
-const buildAbcExportDiagMetaLines = (normalizedVoiceId, measure, safeMeasureNumber) => {
-    const fields = Array.from(measure.querySelectorAll(':scope > attributes > miscellaneous > miscellaneous-field[name^="mks:diag:"]'));
-    if (!fields.length)
-        return [];
-    const byName = new Map();
-    for (const field of fields) {
-        const name = (field.getAttribute("name") || "").trim();
-        if (!name)
-            continue;
-        const value = (field.textContent || "").trim();
-        byName.set(name, value);
-    }
-    const orderedNames = Array.from(byName.keys()).sort((a, b) => {
-        const isCountA = a === "mks:diag:count";
-        const isCountB = b === "mks:diag:count";
-        if (isCountA && !isCountB)
-            return -1;
-        if (!isCountA && isCountB)
-            return 1;
-        return a.localeCompare(b);
-    });
-    return orderedNames.map((name) => {
-        const value = byName.get(name) || "";
-        return `%@mks diag voice=${normalizedVoiceId} measure=${safeMeasureNumber} name=${name} enc=uri-v1 value=${encodeURIComponent(value)}`;
-    });
-};
-const buildAbcExportMeasureMetaLine = (normalizedVoiceId, measure, safeMeasureNumber, hasRightRepeat, rightEndingNumber, rightEndingType) => {
-    const rawMeasureNumber = (measure.getAttribute("number") || "").trim() || String(safeMeasureNumber);
-    const implicitAttr = (measure.getAttribute("implicit") || "").trim().toLowerCase();
-    const isImplicit = implicitAttr === "yes" || implicitAttr === "true" || implicitAttr === "1";
-    const rightRepeatNode = measure.querySelector(':scope > barline[location="right"] > repeat');
-    const repeatTimes = Number.parseInt(String((rightRepeatNode === null || rightRepeatNode === void 0 ? void 0 : rightRepeatNode.getAttribute("times")) || ""), 10);
-    if (!isImplicit &&
-        rawMeasureNumber === String(safeMeasureNumber) &&
-        (!hasRightRepeat || !Number.isFinite(repeatTimes) || repeatTimes <= 2) &&
-        (!rightEndingNumber || rightEndingType !== "discontinue")) {
-        return null;
-    }
-    const metaChunks = [
-        `%@mks measure voice=${normalizedVoiceId} measure=${safeMeasureNumber}`,
-        `number=${rawMeasureNumber}`,
-        `implicit=${isImplicit ? 1 : 0}`,
-    ];
-    if (hasRightRepeat && Number.isFinite(repeatTimes) && repeatTimes > 2) {
-        metaChunks.push(`times=${Math.round(repeatTimes)}`);
-    }
-    if (rightEndingNumber && rightEndingType === "discontinue") {
-        metaChunks.push(`ending-stop=${rightEndingNumber}`);
-        metaChunks.push(`ending-type=${rightEndingType}`);
-    }
-    return metaChunks.join(" ");
-};
 const applyAbcExportDirectionToPending = (direction, pendingDirectionWords, pendingDirectionDecorations, activeWedgeType) => {
-    const rehearsalTexts = Array.from(direction.querySelectorAll(":scope > direction-type > rehearsal"))
-        .map((node) => abcQuotedTextEscape(node.textContent || ""))
-        .filter(Boolean);
-    for (const rehearsalText of rehearsalTexts) {
-        pendingDirectionDecorations.push(`!rehearsal:${rehearsalText}!`);
-    }
-    const words = (0, direction_text_1.extractMusicXmlDirectionWords)(direction)
+    appendAbcExportDirectionWords(direction, pendingDirectionWords);
+    appendAbcExportDirectionTextDecorations(direction, pendingDirectionDecorations);
+    appendAbcExportDirectionSoundDecorations(direction, pendingDirectionDecorations);
+    return appendAbcExportDirectionFeatureDecorations(direction, pendingDirectionDecorations, activeWedgeType);
+};
+const appendAbcExportDirectionWords = (direction, pendingDirectionWords) => {
+    pendingDirectionWords.push(...(0, direction_text_1.extractMusicXmlDirectionWords)(direction)
         .map((feature) => abcQuotedTextEscape(feature.text))
-        .filter(Boolean);
-    pendingDirectionWords.push(...words);
-    if (direction.querySelector(":scope > direction-type > segno")) {
-        pendingDirectionDecorations.push("!segno!");
+        .filter((word) => word.length > 0));
+};
+const appendAbcExportDirectionTextDecorations = (direction, pendingDirectionDecorations) => {
+    for (const rehearsalText of Array.from(direction.querySelectorAll(":scope > direction-type > rehearsal"))
+        .map((node) => { var _a; return abcQuotedTextEscape((_a = node.textContent) !== null && _a !== void 0 ? _a : ""); })
+        .filter((text) => text.length > 0)) {
+        appendAbcExportDirectionPresenceDecoration(pendingDirectionDecorations, true, `!rehearsal:${rehearsalText}!`);
     }
-    if (direction.querySelector(":scope > direction-type > coda")) {
-        pendingDirectionDecorations.push("!coda!");
-    }
-    if (direction.querySelector(':scope > sound[fine="yes"]')) {
-        pendingDirectionDecorations.push("!fine!");
-    }
-    const hasDaCapo = Boolean(direction.querySelector(':scope > sound[dacapo="yes"]'));
-    const hasToCoda = Boolean(direction.querySelector(":scope > sound[tocoda]"));
-    if (hasDaCapo && hasToCoda) {
-        pendingDirectionDecorations.push("!dacoda!");
-    }
-    else if (hasDaCapo) {
-        pendingDirectionDecorations.push("!dacapo!");
-    }
-    if (direction.querySelector(":scope > sound[dalsegno]")) {
-        pendingDirectionDecorations.push("!dalsegno!");
-    }
-    if (hasToCoda && !hasDaCapo) {
-        pendingDirectionDecorations.push("!tocoda!");
-    }
+};
+const appendAbcExportDirectionSoundDecorations = (direction, pendingDirectionDecorations) => {
+    appendAbcExportDirectionMarkerDecorations(direction, pendingDirectionDecorations);
+    appendAbcExportDirectionJumpDecorations(direction, pendingDirectionDecorations);
+};
+const appendAbcExportDirectionMarkerDecorations = (direction, pendingDirectionDecorations) => {
+    appendAbcExportDirectionPresenceDecorations(pendingDirectionDecorations, [
+        [direction.querySelector(":scope > direction-type > segno") !== null, "!segno!"],
+        [direction.querySelector(":scope > direction-type > coda") !== null, "!coda!"],
+        [direction.querySelector(':scope > sound[fine="yes"]') !== null, "!fine!"],
+    ]);
+};
+const appendAbcExportDirectionJumpDecorations = (direction, pendingDirectionDecorations) => {
+    appendAbcExportDirectionDaCapoDecorations(direction, pendingDirectionDecorations);
+    appendAbcExportDirectionDalSegnoDecorations(direction, pendingDirectionDecorations);
+    appendAbcExportDirectionToCodaDecorations(direction, pendingDirectionDecorations);
+};
+const appendAbcExportDirectionDaCapoDecorations = (direction, pendingDirectionDecorations) => {
+    const hasDaCapo = direction.querySelector(':scope > sound[dacapo="yes"]') !== null;
+    const hasToCoda = direction.querySelector(":scope > sound[tocoda]") !== null;
+    appendAbcExportDirectionPresenceDecoration(pendingDirectionDecorations, hasDaCapo && hasToCoda, "!dacoda!");
+    appendAbcExportDirectionPresenceDecoration(pendingDirectionDecorations, hasDaCapo && !hasToCoda, "!dacapo!");
+};
+const appendAbcExportDirectionDalSegnoDecorations = (direction, pendingDirectionDecorations) => {
+    appendAbcExportDirectionPresenceDecoration(pendingDirectionDecorations, direction.querySelector(":scope > sound[dalsegno]") !== null, "!dalsegno!");
+};
+const appendAbcExportDirectionToCodaDecorations = (direction, pendingDirectionDecorations) => {
+    appendAbcExportDirectionPresenceDecoration(pendingDirectionDecorations, direction.querySelector(":scope > sound[tocoda]") !== null && direction.querySelector(':scope > sound[dacapo="yes"]') === null, "!tocoda!");
+};
+const appendAbcExportDirectionFeatureDecorations = (direction, pendingDirectionDecorations, activeWedgeType) => {
     const directionFeatures = (0, dynamics_1.extractMusicXmlDirectionFeatures)(direction);
+    appendAbcExportDirectionDynamicDecorations(directionFeatures, pendingDirectionDecorations);
+    return appendAbcExportDirectionWedgeDecorations(directionFeatures, pendingDirectionDecorations, activeWedgeType);
+};
+const appendAbcExportDirectionWedgeDecorations = (directionFeatures, pendingDirectionDecorations, activeWedgeType) => appendAbcExportDirectionWedgeStopDecorations(directionFeatures, pendingDirectionDecorations, appendAbcExportDirectionWedgeStartDecorations(directionFeatures, pendingDirectionDecorations, activeWedgeType));
+const appendAbcExportDirectionWedgeStartDecorations = (directionFeatures, pendingDirectionDecorations, activeWedgeType) => {
+    const crescendoWedgeType = appendAbcExportDirectionWedgeMatch(directionFeatures, pendingDirectionDecorations, activeWedgeType, (feature) => feature.kind === "wedge" && feature.wedgeType === "crescendo", "!crescendo(!", "crescendo");
+    return appendAbcExportDirectionWedgeMatch(directionFeatures, pendingDirectionDecorations, crescendoWedgeType, (feature) => feature.kind === "wedge" && feature.wedgeType === "diminuendo", "!diminuendo(!", "diminuendo");
+};
+const appendAbcExportDirectionWedgeStopDecorations = (directionFeatures, pendingDirectionDecorations, activeWedgeType) => {
     let nextWedgeType = activeWedgeType;
     for (const feature of directionFeatures) {
-        if (feature.kind === "wedge" && feature.wedgeType === "crescendo") {
-            pendingDirectionDecorations.push("!crescendo(!");
-            nextWedgeType = "crescendo";
-        }
-        else if (feature.kind === "wedge" && feature.wedgeType === "diminuendo") {
-            pendingDirectionDecorations.push("!diminuendo(!");
-            nextWedgeType = "diminuendo";
-        }
-        else if (feature.kind === "wedge" && feature.wedgeType === "stop") {
+        if (feature.kind === "wedge" && feature.wedgeType === "stop") {
             pendingDirectionDecorations.push(nextWedgeType === "diminuendo" ? "!diminuendo)!" : "!crescendo)!");
             nextWedgeType = "";
         }
     }
-    for (const feature of directionFeatures) {
-        if (feature.kind === "dynamic")
-            pendingDirectionDecorations.push(`!${feature.mark}!`);
-    }
     return nextWedgeType;
+};
+const appendAbcExportDirectionWedgeMatch = (directionFeatures, pendingDirectionDecorations, activeWedgeType, predicate, decoration, nextWedgeType) => {
+    let result = activeWedgeType;
+    for (const feature of directionFeatures) {
+        if (predicate(feature)) {
+            pendingDirectionDecorations.push(decoration);
+            result = nextWedgeType;
+        }
+    }
+    return result;
+};
+const appendAbcExportDirectionDynamicDecorations = (directionFeatures, pendingDirectionDecorations) => {
+    appendAbcExportDirectionSfzDecorations(directionFeatures, pendingDirectionDecorations);
+    appendAbcExportDirectionStandardDynamicDecorations(directionFeatures, pendingDirectionDecorations);
+};
+const appendAbcExportDirectionSfzDecorations = (directionFeatures, pendingDirectionDecorations) => {
+    appendAbcExportDirectionFeatureMatches(directionFeatures, pendingDirectionDecorations, (feature) => feature.kind === "dynamic" && feature.mark === "sfz", () => "!sfz!");
+};
+const appendAbcExportDirectionStandardDynamicDecorations = (directionFeatures, pendingDirectionDecorations) => {
+    appendAbcExportDirectionFeatureMatches(directionFeatures, pendingDirectionDecorations, (feature) => feature.kind === "dynamic" && feature.mark !== "sfz", (feature) => `!${feature.mark}!`);
+};
+const appendAbcExportDirectionPresenceDecoration = (pendingDirectionDecorations, hasDecoration, decoration) => {
+    if (hasDecoration) {
+        pendingDirectionDecorations.push(decoration);
+    }
+};
+const appendAbcExportDirectionPresenceDecorations = (pendingDirectionDecorations, entries) => {
+    for (const [hasDecoration, decoration] of entries) {
+        appendAbcExportDirectionPresenceDecoration(pendingDirectionDecorations, hasDecoration, decoration);
+    }
+};
+const appendAbcExportDirectionFeatureMatches = (directionFeatures, pendingDirectionDecorations, predicate, decorationFromFeature) => {
+    for (const feature of directionFeatures) {
+        if (predicate(feature)) {
+            pendingDirectionDecorations.push(decorationFromFeature(feature));
+        }
+    }
 };
 const isMusicXmlNoteInAbcExportLane = (note, lane) => {
     var _a, _b, _c, _d, _e, _f;
@@ -26340,7 +26189,7 @@ const isMusicXmlNoteInAbcExportLane = (note, lane) => {
     return true;
 };
 const buildAbcExportPitchToken = (note, keyAlterMap, measureAccidentalByStepOctave) => {
-    var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l;
+    var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o;
     if (note.querySelector(":scope > rest"))
         return "z";
     const step = ((_b = (_a = note.querySelector(":scope > pitch > step")) === null || _a === void 0 ? void 0 : _a.textContent) === null || _b === void 0 ? void 0 : _b.trim()) || "C";
@@ -26353,11 +26202,11 @@ const buildAbcExportPitchToken = (note, keyAlterMap, measureAccidentalByStepOcta
     const accidentalNode = note.querySelector(":scope > accidental");
     const accidentalText = (_j = (_h = accidentalNode === null || accidentalNode === void 0 ? void 0 : accidentalNode.textContent) === null || _h === void 0 ? void 0 : _h.trim()) !== null && _j !== void 0 ? _j : "";
     const accidentalAlter = musicXmlAccidentalTextToAlter(accidentalText);
-    const accidentalEditorial = (((accidentalNode === null || accidentalNode === void 0 ? void 0 : accidentalNode.getAttribute("editorial")) || "").trim().toLowerCase() === "yes");
-    const accidentalCautionary = (((accidentalNode === null || accidentalNode === void 0 ? void 0 : accidentalNode.getAttribute("cautionary")) || "").trim().toLowerCase() === "yes");
-    const keyAlter = (_k = keyAlterMap[upperStep]) !== null && _k !== void 0 ? _k : 0;
+    const accidentalEditorial = (((_k = accidentalNode === null || accidentalNode === void 0 ? void 0 : accidentalNode.getAttribute("editorial")) !== null && _k !== void 0 ? _k : "").trim().toLowerCase() === "yes");
+    const accidentalCautionary = (((_l = accidentalNode === null || accidentalNode === void 0 ? void 0 : accidentalNode.getAttribute("cautionary")) !== null && _l !== void 0 ? _l : "").trim().toLowerCase() === "yes");
+    const keyAlter = (_m = keyAlterMap[upperStep]) !== null && _m !== void 0 ? _m : 0;
     const currentAlter = measureAccidentalByStepOctave.has(stepOctaveKey)
-        ? (_l = measureAccidentalByStepOctave.get(stepOctaveKey)) !== null && _l !== void 0 ? _l : 0
+        ? (_o = measureAccidentalByStepOctave.get(stepOctaveKey)) !== null && _o !== void 0 ? _o : 0
         : keyAlter;
     // In MusicXML pitch, omitted <alter> means natural (0), not "follow key accidental".
     // Key signature context is only used to decide whether an explicit accidental token is needed.
@@ -26394,14 +26243,6 @@ const appendAbcExportGraceToken = (pendingGraceTokens, pitchToken, len, hasTieSt
         : `[${last}${graceSlashPrefix}${pitchToken}]`;
     pendingGraceTokens.push(merged);
 };
-const readAbcExportTimeModification = (note) => {
-    var _a, _b, _c, _d;
-    const actual = Number(((_b = (_a = note.querySelector(":scope > time-modification > actual-notes")) === null || _a === void 0 ? void 0 : _a.textContent) === null || _b === void 0 ? void 0 : _b.trim()) || "");
-    const normal = Number(((_d = (_c = note.querySelector(":scope > time-modification > normal-notes")) === null || _c === void 0 ? void 0 : _c.textContent) === null || _d === void 0 ? void 0 : _d.trim()) || "");
-    if (!Number.isFinite(actual) || actual <= 0 || !Number.isFinite(normal) || normal <= 0)
-        return null;
-    return { actual: Math.round(actual), normal: Math.round(normal) };
-};
 const buildAbcExportLengthToken = (noteDuration, currentDivisions, unitLength, timeModification) => {
     const rawWholeFraction = exports.AbcCommon.reduceFraction(noteDuration, currentDivisions * 4, { num: 1, den: 4 });
     const abcBaseWholeFraction = timeModification
@@ -26425,11 +26266,6 @@ const updateAbcExportActiveTupletBeforeEvent = (activeTuplet, hasTupletStart, ti
     }
     return activeTuplet;
 };
-const buildAbcExportTupletPrefix = (activeTuplet, isChord) => {
-    if (isChord || !activeTuplet || activeTuplet.remaining !== activeTuplet.actual)
-        return "";
-    return `(${activeTuplet.actual}:${activeTuplet.normal}:${activeTuplet.actual}`;
-};
 const advanceAbcExportActiveTupletAfterEvent = (activeTuplet, isChord) => {
     if (isChord || !activeTuplet)
         return activeTuplet;
@@ -26437,165 +26273,26 @@ const advanceAbcExportActiveTupletAfterEvent = (activeTuplet, isChord) => {
     return activeTuplet.remaining <= 0 ? null : activeTuplet;
 };
 const takeAbcExportQueuedEventPrefix = (isChord, pendingHarmonySymbols, pendingDirectionWords, pendingDirectionDecorations, pendingGraceTokens) => {
-    const harmonyPrefix = !isChord && pendingHarmonySymbols.length > 0
-        ? `${pendingHarmonySymbols.map((symbol) => `"${abcQuotedTextEscape(symbol)}"`).join("")}`
-        : "";
-    const wordsPrefix = !isChord && pendingDirectionWords.length > 0
-        ? `${pendingDirectionWords.map((word) => `"${word}"`).join("")}`
-        : "";
-    const directionDecorationPrefix = !isChord && pendingDirectionDecorations.length > 0 ? pendingDirectionDecorations.join("") : "";
+    const harmonyPrefix = !isChord && pendingHarmonySymbols.length > 0 ? pendingHarmonySymbols.map((item) => `"${abcQuotedTextEscape(item)}"`).join("") : "";
+    const wordsPrefix = !isChord && pendingDirectionWords.length > 0 ? pendingDirectionWords.map((item) => `"${item}"`).join("") : "";
+    const decorationPrefix = !isChord && pendingDirectionDecorations.length > 0 ? pendingDirectionDecorations.join("") : "";
     const gracePrefix = pendingGraceTokens.length > 0 ? `{${pendingGraceTokens.join("")}}` : "";
-    if (!isChord && pendingHarmonySymbols.length > 0) {
+    if (!isChord) {
         pendingHarmonySymbols.length = 0;
-    }
-    if (!isChord && pendingDirectionWords.length > 0) {
         pendingDirectionWords.length = 0;
-    }
-    if (!isChord && pendingDirectionDecorations.length > 0) {
         pendingDirectionDecorations.length = 0;
-    }
-    if (pendingGraceTokens.length > 0) {
         pendingGraceTokens.length = 0;
     }
-    return `${harmonyPrefix}${wordsPrefix}${directionDecorationPrefix}${gracePrefix}`;
-};
-const buildAbcExportTrillMetaLine = (normalizedVoiceId, measure, fallbackMeasureNumber, eventNo, trillAccidentalText) => {
-    const measureNumber = measure.getAttribute("number") || fallbackMeasureNumber;
-    return `%@mks trill voice=${normalizedVoiceId} measure=${measureNumber} event=${eventNo} upper=${trillAccidentalText}`;
-};
-const buildAbcExportOrnamentPrefixInfo = (note) => {
-    var _a, _b;
-    const ornamentFeatures = (0, ornaments_1.extractMusicXmlOrnamentFeatures)(note);
-    const ornamentKinds = new Set(ornamentFeatures.map((feature) => feature.kind));
-    const hasTrillMark = ornamentKinds.has("trill-mark");
-    const hasTurn = ornamentKinds.has("turn");
-    const hasInvertedTurn = ornamentKinds.has("inverted-turn");
-    const hasTurnSlash = ornamentFeatures.some((feature) => (feature.kind === "turn" || feature.kind === "inverted-turn") && feature.slash);
-    const hasDelayedTurn = ornamentKinds.has("delayed-turn");
-    const hasMordent = ornamentKinds.has("mordent");
-    const hasInvertedMordent = ornamentKinds.has("inverted-mordent");
-    const tremoloFeature = ornamentFeatures.find((feature) => feature.kind === "tremolo");
-    const hasSchleifer = ornamentKinds.has("schleifer");
-    const hasShake = ornamentKinds.has("shake");
-    const hasGlissandoStart = Boolean(note.querySelector(':scope > notations > glissando[type="start"]'));
-    const hasGlissandoStop = Boolean(note.querySelector(':scope > notations > glissando[type="stop"]'));
-    const hasSlideStart = Boolean(note.querySelector(':scope > notations > slide[type="start"]'));
-    const hasSlideStop = Boolean(note.querySelector(':scope > notations > slide[type="stop"]'));
-    const hasArpeggiate = Boolean(note.querySelector(":scope > notations > arpeggiate"));
-    const hasWavyLineStart = Array.from(note.querySelectorAll(":scope > notations > ornaments > wavy-line")).some((node) => {
-        var _a;
-        const type = ((_a = node.getAttribute("type")) !== null && _a !== void 0 ? _a : "").trim().toLowerCase();
-        return type === "" || type === "start";
-    });
-    const hasWavyLineStop = Array.from(note.querySelectorAll(":scope > notations > ornaments > wavy-line")).some((node) => {
-        var _a;
-        const type = ((_a = node.getAttribute("type")) !== null && _a !== void 0 ? _a : "").trim().toLowerCase();
-        return type === "stop";
-    });
-    const hasTrill = hasTrillMark || hasWavyLineStart;
-    const turnType = hasInvertedTurn ? "inverted-turn" : (hasTurn ? "turn" : "");
-    const mordentType = hasInvertedMordent ? "inverted-mordent" : (hasMordent ? "mordent" : "");
-    const tremoloType = (tremoloFeature === null || tremoloFeature === void 0 ? void 0 : tremoloFeature.kind) === "tremolo" && tremoloFeature.tremoloType
-        ? tremoloFeature.tremoloType
-        : "";
-    const tremoloMarks = (tremoloFeature === null || tremoloFeature === void 0 ? void 0 : tremoloFeature.kind) === "tremolo" && tremoloFeature.marks ? tremoloFeature.marks : 1;
-    const trillAccidentalText = ((_b = (_a = note.querySelector(":scope > notations > ornaments > accidental-mark")) === null || _a === void 0 ? void 0 : _a.textContent) === null || _b === void 0 ? void 0 : _b.trim()) || "";
-    const trillPrefix = hasWavyLineStop
-        ? "!trill)!"
-        : (hasWavyLineStart && !hasTrillMark ? "!trill!" : (hasWavyLineStart ? "!trill(!" : (hasTrill ? "!trill!" : "")));
-    const turnPrefix = turnType === "inverted-turn"
-        ? (hasDelayedTurn ? "!delayedinvertedturn!" : (hasTurnSlash ? "!invertedturnx!" : "!invertedturn!"))
-        : (turnType === "turn" ? (hasDelayedTurn ? "!delayedturn!" : (hasTurnSlash ? "!turnx!" : "!turn!")) : "");
-    const mordentPrefix = mordentType === "inverted-mordent" ? "!pralltriller!" : (mordentType === "mordent" ? "!mordent!" : "");
-    const tremoloPrefix = tremoloType ? `!tremolo-${tremoloType}-${tremoloMarks}!` : "";
-    const glissandoPrefix = hasGlissandoStart ? "!gliss-start!" : (hasGlissandoStop ? "!gliss-stop!" : "");
-    const slidePrefix = hasSlideStart ? "!slide!" : (hasSlideStop ? "!slide-stop!" : "");
-    const schleiferPrefix = hasSchleifer ? "!schleifer!" : "";
-    const shakePrefix = hasShake ? "!shake!" : "";
-    const arpeggiatePrefix = hasArpeggiate ? "!arpeggio!" : "";
-    return {
-        prefix: `${trillPrefix}${turnPrefix}${mordentPrefix}${tremoloPrefix}${glissandoPrefix}${slidePrefix}${schleiferPrefix}${shakePrefix}${arpeggiatePrefix}`,
-        hasTrill,
-        trillAccidentalText,
-    };
-};
-const buildAbcExportTechnicalPrefix = (note) => {
-    const hasUpBow = Boolean(note.querySelector(":scope > notations > technical > up-bow"));
-    const hasDownBow = Boolean(note.querySelector(":scope > notations > technical > down-bow"));
-    const hasDoubleTongue = Boolean(note.querySelector(":scope > notations > technical > double-tongue"));
-    const hasTripleTongue = Boolean(note.querySelector(":scope > notations > technical > triple-tongue"));
-    const hasHeel = Boolean(note.querySelector(":scope > notations > technical > heel"));
-    const hasToe = Boolean(note.querySelector(":scope > notations > technical > toe"));
-    const fingeringTexts = Array.from(note.querySelectorAll(":scope > notations > technical > fingering"))
-        .map((node) => (node.textContent || "").trim())
-        .filter(Boolean);
-    const stringTexts = Array.from(note.querySelectorAll(":scope > notations > technical > string"))
-        .map((node) => (node.textContent || "").trim())
-        .filter(Boolean);
-    const pluckTexts = Array.from(note.querySelectorAll(":scope > notations > technical > pluck"))
-        .map((node) => (node.textContent || "").trim())
-        .filter(Boolean);
-    const hasOpenString = Boolean(note.querySelector(":scope > notations > technical > open-string"));
-    const hasSnapPizzicato = Boolean(note.querySelector(":scope > notations > technical > snap-pizzicato"));
-    const hasHarmonic = Boolean(note.querySelector(":scope > notations > technical > harmonic"));
-    const hasStopped = Boolean(note.querySelector(":scope > notations > technical > stopped"));
-    const hasThumbPosition = Boolean(note.querySelector(":scope > notations > technical > thumb-position"));
-    const fingeringPrefix = fingeringTexts
-        .map((value) => (/^[0-5]$/.test(value) ? `!${value}!` : `!fingering:${value}!`))
-        .join("");
-    return [
-        hasUpBow ? "!upbow!" : "",
-        hasDownBow ? "!downbow!" : "",
-        hasDoubleTongue ? "!doubletongue!" : "",
-        hasTripleTongue ? "!tripletongue!" : "",
-        hasHeel ? "!heel!" : "",
-        hasToe ? "!toe!" : "",
-        fingeringPrefix,
-        stringTexts.map((value) => `!string:${value}!`).join(""),
-        pluckTexts.map((value) => `!pluck:${value}!`).join(""),
-        hasOpenString ? "!open!" : "",
-        hasSnapPizzicato ? "!snap!" : "",
-        hasHarmonic ? "!harmonic!" : "",
-        hasStopped ? "!stopped!" : "",
-        hasThumbPosition ? "!thumb!" : "",
-    ].join("");
-};
-const buildAbcExportFermataPrefix = (note) => {
-    var _a, _b;
-    const fermata = note.querySelector(":scope > notations > fermata");
-    if (!fermata)
-        return "";
-    const type = ((_a = fermata.getAttribute("type")) === null || _a === void 0 ? void 0 : _a.trim().toLowerCase()) || "";
-    const shape = ((_b = fermata.textContent) === null || _b === void 0 ? void 0 : _b.trim().toLowerCase()) || "";
-    return type === "inverted" || shape === "inverted" ? "!invertedfermata!" : "!fermata!";
-};
-const buildAbcExportArticulationPrefix = (note) => {
-    const articulationKinds = new Set((0, articulations_1.extractMusicXmlArticulationKinds)(note));
-    const phraseMarkText = Array.from(note.querySelectorAll(":scope > notations > articulations > other-articulation"))
-        .map((node) => (node.textContent || "").trim().toLowerCase())
-        .find((text) => text === "shortphrase" || text === "mediumphrase" || text === "longphrase") || "";
-    return [
-        articulationKinds.has("staccatissimo") ? "!wedge!" : (articulationKinds.has("staccato") ? "!staccato!" : ""),
-        articulationKinds.has("accent") ? "!accent!" : "",
-        articulationKinds.has("tenuto") ? "!tenuto!" : "",
-        note.querySelector(":scope > notations > articulations > stress") ? "!stress!" : "",
-        note.querySelector(":scope > notations > articulations > unstress") ? "!unstress!" : "",
-        articulationKinds.has("strong-accent") ? "!marcato!" : "",
-        articulationKinds.has("breath-mark") ? "!breath!" : "",
-        articulationKinds.has("caesura") ? "!caesura!" : "",
-        phraseMarkText === "shortphrase" || phraseMarkText === "mediumphrase" || phraseMarkText === "longphrase"
-            ? `!${phraseMarkText}!`
-            : "",
-    ].join("");
+    return `${harmonyPrefix}${wordsPrefix}${decorationPrefix}${gracePrefix}`;
 };
 const appendAbcExportLyricToken = (note, lyricTokens, pendingLyricExtension) => {
-    var _a, _b, _c, _d;
+    var _a, _b, _c, _d, _e, _f;
     if (note.querySelector(":scope > rest"))
         return pendingLyricExtension;
     const lyric = note.querySelector(":scope > lyric");
-    const lyricText = ((_b = (_a = lyric === null || lyric === void 0 ? void 0 : lyric.querySelector(":scope > text")) === null || _a === void 0 ? void 0 : _a.textContent) === null || _b === void 0 ? void 0 : _b.trim()) || "";
-    const lyricSyllabic = ((_d = (_c = lyric === null || lyric === void 0 ? void 0 : lyric.querySelector(":scope > syllabic")) === null || _c === void 0 ? void 0 : _c.textContent) === null || _d === void 0 ? void 0 : _d.trim()) || "single";
-    const lyricExtend = Boolean(lyric === null || lyric === void 0 ? void 0 : lyric.querySelector(":scope > extend"));
+    const lyricText = (_c = (_b = (_a = lyric === null || lyric === void 0 ? void 0 : lyric.querySelector(":scope > text")) === null || _a === void 0 ? void 0 : _a.textContent) === null || _b === void 0 ? void 0 : _b.trim()) !== null && _c !== void 0 ? _c : "";
+    const lyricSyllabic = (_f = (_e = (_d = lyric === null || lyric === void 0 ? void 0 : lyric.querySelector(":scope > syllabic")) === null || _d === void 0 ? void 0 : _d.textContent) === null || _e === void 0 ? void 0 : _e.trim()) !== null && _f !== void 0 ? _f : "single";
+    const lyricExtend = (lyric === null || lyric === void 0 ? void 0 : lyric.querySelector(":scope > extend")) !== null;
     if (lyricText) {
         lyricTokens.push(abcLyricTokenFromMusicXml(lyricText, lyricSyllabic));
         return lyricExtend;
@@ -26607,71 +26304,65 @@ const appendAbcExportLyricToken = (note, lyricTokens, pendingLyricExtension) => 
     lyricTokens.push("*");
     return false;
 };
-const buildAbcExportPendingEventToken = (pending) => {
-    const tieSuffix = pending.tie ? "-" : "";
-    const slurStopSuffix = pending.slurStop ? ")" : "";
-    if (pending.pitches.length === 1) {
-        return `${pending.prefix}${pending.pitches[0]}${pending.len}${tieSuffix}${slurStopSuffix}`;
-    }
-    return `${pending.prefix}[${pending.pitches.join("")}]${pending.len}${tieSuffix}${slurStopSuffix}`;
-};
 const flushAbcExportPendingEvent = (pending, tokens) => {
     if (pending) {
-        tokens.push(buildAbcExportPendingEventToken(pending));
+        const tieSuffix = pending.tie ? "-" : "";
+        const slurStopSuffix = pending.slurStop ? ")" : "";
+        tokens.push(pending.pitches.length === 1
+            ? `${pending.prefix}${pending.pitches[0]}${pending.len}${tieSuffix}${slurStopSuffix}`
+            : `${pending.prefix}[${pending.pitches.join("")}]${pending.len}${tieSuffix}${slurStopSuffix}`);
     }
     return null;
 };
-const createAbcExportPendingEvent = (pitchToken, len, hasTieStart, hasSlurStop, eventPrefix) => ({
-    pitches: [pitchToken],
-    len,
-    tie: hasTieStart,
-    slurStop: hasSlurStop,
-    prefix: eventPrefix,
-});
 const appendAbcExportChordPitchToPendingEvent = (pending, pitchToken, hasTieStart, hasSlurStop) => {
     pending.pitches.push(pitchToken);
     pending.tie = pending.tie || hasTieStart;
     pending.slurStop = pending.slurStop || hasSlurStop;
 };
-const appendAbcExportTrillMetaLineIfNeeded = (metaLines, normalizedVoiceId, measure, fallbackMeasureNumber, eventNo, ornamentPrefixInfo) => {
-    if (!ornamentPrefixInfo.hasTrill || !ornamentPrefixInfo.trillAccidentalText)
-        return;
-    metaLines.push(buildAbcExportTrillMetaLine(normalizedVoiceId, measure, fallbackMeasureNumber, eventNo, ornamentPrefixInfo.trillAccidentalText));
-};
-const readAbcExportNoteEventInfo = (note, currentDivisions, unitLength) => {
-    var _a, _b, _c, _d;
-    const isChord = Boolean(note.querySelector(":scope > chord"));
-    const isGrace = Boolean(note.querySelector(":scope > grace"));
-    const duration = Number(((_b = (_a = note.querySelector(":scope > duration")) === null || _a === void 0 ? void 0 : _a.textContent) === null || _b === void 0 ? void 0 : _b.trim()) || "0");
-    if (!isGrace && (!Number.isFinite(duration) || duration <= 0))
-        return null;
-    const noteDuration = isGrace
-        ? (Number.isFinite(duration) && duration > 0 ? duration : Math.round(currentDivisions / 2))
-        : duration;
-    const tieState = (0, ties_1.extractMusicXmlTieState)(note);
-    const slurFeatures = (0, slurs_1.extractMusicXmlSlurFeatures)(note);
-    const timeModification = readAbcExportTimeModification(note);
+const startAbcExportPendingEventForNote = (flushPending, pending, tokens, metaLines, normalizedVoiceId, measure, fallbackMeasureNumber, ornamentPrefixInfo, pitchToken, len, hasTieStart, hasSlurStop, eventPrefix, eventNo) => {
+    const nextEventNo = eventNo + 1;
+    const trillMetaLine = ornamentPrefixInfo.hasTrill && ornamentPrefixInfo.trillAccidentalText
+        ? `%@mks trill voice=${normalizedVoiceId} measure=${measure.getAttribute("number") || fallbackMeasureNumber} event=${nextEventNo} upper=${ornamentPrefixInfo.trillAccidentalText}`
+        : "";
+    if (trillMetaLine)
+        metaLines.push(trillMetaLine);
+    if (flushPending)
+        flushAbcExportPendingEvent(pending, tokens);
     return {
-        isChord,
-        isGrace,
-        hasTieStart: tieState.tieStart,
-        ornamentPrefixInfo: buildAbcExportOrnamentPrefixInfo(note),
-        hasSlurStart: slurFeatures.some((slur) => slur.type === "start"),
-        hasSlurStop: slurFeatures.some((slur) => slur.type === "stop"),
-        hasGraceSlash: ((_d = (_c = note.querySelector(":scope > grace")) === null || _c === void 0 ? void 0 : _c.getAttribute("slash")) !== null && _d !== void 0 ? _d : "").trim().toLowerCase() === "yes",
-        hasTupletStart: Boolean(note.querySelector(':scope > notations > tuplet[type="start"]')),
-        timeModification,
-        len: buildAbcExportLengthToken(noteDuration, currentDivisions, unitLength, timeModification),
+        pending: {
+            pitches: [pitchToken],
+            len,
+            tie: hasTieStart,
+            slurStop: hasSlurStop,
+            prefix: eventPrefix,
+        },
+        eventNo: nextEventNo,
     };
 };
 const buildAbcExportEventPrefix = (note, noteEventInfo, activeTuplet, pendingHarmonySymbols, pendingDirectionWords, pendingDirectionDecorations, pendingGraceTokens) => {
-    const tupletPrefix = buildAbcExportTupletPrefix(activeTuplet, noteEventInfo.isChord);
-    const articulationPrefix = buildAbcExportArticulationPrefix(note);
-    const technicalPrefix = buildAbcExportTechnicalPrefix(note);
-    const fermataPrefix = buildAbcExportFermataPrefix(note);
+    var _a, _b, _c;
+    const tupletPrefix = noteEventInfo.isChord || !activeTuplet || activeTuplet.remaining !== activeTuplet.actual
+        ? ""
+        : `(${activeTuplet.actual}:${activeTuplet.normal}:${activeTuplet.actual}`;
+    const articulationKinds = new Set((0, articulations_1.extractMusicXmlArticulationKinds)(note));
+    const otherPhrase = (_a = Array.from(note.querySelectorAll(":scope > notations > articulations > other-articulation"))
+        .map((node) => { var _a; return ((_a = node.textContent) !== null && _a !== void 0 ? _a : "").trim().toLowerCase(); })
+        .find((text) => text === "shortphrase" || text === "mediumphrase" || text === "longphrase")) !== null && _a !== void 0 ? _a : "";
+    const articulationPrefix = `${articulationKinds.has("staccatissimo") ? "!wedge!" : (articulationKinds.has("staccato") ? "!staccato!" : "")}${articulationKinds.has("accent") ? "!accent!" : ""}${articulationKinds.has("tenuto") ? "!tenuto!" : ""}${note.querySelector(":scope > notations > articulations > stress") !== null ? "!stress!" : ""}${note.querySelector(":scope > notations > articulations > unstress") !== null ? "!unstress!" : ""}${articulationKinds.has("strong-accent") ? "!marcato!" : ""}${articulationKinds.has("breath-mark") ? "!breath!" : ""}${articulationKinds.has("caesura") ? "!caesura!" : ""}${otherPhrase ? `!${otherPhrase}!` : ""}`;
+    const technicalPrefix = `${`${note.querySelector(":scope > notations > technical > up-bow") ? "!upbow!" : ""}${note.querySelector(":scope > notations > technical > down-bow") ? "!downbow!" : ""}`}${`${note.querySelector(":scope > notations > technical > double-tongue") ? "!doubletongue!" : ""}${note.querySelector(":scope > notations > technical > triple-tongue") ? "!tripletongue!" : ""}${note.querySelector(":scope > notations > technical > heel") ? "!heel!" : ""}${note.querySelector(":scope > notations > technical > toe") ? "!toe!" : ""}`}${Array.from(note.querySelectorAll(":scope > notations > technical > fingering")).map((node) => { var _a; return ((_a = node.textContent) !== null && _a !== void 0 ? _a : "").trim(); }).filter((text) => text.length > 0).map((value) => (/^[0-5]$/.test(value) ? `!${value}!` : `!fingering:${value}!`)).join("")}${Array.from(note.querySelectorAll(":scope > notations > technical > string")).map((node) => { var _a; return ((_a = node.textContent) !== null && _a !== void 0 ? _a : "").trim(); }).filter((text) => text.length > 0).map((value) => `!string:${value}!`).join("")}${Array.from(note.querySelectorAll(":scope > notations > technical > pluck")).map((node) => { var _a; return ((_a = node.textContent) !== null && _a !== void 0 ? _a : "").trim(); }).filter((text) => text.length > 0).map((value) => `!pluck:${value}!`).join("")}${`${note.querySelector(":scope > notations > technical > open-string") ? "!open!" : ""}${note.querySelector(":scope > notations > technical > snap-pizzicato") ? "!snap!" : ""}${note.querySelector(":scope > notations > technical > harmonic") ? "!harmonic!" : ""}${note.querySelector(":scope > notations > technical > stopped") ? "!stopped!" : ""}${note.querySelector(":scope > notations > technical > thumb-position") ? "!thumb!" : ""}`}`;
+    const fermata = note.querySelector(":scope > notations > fermata");
+    const fermataPrefix = fermata ? (((_b = fermata.getAttribute("type")) === null || _b === void 0 ? void 0 : _b.trim().toLowerCase()) === "inverted" || ((_c = fermata.textContent) === null || _c === void 0 ? void 0 : _c.trim().toLowerCase()) === "inverted" ? "!invertedfermata!" : "!fermata!") : "";
     const slurStartPrefix = noteEventInfo.hasSlurStart ? "(" : "";
-    const queuedPrefix = takeAbcExportQueuedEventPrefix(noteEventInfo.isChord, pendingHarmonySymbols, pendingDirectionWords, pendingDirectionDecorations, pendingGraceTokens);
-    return `${queuedPrefix}${tupletPrefix}${slurStartPrefix}${noteEventInfo.ornamentPrefixInfo.prefix}${articulationPrefix}${technicalPrefix}${fermataPrefix}`;
+    const parts = [
+        takeAbcExportQueuedEventPrefix(noteEventInfo.isChord, pendingHarmonySymbols, pendingDirectionWords, pendingDirectionDecorations, pendingGraceTokens),
+        tupletPrefix,
+        slurStartPrefix,
+        noteEventInfo.ornamentPrefixInfo.prefix,
+        articulationPrefix,
+        technicalPrefix,
+        fermataPrefix,
+    ];
+    return parts.join("");
 };
 const flushAbcExportPendingGraceTokens = (pendingGraceTokens, tokens) => {
     if (pendingGraceTokens.length === 0)
@@ -26687,39 +26378,6 @@ const appendAbcExportEmptyMeasureRestTokenIfNeeded = (tokens, currentDivisions, 
     const lenRatio = exports.AbcCommon.divideFractions(wholeFraction, unitLength, { num: 1, den: 1 });
     tokens.push(`z${exports.AbcCommon.abcLengthTokenFromFraction(lenRatio)}`);
 };
-const buildAbcExportMeasureText = (tokens, needsInlineKeyChange, currentFifths, boundaryInfo) => {
-    const measureTokenText = tokens.join(" ");
-    const keyPrefix = needsInlineKeyChange
-        ? `[K:${exports.AbcCommon.keyFromFifthsMode(Math.max(-7, Math.min(7, Math.round(currentFifths))), "major")}]`
-        : "";
-    const leftPrefix = `${boundaryInfo.hasLeftRepeat ? "|:" : ""}${boundaryInfo.leftEndingNumber ? `[${boundaryInfo.leftEndingNumber}` : ""}`;
-    let rightSuffix = "|";
-    if (boundaryInfo.hasRightRepeat && boundaryInfo.rightEndingNumber) {
-        rightSuffix = `:|]`;
-    }
-    else if (boundaryInfo.hasRightRepeat) {
-        rightSuffix = ":|";
-    }
-    else if (boundaryInfo.rightEndingNumber) {
-        rightSuffix = "]|";
-    }
-    return `${leftPrefix}${leftPrefix ? " " : ""}${keyPrefix}${keyPrefix ? " " : ""}${measureTokenText} ${rightSuffix}`.trim();
-};
-const readAbcExportMeasureBoundaryInfo = (measure) => {
-    const leftRepeatNode = measure.querySelector(':scope > barline[location="left"] > repeat');
-    const rightRepeatNode = measure.querySelector(':scope > barline[location="right"] > repeat');
-    const leftEndingNode = measure.querySelector(':scope > barline[location="left"] > ending');
-    const rightEndingNode = measure.querySelector(':scope > barline[location="right"] > ending');
-    const leftRepeatDir = ((leftRepeatNode === null || leftRepeatNode === void 0 ? void 0 : leftRepeatNode.getAttribute("direction")) || "").trim().toLowerCase();
-    const rightRepeatDir = ((rightRepeatNode === null || rightRepeatNode === void 0 ? void 0 : rightRepeatNode.getAttribute("direction")) || "").trim().toLowerCase();
-    return {
-        hasLeftRepeat: leftRepeatDir === "forward",
-        hasRightRepeat: rightRepeatDir === "backward",
-        leftEndingNumber: ((leftEndingNode === null || leftEndingNode === void 0 ? void 0 : leftEndingNode.getAttribute("number")) || "").trim(),
-        rightEndingNumber: ((rightEndingNode === null || rightEndingNode === void 0 ? void 0 : rightEndingNode.getAttribute("number")) || "").trim(),
-        rightEndingType: ((rightEndingNode === null || rightEndingNode === void 0 ? void 0 : rightEndingNode.getAttribute("type")) || "").trim().toLowerCase(),
-    };
-};
 const applyAbcExportMeasureAttributesToState = (measure, state) => {
     var _a, _b, _c, _d;
     const parsedDiv = parseOptionalMusicXmlNumber((_a = measure.querySelector("attributes > divisions")) === null || _a === void 0 ? void 0 : _a.textContent);
@@ -26734,10 +26392,51 @@ const applyAbcExportMeasureAttributesToState = (measure, state) => {
     };
 };
 const appendAbcExportMeasureMetaLines = (metaLines, normalizedVoiceId, measure, safeMeasureNumber, boundaryInfo) => {
-    const measureMetaLine = buildAbcExportMeasureMetaLine(normalizedVoiceId, measure, safeMeasureNumber, boundaryInfo.hasRightRepeat, boundaryInfo.rightEndingNumber, boundaryInfo.rightEndingType);
+    var _a, _b, _c, _d, _e;
+    const rawMeasureNumber = ((_a = measure.getAttribute("number")) !== null && _a !== void 0 ? _a : "").trim() || String(safeMeasureNumber);
+    const implicitAttr = ((_b = measure.getAttribute("implicit")) !== null && _b !== void 0 ? _b : "").trim().toLowerCase();
+    const isImplicit = implicitAttr === "yes" || implicitAttr === "true" || implicitAttr === "1";
+    const rightRepeatNode = measure.querySelector(':scope > barline[location="right"] > repeat');
+    const repeatTimes = Number.parseInt(String((_c = rightRepeatNode === null || rightRepeatNode === void 0 ? void 0 : rightRepeatNode.getAttribute("times")) !== null && _c !== void 0 ? _c : ""), 10);
+    const measureMetaLine = !isImplicit &&
+        rawMeasureNumber === String(safeMeasureNumber) &&
+        (!boundaryInfo.hasRightRepeat || !Number.isFinite(repeatTimes) || repeatTimes <= 2) &&
+        (!boundaryInfo.rightEndingNumber || boundaryInfo.rightEndingType !== "discontinue")
+        ? null
+        : [
+            `%@mks measure voice=${normalizedVoiceId} measure=${safeMeasureNumber}`,
+            `number=${rawMeasureNumber}`,
+            `implicit=${isImplicit ? 1 : 0}`,
+            ...(boundaryInfo.hasRightRepeat && Number.isFinite(repeatTimes) && repeatTimes > 2 ? [`times=${Math.round(repeatTimes)}`] : []),
+            ...(boundaryInfo.rightEndingNumber && boundaryInfo.rightEndingType === "discontinue"
+                ? [`ending-stop=${boundaryInfo.rightEndingNumber}`, `ending-type=${boundaryInfo.rightEndingType}`]
+                : []),
+        ].join(" ");
     if (measureMetaLine)
         metaLines.push(measureMetaLine);
-    metaLines.push(...buildAbcExportDiagMetaLines(normalizedVoiceId, measure, safeMeasureNumber));
+    const diagFields = Array.from(measure.querySelectorAll(':scope > attributes > miscellaneous > miscellaneous-field[name^="mks:diag:"]'));
+    if (diagFields.length > 0) {
+        const byName = new Map();
+        for (const field of diagFields) {
+            const name = ((_d = field.getAttribute("name")) !== null && _d !== void 0 ? _d : "").trim();
+            if (!name)
+                continue;
+            byName.set(name, ((_e = field.textContent) !== null && _e !== void 0 ? _e : "").trim());
+        }
+        const orderedNames = Array.from(byName.keys()).sort((a, b) => {
+            const isCountA = a === "mks:diag:count";
+            const isCountB = b === "mks:diag:count";
+            if (isCountA && !isCountB)
+                return -1;
+            if (!isCountA && isCountB)
+                return 1;
+            return a.localeCompare(b);
+        });
+        metaLines.push(...orderedNames.map((name) => {
+            var _a;
+            return `%@mks diag voice=${normalizedVoiceId} measure=${safeMeasureNumber} name=${name} enc=uri-v1 value=${encodeURIComponent((_a = byName.get(name)) !== null && _a !== void 0 ? _a : "")}`;
+        }));
+    }
 };
 const applyAbcExportNonNoteChildToPending = (child, pendingHarmonySymbols, pendingDirectionWords, pendingDirectionDecorations, activeWedgeType) => {
     if (child.tagName === "harmony") {
@@ -26765,35 +26464,39 @@ const updateAbcExportActiveTupletBeforeNoteEvent = (activeTuplet, noteEventInfo)
 const updateAbcExportPendingEventForNote = (pending, tokens, eventNo, metaLines, normalizedVoiceId, measure, fallbackMeasureNumber, noteEventInfo, pitchToken, eventPrefix) => {
     const { isChord, hasTieStart, ornamentPrefixInfo, hasSlurStop, len, } = noteEventInfo;
     if (!isChord) {
-        const nextEventNo = eventNo + 1;
-        appendAbcExportTrillMetaLineIfNeeded(metaLines, normalizedVoiceId, measure, fallbackMeasureNumber, nextEventNo, ornamentPrefixInfo);
-        flushAbcExportPendingEvent(pending, tokens);
-        return {
-            pending: createAbcExportPendingEvent(pitchToken, len, hasTieStart, hasSlurStop, eventPrefix),
-            eventNo: nextEventNo,
-        };
+        return startAbcExportPendingEventForNote(true, pending, tokens, metaLines, normalizedVoiceId, measure, fallbackMeasureNumber, ornamentPrefixInfo, pitchToken, len, hasTieStart, hasSlurStop, eventPrefix, eventNo);
     }
     if (!pending) {
-        const nextEventNo = eventNo + 1;
-        appendAbcExportTrillMetaLineIfNeeded(metaLines, normalizedVoiceId, measure, fallbackMeasureNumber, nextEventNo, ornamentPrefixInfo);
-        return {
-            pending: createAbcExportPendingEvent(pitchToken, len, hasTieStart, hasSlurStop, eventPrefix),
-            eventNo: nextEventNo,
-        };
+        return startAbcExportPendingEventForNote(false, pending, tokens, metaLines, normalizedVoiceId, measure, fallbackMeasureNumber, ornamentPrefixInfo, pitchToken, len, hasTieStart, hasSlurStop, eventPrefix, eventNo);
     }
     appendAbcExportChordPitchToPendingEvent(pending, pitchToken, hasTieStart, hasSlurStop);
     return { pending, eventNo };
 };
 const updateAbcExportStateAfterNoteEvent = (note, noteEventInfo, activeTuplet, lyricTokens, pendingLyricExtension) => {
-    const nextActiveTuplet = advanceAbcExportActiveTupletAfterEvent(activeTuplet, noteEventInfo.isChord);
     return {
-        activeTuplet: nextActiveTuplet,
-        pendingLyricExtension: noteEventInfo.isChord
-            ? pendingLyricExtension
-            : appendAbcExportLyricToken(note, lyricTokens, pendingLyricExtension),
+        activeTuplet: advanceAbcExportActiveTupletAfterEvent(activeTuplet, noteEventInfo.isChord),
+        pendingLyricExtension: noteEventInfo.isChord ? pendingLyricExtension : appendAbcExportLyricToken(note, lyricTokens, pendingLyricExtension),
+    };
+};
+const applyAbcExportNoteEvent = (child, noteEventInfo, activeTuplet, pending, eventNo, pendingGraceTokens, pendingHarmonySymbols, pendingDirectionWords, pendingDirectionDecorations, tokens, metaLines, normalizedVoiceId, measure, fallbackMeasureNumber, keyAlterMap, measureAccidentalByStepOctave, lyricTokens, pendingLyricExtension) => {
+    const pitchToken = buildAbcExportPitchToken(child, keyAlterMap, measureAccidentalByStepOctave);
+    if (applyAbcExportGraceNoteToPending(noteEventInfo, pendingGraceTokens, pitchToken)) {
+        return { handled: true, pending, eventNo, activeTuplet, pendingLyricExtension };
+    }
+    const nextActiveTuplet = updateAbcExportActiveTupletBeforeNoteEvent(activeTuplet, noteEventInfo);
+    const eventPrefix = buildAbcExportEventPrefix(child, noteEventInfo, nextActiveTuplet, pendingHarmonySymbols, pendingDirectionWords, pendingDirectionDecorations, pendingGraceTokens);
+    const pendingEventUpdate = updateAbcExportPendingEventForNote(pending, tokens, eventNo, metaLines, normalizedVoiceId, measure, fallbackMeasureNumber, noteEventInfo, pitchToken, eventPrefix);
+    const postNoteEventState = updateAbcExportStateAfterNoteEvent(child, noteEventInfo, nextActiveTuplet, lyricTokens, pendingLyricExtension);
+    return {
+        handled: true,
+        pending: pendingEventUpdate.pending,
+        eventNo: pendingEventUpdate.eventNo,
+        activeTuplet: postNoteEventState.activeTuplet,
+        pendingLyricExtension: postNoteEventState.pendingLyricExtension,
     };
 };
 const processAbcExportNoteChild = (context) => {
+    var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p;
     const { child, lane, currentDivisions, unitLength, keyAlterMap, measureAccidentalByStepOctave, pendingGraceTokens, pendingHarmonySymbols, pendingDirectionWords, pendingDirectionDecorations, tokens, metaLines, normalizedVoiceId, measure, fallbackMeasureNumber, lyricTokens, } = context;
     let { activeTuplet, pending, eventNo, pendingLyricExtension, } = context;
     if (child.tagName !== "note") {
@@ -26802,28 +26505,121 @@ const processAbcExportNoteChild = (context) => {
     if (!isMusicXmlNoteInAbcExportLane(child, lane)) {
         return { handled: true, pending, eventNo, activeTuplet, pendingLyricExtension };
     }
-    const noteEventInfo = readAbcExportNoteEventInfo(child, currentDivisions, unitLength);
-    if (!noteEventInfo) {
+    const isChord = child.querySelector(":scope > chord") !== null;
+    const isGrace = child.querySelector(":scope > grace") !== null;
+    const duration = Number((_c = (_b = (_a = child.querySelector(":scope > duration")) === null || _a === void 0 ? void 0 : _a.textContent) === null || _b === void 0 ? void 0 : _b.trim()) !== null && _c !== void 0 ? _c : "0");
+    if (!isGrace && (!Number.isFinite(duration) || duration <= 0)) {
         return { handled: true, pending, eventNo, activeTuplet, pendingLyricExtension };
     }
-    const pitchToken = buildAbcExportPitchToken(child, keyAlterMap, measureAccidentalByStepOctave);
-    if (applyAbcExportGraceNoteToPending(noteEventInfo, pendingGraceTokens, pitchToken)) {
-        return { handled: true, pending, eventNo, activeTuplet, pendingLyricExtension };
-    }
-    activeTuplet = updateAbcExportActiveTupletBeforeNoteEvent(activeTuplet, noteEventInfo);
-    const eventPrefix = buildAbcExportEventPrefix(child, noteEventInfo, activeTuplet, pendingHarmonySymbols, pendingDirectionWords, pendingDirectionDecorations, pendingGraceTokens);
-    const pendingEventUpdate = updateAbcExportPendingEventForNote(pending, tokens, eventNo, metaLines, normalizedVoiceId, measure, fallbackMeasureNumber, noteEventInfo, pitchToken, eventPrefix);
-    pending = pendingEventUpdate.pending;
-    eventNo = pendingEventUpdate.eventNo;
-    const postNoteEventState = updateAbcExportStateAfterNoteEvent(child, noteEventInfo, activeTuplet, lyricTokens, pendingLyricExtension);
-    return {
-        handled: true,
-        pending,
-        eventNo,
-        activeTuplet: postNoteEventState.activeTuplet,
-        pendingLyricExtension: postNoteEventState.pendingLyricExtension,
+    const noteDuration = isGrace
+        ? (Number.isFinite(duration) && duration > 0 ? duration : Math.round(currentDivisions / 2))
+        : duration;
+    const tieState = (0, ties_1.extractMusicXmlTieState)(child);
+    const slurFeatures = (0, slurs_1.extractMusicXmlSlurFeatures)(child);
+    const actualNotes = Number((_f = (_e = (_d = child.querySelector(":scope > time-modification > actual-notes")) === null || _d === void 0 ? void 0 : _d.textContent) === null || _e === void 0 ? void 0 : _e.trim()) !== null && _f !== void 0 ? _f : "");
+    const normalNotes = Number((_j = (_h = (_g = child.querySelector(":scope > time-modification > normal-notes")) === null || _g === void 0 ? void 0 : _g.textContent) === null || _h === void 0 ? void 0 : _h.trim()) !== null && _j !== void 0 ? _j : "");
+    const timeModification = Number.isFinite(actualNotes) && actualNotes > 0 && Number.isFinite(normalNotes) && normalNotes > 0
+        ? { actual: Math.round(actualNotes), normal: Math.round(normalNotes) }
+        : null;
+    const ornamentFeatures = (0, ornaments_1.extractMusicXmlOrnamentFeatures)(child);
+    const ornamentKinds = new Set(ornamentFeatures.map((feature) => feature.kind));
+    const hasTrillMark = ornamentKinds.has("trill-mark");
+    const hasWavyLineStart = Array.from(child.querySelectorAll(":scope > notations > ornaments > wavy-line")).some((node) => { var _a, _b; return ((_a = node.getAttribute("type")) !== null && _a !== void 0 ? _a : "").trim().toLowerCase() === "" || ((_b = node.getAttribute("type")) !== null && _b !== void 0 ? _b : "").trim().toLowerCase() === "start"; });
+    const hasWavyLineStop = Array.from(child.querySelectorAll(":scope > notations > ornaments > wavy-line")).some((node) => { var _a; return ((_a = node.getAttribute("type")) !== null && _a !== void 0 ? _a : "").trim().toLowerCase() === "stop"; });
+    const ornamentTrillPrefix = hasWavyLineStop
+        ? "!trill)!"
+        : hasWavyLineStart && !hasTrillMark
+            ? "!trill!"
+            : hasWavyLineStart
+                ? "!trill(!"
+                : hasTrillMark
+                    ? "!trill!"
+                    : "";
+    const noteEventInfo = {
+        isChord,
+        isGrace,
+        hasTieStart: tieState.tieStart,
+        ornamentPrefixInfo: {
+            prefix: `${ornamentTrillPrefix}${`${ornamentKinds.has("inverted-turn") ? (ornamentKinds.has("delayed-turn") ? "!delayedinvertedturn!" : (ornamentFeatures.some((feature) => feature.kind === "inverted-turn" && feature.slash) ? "!invertedturnx!" : "!invertedturn!")) : ""}${ornamentKinds.has("turn") ? (ornamentKinds.has("delayed-turn") ? "!delayedturn!" : (ornamentFeatures.some((feature) => feature.kind === "turn" && feature.slash) ? "!turnx!" : "!turn!")) : ""}`}${`${ornamentKinds.has("inverted-mordent") ? "!pralltriller!" : ""}${ornamentKinds.has("mordent") ? "!mordent!" : ""}`}${["single", "start", "stop"].map((tremoloType) => {
+                const tremoloFeature = ornamentFeatures.find((feature) => feature.kind === "tremolo" && feature.tremoloType === tremoloType);
+                return tremoloFeature ? `!tremolo-${tremoloType}-${tremoloFeature.marks ? tremoloFeature.marks : 1}!` : "";
+            }).join("")}${`${child.querySelector(':scope > notations > glissando[type="start"]') ? "!gliss-start!" : ""}${child.querySelector(':scope > notations > glissando[type="stop"]') ? "!gliss-stop!" : ""}${child.querySelector(':scope > notations > slide[type="start"]') ? "!slide!" : ""}${child.querySelector(':scope > notations > slide[type="stop"]') ? "!slide-stop!" : ""}${ornamentKinds.has("schleifer") ? "!schleifer!" : ""}${ornamentKinds.has("shake") ? "!shake!" : ""}${child.querySelector(":scope > notations > arpeggiate") ? "!arpeggio!" : ""}`}`,
+            hasTrill: hasTrillMark || hasWavyLineStart,
+            trillAccidentalText: (_m = (_l = (_k = child.querySelector(":scope > notations > ornaments > accidental-mark")) === null || _k === void 0 ? void 0 : _k.textContent) === null || _l === void 0 ? void 0 : _l.trim()) !== null && _m !== void 0 ? _m : "",
+        },
+        hasSlurStart: slurFeatures.some((slur) => slur.type === "start"),
+        hasSlurStop: slurFeatures.some((slur) => slur.type === "stop"),
+        hasGraceSlash: ((_p = (_o = child.querySelector(":scope > grace")) === null || _o === void 0 ? void 0 : _o.getAttribute("slash")) !== null && _p !== void 0 ? _p : "").trim().toLowerCase() === "yes",
+        hasTupletStart: child.querySelector(':scope > notations > tuplet[type="start"]') !== null,
+        timeModification,
+        len: buildAbcExportLengthToken(noteDuration, currentDivisions, unitLength, timeModification),
     };
+    return applyAbcExportNoteEvent(child, noteEventInfo, activeTuplet, pending, eventNo, pendingGraceTokens, pendingHarmonySymbols, pendingDirectionWords, pendingDirectionDecorations, tokens, metaLines, normalizedVoiceId, measure, fallbackMeasureNumber, keyAlterMap, measureAccidentalByStepOctave, lyricTokens, pendingLyricExtension);
 };
+const processAbcExportMeasureChild = (child, state) => {
+    if (processAbcExportMeasureNonNoteChild(child, state)) {
+        return;
+    }
+    processAbcExportMeasureNoteChild(child, state);
+};
+const processAbcExportMeasureNonNoteChild = (child, state) => {
+    const nonNoteDispatch = applyAbcExportNonNoteChildToPending(child, state.pendingHarmonySymbols, state.pendingDirectionWords, state.pendingDirectionDecorations, state.activeWedgeType);
+    state.activeWedgeType = nonNoteDispatch.activeWedgeType;
+    return nonNoteDispatch.handled;
+};
+const processAbcExportMeasureNoteChild = (child, state) => {
+    const noteChildProcess = processAbcExportNoteChild({
+        child,
+        lane: state.lane,
+        currentDivisions: state.currentDivisions,
+        unitLength: state.unitLength,
+        keyAlterMap: state.keyAlterMap,
+        measureAccidentalByStepOctave: state.measureAccidentalByStepOctave,
+        pendingGraceTokens: state.pendingGraceTokens,
+        activeTuplet: state.activeTuplet,
+        pendingHarmonySymbols: state.pendingHarmonySymbols,
+        pendingDirectionWords: state.pendingDirectionWords,
+        pendingDirectionDecorations: state.pendingDirectionDecorations,
+        pending: state.pending,
+        tokens: state.tokens,
+        eventNo: state.eventNo,
+        metaLines: state.metaLines,
+        normalizedVoiceId: state.normalizedVoiceId,
+        measure: state.measure,
+        fallbackMeasureNumber: state.fallbackMeasureNumber,
+        lyricTokens: state.lyricTokens,
+        pendingLyricExtension: state.pendingLyricExtension,
+    });
+    if (!noteChildProcess.handled) {
+        return;
+    }
+    state.pending = noteChildProcess.pending;
+    state.eventNo = noteChildProcess.eventNo;
+    state.activeTuplet = noteChildProcess.activeTuplet;
+    state.pendingLyricExtension = noteChildProcess.pendingLyricExtension;
+};
+const createAbcExportMeasureChildProcessingState = (context, pendingGraceTokens, pendingHarmonySymbols, pendingDirectionWords, pendingDirectionDecorations) => ({
+    lane: context.lane,
+    currentDivisions: context.currentDivisions,
+    unitLength: context.unitLength,
+    keyAlterMap: context.keyAlterMap,
+    measureAccidentalByStepOctave: context.measureAccidentalByStepOctave,
+    pendingGraceTokens,
+    pendingHarmonySymbols,
+    pendingDirectionWords,
+    pendingDirectionDecorations,
+    tokens: context.tokens,
+    metaLines: context.metaLines,
+    normalizedVoiceId: context.normalizedVoiceId,
+    measure: context.measure,
+    fallbackMeasureNumber: context.fallbackMeasureNumber,
+    lyricTokens: context.lyricTokens,
+    pending: null,
+    eventNo: 0,
+    activeTuplet: null,
+    pendingLyricExtension: context.pendingLyricExtension,
+    activeWedgeType: "",
+});
 const processAbcExportMeasureChildren = (context) => {
     const { measure, lane, currentDivisions, unitLength, keyAlterMap, measureAccidentalByStepOctave, tokens, metaLines, normalizedVoiceId, fallbackMeasureNumber, lyricTokens, } = context;
     let { pendingLyricExtension } = context;
@@ -26832,55 +26628,32 @@ const processAbcExportMeasureChildren = (context) => {
     const pendingHarmonySymbols = [];
     const pendingDirectionWords = [];
     const pendingDirectionDecorations = [];
-    let activeWedgeType = "";
-    let activeTuplet = null;
-    let eventNo = 0;
+    const state = createAbcExportMeasureChildProcessingState(context, pendingGraceTokens, pendingHarmonySymbols, pendingDirectionWords, pendingDirectionDecorations);
     for (const child of Array.from(measure.children)) {
-        const nonNoteDispatch = applyAbcExportNonNoteChildToPending(child, pendingHarmonySymbols, pendingDirectionWords, pendingDirectionDecorations, activeWedgeType);
-        activeWedgeType = nonNoteDispatch.activeWedgeType;
-        if (nonNoteDispatch.handled) {
-            continue;
-        }
-        const noteChildProcess = processAbcExportNoteChild({
-            child,
-            lane,
-            currentDivisions,
-            unitLength,
-            keyAlterMap,
-            measureAccidentalByStepOctave,
-            pendingGraceTokens,
-            activeTuplet,
-            pendingHarmonySymbols,
-            pendingDirectionWords,
-            pendingDirectionDecorations,
-            pending,
-            tokens,
-            eventNo,
-            metaLines,
-            normalizedVoiceId,
-            measure,
-            fallbackMeasureNumber,
-            lyricTokens,
-            pendingLyricExtension,
-        });
-        if (!noteChildProcess.handled)
-            continue;
-        pending = noteChildProcess.pending;
-        eventNo = noteChildProcess.eventNo;
-        activeTuplet = noteChildProcess.activeTuplet;
-        pendingLyricExtension = noteChildProcess.pendingLyricExtension;
+        processAbcExportMeasureChild(child, state);
     }
     return {
-        pending,
+        pending: state.pending,
         pendingGraceTokens,
-        pendingLyricExtension,
+        pendingLyricExtension: state.pendingLyricExtension,
     };
 };
 const renderAbcExportMeasureText = (context) => {
+    var _a, _b, _c, _d, _e;
     const { measure, lane, lastEmittedKeyFifths, unitLength, metaLines, normalizedVoiceId, fallbackMeasureNumber, lyricTokens, } = context;
     let { pendingLyricExtension } = context;
     const measureState = applyAbcExportMeasureAttributesToState(measure, context.measureState);
-    const boundaryInfo = readAbcExportMeasureBoundaryInfo(measure);
+    const leftRepeatNode = measure.querySelector(':scope > barline[location="left"] > repeat');
+    const rightRepeatNode = measure.querySelector(':scope > barline[location="right"] > repeat');
+    const leftEndingNode = measure.querySelector(':scope > barline[location="left"] > ending');
+    const rightEndingNode = measure.querySelector(':scope > barline[location="right"] > ending');
+    const boundaryInfo = {
+        hasLeftRepeat: ((_a = leftRepeatNode === null || leftRepeatNode === void 0 ? void 0 : leftRepeatNode.getAttribute("direction")) !== null && _a !== void 0 ? _a : "").trim().toLowerCase() === "forward",
+        hasRightRepeat: ((_b = rightRepeatNode === null || rightRepeatNode === void 0 ? void 0 : rightRepeatNode.getAttribute("direction")) !== null && _b !== void 0 ? _b : "").trim().toLowerCase() === "backward",
+        leftEndingNumber: ((_c = leftEndingNode === null || leftEndingNode === void 0 ? void 0 : leftEndingNode.getAttribute("number")) !== null && _c !== void 0 ? _c : "").trim(),
+        rightEndingNumber: ((_d = rightEndingNode === null || rightEndingNode === void 0 ? void 0 : rightEndingNode.getAttribute("number")) !== null && _d !== void 0 ? _d : "").trim(),
+        rightEndingType: ((_e = rightEndingNode === null || rightEndingNode === void 0 ? void 0 : rightEndingNode.getAttribute("type")) !== null && _e !== void 0 ? _e : "").trim().toLowerCase(),
+    };
     appendAbcExportMeasureMetaLines(metaLines, normalizedVoiceId, measure, fallbackMeasureNumber, boundaryInfo);
     const { currentDivisions, currentFifths, currentBeats, currentBeatType } = measureState;
     const needsInlineKeyChange = lastEmittedKeyFifths === null || lastEmittedKeyFifths !== currentFifths;
@@ -26905,27 +26678,26 @@ const renderAbcExportMeasureText = (context) => {
     flushAbcExportPendingGraceTokens(measureChildren.pendingGraceTokens, tokens);
     flushAbcExportPendingEvent(measureChildren.pending, tokens);
     appendAbcExportEmptyMeasureRestTokenIfNeeded(tokens, currentDivisions, currentBeats, currentBeatType, unitLength);
+    const boundaryPrefix = `${boundaryInfo.hasLeftRepeat ? "|:" : ""}${boundaryInfo.leftEndingNumber ? `[${boundaryInfo.leftEndingNumber}` : ""}`;
+    const keyPrefix = needsInlineKeyChange
+        ? `[K:${exports.AbcCommon.keyFromFifthsMode(Math.max(-7, Math.min(7, Math.round(currentFifths))), "major")}]`
+        : "";
+    const boundarySuffix = boundaryInfo.hasRightRepeat
+        ? (boundaryInfo.rightEndingNumber ? ":|]" : ":|")
+        : (boundaryInfo.rightEndingNumber ? "]|" : "|");
     return {
-        measureText: buildAbcExportMeasureText(tokens, needsInlineKeyChange, currentFifths, boundaryInfo),
+        measureText: [
+            ...(boundaryPrefix ? [boundaryPrefix] : []),
+            ...(keyPrefix ? [keyPrefix] : []),
+            tokens.join(" "),
+            ...(boundarySuffix ? [boundarySuffix] : []),
+        ]
+            .join(" ")
+            .trim(),
         measureState,
         lastEmittedKeyFifths: currentFifths,
         pendingLyricExtension,
     };
-};
-const appendAbcExportLaneHeader = (context) => {
-    const { part, partName, measures, laneDefs, lane, headerLines, metaLines, } = context;
-    const normalizedVoiceId = lane.voiceId.replace(/[^A-Za-z0-9_.-]/g, "_");
-    const laneName = buildAbcExportLaneName(partName, laneDefs.length, lane);
-    const abcClef = resolveAbcExportLaneClef(part, measures, lane.staff);
-    const clefSuffix = abcClef ? ` clef=${abcClef}` : "";
-    headerLines.push(`V:${normalizedVoiceId} name="${laneName}"${clefSuffix}`);
-    for (const measure of measures) {
-        const transposeMetaLine = buildAbcExportTransposeMetaLine(normalizedVoiceId, measure);
-        if (transposeMetaLine)
-            metaLines.push(transposeMetaLine);
-        break;
-    }
-    return normalizedVoiceId;
 };
 const readAbcExportPartInitialFifths = (part, fallbackFifths) => {
     var _a;
@@ -26934,211 +26706,151 @@ const readAbcExportPartInitialFifths = (part, fallbackFifths) => {
         ? Math.round(partInitialFifthsRaw)
         : (Number.isFinite(fallbackFifths) ? Math.round(fallbackFifths) : 0);
 };
-const createAbcExportInitialMeasureState = (part, fifths, meterBeats, meterBeatType) => ({
+const createAbcExportInitialMeasureStateFromPart = (part, fifths, meterBeats, meterBeatType) => ({
     currentDivisions: 480,
     currentFifths: readAbcExportPartInitialFifths(part, fifths),
     currentBeats: Number(meterBeats) || 4,
     currentBeatType: Number(meterBeatType) || 4,
 });
-const renderAbcExportLaneBody = (context, normalizedVoiceId) => {
-    const { part, measures, lane, fifths, meterBeats, meterBeatType, unitLength, metaLines, } = context;
-    let measureState = createAbcExportInitialMeasureState(part, fifths, meterBeats, meterBeatType);
-    let lastEmittedKeyFifths = Number.isFinite(fifths) ? Math.round(fifths) : 0;
-    const measureTexts = [];
-    const lyricTokens = [];
-    let pendingLyricExtension = false;
-    for (const measure of measures) {
-        const safeMeasureNumber = measureTexts.length + 1;
-        const renderedMeasure = renderAbcExportMeasureText({
-            measure,
-            lane,
-            measureState,
-            lastEmittedKeyFifths,
-            unitLength,
-            metaLines,
-            normalizedVoiceId,
-            fallbackMeasureNumber: safeMeasureNumber,
-            lyricTokens,
-            pendingLyricExtension,
-        });
-        measureState = renderedMeasure.measureState;
-        lastEmittedKeyFifths = renderedMeasure.lastEmittedKeyFifths;
-        pendingLyricExtension = renderedMeasure.pendingLyricExtension;
-        measureTexts.push(renderedMeasure.measureText);
-    }
-    return { measureTexts, lyricTokens };
+const createAbcExportLaneBodyStateFromPart = (part, fifths, meterBeats, meterBeatType) => ({
+    measureState: createAbcExportInitialMeasureStateFromPart(part, fifths, meterBeats, meterBeatType),
+    lastEmittedKeyFifths: Number.isFinite(fifths) ? Math.round(fifths) : 0,
+    measureTexts: [],
+    lyricTokens: [],
+    pendingLyricExtension: false,
+});
+const appendAbcExportLaneBodyMeasure = (state, measure, lane, unitLength, metaLines, normalizedVoiceId) => {
+    const renderedMeasure = renderAbcExportMeasureText({
+        measure,
+        lane,
+        measureState: state.measureState,
+        lastEmittedKeyFifths: state.lastEmittedKeyFifths,
+        unitLength,
+        metaLines,
+        normalizedVoiceId,
+        fallbackMeasureNumber: state.measureTexts.length + 1,
+        lyricTokens: state.lyricTokens,
+        pendingLyricExtension: state.pendingLyricExtension,
+    });
+    state.measureState = renderedMeasure.measureState;
+    state.lastEmittedKeyFifths = renderedMeasure.lastEmittedKeyFifths;
+    state.pendingLyricExtension = renderedMeasure.pendingLyricExtension;
+    state.measureTexts.push(renderedMeasure.measureText);
 };
-const appendAbcExportRenderedLaneBody = (bodyLines, normalizedVoiceId, renderedLaneBody) => {
-    const { measureTexts, lyricTokens } = renderedLaneBody;
-    bodyLines.push(`V:${normalizedVoiceId}`);
-    bodyLines.push(measureTexts.join(" "));
-    if (lyricTokens.some((token) => token !== "*")) {
-        bodyLines.push(`w: ${lyricTokens.join(" ")}`);
-    }
-};
-const appendAbcExportLaneBody = (context, normalizedVoiceId) => {
-    const { bodyLines } = context;
-    appendAbcExportRenderedLaneBody(bodyLines, normalizedVoiceId, renderAbcExportLaneBody(context, normalizedVoiceId));
-};
-const appendAbcExportLane = (context) => {
-    const normalizedVoiceId = appendAbcExportLaneHeader(context);
-    appendAbcExportLaneBody(context, normalizedVoiceId);
-};
-const createAbcExportPartRenderInfo = (part, partIndex, partNameById) => {
-    const partId = part.getAttribute("id") || `P${partIndex + 1}`;
-    return {
-        partName: partNameById.get(partId) || partId,
-        measures: Array.from(part.querySelectorAll(":scope > measure")),
-        laneDefs: buildAbcExportLaneDefinitions(part, partId),
-    };
-};
-const appendAbcExportPartLanes = (context, partRenderInfo) => {
-    const { part, fifths, meterBeats, meterBeatType, unitLength, headerLines, bodyLines, metaLines, } = context;
-    const { partName, measures, laneDefs } = partRenderInfo;
+const appendAbcExportPartFromRenderContext = (context) => {
+    var _a, _b, _c, _d, _e, _f, _g;
+    const partId = context.part.getAttribute("id") || `P${context.partIndex + 1}`;
+    const partName = context.partNameById.get(partId) || partId;
+    const measures = Array.from(context.part.querySelectorAll(":scope > measure"));
+    const laneDefs = buildAbcExportLaneDefinitions(context.part, partId);
     for (const lane of laneDefs) {
-        appendAbcExportLane({
-            part,
+        const laneContext = {
+            part: context.part,
             partName,
             measures,
             laneDefs,
             lane,
-            fifths,
-            meterBeats,
-            meterBeatType,
-            unitLength,
-            headerLines,
-            bodyLines,
-            metaLines,
+            fifths: context.fifths,
+            meterBeats: context.meterBeats,
+            meterBeatType: context.meterBeatType,
+            unitLength: context.unitLength,
+            headerLines: context.headerLines,
+            bodyLines: context.bodyLines,
+            metaLines: context.metaLines,
+        };
+        const normalizedVoiceId = laneContext.lane.voiceId.replace(/[^A-Za-z0-9_.-]/g, "_");
+        const laneName = laneContext.laneDefs.length <= 1
+            ? laneContext.partName
+            : laneContext.lane.staff && laneContext.lane.voice
+                ? `${laneContext.partName} (Staff ${laneContext.lane.staff} Voice ${laneContext.lane.voice})`
+                : laneContext.lane.staff
+                    ? `${laneContext.partName} (Staff ${laneContext.lane.staff})`
+                    : laneContext.lane.voice
+                        ? `${laneContext.partName} (Voice ${laneContext.lane.voice})`
+                        : `${laneContext.partName} (Lane)`;
+        const abcClef = resolveAbcExportLaneClef(laneContext.part, laneContext.measures, laneContext.lane.staff);
+        const clefSuffix = abcClef ? ` clef=${abcClef}` : "";
+        laneContext.headerLines.push(`V:${normalizedVoiceId} name="${laneName}"${clefSuffix}`);
+        const transposeNode = (_a = laneContext.measures[0]) === null || _a === void 0 ? void 0 : _a.querySelector(":scope > attributes > transpose");
+        if (transposeNode) {
+            const chromatic = Number((_d = (_c = (_b = transposeNode.querySelector(":scope > chromatic")) === null || _b === void 0 ? void 0 : _b.textContent) === null || _c === void 0 ? void 0 : _c.trim()) !== null && _d !== void 0 ? _d : "");
+            const diatonic = Number((_g = (_f = (_e = transposeNode.querySelector(":scope > diatonic")) === null || _e === void 0 ? void 0 : _e.textContent) === null || _f === void 0 ? void 0 : _f.trim()) !== null && _g !== void 0 ? _g : "");
+            if (Number.isFinite(chromatic) || Number.isFinite(diatonic)) {
+                laneContext.metaLines.push([
+                    `%@mks transpose voice=${normalizedVoiceId}`,
+                    ...(Number.isFinite(chromatic) ? [`chromatic=${Math.round(chromatic)}`] : []),
+                    ...(Number.isFinite(diatonic) ? [`diatonic=${Math.round(diatonic)}`] : []),
+                ].join(" "));
+            }
+        }
+        const state = createAbcExportLaneBodyStateFromPart(laneContext.part, laneContext.fifths, laneContext.meterBeats, laneContext.meterBeatType);
+        for (const measure of laneContext.measures) {
+            appendAbcExportLaneBodyMeasure(state, measure, laneContext.lane, laneContext.unitLength, laneContext.metaLines, normalizedVoiceId);
+        }
+        laneContext.bodyLines.push(`V:${normalizedVoiceId}`, state.measureTexts.join(" "));
+        if (state.lyricTokens.some((token) => token !== "*")) {
+            laneContext.bodyLines.push(`w: ${state.lyricTokens.join(" ")}`);
+        }
+    }
+};
+const appendAbcExportParts = (parts, exportContext) => {
+    for (const [partIndex, part] of parts.entries()) {
+        appendAbcExportPartFromRenderContext({
+            part,
+            partIndex,
+            partNameById: exportContext.partNameById,
+            fifths: exportContext.fifths,
+            meterBeats: exportContext.meterBeats,
+            meterBeatType: exportContext.meterBeatType,
+            unitLength: exportContext.unitLength,
+            headerLines: exportContext.headerLines,
+            bodyLines: exportContext.bodyLines,
+            metaLines: exportContext.metaLines,
         });
     }
 };
-const appendAbcExportPart = (context) => {
-    const { part, partIndex, partNameById, } = context;
-    appendAbcExportPartLanes(context, createAbcExportPartRenderInfo(part, partIndex, partNameById));
-};
-const hasAbcExportUnitTempoHeader = (initialTempo) => Boolean(initialTempo.unit && Number.isFinite(initialTempo.bpm) && initialTempo.bpm > 0);
-const buildAbcExportUnitTempoHeader = (initialTempo) => {
-    if (hasAbcExportUnitTempoHeader(initialTempo)) {
-        return `Q:${fractionToAbcTempoUnit(initialTempo.unit)}=${Math.round(initialTempo.bpm)}`;
-    }
-    return "";
-};
-const buildAbcExportFallbackTempoHeader = (tempoBpm) => Number.isFinite(tempoBpm) ? `Q:1/4=${Math.round(tempoBpm)}` : "";
-const buildAbcExportTempoHeaderFromInitialTempo = (initialTempo) => {
-    var _a;
-    const tempoBpm = (_a = initialTempo === null || initialTempo === void 0 ? void 0 : initialTempo.bpm) !== null && _a !== void 0 ? _a : NaN;
-    if (initialTempo) {
-        const unitTempoHeader = buildAbcExportUnitTempoHeader(initialTempo);
-        if (unitTempoHeader)
-            return unitTempoHeader;
-    }
-    return buildAbcExportFallbackTempoHeader(tempoBpm);
-};
-const buildAbcExportTempoHeader = (doc) => buildAbcExportTempoHeaderFromInitialTempo(readInitialTempoFromMusicXml(doc));
-const readAbcExportTitle = (doc) => {
-    var _a, _b, _c, _d;
-    return ((_b = (_a = doc.querySelector("work > work-title")) === null || _a === void 0 ? void 0 : _a.textContent) === null || _b === void 0 ? void 0 : _b.trim()) ||
-        ((_d = (_c = doc.querySelector("movement-title")) === null || _c === void 0 ? void 0 : _c.textContent) === null || _d === void 0 ? void 0 : _d.trim()) ||
-        "mikuscore";
-};
-const readAbcExportComposer = (doc) => { var _a, _b; return ((_b = (_a = doc.querySelector('identification > creator[type="composer"]')) === null || _a === void 0 ? void 0 : _a.textContent) === null || _b === void 0 ? void 0 : _b.trim()) || ""; };
-const readAbcExportDocumentCredits = (doc) => ({
-    title: readAbcExportTitle(doc),
-    composer: readAbcExportComposer(doc),
-});
-const readAbcExportMeterBeats = (firstMeasure) => { var _a, _b; return ((_b = (_a = firstMeasure === null || firstMeasure === void 0 ? void 0 : firstMeasure.querySelector("attributes > time > beats")) === null || _a === void 0 ? void 0 : _a.textContent) === null || _b === void 0 ? void 0 : _b.trim()) || "4"; };
-const readAbcExportMeterBeatType = (firstMeasure) => { var _a, _b; return ((_b = (_a = firstMeasure === null || firstMeasure === void 0 ? void 0 : firstMeasure.querySelector("attributes > time > beat-type")) === null || _a === void 0 ? void 0 : _a.textContent) === null || _b === void 0 ? void 0 : _b.trim()) || "4"; };
-const readAbcExportDocumentMeterInfo = (firstMeasure) => ({
-    meterBeats: readAbcExportMeterBeats(firstMeasure),
-    meterBeatType: readAbcExportMeterBeatType(firstMeasure),
-});
-const buildAbcExportKeyFromFifthsMode = (fifths, mode) => exports.AbcCommon.keyFromFifthsMode(Number.isFinite(fifths) ? fifths : 0, mode);
-const readAbcExportKeyFifths = (firstMeasure) => { var _a, _b; return Number(((_b = (_a = firstMeasure === null || firstMeasure === void 0 ? void 0 : firstMeasure.querySelector("attributes > key > fifths")) === null || _a === void 0 ? void 0 : _a.textContent) === null || _b === void 0 ? void 0 : _b.trim()) || "0"); };
-const readAbcExportKeyMode = (firstMeasure) => { var _a, _b; return ((_b = (_a = firstMeasure === null || firstMeasure === void 0 ? void 0 : firstMeasure.querySelector("attributes > key > mode")) === null || _a === void 0 ? void 0 : _a.textContent) === null || _b === void 0 ? void 0 : _b.trim()) || "major"; };
-const readAbcExportDocumentKeyInfo = (firstMeasure) => {
-    const fifths = readAbcExportKeyFifths(firstMeasure);
-    const mode = readAbcExportKeyMode(firstMeasure);
-    return {
+const exportMusicXmlDomToAbc = (doc) => {
+    var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p, _q, _r, _s, _t, _u, _v, _w;
+    const title = (_f = (_c = (_b = (_a = doc.querySelector("work > work-title")) === null || _a === void 0 ? void 0 : _a.textContent) === null || _b === void 0 ? void 0 : _b.trim()) !== null && _c !== void 0 ? _c : (_e = (_d = doc.querySelector("movement-title")) === null || _d === void 0 ? void 0 : _d.textContent) === null || _e === void 0 ? void 0 : _e.trim()) !== null && _f !== void 0 ? _f : "mikuscore";
+    const composer = (_j = (_h = (_g = doc.querySelector('identification > creator[type="composer"]')) === null || _g === void 0 ? void 0 : _g.textContent) === null || _h === void 0 ? void 0 : _h.trim()) !== null && _j !== void 0 ? _j : "";
+    const firstMeasure = doc.querySelector("score-partwise > part > measure");
+    const meterBeats = (_m = (_l = (_k = firstMeasure === null || firstMeasure === void 0 ? void 0 : firstMeasure.querySelector("attributes > time > beats")) === null || _k === void 0 ? void 0 : _k.textContent) === null || _l === void 0 ? void 0 : _l.trim()) !== null && _m !== void 0 ? _m : "4";
+    const meterBeatType = (_q = (_p = (_o = firstMeasure === null || firstMeasure === void 0 ? void 0 : firstMeasure.querySelector("attributes > time > beat-type")) === null || _o === void 0 ? void 0 : _o.textContent) === null || _p === void 0 ? void 0 : _p.trim()) !== null && _q !== void 0 ? _q : "4";
+    const fifths = Number((_t = (_s = (_r = firstMeasure === null || firstMeasure === void 0 ? void 0 : firstMeasure.querySelector("attributes > key > fifths")) === null || _r === void 0 ? void 0 : _r.textContent) === null || _s === void 0 ? void 0 : _s.trim()) !== null && _t !== void 0 ? _t : "0");
+    const mode = (_w = (_v = (_u = firstMeasure === null || firstMeasure === void 0 ? void 0 : firstMeasure.querySelector("attributes > key > mode")) === null || _u === void 0 ? void 0 : _u.textContent) === null || _v === void 0 ? void 0 : _v.trim()) !== null && _w !== void 0 ? _w : "major";
+    const initialTempo = readInitialTempoFromMusicXml(doc);
+    const abcTempoHeader = initialTempo
+        ? (initialTempo.unit && Number.isFinite(initialTempo.bpm) && initialTempo.bpm > 0
+            ? `Q:${fractionToAbcTempoUnit(initialTempo.unit)}=${Math.round(initialTempo.bpm)}`
+            : (Number.isFinite(initialTempo.bpm) ? `Q:1/4=${Math.round(initialTempo.bpm)}` : ""))
+        : "";
+    const exportContext = {
+        headerLines: [
+            "X:1",
+            `T:${title}`,
+            composer ? `C:${composer}` : "",
+            `M:${meterBeats}/${meterBeatType}`,
+            `L:${fractionToAbcTempoUnit(DEFAULT_UNIT)}`,
+            abcTempoHeader,
+            `K:${exports.AbcCommon.keyFromFifthsMode(Number.isFinite(fifths) ? fifths : 0, mode)}`,
+        ].filter((line) => line.length > 0),
+        bodyLines: [],
+        metaLines: [],
+        partNameById: new Map(Array.from(doc.querySelectorAll("part-list > score-part"))
+            .map((scorePart) => {
+            var _a, _b, _c;
+            const id = (_a = scorePart.getAttribute("id")) !== null && _a !== void 0 ? _a : "";
+            return id ? [id, ((_c = (_b = scorePart.querySelector("part-name")) === null || _b === void 0 ? void 0 : _b.textContent) === null || _c === void 0 ? void 0 : _c.trim()) || id] : null;
+        })
+            .filter((entry) => entry !== null)),
         fifths,
-        key: buildAbcExportKeyFromFifthsMode(fifths, mode),
+        meterBeats,
+        meterBeatType,
+        unitLength: DEFAULT_UNIT,
     };
+    appendAbcExportParts(Array.from(doc.querySelectorAll("score-partwise > part")), exportContext);
+    return `${exportContext.headerLines.join("\n")}\n\n${exportContext.bodyLines.join("\n")}${exportContext.metaLines.length > 0 ? `\n${exportContext.metaLines.join("\n")}\n` : "\n"}`;
 };
-const createAbcExportDocumentMeterKeyInfoFromParts = (meterInfo, keyInfo) => ({
-    meterBeats: meterInfo.meterBeats,
-    meterBeatType: meterInfo.meterBeatType,
-    fifths: keyInfo.fifths,
-    key: keyInfo.key,
-});
-const readAbcExportDocumentMeterKeyInfo = (firstMeasure) => {
-    const meterInfo = readAbcExportDocumentMeterInfo(firstMeasure);
-    const keyInfo = readAbcExportDocumentKeyInfo(firstMeasure);
-    return createAbcExportDocumentMeterKeyInfoFromParts(meterInfo, keyInfo);
-};
-const readAbcExportFirstMeasure = (doc) => doc.querySelector("score-partwise > part > measure");
-const createAbcExportDocumentHeaderInfoFromParts = (credits, meterKeyInfo, abcTempoHeader) => ({
-    title: credits.title,
-    composer: credits.composer,
-    meterBeats: meterKeyInfo.meterBeats,
-    meterBeatType: meterKeyInfo.meterBeatType,
-    fifths: meterKeyInfo.fifths,
-    key: meterKeyInfo.key,
-    abcTempoHeader,
-});
-const createAbcExportDocumentHeaderInfo = (doc) => createAbcExportDocumentHeaderInfoFromParts(readAbcExportDocumentCredits(doc), readAbcExportDocumentMeterKeyInfo(readAbcExportFirstMeasure(doc)), buildAbcExportTempoHeader(doc));
-const buildAbcExportRawHeaderLines = (headerInfo) => {
-    const { title, composer, meterBeats, meterBeatType, key, abcTempoHeader } = headerInfo;
-    return [
-        "X:1",
-        `T:${title}`,
-        composer ? `C:${composer}` : "",
-        `M:${meterBeats}/${meterBeatType}`,
-        `L:${fractionToAbcTempoUnit(DEFAULT_UNIT)}`,
-        abcTempoHeader,
-        `K:${key}`,
-    ];
-};
-const buildAbcExportHeaderLines = (headerInfo) => buildAbcExportRawHeaderLines(headerInfo).filter(Boolean);
-const createAbcExportInitialDocumentContext = (headerInfo, partNameById) => ({
-    headerLines: buildAbcExportHeaderLines(headerInfo),
-    bodyLines: [],
-    metaLines: [],
-    partNameById,
-    fifths: headerInfo.fifths,
-    meterBeats: headerInfo.meterBeats,
-    meterBeatType: headerInfo.meterBeatType,
-    unitLength: DEFAULT_UNIT,
-});
-const createAbcExportDocumentContext = (doc) => createAbcExportInitialDocumentContext(createAbcExportDocumentHeaderInfo(doc), buildAbcExportPartNameById(doc));
-const buildAbcExportMetaBlock = (metaLines) => metaLines.length > 0 ? `\n${metaLines.join("\n")}\n` : "\n";
-const buildAbcExportDocumentTextFromLines = (headerLines, bodyLines, metaLines) => {
-    const metaBlock = buildAbcExportMetaBlock(metaLines);
-    return `${headerLines.join("\n")}\n\n${bodyLines.join("\n")}${metaBlock}`;
-};
-const buildAbcExportDocumentText = (exportContext) => buildAbcExportDocumentTextFromLines(exportContext.headerLines, exportContext.bodyLines, exportContext.metaLines);
-const createAbcExportPartRenderContext = (part, partIndex, exportContext) => ({
-    part,
-    partIndex,
-    partNameById: exportContext.partNameById,
-    fifths: exportContext.fifths,
-    meterBeats: exportContext.meterBeats,
-    meterBeatType: exportContext.meterBeatType,
-    unitLength: exportContext.unitLength,
-    headerLines: exportContext.headerLines,
-    bodyLines: exportContext.bodyLines,
-    metaLines: exportContext.metaLines,
-});
-const readAbcExportParts = (doc) => Array.from(doc.querySelectorAll("score-partwise > part"));
-const appendAbcExportParts = (parts, exportContext) => {
-    parts.forEach((part, partIndex) => {
-        appendAbcExportPart(createAbcExportPartRenderContext(part, partIndex, exportContext));
-    });
-};
-const renderAbcExportDocumentContext = (doc) => {
-    const exportContext = createAbcExportDocumentContext(doc);
-    appendAbcExportParts(readAbcExportParts(doc), exportContext);
-    return exportContext;
-};
-const exportMusicXmlDomToAbc = (doc) => buildAbcExportDocumentText(renderAbcExportDocumentContext(doc));
 exports.exportMusicXmlDomToAbc = exportMusicXmlDomToAbc;
 const xmlEscape = (text) => text
     .replace(/&/g, "&amp;")
@@ -27146,189 +26858,157 @@ const xmlEscape = (text) => text
     .replace(/>/g, "&gt;")
     .replace(/"/g, "&quot;")
     .replace(/'/g, "&apos;");
-const abcQuotedTextEscape = (text) => String(text || "")
+const abcQuotedTextEscape = (text) => String(text !== null && text !== void 0 ? text : "")
     .replace(/"/g, "'")
     .replace(/\s+/g, " ")
     .trim();
-const normalizeChordToken = (raw) => String(raw || "")
+const normalizeChordToken = (raw) => String(raw !== null && raw !== void 0 ? raw : "")
     .trim()
     .replace(/♯/g, "#")
     .replace(/♭/g, "b")
     .replace(/\s+/g, "");
 const ABC_CHORD_SYMBOL_PATTERN = /^([A-G](?:#|b)?)([^/\s"]*)?(?:\/([A-G](?:#|b)?))?$/;
-const isLikelyAbcChordSymbol = (raw) => {
-    const text = normalizeChordToken(raw);
-    return ABC_CHORD_SYMBOL_PATTERN.test(text);
+const isLikelyAbcChordSymbol = (raw) => ABC_CHORD_SYMBOL_PATTERN.test(normalizeChordToken(raw));
+const normalizeHarmonyChordSuffix = (suffixRaw) => String(suffixRaw !== null && suffixRaw !== void 0 ? suffixRaw : "").trim().toLowerCase();
+const abcHarmonyKindBySuffix = {
+    "": "major",
+    m: "minor",
+    min: "minor",
+    "6": "major-sixth",
+    m6: "minor-sixth",
+    min6: "minor-sixth",
+    "7": "dominant",
+    "7sus4": "suspended-fourth",
+    "9": "dominant-ninth",
+    "11": "dominant-11th",
+    "13": "dominant-13th",
+    maj7: "major-seventh",
+    maj9: "major-ninth",
+    m9: "minor-ninth",
+    min9: "minor-ninth",
+    m7: "minor-seventh",
+    min7: "minor-seventh",
+    dim: "diminished",
+    dim7: "diminished-seventh",
+    aug: "augmented",
+    "+": "augmented",
+    sus4: "suspended-fourth",
+    sus2: "suspended-second",
+    "m7b5": "half-diminished",
+    min7b5: "half-diminished",
+    "ø": "half-diminished",
 };
-const normalizeHarmonyChordSuffix = (suffixRaw) => String(suffixRaw || "").trim().toLowerCase();
 const xmlHarmonyKindFromChordSuffix = (suffixRaw) => {
+    var _a;
     const suffix = normalizeHarmonyChordSuffix(suffixRaw);
-    if (!suffix)
-        return "major";
-    if (suffix === "m" || suffix === "min")
-        return "minor";
-    if (suffix === "6")
-        return "major-sixth";
-    if (suffix === "m6" || suffix === "min6")
-        return "minor-sixth";
-    if (suffix === "7")
-        return "dominant";
-    if (suffix === "7sus4")
-        return "suspended-fourth";
-    if (suffix === "9")
-        return "dominant-ninth";
-    if (suffix === "11")
-        return "dominant-11th";
-    if (suffix === "13")
-        return "dominant-13th";
-    if (suffix === "maj7")
-        return "major-seventh";
-    if (suffix === "maj9")
-        return "major-ninth";
-    if (suffix === "m9" || suffix === "min9")
-        return "minor-ninth";
-    if (suffix === "m7" || suffix === "min7")
-        return "minor-seventh";
-    if (suffix === "dim")
-        return "diminished";
-    if (suffix === "dim7")
-        return "diminished-seventh";
-    if (suffix === "aug" || suffix === "+")
-        return "augmented";
-    if (suffix === "sus4")
-        return "suspended-fourth";
-    if (suffix === "sus2")
-        return "suspended-second";
-    if (suffix === "m7b5" || suffix === "min7b5" || suffix === "ø")
-        return "half-diminished";
-    return null;
+    return (_a = abcHarmonyKindBySuffix[suffix]) !== null && _a !== void 0 ? _a : null;
 };
 const xmlHarmonyRootFromChordToken = (token) => {
-    const m = String(token || "").match(/^([A-G])(#|b)?$/);
-    if (!m)
-        return null;
-    return {
-        step: m[1],
-        alter: m[2] === "#" ? 1 : (m[2] === "b" ? -1 : 0),
-    };
+    const m = String(token !== null && token !== void 0 ? token : "").match(/^([A-G])(#|b)?$/);
+    return m
+        ? {
+            step: m[1],
+            alter: m[2] === "#" ? 1 : (m[2] === "b" ? -1 : 0),
+        }
+        : null;
 };
 const parseAbcChordSymbolParts = (raw) => {
+    var _a, _b;
     const normalized = normalizeChordToken(raw);
     const match = normalized.match(ABC_CHORD_SYMBOL_PATTERN);
     if (!match)
         return null;
-    const root = xmlHarmonyRootFromChordToken(match[1] || "");
+    const root = xmlHarmonyRootFromChordToken((_a = match[1]) !== null && _a !== void 0 ? _a : "");
     if (!root)
         return null;
     const bass = match[3] ? xmlHarmonyRootFromChordToken(match[3]) : null;
     return {
         normalized,
         root,
-        suffix: String(match[2] || ""),
+        suffix: String((_b = match[2]) !== null && _b !== void 0 ? _b : ""),
         bass,
     };
 };
-const buildHarmonyPitchXml = (tagName, pitch) => {
-    const childPrefix = tagName === "root" ? "root" : "bass";
-    return [
-        `<${tagName}>`,
-        `<${childPrefix}-step>${xmlEscape(pitch.step)}</${childPrefix}-step>`,
-        pitch.alter !== 0 ? `<${childPrefix}-alter>${pitch.alter}</${childPrefix}-alter>` : "",
-        `</${tagName}>`,
-    ].join("");
-};
-const buildHarmonyKindXml = (normalized, kind) => `<kind text="${xmlEscape(normalized)}">${kind}</kind>`;
-const buildHarmonyXmlFromParts = (parts, kind) => [
-    "<harmony>",
-    buildHarmonyPitchXml("root", parts.root),
-    parts.bass ? buildHarmonyPitchXml("bass", parts.bass) : "",
-    buildHarmonyKindXml(parts.normalized, kind),
-    "</harmony>",
+const buildHarmonyPitchXml = (tagName, pitch) => [
+    `<${tagName}>`,
+    `<${tagName}-step>${xmlEscape(pitch.step)}</${tagName}-step>`,
+    pitch.alter !== 0 ? `<${tagName}-alter>${pitch.alter}</${tagName}-alter>` : "",
+    `</${tagName}>`,
 ].join("");
 const buildHarmonyXmlFromChordSymbol = (raw) => {
     const parts = parseAbcChordSymbolParts(raw);
     if (!parts)
         return "";
     const kind = xmlHarmonyKindFromChordSuffix(parts.suffix);
-    if (!kind)
-        return "";
-    return buildHarmonyXmlFromParts(parts, kind);
+    return kind
+        ? [
+            "<harmony>",
+            buildHarmonyPitchXml("root", parts.root),
+            parts.bass ? buildHarmonyPitchXml("bass", parts.bass) : "",
+            `<kind text="${xmlEscape(parts.normalized)}">${kind}</kind>`,
+            "</harmony>",
+        ].join("")
+        : "";
 };
-const abcHarmonyPitchTokenFromStepAlter = (step, alter) => {
-    const normalizedStep = String(step || "").trim().toUpperCase();
-    if (!/^[A-G]$/.test(normalizedStep))
-        return "";
-    return `${normalizedStep}${alter === 1 ? "#" : (alter === -1 ? "b" : "")}`;
+const abcHarmonySuffixByKindValue = {
+    major: "",
+    minor: "m",
+    "major-sixth": "6",
+    "minor-sixth": "m6",
+    dominant: "7",
+    "dominant-11th": "11",
+    "dominant-13th": "13",
+    "dominant-ninth": "9",
+    "major-seventh": "maj7",
+    "major-ninth": "maj9",
+    "minor-ninth": "m9",
+    "minor-seventh": "m7",
+    diminished: "dim",
+    "diminished-seventh": "dim7",
+    augmented: "aug",
+    "suspended-fourth": "sus4",
+    "suspended-second": "sus2",
+    "half-diminished": "m7b5",
 };
-const abcHarmonyPitchFromNode = (node, prefix) => {
-    var _a, _b;
-    if (!node)
-        return null;
-    const step = (((_a = node.querySelector(`:scope > ${prefix}-step`)) === null || _a === void 0 ? void 0 : _a.textContent) || "").trim();
-    const alter = Number(((_b = node.querySelector(`:scope > ${prefix}-alter`)) === null || _b === void 0 ? void 0 : _b.textContent) || "0");
-    return { step, alter };
-};
-const abcHarmonyPitchTokenFromNode = (node, prefix) => {
-    const pitch = abcHarmonyPitchFromNode(node, prefix);
-    return pitch ? abcHarmonyPitchTokenFromStepAlter(pitch.step, pitch.alter) : "";
-};
-const abcHarmonySuffixFromKindValue = (kindValue) => kindValue === "major" ? "" :
-    kindValue === "minor" ? "m" :
-        kindValue === "major-sixth" ? "6" :
-            kindValue === "minor-sixth" ? "m6" :
-                kindValue === "dominant" ? "7" :
-                    kindValue === "dominant-11th" ? "11" :
-                        kindValue === "dominant-13th" ? "13" :
-                            kindValue === "dominant-ninth" ? "9" :
-                                kindValue === "major-seventh" ? "maj7" :
-                                    kindValue === "major-ninth" ? "maj9" :
-                                        kindValue === "minor-ninth" ? "m9" :
-                                            kindValue === "minor-seventh" ? "m7" :
-                                                kindValue === "diminished" ? "dim" :
-                                                    kindValue === "diminished-seventh" ? "dim7" :
-                                                        kindValue === "augmented" ? "aug" :
-                                                            kindValue === "suspended-fourth" ? "sus4" :
-                                                                kindValue === "suspended-second" ? "sus2" :
-                                                                    kindValue === "half-diminished" ? "m7b5" :
-                                                                        "";
-const abcHarmonyKindTextOverride = (kindNode) => {
-    const kindTextAttr = ((kindNode === null || kindNode === void 0 ? void 0 : kindNode.getAttribute("text")) || "").trim();
-    return kindTextAttr ? abcQuotedTextEscape(kindTextAttr) : "";
-};
-const normalizeHarmonyKindValue = (kindValue) => String(kindValue || "").trim().toLowerCase();
-const abcHarmonyKindValueFromNode = (kindNode) => normalizeHarmonyKindValue((kindNode === null || kindNode === void 0 ? void 0 : kindNode.textContent) || "");
-const abcHarmonySuffixFromKindNode = (kindNode) => abcHarmonySuffixFromKindValue(abcHarmonyKindValueFromNode(kindNode));
-const abcHarmonyBassTokenFromNode = (node) => {
-    const bassPitchToken = abcHarmonyPitchTokenFromNode(node, "bass");
-    return bassPitchToken ? `/${bassPitchToken}` : "";
-};
-const buildAbcHarmonyChordSymbol = (rootToken, suffix, bassToken) => `${rootToken}${suffix}${bassToken}`;
 const abcChordSymbolFromHarmony = (harmony) => {
+    var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m;
     if (!harmony)
         return "";
-    const rootToken = abcHarmonyPitchTokenFromNode(harmony.querySelector(":scope > root"), "root");
+    const rootNode = harmony.querySelector(":scope > root");
+    const rootStep = rootNode ? ((_b = (_a = rootNode.querySelector(":scope > root-step")) === null || _a === void 0 ? void 0 : _a.textContent) !== null && _b !== void 0 ? _b : "").trim() : "";
+    const rootAlter = rootNode ? Number((_d = (_c = rootNode.querySelector(":scope > root-alter")) === null || _c === void 0 ? void 0 : _c.textContent) !== null && _d !== void 0 ? _d : "0") : 0;
+    const rootNormalizedStep = String(rootStep !== null && rootStep !== void 0 ? rootStep : "").trim().toUpperCase();
+    const rootToken = /^[A-G]$/.test(rootNormalizedStep)
+        ? `${rootNormalizedStep}${rootAlter === 1 ? "#" : (rootAlter === -1 ? "b" : "")}`
+        : "";
     if (!rootToken)
         return "";
     const kindNode = harmony.querySelector(":scope > kind");
-    const kindTextOverride = abcHarmonyKindTextOverride(kindNode);
-    if (kindTextOverride)
-        return kindTextOverride;
-    const suffix = abcHarmonySuffixFromKindNode(kindNode);
-    const bassToken = abcHarmonyBassTokenFromNode(harmony.querySelector(":scope > bass"));
-    return buildAbcHarmonyChordSymbol(rootToken, suffix, bassToken);
+    const kindTextAttr = (_f = (_e = kindNode === null || kindNode === void 0 ? void 0 : kindNode.getAttribute("text")) === null || _e === void 0 ? void 0 : _e.trim()) !== null && _f !== void 0 ? _f : "";
+    if (kindTextAttr)
+        return abcQuotedTextEscape(kindTextAttr);
+    const bassNode = harmony.querySelector(":scope > bass");
+    const bassStep = bassNode ? ((_h = (_g = bassNode.querySelector(":scope > bass-step")) === null || _g === void 0 ? void 0 : _g.textContent) !== null && _h !== void 0 ? _h : "").trim() : "";
+    const bassAlter = bassNode ? Number((_k = (_j = bassNode.querySelector(":scope > bass-alter")) === null || _j === void 0 ? void 0 : _j.textContent) !== null && _k !== void 0 ? _k : "0") : 0;
+    const bassNormalizedStep = String(bassStep !== null && bassStep !== void 0 ? bassStep : "").trim().toUpperCase();
+    const bassPitchToken = /^[A-G]$/.test(bassNormalizedStep)
+        ? `${bassNormalizedStep}${bassAlter === 1 ? "#" : (bassAlter === -1 ? "b" : "")}`
+        : "";
+    const kindValue = String((_l = kindNode === null || kindNode === void 0 ? void 0 : kindNode.textContent) !== null && _l !== void 0 ? _l : "").trim().toLowerCase();
+    const suffix = (_m = abcHarmonySuffixByKindValue[kindValue]) !== null && _m !== void 0 ? _m : "";
+    return `${rootToken}${suffix}${bassPitchToken ? `/${bassPitchToken}` : ""}`;
 };
-const normalizeAbcLyricText = (text) => String(text || "").trim().replace(/\s+/g, "~");
-const normalizeAbcLyricSyllabicMode = (syllabic) => String(syllabic || "single").trim().toLowerCase();
+const normalizeAbcLyricText = (text) => String(text !== null && text !== void 0 ? text : "").trim().replace(/\s+/g, "~");
+const normalizeAbcLyricSyllabicMode = (syllabic) => String(syllabic !== null && syllabic !== void 0 ? syllabic : "single").trim().toLowerCase();
 const shouldAppendAbcLyricHyphen = (syllabicMode) => syllabicMode === "begin" || syllabicMode === "middle";
-const buildAbcLyricTextToken = (normalizedText, syllabicMode) => shouldAppendAbcLyricHyphen(syllabicMode) ? `${normalizedText}-` : normalizedText;
 const abcLyricTokenFromMusicXml = (text, syllabic) => {
     const normalized = normalizeAbcLyricText(text);
     const mode = normalizeAbcLyricSyllabicMode(syllabic);
     if (!normalized)
         return "*";
-    return buildAbcLyricTextToken(normalized, mode);
+    return shouldAppendAbcLyricHyphen(mode) ? `${normalized}-` : normalized;
 };
-const normalizeMusicXmlTypeName = (t) => String(t || "").trim();
+const normalizeMusicXmlTypeName = (t) => String(t !== null && t !== void 0 ? t : "").trim();
 const isSupportedMusicXmlTypeName = (typeName) => typeName === "16th" ||
     typeName === "32nd" ||
     typeName === "64th" ||
@@ -27339,20 +27019,14 @@ const isSupportedMusicXmlTypeName = (typeName) => typeName === "16th" ||
     typeName === "eighth";
 const normalizeTypeForMusicXml = (t) => {
     const raw = normalizeMusicXmlTypeName(t);
-    if (!raw)
-        return "quarter";
-    if (isSupportedMusicXmlTypeName(raw))
-        return raw;
-    return "quarter";
+    return raw && isSupportedMusicXmlTypeName(raw) ? raw : "quarter";
 };
-const normalizeMusicXmlVoiceText = (voice) => String(voice || "").trim();
+const normalizeMusicXmlVoiceText = (voice) => String(voice !== null && voice !== void 0 ? voice : "").trim();
 const isPositiveIntegerVoiceText = (voiceText) => /^[1-9]\d*$/.test(voiceText);
-const extractFirstVoiceNumberText = (voiceText) => { var _a; return ((_a = voiceText.match(/\d+/)) === null || _a === void 0 ? void 0 : _a[0]) || ""; };
+const extractFirstVoiceNumberText = (voiceText) => { var _a, _b; return (_b = (_a = voiceText.match(/\d+/)) === null || _a === void 0 ? void 0 : _a[0]) !== null && _b !== void 0 ? _b : ""; };
 const normalizeMusicXmlVoiceNumberText = (voiceNumberText) => {
     const n = Number(voiceNumberText);
-    if (!Number.isFinite(n) || n <= 0)
-        return "1";
-    return String(Math.round(n));
+    return Number.isFinite(n) && n > 0 ? String(Math.round(n)) : "1";
 };
 const normalizeVoiceForMusicXml = (voice) => {
     const raw = normalizeMusicXmlVoiceText(voice);
@@ -27361,9 +27035,7 @@ const normalizeVoiceForMusicXml = (voice) => {
     if (isPositiveIntegerVoiceText(raw))
         return raw;
     const numberText = extractFirstVoiceNumberText(raw);
-    if (!numberText)
-        return "1";
-    return normalizeMusicXmlVoiceNumberText(numberText);
+    return numberText ? normalizeMusicXmlVoiceNumberText(numberText) : "1";
 };
 const midiByStepForAbcImport = {
     C: 0,
@@ -27374,30 +27046,23 @@ const midiByStepForAbcImport = {
     A: 9,
     B: 11,
 };
-const normalizeAbcImportStep = (step) => String(step || "").trim().toUpperCase();
-const normalizeAbcImportOctave = (octave) => Number.isFinite(octave) ? Math.round(Number(octave)) : 4;
-const normalizeAbcImportAlter = (alter) => Number.isFinite(alter) ? Math.round(Number(alter)) : 0;
-const abcImportPitchToMidi = (step, octave, alter) => (octave + 1) * 12 + midiByStepForAbcImport[step] + alter;
-const noteToMidiForAbcClefInference = (note) => {
-    if (!note || note.isRest)
-        return null;
-    const step = normalizeAbcImportStep(note.step);
-    if (!Object.prototype.hasOwnProperty.call(midiByStepForAbcImport, step)) {
-        return null;
-    }
-    const octave = normalizeAbcImportOctave(note.octave);
-    const alter = normalizeAbcImportAlter(note.alter);
-    return abcImportPitchToMidi(step, octave, alter);
-};
-const normalizeAbcImportClefName = (clef) => String(clef || "").trim().toLowerCase();
+const normalizeAbcImportStep = (step) => String(step !== null && step !== void 0 ? step : "").trim().toUpperCase();
+const normalizeAbcImportClefName = (clef) => String(clef !== null && clef !== void 0 ? clef : "").trim().toLowerCase();
 const collectAbcImportClefMidiKeys = (part) => {
+    var _a;
     const keys = [];
-    for (const measure of (part === null || part === void 0 ? void 0 : part.measures) || []) {
-        for (const note of measure || []) {
-            const midi = noteToMidiForAbcClefInference(note);
-            if (Number.isFinite(midi)) {
-                keys.push(midi);
+    for (const measure of (_a = part === null || part === void 0 ? void 0 : part.measures) !== null && _a !== void 0 ? _a : []) {
+        for (const note of measure !== null && measure !== void 0 ? measure : []) {
+            if (!note || note.isRest) {
+                continue;
             }
+            const step = normalizeAbcImportStep(note.step);
+            if (!Object.prototype.hasOwnProperty.call(midiByStepForAbcImport, step)) {
+                continue;
+            }
+            const octave = Number.isFinite(Number(note.octave)) ? Math.round(Number(note.octave)) : 4;
+            const alter = Number.isFinite(Number(note.alter)) ? Math.round(Number(note.alter)) : 0;
+            keys.push((octave + 1) * 12 + midiByStepForAbcImport[step] + alter);
         }
     }
     return keys;
@@ -27405,163 +27070,29 @@ const collectAbcImportClefMidiKeys = (part) => {
 const abcImportClefNameFromMidiKeys = (keys) => (0, staffClefPolicy_1.chooseSingleClefByKeys)(keys) === "F" ? "bass" : "treble";
 const resolveAbcImportClef = (part) => {
     const explicit = normalizeAbcImportClefName(part === null || part === void 0 ? void 0 : part.clef);
+    const keys = collectAbcImportClefMidiKeys(part);
     if (explicit)
         return explicit;
-    const keys = collectAbcImportClefMidiKeys(part);
     if (!keys.length)
-        return "";
+        return explicit;
     return abcImportClefNameFromMidiKeys(keys);
 };
-const clefFeatureFromAbcClefName = (clef) => {
-    if (clef === "bass" || clef === "f") {
-        return { sign: "F", line: 4 };
-    }
-    if (clef === "alto" || clef === "c3") {
-        return { sign: "C", line: 3 };
-    }
-    if (clef === "tenor" || clef === "c4") {
-        return { sign: "C", line: 4 };
-    }
-    return { sign: "G", line: 2 };
+const clefFeatureByAbcClefName = {
+    bass: { sign: "F", line: 4 },
+    f: { sign: "F", line: 4 },
+    alto: { sign: "C", line: 3 },
+    c3: { sign: "C", line: 3 },
+    tenor: { sign: "C", line: 4 },
+    c4: { sign: "C", line: 4 },
+    treble: { sign: "G", line: 2 },
+    g: { sign: "G", line: 2 },
 };
-const clefXmlFromAbcClef = (rawClef) => {
-    const clef = normalizeAbcImportClefName(rawClef);
-    return (0, clefs_1.buildMusicXmlClefXml)(clefFeatureFromAbcClefName(clef));
-};
+const clefFeatureFromAbcClefName = (clef) => { var _a; return (_a = clefFeatureByAbcClefName[clef]) !== null && _a !== void 0 ? _a : { sign: "G", line: 2 }; };
+const clefXmlFromAbcClef = (rawClef) => (0, clefs_1.buildMusicXmlClefXml)(clefFeatureFromAbcClefName(normalizeAbcImportClefName(rawClef)));
 exports.clefXmlFromAbcClef = clefXmlFromAbcClef;
 const toHex = (value, width = 2) => {
-    const safe = Math.max(0, Math.round(Number(value) || 0));
+    const safe = Math.max(0, Math.round(Number(value !== null && value !== void 0 ? value : 0)));
     return `0x${safe.toString(16).toUpperCase().padStart(width, "0")}`;
-};
-const normalizeAbcDebugStep = (note) => note.isRest ? "R" : (/^[A-G]$/.test(String(note.step || "").toUpperCase()) ? String(note.step).toUpperCase() : "C");
-const normalizeAbcDebugOctave = (octave) => Number.isFinite(octave) ? Math.max(0, Math.min(9, Math.round(Number(octave)))) : 4;
-const normalizeAbcDebugAlter = (alter) => Number.isFinite(alter) ? Math.round(Number(alter)) : 0;
-const buildAbcMeasureDebugMiscXmlCoreFields = (index, measureNo, voice, note) => [`idx=${toHex(index, 4)}`, `m=${toHex(measureNo, 4)}`, `v=${xmlEscape(voice)}`].join(";");
-const buildAbcMeasureDebugMiscXmlNoteFields = (note, step, octave, alter, dur) => [
-    `r=${note.isRest ? "1" : "0"}`,
-    `g=${note.grace ? "1" : "0"}`,
-    `ch=${note.chord ? "1" : "0"}`,
-    `st=${step}`,
-    `al=${String(alter)}`,
-    `oc=${toHex(octave, 2)}`,
-    `dd=${toHex(dur, 4)}`,
-    `tp=${xmlEscape(normalizeTypeForMusicXml(note.type))}`,
-].join(";");
-const buildAbcMeasureDebugMiscXmlCountField = (noteCount) => `<miscellaneous-field name="mks:dbg:abc:meta:count">${toHex(noteCount, 4)}</miscellaneous-field>`;
-const buildAbcMeasureDebugMiscXmlEntry = (note, index, measureNo) => `<miscellaneous-field name="mks:dbg:abc:meta:${String(index + 1).padStart(4, "0")}">${buildAbcMeasureDebugMiscXmlPayload(note, index, measureNo)}</miscellaneous-field>`;
-const buildAbcMeasureDebugMiscXmlPayload = (note, index, measureNo) => {
-    const voice = normalizeVoiceForMusicXml(note.voice);
-    const step = normalizeAbcDebugStep(note);
-    const octave = normalizeAbcDebugOctave(note.octave);
-    const alter = normalizeAbcDebugAlter(note.alter);
-    const dur = note.grace ? 0 : Math.max(1, Math.round(Number(note.duration) || 1));
-    return [buildAbcMeasureDebugMiscXmlCoreFields(index, measureNo, voice, note), buildAbcMeasureDebugMiscXmlNoteFields(note, step, octave, alter, dur)].join(";");
-};
-const buildAbcMeasureDebugMiscXml = (notes, measureNo) => {
-    if (!notes.length)
-        return "";
-    let xml = "<attributes><miscellaneous>";
-    xml += buildAbcMeasureDebugMiscXmlCountField(notes.length);
-    xml += buildAbcMeasureDebugMiscXmlEntryParts(notes, measureNo).join("");
-    xml += "</miscellaneous></attributes>";
-    return xml;
-};
-const buildAbcMeasureDebugMiscXmlEntryParts = (notes, measureNo) => notes.map((note, index) => buildAbcMeasureDebugMiscXmlEntry(note, index, measureNo));
-const encodeAbcSourceForMiscXml = (abcSource) => String(abcSource !== null && abcSource !== void 0 ? abcSource : "")
-    .replace(/\\/g, "\\\\")
-    .replace(/\r/g, "\\r")
-    .replace(/\n/g, "\\n");
-const buildAbcSourceMiscXmlEncodingField = () => `<miscellaneous-field name="mks:src:abc:raw-encoding">escape-v1</miscellaneous-field>`;
-const buildAbcSourceMiscXmlLengthFields = (source, encoded) => buildAbcSourceMiscXmlLengthFieldParts(source, encoded).join("");
-const buildAbcSourceMiscXmlLengthFieldParts = (source, encoded) => [
-    buildAbcSourceMiscXmlRawLengthField(source),
-    buildAbcSourceMiscXmlRawEncodedLengthField(encoded),
-];
-const buildAbcSourceMiscXmlRawLengthField = (source) => `<miscellaneous-field name="mks:src:abc:raw-length">${xmlEscape(String(source.length))}</miscellaneous-field>`;
-const buildAbcSourceMiscXmlRawEncodedLengthField = (encoded) => `<miscellaneous-field name="mks:src:abc:raw-encoded-length">${xmlEscape(String(encoded.length))}</miscellaneous-field>`;
-const buildAbcSourceMiscXmlStateFields = (chunks, truncated) => buildAbcSourceMiscXmlStateFieldParts(chunks, truncated).join("");
-const buildAbcSourceMiscXmlStateFieldParts = (chunks, truncated) => [
-    buildAbcSourceMiscXmlChunkCountField(chunks),
-    buildAbcSourceMiscXmlTruncatedField(truncated),
-];
-const buildAbcSourceMiscXmlChunkCountField = (chunks) => `<miscellaneous-field name="mks:src:abc:raw-chunks">${xmlEscape(String(chunks.length))}</miscellaneous-field>`;
-const buildAbcSourceMiscXmlTruncatedField = (truncated) => `<miscellaneous-field name="mks:src:abc:raw-truncated">${truncated ? "1" : "0"}</miscellaneous-field>`;
-const buildAbcSourceMiscXmlChunkFields = (chunks) => {
-    return buildAbcSourceMiscXmlChunkFieldsXml(chunks);
-};
-const buildAbcSourceMiscXmlChunkFieldsXml = (chunks) => buildAbcSourceMiscXmlChunkEntryParts(chunks).join("");
-const buildAbcSourceMiscXmlChunkEntryParts = (chunks) => {
-    const chunkParts = [];
-    for (let i = 0; i < chunks.length; i += 1) {
-        chunkParts.push(buildAbcSourceMiscXmlChunkEntry(chunks[i], i));
-    }
-    return chunkParts;
-};
-const buildAbcSourceMiscXmlChunkEntry = (chunk, index) => `<miscellaneous-field name="mks:src:abc:raw-${String(index + 1).padStart(4, "0")}">${xmlEscape(chunk)}</miscellaneous-field>`;
-const buildAbcSourceMiscXmlChunks = (encoded) => {
-    const CHUNK_SIZE = 240;
-    const MAX_CHUNKS = 512;
-    const chunks = [];
-    for (let i = 0; i < encoded.length && chunks.length < MAX_CHUNKS; i += CHUNK_SIZE) {
-        chunks.push(encoded.slice(i, i + CHUNK_SIZE));
-    }
-    return chunks;
-};
-const buildAbcSourceMiscXmlBody = (source, encoded, chunks, truncated) => buildAbcSourceMiscXmlBodyFields(source, encoded, chunks, truncated).join("");
-const buildAbcSourceMiscXmlBodyFields = (source, encoded, chunks, truncated) => [...buildAbcSourceMiscXmlBodyHeaderFieldItems(source, encoded, chunks, truncated), ...buildAbcSourceMiscXmlBodyChunkFieldParts(chunks)];
-const buildAbcSourceMiscXmlBodyHeaderFieldItems = (source, encoded, chunks, truncated) => [
-    buildAbcSourceMiscXmlEncodingField(),
-    buildAbcSourceMiscXmlLengthFields(source, encoded),
-    buildAbcSourceMiscXmlStateFields(chunks, truncated),
-];
-const buildAbcSourceMiscXmlBodyChunkFieldParts = (chunks) => [buildAbcSourceMiscXmlChunkFields(chunks)];
-const buildAbcSourceMiscXml = (abcSource) => {
-    const source = String(abcSource !== null && abcSource !== void 0 ? abcSource : "");
-    if (!source.length)
-        return "";
-    const encoded = encodeAbcSourceForMiscXml(source);
-    const chunks = buildAbcSourceMiscXmlChunks(encoded);
-    const truncated = chunks.join("").length < encoded.length;
-    return `<attributes><miscellaneous>${buildAbcSourceMiscXmlBody(source, encoded, chunks, truncated)}</miscellaneous></attributes>`;
-};
-const buildAbcDiagMiscXmlPayload = (item) => {
-    return [...buildAbcDiagMiscXmlCoreFieldParts(item), ...buildAbcDiagMiscXmlOptionalFields(item)].join(";");
-};
-const buildAbcDiagMiscXmlCoreFieldParts = (item) => [`level=${item.level}`, `code=${item.code}`, `fmt=${item.fmt}`];
-const buildAbcDiagMiscXmlNumericOptionalFields = (item) => buildAbcDiagMiscXmlNumericOptionalFieldParts(item);
-const buildAbcDiagMiscXmlNumericOptionalFieldParts = (item) => [...buildAbcDiagMiscXmlMeasureOptionalParts(item.measure), ...buildAbcDiagMiscXmlMovedEventsOptionalParts(item.movedEvents)];
-const buildAbcDiagMiscXmlMeasureOptionalParts = (measure) => [Number.isFinite(measure) ? `measure=${Math.max(1, Math.round(Number(measure)))}` : ""].filter(Boolean);
-const buildAbcDiagMiscXmlMovedEventsOptionalParts = (movedEvents) => [Number.isFinite(movedEvents) ? `movedEvents=${Math.max(0, Math.round(Number(movedEvents)))}` : ""].filter(Boolean);
-const buildAbcDiagMiscXmlTextOptionalFields = (item) => buildAbcDiagMiscXmlTextOptionalFieldParts(item);
-const buildAbcDiagMiscXmlTextOptionalFieldParts = (item) => [
-    item.voiceId ? `voice=${xmlEscape(item.voiceId)}` : "",
-    item.action ? `action=${xmlEscape(item.action)}` : "",
-    item.message ? `message=${xmlEscape(item.message)}` : "",
-].filter(Boolean);
-const buildAbcDiagMiscXmlOptionalFields = (item) => buildAbcDiagMiscXmlOptionalFieldParts(item);
-const buildAbcDiagMiscXmlOptionalFieldParts = (item) => [...buildAbcDiagMiscXmlNumericOptionalFields(item), ...buildAbcDiagMiscXmlTextOptionalFields(item)];
-const buildAbcDiagMiscXmlEntry = (item, index) => `<miscellaneous-field name="${buildAbcDiagMiscXmlEntryName(index)}">${buildAbcDiagMiscXmlEntryPayload(item)}</miscellaneous-field>`;
-const buildAbcDiagMiscXmlEntryName = (index) => `mks:diag:${String(index + 1).padStart(4, "0")}`;
-const buildAbcDiagMiscXmlEntryPayload = (item) => buildAbcDiagMiscXmlPayload(item);
-const buildAbcDiagMiscXmlCountField = (maxEntries) => `<miscellaneous-field name="mks:diag:count">${maxEntries}</miscellaneous-field>`;
-const buildAbcDiagMiscXmlEntries = (diagnostics, maxEntries) => buildAbcDiagMiscXmlEntryList(diagnostics, maxEntries);
-const buildAbcDiagMiscXmlEntryList = (diagnostics, maxEntries) => buildAbcDiagMiscXmlEntryParts(diagnostics, maxEntries).join("");
-const buildAbcDiagMiscXmlEntryParts = (diagnostics, maxEntries) => {
-    const entryParts = [];
-    for (let i = 0; i < maxEntries; i += 1) {
-        entryParts.push(buildAbcDiagMiscXmlEntry(diagnostics[i], i));
-    }
-    return entryParts;
-};
-const buildAbcDiagMiscXml = (diagnostics) => {
-    if (!diagnostics.length)
-        return "";
-    const maxEntries = Math.min(256, diagnostics.length);
-    let xml = "<attributes><miscellaneous>";
-    xml += buildAbcDiagMiscXmlCountField(maxEntries);
-    xml += buildAbcDiagMiscXmlEntries(diagnostics, maxEntries);
-    xml += "</miscellaneous></attributes>";
-    return xml;
 };
 const prettyPrintXml = (xml) => {
     const compact = xml.replace(/>\s+</g, "><").trim();
@@ -27582,15 +27113,10 @@ const prettyPrintXml = (xml) => {
     }
     return lines.join("\n");
 };
-const resolveAbcParsedPartsForExport = (parts) => {
-    const safeParts = parts && parts.length > 0
-        ? parts
-        : [{ partId: "P1", partName: "Voice 1", measures: [[]] }];
-    return safeParts.map((part) => ({
-        ...part,
-        clef: resolveAbcImportClef(part),
-    }));
-};
+const resolveAbcParsedPartsForExport = (parts) => (parts && parts.length > 0 ? parts : [{ partId: "P1", partName: "Voice 1", measures: [[]] }]).map((part) => ({
+    ...part,
+    clef: resolveAbcImportClef(part),
+}));
 const buildAbcMusicXmlExportContext = (parsed) => {
     var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l;
     const resolvedParts = resolveAbcParsedPartsForExport(parsed.parts);
@@ -27622,37 +27148,43 @@ const buildAbcMusicXmlExportContext = (parsed) => {
         tempoBpm,
     };
 };
-const buildAbcScorePartwiseXmlDocument = (title, composer, partListXml, partBodyXml) => {
-    return [
-        '<?xml version="1.0" encoding="UTF-8"?>',
-        '<score-partwise version="4.0">',
-        `<work><work-title>${xmlEscape(title)}</work-title></work>`,
-        `<identification><creator type="composer">${xmlEscape(composer)}</creator></identification>`,
-        `<part-list>${partListXml}</part-list>`,
-        partBodyXml,
-        "</score-partwise>",
-    ].join("");
-};
-const buildMusicXmlFromAbcParsed = (parsed, abcSource, options = {}) => {
-    var _a, _b, _c;
-    const debugMetadata = (_a = options.debugMetadata) !== null && _a !== void 0 ? _a : true;
-    const sourceMetadata = (_b = options.sourceMetadata) !== null && _b !== void 0 ? _b : true;
-    const debugPrettyPrint = (_c = options.debugPrettyPrint) !== null && _c !== void 0 ? _c : debugMetadata;
-    const exportContext = buildAbcMusicXmlExportContext(parsed);
-    const buildMeasureNotesXml = (notes, staffOverride = null) => buildAbcMeasureNotesXml(notes, exportContext.measureDurationDiv, exportContext.emptyMeasureRestType, exportContext.beatDiv, staffOverride);
-    const partListXml = buildAbcPartListXml(exportContext.resolvedParts);
-    const partBodyXml = buildAbcPartBodyXml(exportContext.resolvedParts, exportContext.measureCount, exportContext.defaultFifths, exportContext.beats, exportContext.beatType, exportContext.tempoBpm, debugMetadata, sourceMetadata, parsed.diagnostics, abcSource, buildMeasureNotesXml);
-    const xml = buildAbcScorePartwiseXmlDocument(exportContext.title, exportContext.composer, partListXml, partBodyXml);
-    return debugPrettyPrint ? prettyPrintXml(xml) : xml;
-};
+const buildAbcScorePartwiseXmlDocument = (title, composer, partListXml, partBodyXml) => [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<score-partwise version="4.0">',
+    `<work><work-title>${xmlEscape(title)}</work-title></work>`,
+    `<identification><creator type="composer">${xmlEscape(composer)}</creator></identification>`,
+    `<part-list>${partListXml}</part-list>`,
+    partBodyXml,
+    "</score-partwise>",
+].join("");
 const convertAbcToMusicXml = (abcSource, options = {}) => {
+    var _a, _b, _c;
     const parsed = exports.AbcCompatParser.parseForMusicXml(abcSource, {
         defaultTitle: "mikuscore",
         defaultComposer: "Unknown",
         inferTransposeFromPartName: true,
         overfullCompatibilityMode: options.overfullCompatibilityMode !== false,
     });
-    return buildMusicXmlFromAbcParsed(parsed, abcSource, options);
+    const debugMetadata = (_a = options.debugMetadata) !== null && _a !== void 0 ? _a : true;
+    const sourceMetadata = (_b = options.sourceMetadata) !== null && _b !== void 0 ? _b : true;
+    const debugPrettyPrint = (_c = options.debugPrettyPrint) !== null && _c !== void 0 ? _c : debugMetadata;
+    const exportContext = buildAbcMusicXmlExportContext(parsed);
+    const buildMeasureNotesXml = (notes, staffOverride = null) => buildAbcMeasureNotesXml(notes, exportContext.measureDurationDiv, exportContext.emptyMeasureRestType, exportContext.beatDiv, staffOverride);
+    const partBodyXml = exportContext.resolvedParts
+        .map((part, partIndex) => buildAbcPartXml(part, partIndex, exportContext.measureCount, exportContext.defaultFifths, exportContext.beats, exportContext.beatType, exportContext.tempoBpm, debugMetadata, sourceMetadata, parsed.diagnostics, abcSource, buildMeasureNotesXml))
+        .join("");
+    const xml = buildAbcScorePartwiseXmlDocument(exportContext.title, exportContext.composer, exportContext.resolvedParts
+        .map((part, index) => [
+        `<score-part id="${xmlEscape(part.partId)}">`,
+        `<part-name>${xmlEscape(part.partName || part.partId)}</part-name>`,
+        `<midi-instrument id="${xmlEscape(part.partId)}-I1">`,
+        `<midi-channel>${((index % 16) + 1 === 10) ? 11 : ((index % 16) + 1)}</midi-channel>`,
+        `<midi-program>6</midi-program>`,
+        "</midi-instrument>",
+        "</score-part>",
+    ].join(""))
+        .join(""), partBodyXml);
+    return debugPrettyPrint ? prettyPrintXml(xml) : xml;
 };
 exports.convertAbcToMusicXml = convertAbcToMusicXml;
 

--- a/src/ts/abc-io.ts
+++ b/src/ts/abc-io.ts
@@ -1247,13 +1247,83 @@ const buildAbcRenderedPartMeasureXml = (
         return chunks.length > 0 ? `<barline location="right">${chunks.join("")}</barline>` : "";
       })()
     : "";
-  const debugMiscXml = debugMetadata ? buildAbcMeasureDebugMiscXml(notes, measureNo) : "";
-  const diagMiscXml = buildAbcDiagMiscXml(
+  const debugMiscXml = debugMetadata
+    ? `<attributes><miscellaneous><miscellaneous-field name="mks:dbg:abc:meta:count">${toHex(notes.length, 4)}</miscellaneous-field>${notes
+        .map(
+          (note, index) =>
+            `<miscellaneous-field name="mks:dbg:abc:meta:${String(index + 1).padStart(4, "0")}">${[
+              [
+                `idx=${toHex(index, 4)}`,
+                `m=${toHex(measureNo, 4)}`,
+                `v=${xmlEscape(normalizeVoiceForMusicXml(note.voice))}`,
+              ].join(";"),
+              [
+                `r=${note.isRest ? "1" : "0"}`,
+                `g=${note.grace ? "1" : "0"}`,
+                `ch=${note.chord ? "1" : "0"}`,
+                `st=${note.isRest ? "R" : (/^[A-G]$/.test(String(note.step ?? "").toUpperCase()) ? String(note.step).toUpperCase() : "C")}`,
+                `al=${String(Number.isFinite(Number(note.alter)) ? Math.round(Number(note.alter)) : 0)}`,
+                `oc=${toHex(Number.isFinite(Number(note.octave)) ? Math.max(0, Math.min(9, Math.round(Number(note.octave)))) : 4, 2)}`,
+                `dd=${toHex(note.grace ? 0 : Math.max(1, Math.round(Number(note.duration) || 1)), 4)}`,
+                `tp=${xmlEscape(normalizeTypeForMusicXml(note.type))}`,
+              ].join(";"),
+            ].join(";")}</miscellaneous-field>`,
+        )
+        .join("")}</miscellaneous></attributes>`
+    : "";
+  const diagMiscNotes =
     partIndex === 0 && measureNo === 1
       ? (diagnostics ?? []).filter((diag) => !diag.voiceId || diag.voiceId === (part.voiceId ?? ""))
-      : []
-  );
-  const sourceMiscXml = sourceMetadata && partIndex === 0 && measureNo === 1 ? buildAbcSourceMiscXml(abcSource) : "";
+      : [];
+  const diagMiscXml = diagMiscNotes.length
+    ? `<attributes><miscellaneous><miscellaneous-field name="mks:diag:count">${Math.min(256, diagMiscNotes.length)}</miscellaneous-field>${Array.from(
+        { length: Math.min(256, diagMiscNotes.length) },
+        (_, i) =>
+          `<miscellaneous-field name="mks:diag:${String(i + 1).padStart(4, "0")}">${[
+            `level=${diagMiscNotes[i].level}`,
+            `code=${diagMiscNotes[i].code}`,
+            `fmt=${diagMiscNotes[i].fmt}`,
+            ...(diagMiscNotes[i].measure !== undefined && Number.isFinite(diagMiscNotes[i].measure)
+              ? [`measure=${Math.max(1, Math.round(Number(diagMiscNotes[i].measure)))}`]
+              : []),
+            ...(diagMiscNotes[i].movedEvents !== undefined && Number.isFinite(diagMiscNotes[i].movedEvents)
+              ? [`movedEvents=${Math.max(0, Math.round(Number(diagMiscNotes[i].movedEvents)))}`]
+              : []),
+            ...(diagMiscNotes[i].voiceId ? [`voice=${xmlEscape(diagMiscNotes[i].voiceId)}`] : []),
+            ...(diagMiscNotes[i].action ? [`action=${xmlEscape(diagMiscNotes[i].action)}`] : []),
+            ...(diagMiscNotes[i].message ? [`message=${xmlEscape(diagMiscNotes[i].message)}`] : []),
+          ].join(";")}</miscellaneous-field>`,
+      ).join("")}</miscellaneous></attributes>`
+    : "";
+  const sourceMiscXml =
+    sourceMetadata && partIndex === 0 && measureNo === 1
+      ? (() => {
+          const source = String(abcSource ?? "");
+          if (!source.length) return "";
+          const encoded = source
+            .replace(/\\/g, "\\\\")
+            .replace(/\r/g, "\\r")
+            .replace(/\n/g, "\\n");
+          const CHUNK_SIZE = 240;
+          const MAX_CHUNKS = 512;
+          const chunks: string[] = [];
+          for (let i = 0; i < encoded.length && chunks.length < MAX_CHUNKS; i += CHUNK_SIZE) {
+            chunks.push(encoded.slice(i, i + CHUNK_SIZE));
+          }
+          const truncated = chunks.join("").length < encoded.length;
+          return `<attributes><miscellaneous>${[
+            `<miscellaneous-field name="mks:src:abc:raw-encoding">escape-v1</miscellaneous-field>`,
+            `<miscellaneous-field name="mks:src:abc:raw-length">${xmlEscape(String(source.length))}</miscellaneous-field>`,
+            `<miscellaneous-field name="mks:src:abc:raw-encoded-length">${xmlEscape(String(encoded.length))}</miscellaneous-field>`,
+            `<miscellaneous-field name="mks:src:abc:raw-chunks">${xmlEscape(String(chunks.length))}</miscellaneous-field>`,
+            `<miscellaneous-field name="mks:src:abc:raw-truncated">${truncated ? "1" : "0"}</miscellaneous-field>`,
+            ...chunks.map(
+              (chunk, index) =>
+                `<miscellaneous-field name="mks:src:abc:raw-${String(index + 1).padStart(4, "0")}">${xmlEscape(chunk)}</miscellaneous-field>`,
+            ),
+          ].join("")}</miscellaneous></attributes>`;
+        })()
+      : "";
   const xmlMeasureNumber = xmlEscape(String(measureMeta?.number || measureNo));
   const implicitAttr = measureMeta?.implicit || inferredImplicitPickup ? ' implicit="yes"' : "";
   return `<measure number="${xmlMeasureNumber}"${implicitAttr}>${repeatStartXml}${headerXml}${tempoDirectionXml}${debugMiscXml}${diagMiscXml}${sourceMiscXml}${notesXml}${repeatEndXml}</measure>`;
@@ -1327,422 +1397,6 @@ const buildAbcPartXml = (
   return `<part id="${xmlEscape(part.partId)}">${measureParts.join("")}</part>`;
 };
 
-const buildAbcNoteHarmonyAndWordsDirectionXml = (note: AbcParsedNote): string =>
-  note.chord
-    ? ""
-    : buildAbcNoteOptionalXmlParts([
-        note.chordSymbols?.map((chordSymbol) => buildHarmonyXmlFromChordSymbol(chordSymbol) || buildMusicXmlWordsDirectionXml({ text: String(chordSymbol) })).join("") ?? "",
-        note.annotations?.filter((annotation) => annotation.trim().length > 0).map((annotation) => buildMusicXmlWordsDirectionXml({ text: String(annotation) })).join("") ?? "",
-      ]).join("");
-
-const buildAbcNoteControlDirectionXml = (note: AbcParsedNote): string =>
-  buildAbcNoteControlDirectionXmlParts(note).join("");
-
-const buildAbcNoteControlDirectionXmlParts = (note: AbcParsedNote): string[] => [
-  ...buildAbcNoteMarkerDirectionXmlParts(note),
-  ...buildAbcNoteJumpDirectionXmlParts(note),
-  ...buildAbcNoteExpressionDirectionXmlParts(note),
-];
-
-const buildAbcNoteMarkerDirectionXmlParts = (note: AbcParsedNote): string[] => [
-  ...buildAbcNoteMarkerSegnoXmlParts(note),
-  ...buildAbcNoteMarkerCodaXmlParts(note),
-  ...buildAbcNoteMarkerRehearsalXmlParts(note),
-];
-
-const buildAbcNoteMarkerSegnoXmlParts = (note: AbcParsedNote): string[] =>
-  note.segno ? ["<direction><direction-type><segno/></direction-type></direction>"] : [];
-
-const buildAbcNoteMarkerCodaXmlParts = (note: AbcParsedNote): string[] =>
-  note.coda ? ["<direction><direction-type><coda/></direction-type></direction>"] : [];
-
-const buildAbcNoteMarkerRehearsalXmlParts = (note: AbcParsedNote): string[] =>
-  note.rehearsalMark
-    ? [`<direction><direction-type><rehearsal>${xmlEscape(String(note.rehearsalMark))}</rehearsal></direction-type></direction>`]
-    : [];
-
-const buildAbcNoteJumpDirectionXmlParts = (note: AbcParsedNote): string[] => [
-  ...buildAbcNoteFineJumpXmlParts(note),
-  ...buildAbcNoteDaCapoJumpXmlParts(note),
-  ...buildAbcNoteDalSegnoJumpXmlParts(note),
-  ...buildAbcNoteToCodaJumpXmlParts(note),
-];
-
-const buildAbcNoteFineJumpXmlParts = (note: AbcParsedNote): string[] =>
-  note.fine ? ['<direction><sound fine="yes"/></direction>'] : [];
-
-const buildAbcNoteDaCapoJumpXmlParts = (note: AbcParsedNote): string[] =>
-  note.daCapo ? ['<direction><sound dacapo="yes"/></direction>'] : [];
-
-const buildAbcNoteDalSegnoJumpXmlParts = (note: AbcParsedNote): string[] =>
-  note.dalSegno ? ['<direction><sound dalsegno="segno"/></direction>'] : [];
-
-const buildAbcNoteToCodaJumpXmlParts = (note: AbcParsedNote): string[] =>
-  note.toCoda ? ['<direction><sound tocoda="coda"/></direction>'] : [];
-
-const buildAbcNoteExpressionDirectionXmlParts = (note: AbcParsedNote): string[] =>
-  buildAbcNoteOptionalXmlParts([
-    buildAbcNoteWedgeDirectionXmlPart(note),
-    buildAbcNoteDynamicDirectionXmlPart(note),
-    buildAbcNoteSfzDirectionXmlPart(note),
-  ]);
-
-const buildAbcNoteWedgeDirectionXmlPart = (note: AbcParsedNote): string =>
-  note.crescendoStart
-    ? buildMusicXmlDirectionFeatureXml({ kind: "wedge", wedgeType: "crescendo" })
-    : note.diminuendoStart
-      ? buildMusicXmlDirectionFeatureXml({ kind: "wedge", wedgeType: "diminuendo" })
-      : note.crescendoStop || note.diminuendoStop
-        ? buildMusicXmlDirectionFeatureXml({ kind: "wedge", wedgeType: "stop" })
-        : "";
-
-const buildAbcNoteDynamicDirectionXmlPart = (note: AbcParsedNote): string =>
-  note.dynamicMark
-    ? (() => {
-        const dynamicMark = normalizeDynamicMark(String(note.dynamicMark));
-        return dynamicMark ? buildMusicXmlDirectionFeatureXml({ kind: "dynamic", mark: dynamicMark }) : "";
-      })()
-    : "";
-
-const buildAbcNoteSfzDirectionXmlPart = (note: AbcParsedNote): string =>
-  note.sfz ? buildMusicXmlDirectionFeatureXml({ kind: "dynamic", mark: "sfz" }) : "";
-
-const buildAbcNoteLeadingDirectionXml = (note: AbcParsedNote): string =>
-  note.chord
-    ? ""
-    : buildAbcNoteOptionalXmlParts([
-        note.chordSymbols?.map((chordSymbol) => buildHarmonyXmlFromChordSymbol(chordSymbol) || buildMusicXmlWordsDirectionXml({ text: String(chordSymbol) })).join("") ?? "",
-        note.annotations?.filter((annotation) => annotation.trim().length > 0).map((annotation) => buildMusicXmlWordsDirectionXml({ text: String(annotation) })).join("") ?? "",
-        ...buildAbcNoteControlDirectionXmlParts(note),
-      ]).join("");
-
-const buildAbcNotePitchOrRestXml = (note: AbcParsedNote): string =>
-  buildAbcNotePitchOrRestXmlParts(note).join("");
-
-const buildAbcNotePitchOrRestXmlParts = (note: AbcParsedNote): string[] =>
-  note.isRest ? [buildAbcNoteRestXmlPart()] : [buildAbcNotePitchXmlPart(note)];
-
-const buildAbcNoteRestXmlPart = (): string => "<rest/>";
-
-const buildAbcNotePitchXmlPart = (note: AbcParsedNote): string =>
-  buildMusicXmlPitchXml({
-    step: note.step,
-    alter: note.alter,
-    octave: note.octave,
-  });
-
-const buildAbcNoteLyricXml = (note: AbcParsedNote): string =>
-  buildMusicXmlLyricXml({
-    text: note.lyricText,
-    syllabic: note.lyricSyllabic || "single",
-    extend: note.lyricExtend,
-  });
-
-const buildAbcNoteTimeModificationXml = (note: AbcParsedNote): string =>
-  buildMusicXmlTimeModificationXml({
-    actualNotes: note.timeModification?.actual,
-    normalNotes: note.timeModification?.normal,
-  });
-
-const buildAbcNoteAccidentalXml = (note: AbcParsedNote): string =>
-  buildMusicXmlAccidentalXml({
-    text: note.accidentalText,
-    editorial: note.accidentalEditorial,
-    cautionary: note.accidentalCautionary,
-  });
-
-const buildAbcNoteCoreOpenXmlParts = (note: AbcParsedNote, staffOverride: number | null): string[] => [
-  ...buildAbcNoteCoreHeaderXmlParts(note),
-  ...buildAbcNoteCorePitchAndDurationXmlParts(note),
-  ...buildAbcNoteCoreIdentityXmlParts(note, staffOverride),
-];
-
-const buildAbcNoteCoreHeaderXmlParts = (note: AbcParsedNote): string[] => [
-  buildAbcNoteCoreNoteStartXmlPart(),
-  ...buildAbcNoteCoreChordXmlParts(note),
-  ...buildAbcNoteCoreGraceXmlParts(note),
-];
-
-const buildAbcNoteCoreNoteStartXmlPart = (): string => "<note>";
-
-const buildAbcNoteCoreChordXmlParts = (note: AbcParsedNote): string[] =>
-  note.chord ? ["<chord/>"] : [];
-
-const buildAbcNoteCoreGraceXmlParts = (note: AbcParsedNote): string[] =>
-  note.grace ? [buildMusicXmlGraceXml({ slash: note.graceSlash })] : [];
-
-const buildAbcNoteCorePitchAndDurationXmlParts = (note: AbcParsedNote): string[] => [
-  buildAbcNotePitchOrRestXml(note),
-  ...buildAbcNoteCoreDurationXmlParts(note),
-];
-
-const buildAbcNoteCoreDurationXmlParts = (note: AbcParsedNote): string[] =>
-  note.grace ? [] : [buildAbcNoteCoreDurationXmlPart(note)];
-
-const buildAbcNoteCoreDurationXmlPart = (note: AbcParsedNote): string =>
-  buildAbcNoteCoreDurationXmlFromValuePart(buildAbcNoteCoreDurationValuePart(note));
-
-const buildAbcNoteCoreDurationValuePart = (note: AbcParsedNote): number => Math.max(1, Math.round(Number(note.duration) || 1));
-
-const buildAbcNoteCoreDurationXmlFromValuePart = (durationValue: number): string => `<duration>${durationValue}</duration>`;
-
-const buildAbcNoteCoreIdentityXmlParts = (note: AbcParsedNote, staffOverride: number | null): string[] => [
-  ...buildAbcNoteCorePlacementIdentityXmlParts(note, staffOverride),
-  ...buildAbcNoteCoreTextIdentityXmlParts(note),
-];
-
-const buildAbcNoteCorePlacementIdentityXmlParts = (
-  note: AbcParsedNote,
-  staffOverride: number | null
-): string[] => {
-  const staffXmlPart = buildAbcNoteCoreStaffXmlPart(note, staffOverride);
-  return [buildAbcNoteCoreVoiceXmlPart(note), ...(staffXmlPart ? [staffXmlPart] : [])];
-};
-
-const buildAbcNoteCoreTextIdentityXmlParts = (note: AbcParsedNote): string[] => [
-  buildAbcNoteLyricXml(note),
-  buildAbcNoteCoreTypeXmlPart(note),
-];
-
-const buildAbcNoteCoreVoiceXmlPart = (note: AbcParsedNote): string =>
-  `<voice>${xmlEscape(normalizeVoiceForMusicXml(note.voice))}</voice>`;
-
-const buildAbcNoteCoreStaffXmlPart = (note: AbcParsedNote, staffOverride: number | null): string => {
-  const staffValue = buildAbcNoteCoreStaffValuePart(note, staffOverride);
-  return staffValue ? buildAbcNoteCoreStaffXmlFromValuePart(staffValue) : "";
-};
-
-const buildAbcNoteCoreStaffValuePart = (note: AbcParsedNote, staffOverride: number | null): number | null => {
-  const staff = Number(note.staff);
-  return staffOverride ?? (Number.isFinite(staff) ? Math.max(1, Math.round(staff || 1)) : null);
-};
-
-const buildAbcNoteCoreStaffXmlFromValuePart = (staffValue: number): string => `<staff>${staffValue}</staff>`;
-
-const buildAbcNoteCoreTypeXmlPart = (note: AbcParsedNote): string => `<type>${normalizeTypeForMusicXml(note.type)}</type>`;
-
-const buildAbcNoteCoreBeamPart = (
-  note: AbcParsedNote,
-  noteIndex: number,
-  beamXmlByNoteIndex: Map<number, string>
-): string =>
-  !note.chord && beamXmlByNoteIndex.has(noteIndex) ? String(beamXmlByNoteIndex.get(noteIndex)) : "";
-
-const buildAbcNoteCoreTailXmlParts = (note: AbcParsedNote): string[] => [
-  ...buildAbcNoteCoreNotationTailXmlParts(note),
-  ...buildAbcNoteCoreTieItemsXmlParts(note),
-];
-
-const buildAbcNoteCoreNotationTailXmlParts = (note: AbcParsedNote): string[] => [
-  buildAbcNoteTimeModificationXml(note),
-  buildAbcNoteAccidentalXml(note),
-];
-
-const buildAbcNoteCoreTieItemsXmlParts = (note: AbcParsedNote): string[] => [
-  buildMusicXmlTieItemsXml({
-    tieStart: !!note.tieStart,
-    tieStop: !!note.tieStop,
-  }),
-];
-
-const buildAbcNoteOrnamentsXml = (note: AbcParsedNote): string =>
-  [
-    ...buildAbcNoteOrnamentsFeatureXmlParts(note),
-    ...buildAbcNoteOrnamentsMotionXmlParts(note),
-  ].join("");
-
-const buildAbcNoteOrnamentsFeatureXmlParts = (note: AbcParsedNote): string[] =>
-  buildAbcNoteOptionalXmlParts([
-    buildAbcNoteOrnamentsWavyLinePart(note),
-    buildAbcNoteOrnamentsTurnPart(note),
-    buildAbcNoteOrnamentsMordentPart(note),
-    buildAbcNoteOrnamentsTremoloPart(note),
-    buildAbcNoteOrnamentsSchleiferPart(note),
-    buildAbcNoteOrnamentsShakePart(note),
-  ]);
-
-const buildAbcNoteOrnamentsMotionXmlParts = (note: AbcParsedNote): string[] =>
-  buildAbcNoteOptionalXmlParts([
-    buildAbcNoteOrnamentsGlissandoXmlPart(note),
-    buildAbcNoteOrnamentsSlideXmlPart(note),
-    buildAbcNoteOrnamentsArpeggiatePart(note),
-  ]);
-
-const buildAbcNoteOrnamentsGlissandoXmlPart = (note: AbcParsedNote): string =>
-  buildAbcNotePairedXmlParts(buildAbcNoteOrnamentsGlissandoStartPart(note), buildAbcNoteOrnamentsGlissandoStopPart(note));
-
-const buildAbcNoteOrnamentsGlissandoStartPart = (note: AbcParsedNote): string =>
-  note.glissandoStart ? '<glissando type="start" number="1">wavy</glissando>' : "";
-
-const buildAbcNoteOrnamentsGlissandoStopPart = (note: AbcParsedNote): string =>
-  note.glissandoStop ? '<glissando type="stop" number="1">wavy</glissando>' : "";
-
-const buildAbcNoteOrnamentsSlideXmlPart = (note: AbcParsedNote): string =>
-  buildAbcNotePairedXmlParts(buildAbcNoteOrnamentsSlideStartPart(note), buildAbcNoteOrnamentsSlideStopPart(note));
-
-const buildAbcNoteOrnamentsSlideStartPart = (note: AbcParsedNote): string =>
-  note.slideStart ? '<slide type="start" number="1"/>' : "";
-
-const buildAbcNoteOrnamentsSlideStopPart = (note: AbcParsedNote): string =>
-  note.slideStop ? '<slide type="stop" number="1"/>' : "";
-
-const buildAbcNoteOrnamentsArpeggiatePart = (note: AbcParsedNote): string =>
-  note.arpeggiate ? "<arpeggiate/>" : "";
-
-const buildAbcNotePairedXmlParts = (startPart: string, stopPart: string): string =>
-  [startPart, stopPart].join("");
-
-const buildAbcNoteOptionalXmlParts = (parts: string[]): string[] => parts.filter((part) => part.length > 0);
-
-const buildAbcNoteOrnamentsWavyLinePart = (note: AbcParsedNote): string =>
-  buildAbcNoteWrappedXml(
-    "ornaments",
-    buildAbcNoteOptionalXmlParts([
-      buildAbcNoteOrnamentsTrillMarkPart(note),
-      buildAbcNoteOrnamentsWavyLineMotionPart(note),
-      buildAbcNoteOrnamentsTrillAccidentalMarkPart(note),
-    ])
-  );
-
-const buildAbcNoteOrnamentsTrillMarkPart = (note: AbcParsedNote): string =>
-  note.trill ? buildMusicXmlOrnamentItemsXml([{ kind: "trill-mark" }]) : "";
-
-const buildAbcNoteOrnamentsWavyLineMotionPart = (note: AbcParsedNote): string =>
-  note.trillLineStop ? '<wavy-line type="stop"/>' : note.trillLineStart ? '<wavy-line type="start"/>' : "";
-
-const buildAbcNoteOrnamentsTrillAccidentalMarkPart = (note: AbcParsedNote): string =>
-  note.trillAccidentalText ? `<accidental-mark>${xmlEscape(String(note.trillAccidentalText))}</accidental-mark>` : "";
-
-const buildAbcNoteOrnamentsTurnPart = (note: AbcParsedNote): string =>
-  note.turnType ? buildMusicXmlOrnamentsXml(buildAbcNoteOrnamentsTurnItems(note)) : "";
-
-const buildAbcNoteOrnamentsTurnItems = (note: AbcParsedNote): AbcExportOrnamentFeature[] => [
-  buildAbcNoteOrnamentsTurnMainItem(note),
-  ...(note.delayedTurn ? [buildAbcNoteOrnamentsDelayedTurnItem()] : []),
-];
-
-const buildAbcNoteOrnamentsTurnMainItem = (note: AbcParsedNote): AbcExportOrnamentFeature => ({
-  kind: note.turnType === "inverted-turn" ? "inverted-turn" : "turn",
-  ...(note.turnSlash ? { slash: true } : {}),
-});
-
-const buildAbcNoteOrnamentsDelayedTurnItem = (): AbcExportOrnamentFeature => ({ kind: "delayed-turn" });
-
-const buildAbcNoteOrnamentsMordentPart = (note: AbcParsedNote): string =>
-  note.mordentType ? buildMusicXmlOrnamentsXml([buildAbcNoteOrnamentsMordentItem(note)]) : "";
-
-const buildAbcNoteOrnamentsMordentItem = (note: AbcParsedNote): AbcExportOrnamentFeature => ({
-  kind: note.mordentType === "inverted-mordent" ? "inverted-mordent" : "mordent",
-});
-
-const buildAbcNoteOrnamentsTremoloPart = (note: AbcParsedNote): string =>
-  note.tremoloType ? buildMusicXmlOrnamentsXml([buildAbcNoteOrnamentsTremoloItem(note)]) : "";
-
-const buildAbcNoteOrnamentsTremoloItem = (note: AbcParsedNote): AbcExportOrnamentFeature => ({
-  kind: "tremolo",
-  tremoloType: note.tremoloType,
-  marks: note.tremoloMarks,
-});
-
-const buildAbcNoteOrnamentsSchleiferPart = (note: AbcParsedNote): string =>
-  note.schleifer ? buildMusicXmlOrnamentsXml([buildAbcNoteOrnamentsSchleiferItem()]) : "";
-
-const buildAbcNoteOrnamentsShakePart = (note: AbcParsedNote): string =>
-  note.shake ? buildMusicXmlOrnamentsXml([buildAbcNoteOrnamentsShakeItem()]) : "";
-
-const buildAbcNoteOrnamentsSchleiferItem = (): AbcExportOrnamentFeature => ({ kind: "schleifer" });
-
-const buildAbcNoteOrnamentsShakeItem = (): AbcExportOrnamentFeature => ({ kind: "shake" });
-
-const buildAbcNoteArticulationsXml = (note: AbcParsedNote): string =>
-  buildAbcNoteWrappedXml(
-    "articulations",
-    buildAbcNoteOptionalXmlParts([
-      buildAbcNoteArticulationFeatureItemsXml(note),
-      ...buildAbcNoteArticulationDecorativeXmlParts(note),
-    ])
-  );
-
-const buildAbcNoteArticulationDecorativeXmlParts = (note: AbcParsedNote): string[] =>
-  buildAbcNoteOptionalXmlParts([
-    note.stress ? "<stress/>" : "",
-    note.unstress ? "<unstress/>" : "",
-    note.phraseMark ? `<other-articulation>${xmlEscape(String(note.phraseMark))}</other-articulation>` : "",
-  ]);
-
-const buildAbcNoteArticulationFeatureItemsXml = (note: AbcParsedNote): string =>
-  buildMusicXmlArticulationItemsXml(buildAbcNoteArticulationFeatureKinds(note));
-
-const buildAbcNoteArticulationFeatureKinds = (note: AbcParsedNote): string[] => [
-  ...buildAbcNoteArticulationPrimaryKinds(note),
-  ...buildAbcNoteArticulationSecondaryKinds(note),
-];
-
-const buildAbcNoteArticulationPrimaryKinds = (note: AbcParsedNote): string[] =>
-  buildAbcNoteOptionalXmlParts([
-    note.staccato ? "staccato" : "",
-    note.staccatissimo ? "staccatissimo" : "",
-    note.accent ? "accent" : "",
-    note.tenuto ? "tenuto" : "",
-  ]);
-
-const buildAbcNoteArticulationSecondaryKinds = (note: AbcParsedNote): string[] =>
-  buildAbcNoteOptionalXmlParts([
-    note.strongAccent ? "strong-accent" : "",
-    note.breathMark ? "breath-mark" : "",
-    note.caesura ? "caesura" : "",
-  ]);
-
-const buildAbcNoteTechnicalPlainParts = (note: AbcParsedNote): string[] => [
-  ...buildAbcNoteTechnicalBowParts(note),
-  ...buildAbcNoteTechnicalFootParts(note),
-];
-
-const buildAbcNoteTechnicalBowParts = (note: AbcParsedNote): string[] =>
-  buildAbcNoteOptionalXmlParts([
-    note.upBow ? "<up-bow/>" : "",
-    note.downBow ? "<down-bow/>" : "",
-    note.doubleTongue ? "<double-tongue/>" : "",
-    note.tripleTongue ? "<triple-tongue/>" : "",
-  ]);
-
-const buildAbcNoteTechnicalFootParts = (note: AbcParsedNote): string[] =>
-  buildAbcNoteOptionalXmlParts([
-    note.heel ? "<heel/>" : "",
-    note.toe ? "<toe/>" : "",
-  ]);
-
-const buildAbcNoteTechnicalCollectionParts = (note: AbcParsedNote): string[] =>
-  buildAbcNoteMergedXmlParts(
-    note.fingerings ? note.fingerings.map((fingering) => buildMusicXmlFingeringXml(fingering)) : [],
-    note.strings ? note.strings.map((stringText) => buildMusicXmlStringNumberXml(stringText)) : [],
-    note.plucks ? note.plucks.map((pluckText) => (pluckText ? `<pluck>${xmlEscape(pluckText)}</pluck>` : "")) : []
-  );
-
-const buildAbcNoteTechnicalFlagParts = (note: AbcParsedNote): string[] =>
-  buildAbcNoteOptionalXmlParts([
-    buildAbcNoteTechnicalOpenStringFlagPart(note),
-    buildAbcNoteTechnicalSnapPizzicatoFlagPart(note),
-    buildAbcNoteTechnicalHarmonicFlagPart(note),
-    buildAbcNoteTechnicalStoppedFlagPart(note),
-    buildAbcNoteTechnicalThumbPositionFlagPart(note),
-  ]);
-
-const buildAbcNoteTechnicalOpenStringFlagPart = (note: AbcParsedNote): string =>
-  note.openString ? "<open-string/>" : "";
-
-const buildAbcNoteTechnicalSnapPizzicatoFlagPart = (note: AbcParsedNote): string =>
-  note.snapPizzicato ? "<snap-pizzicato/>" : "";
-
-const buildAbcNoteTechnicalHarmonicFlagPart = (note: AbcParsedNote): string =>
-  note.harmonic ? "<harmonic/>" : "";
-
-const buildAbcNoteTechnicalStoppedFlagPart = (note: AbcParsedNote): string =>
-  note.stopped ? "<stopped/>" : "";
-
-const buildAbcNoteTechnicalThumbPositionFlagPart = (note: AbcParsedNote): string =>
-  note.thumbPosition ? "<thumb-position/>" : "";
-
 const hasAbcNoteNotations = (note: AbcParsedNote): boolean =>
   hasAbcNoteTieOrSlurNotations(note) ||
   hasAbcNoteOrnaments(note) ||
@@ -1788,59 +1442,6 @@ const hasAbcNoteTechnicalFlagNotations = (note: AbcParsedNote): boolean =>
 const hasAbcNoteFermataNotation = (note: AbcParsedNote): boolean => !!note.fermataType;
 
 const hasAbcNoteTupletNotations = (note: AbcParsedNote): boolean => !!(note.tupletStart || note.tupletStop);
-
-const buildAbcNoteNotationsXml = (note: AbcParsedNote): string =>
-  hasAbcNoteNotations(note)
-    ? buildAbcNoteWrappedXml(
-        "notations",
-        buildAbcNoteOptionalXmlParts([
-          buildAbcNoteTieNotationParts(note),
-          buildAbcNoteSlurNotationParts(note),
-          buildAbcNoteTupletNotationParts(note),
-          buildAbcNoteOrnamentsXml(note),
-          buildAbcNoteArticulationsXml(note),
-          buildMusicXmlTechnicalXml([
-            ...buildAbcNoteTechnicalPlainParts(note),
-            ...buildAbcNoteTechnicalCollectionParts(note),
-            ...buildAbcNoteTechnicalFlagParts(note),
-          ]),
-          buildAbcNoteFermataNotationPart(note),
-        ])
-      )
-    : "";
-
-const buildAbcNoteTieNotationParts = (note: AbcParsedNote): string =>
-  buildMusicXmlTiedItemsXml({
-    tiedStart: !!note.tieStart,
-    tiedStop: !!note.tieStop,
-  });
-
-const buildAbcNoteSlurNotationParts = (note: AbcParsedNote): string =>
-  buildMusicXmlSlursXml([
-    ...(note.slurStart ? [{ type: "start" as const }] : []),
-    ...(note.slurStop ? [{ type: "stop" as const }] : []),
-  ]);
-
-const buildAbcNoteTupletNotationParts = (note: AbcParsedNote): string =>
-  buildAbcNotePairedXmlParts(
-    buildAbcNoteTupletStartNotationPart(note),
-    buildAbcNoteTupletStopNotationPart(note)
-  );
-
-const buildAbcNoteTupletStartNotationPart = (note: AbcParsedNote): string =>
-  note.tupletStart ? '<tuplet type="start"/>' : "";
-
-const buildAbcNoteTupletStopNotationPart = (note: AbcParsedNote): string =>
-  note.tupletStop ? '<tuplet type="stop"/>' : "";
-
-const buildAbcNoteFermataNotationPart = (note: AbcParsedNote): string =>
-  note.fermataType ? `<fermata>${note.fermataType === "inverted" ? "inverted" : "normal"}</fermata>` : "";
-
-const buildAbcNoteWrappedXml = (tagName: string, parts: string[]): string =>
-  parts.length > 0 ? `<${tagName}>${parts.join("")}</${tagName}>` : "";
-
-const buildAbcNoteMergedXmlParts = (...partsGroups: string[][]): string[] =>
-  partsGroups.reduce<string[]>((allParts, parts) => allParts.concat(parts), []);
 
 const buildAbcBeamXmlByNoteIndex = (
   notes: AbcParsedNote[],
@@ -1905,14 +1506,184 @@ const buildAbcNoteXml = (
   staffOverride: number | null,
   beamXmlByNoteIndex: Map<number, string>
 ): string => {
+  const voice = normalizeVoiceForMusicXml(note.voice);
+  const staff = Number(note.staff);
+  const staffValue = staffOverride ?? (Number.isFinite(staff) ? Math.max(1, Math.round(staff || 1)) : null);
   const chunks: string[] = [];
-  chunks.push(buildAbcNoteLeadingDirectionXml(note));
+  chunks.push(
+    note.chord
+      ? ""
+      : [
+          note.chordSymbols?.map((chordSymbol) => buildHarmonyXmlFromChordSymbol(chordSymbol) || buildMusicXmlWordsDirectionXml({ text: String(chordSymbol) })).join("") ?? "",
+          note.annotations?.filter((annotation) => annotation.trim().length > 0).map((annotation) => buildMusicXmlWordsDirectionXml({ text: String(annotation) })).join("") ?? "",
+          [
+            note.segno ? "<direction><direction-type><segno/></direction-type></direction>" : "",
+            note.coda ? "<direction><direction-type><coda/></direction-type></direction>" : "",
+            note.rehearsalMark
+              ? `<direction><direction-type><rehearsal>${xmlEscape(String(note.rehearsalMark))}</rehearsal></direction-type></direction>`
+              : "",
+            note.fine ? '<direction><sound fine="yes"/></direction>' : "",
+            note.daCapo ? '<direction><sound dacapo="yes"/></direction>' : "",
+            note.dalSegno ? '<direction><sound dalsegno="segno"/></direction>' : "",
+            note.toCoda ? '<direction><sound tocoda="coda"/></direction>' : "",
+            note.crescendoStart
+              ? buildMusicXmlDirectionFeatureXml({ kind: "wedge", wedgeType: "crescendo" })
+              : note.diminuendoStart
+                ? buildMusicXmlDirectionFeatureXml({ kind: "wedge", wedgeType: "diminuendo" })
+                : note.crescendoStop || note.diminuendoStop
+                  ? buildMusicXmlDirectionFeatureXml({ kind: "wedge", wedgeType: "stop" })
+                  : "",
+            note.dynamicMark ? buildMusicXmlDirectionFeatureXml({ kind: "dynamic", mark: normalizeDynamicMark(String(note.dynamicMark)) }) : "",
+            note.sfz ? buildMusicXmlDirectionFeatureXml({ kind: "dynamic", mark: "sfz" }) : "",
+          ]
+            .filter((part) => part.length > 0)
+            .join(""),
+        ]
+          .filter((part) => part.length > 0)
+          .join("")
+  );
   chunks.push([
-    ...buildAbcNoteCoreOpenXmlParts(note, staffOverride),
-    buildAbcNoteCoreBeamPart(note, noteIndex, beamXmlByNoteIndex),
-    ...buildAbcNoteCoreTailXmlParts(note),
+    "<note>",
+    ...(note.chord ? ["<chord/>"] : []),
+    ...(note.grace ? [buildMusicXmlGraceXml({ slash: note.graceSlash })] : []),
+    note.isRest
+      ? "<rest/>"
+      : buildMusicXmlPitchXml({
+          step: note.step,
+          alter: note.alter,
+          octave: note.octave,
+        }),
+    ...(note.grace ? [] : [`<duration>${Math.max(1, Math.round(Number(note.duration) || 1))}</duration>`]),
+    `<voice>${xmlEscape(voice)}</voice>`,
+    ...(staffValue ? [`<staff>${staffValue}</staff>`] : []),
+    buildMusicXmlLyricXml({
+      text: note.lyricText,
+      syllabic: note.lyricSyllabic || "single",
+      extend: note.lyricExtend,
+    }),
+    `<type>${normalizeTypeForMusicXml(note.type)}</type>`,
+    !note.chord && beamXmlByNoteIndex.has(noteIndex) ? String(beamXmlByNoteIndex.get(noteIndex)) : "",
+    buildMusicXmlTimeModificationXml({
+      actualNotes: note.timeModification?.actual,
+      normalNotes: note.timeModification?.normal,
+    }),
+    buildMusicXmlAccidentalXml({
+      text: note.accidentalText,
+      editorial: note.accidentalEditorial,
+      cautionary: note.accidentalCautionary,
+    }),
+    buildMusicXmlTieItemsXml({
+      tieStart: !!note.tieStart,
+      tieStop: !!note.tieStop,
+    }),
   ].join(""));
-  chunks.push(buildAbcNoteNotationsXml(note));
+  chunks.push(
+    hasAbcNoteNotations(note)
+      ? [
+          buildMusicXmlTiedItemsXml({
+            tiedStart: !!note.tieStart,
+            tiedStop: !!note.tieStop,
+          }),
+          buildMusicXmlSlursXml([
+            ...(note.slurStart ? [{ type: "start" as const }] : []),
+            ...(note.slurStop ? [{ type: "stop" as const }] : []),
+          ]),
+          `${note.tupletStart ? '<tuplet type="start"/>' : ""}${note.tupletStop ? '<tuplet type="stop"/>' : ""}`,
+          [
+            [
+              note.trill ? buildMusicXmlOrnamentItemsXml([{ kind: "trill-mark" }]) : "",
+              note.trillLineStop ? '<wavy-line type="stop"/>' : note.trillLineStart ? '<wavy-line type="start"/>' : "",
+              note.trillAccidentalText ? `<accidental-mark>${xmlEscape(String(note.trillAccidentalText))}</accidental-mark>` : "",
+            ]
+              .filter((part) => part.length > 0)
+              .join("")
+              .replace(/^/, "<ornaments>")
+              .concat("</ornaments>"),
+            note.turnType
+              ? buildMusicXmlOrnamentsXml([
+                  {
+                    kind: note.turnType === "inverted-turn" ? "inverted-turn" : "turn",
+                    ...(note.turnSlash ? { slash: true } : {}),
+                  },
+                  ...(note.delayedTurn ? [{ kind: "delayed-turn" as const }] : []),
+                ])
+              : "",
+            note.mordentType
+              ? buildMusicXmlOrnamentsXml([
+                  {
+                    kind: note.mordentType === "inverted-mordent" ? "inverted-mordent" : "mordent",
+                  },
+                ])
+              : "",
+            note.tremoloType
+              ? buildMusicXmlOrnamentsXml([
+                  {
+                    kind: "tremolo",
+                    tremoloType: note.tremoloType,
+                    marks: note.tremoloMarks,
+                  },
+                ])
+              : "",
+            note.schleifer ? buildMusicXmlOrnamentsXml([{ kind: "schleifer" }]) : "",
+            note.shake ? buildMusicXmlOrnamentsXml([{ kind: "shake" }]) : "",
+            `${note.glissandoStart ? '<glissando type="start" number="1">wavy</glissando>' : ""}${note.glissandoStop ? '<glissando type="stop" number="1">wavy</glissando>' : ""}`,
+            `${note.slideStart ? '<slide type="start" number="1"/>' : ""}${note.slideStop ? '<slide type="stop" number="1"/>' : ""}`,
+            note.arpeggiate ? "<arpeggiate/>" : "",
+          ]
+            .filter((part) => part.length > 0)
+            .join(""),
+          [
+            buildMusicXmlArticulationItemsXml([
+              ...[
+                note.staccato ? "staccato" : "",
+                note.staccatissimo ? "staccatissimo" : "",
+                note.accent ? "accent" : "",
+                note.tenuto ? "tenuto" : "",
+              ].filter((part) => part.length > 0),
+              ...[
+                note.strongAccent ? "strong-accent" : "",
+                note.breathMark ? "breath-mark" : "",
+                note.caesura ? "caesura" : "",
+              ].filter((part) => part.length > 0),
+            ]),
+            note.stress ? "<stress/>" : "",
+            note.unstress ? "<unstress/>" : "",
+            note.phraseMark ? `<other-articulation>${xmlEscape(String(note.phraseMark))}</other-articulation>` : "",
+          ]
+            .filter((part) => part.length > 0)
+            .join("")
+            .replace(/^/, "<articulations>")
+            .concat("</articulations>"),
+          buildMusicXmlTechnicalXml([
+            ...[
+              note.upBow ? "<up-bow/>" : "",
+              note.downBow ? "<down-bow/>" : "",
+              note.doubleTongue ? "<double-tongue/>" : "",
+              note.tripleTongue ? "<triple-tongue/>" : "",
+            ].filter((part) => part.length > 0),
+            ...[
+              note.heel ? "<heel/>" : "",
+              note.toe ? "<toe/>" : "",
+            ].filter((part) => part.length > 0),
+            ...(note.fingerings ? note.fingerings.map((fingering) => buildMusicXmlFingeringXml(fingering)) : []),
+            ...(note.strings ? note.strings.map((stringText) => buildMusicXmlStringNumberXml(stringText)) : []),
+            ...(note.plucks ? note.plucks.map((pluckText) => (pluckText ? `<pluck>${xmlEscape(pluckText)}</pluck>` : "")) : []),
+            ...[
+              note.openString ? "<open-string/>" : "",
+              note.snapPizzicato ? "<snap-pizzicato/>" : "",
+              note.harmonic ? "<harmonic/>" : "",
+              note.stopped ? "<stopped/>" : "",
+              note.thumbPosition ? "<thumb-position/>" : "",
+            ].filter((part) => part.length > 0),
+          ]),
+          note.fermataType ? `<fermata>${note.fermataType === "inverted" ? "inverted" : "normal"}</fermata>` : "",
+        ]
+          .filter((part) => part.length > 0)
+          .join("")
+          .replace(/^/, "<notations>")
+          .concat("</notations>")
+      : ""
+  );
   chunks.push("</note>");
   return chunks.join("");
 };
@@ -4523,92 +4294,6 @@ const buildAbcExportLaneDefinitions = (part: Element, partId: string): AbcExport
     });
 };
 
-const buildAbcExportTransposeMetaLine = (
-  normalizedVoiceId: string,
-  measure: Element
-): string | null => {
-  const transposeNode = measure.querySelector(":scope > attributes > transpose");
-  if (!transposeNode) return null;
-  const chromatic = Number(transposeNode.querySelector(":scope > chromatic")?.textContent?.trim() ?? "");
-  const diatonic = Number(transposeNode.querySelector(":scope > diatonic")?.textContent?.trim() ?? "");
-  return Number.isFinite(chromatic) || Number.isFinite(diatonic)
-    ? [
-        `%@mks transpose voice=${normalizedVoiceId}`,
-        ...(Number.isFinite(chromatic) ? [`chromatic=${Math.round(chromatic)}`] : []),
-        ...(Number.isFinite(diatonic) ? [`diatonic=${Math.round(diatonic)}`] : []),
-      ].join(" ")
-    : null;
-};
-
-const buildAbcExportDiagMetaLines = (
-  normalizedVoiceId: string,
-  measure: Element,
-  safeMeasureNumber: number
-): string[] => {
-  const fields = Array.from(
-    measure.querySelectorAll(
-      ':scope > attributes > miscellaneous > miscellaneous-field[name^="mks:diag:"]'
-    )
-  );
-  if (!fields.length) return [];
-  const byName = new Map<string, string>();
-  for (const field of fields) {
-    const name = (field.getAttribute("name") ?? "").trim();
-    if (!name) continue;
-    const value = (field.textContent ?? "").trim();
-    byName.set(name, value);
-  }
-  const orderedNames = Array.from(byName.keys()).sort((a, b) => {
-    const isCountA = a === "mks:diag:count";
-    const isCountB = b === "mks:diag:count";
-    if (isCountA && !isCountB) return -1;
-    if (!isCountA && isCountB) return 1;
-    return a.localeCompare(b);
-  });
-  return orderedNames.map(
-    (name) =>
-      `%@mks diag voice=${normalizedVoiceId} measure=${safeMeasureNumber} name=${name} enc=uri-v1 value=${encodeURIComponent(
-        byName.get(name) ?? ""
-      )}`
-  );
-};
-
-const buildAbcExportMeasureMetaLine = (
-  normalizedVoiceId: string,
-  measure: Element,
-  safeMeasureNumber: number,
-  hasRightRepeat: boolean,
-  rightEndingNumber: string,
-  rightEndingType: string
-): string | null => {
-  const rawMeasureNumber = (measure.getAttribute("number") ?? "").trim() || String(safeMeasureNumber);
-  const implicitAttr = (measure.getAttribute("implicit") ?? "").trim().toLowerCase();
-  const isImplicit = implicitAttr === "yes" || implicitAttr === "true" || implicitAttr === "1";
-  const rightRepeatNode = measure.querySelector(':scope > barline[location="right"] > repeat');
-  const repeatTimes = Number.parseInt(String(rightRepeatNode?.getAttribute("times") ?? ""), 10);
-  if (
-    !isImplicit &&
-    rawMeasureNumber === String(safeMeasureNumber) &&
-    (!hasRightRepeat || !Number.isFinite(repeatTimes) || repeatTimes <= 2) &&
-    (!rightEndingNumber || rightEndingType !== "discontinue")
-  ) {
-    return null;
-  }
-  const metaChunks = [
-    `%@mks measure voice=${normalizedVoiceId} measure=${safeMeasureNumber}`,
-    `number=${rawMeasureNumber}`,
-    `implicit=${isImplicit ? 1 : 0}`,
-  ];
-  if (hasRightRepeat && Number.isFinite(repeatTimes) && repeatTimes > 2) {
-    metaChunks.push(`times=${Math.round(repeatTimes)}`);
-  }
-  if (rightEndingNumber && rightEndingType === "discontinue") {
-    metaChunks.push(`ending-stop=${rightEndingNumber}`);
-    metaChunks.push(`ending-type=${rightEndingType}`);
-  }
-  return metaChunks.join(" ");
-};
-
 const applyAbcExportDirectionToPending = (
   direction: Element,
   pendingDirectionWords: string[],
@@ -5131,21 +4816,6 @@ type AbcExportPartRenderInfo = {
   laneDefs: AbcExportLaneDefinition[];
 };
 
-type AbcExportDocumentHeaderInfo = {
-  title: string;
-  composer: string;
-  meterBeats: string;
-  meterBeatType: string;
-  fifths: number;
-  key: string;
-  abcTempoHeader: string;
-};
-
-type AbcExportDocumentCredits = {
-  title: string;
-  composer: string;
-};
-
 type AbcExportDocumentMeterKeyInfo = {
   meterBeats: string;
   meterBeatType: string;
@@ -5177,13 +4847,6 @@ type AbcExportDocumentContext = {
   meterBeats: string;
   meterBeatType: string;
   unitLength: Fraction;
-};
-
-const readAbcExportTimeModification = (note: Element): AbcExportTimeModification | null => {
-  const actual = Number(note.querySelector(":scope > time-modification > actual-notes")?.textContent?.trim() ?? "");
-  const normal = Number(note.querySelector(":scope > time-modification > normal-notes")?.textContent?.trim() ?? "");
-  if (!Number.isFinite(actual) || actual <= 0 || !Number.isFinite(normal) || normal <= 0) return null;
-  return { actual: Math.round(actual), normal: Math.round(normal) };
 };
 
 const buildAbcExportLengthToken = (
@@ -5220,11 +4883,6 @@ const updateAbcExportActiveTupletBeforeEvent = (
   return activeTuplet;
 };
 
-const buildAbcExportTupletPrefix = (activeTuplet: AbcExportActiveTuplet | null, isChord: boolean): string =>
-  isChord || !activeTuplet || activeTuplet.remaining !== activeTuplet.actual
-    ? ""
-    : `(${activeTuplet.actual}:${activeTuplet.normal}:${activeTuplet.actual}`;
-
 const advanceAbcExportActiveTupletAfterEvent = (
   activeTuplet: AbcExportActiveTuplet | null,
   isChord: boolean
@@ -5241,435 +4899,18 @@ const takeAbcExportQueuedEventPrefix = (
   pendingDirectionDecorations: string[],
   pendingGraceTokens: string[]
 ): string => {
-  return [
-    buildAbcExportPendingHarmonyPrefix(isChord, pendingHarmonySymbols),
-    buildAbcExportPendingWordsPrefix(isChord, pendingDirectionWords),
-    buildAbcExportPendingDirectionDecorationPrefix(isChord, pendingDirectionDecorations),
-    buildAbcExportPendingGracePrefix(pendingGraceTokens),
-  ].join("");
-};
-
-const buildAbcExportPendingHarmonyPrefix = (isChord: boolean, pendingHarmonySymbols: string[]): string =>
-  takeAbcExportPendingTextPrefix({
-    isChord,
-    pending: pendingHarmonySymbols,
-    buildPrefix: (items) => items.map((item) => `"${abcQuotedTextEscape(item)}"`).join(""),
-  });
-
-const buildAbcExportPendingWordsPrefix = (isChord: boolean, pendingDirectionWords: string[]): string =>
-  takeAbcExportPendingTextPrefix({
-    isChord,
-    pending: pendingDirectionWords,
-    buildPrefix: (items) => items.map((item) => `"${item}"`).join(""),
-  });
-
-const buildAbcExportPendingDirectionDecorationPrefix = (
-  isChord: boolean,
-  pendingDirectionDecorations: string[]
-): string =>
-  takeAbcExportPendingTextPrefix({
-    isChord,
-    pending: pendingDirectionDecorations,
-    buildPrefix: (items) => items.join(""),
-  });
-
-const buildAbcExportPendingGracePrefix = (pendingGraceTokens: string[]): string =>
-  takeAbcExportPendingTextPrefix({
-    isChord: false,
-    pending: pendingGraceTokens,
-    buildPrefix: (items) => `{${items.join("")}}`,
-  });
-
-const takeAbcExportPendingTextPrefix = (options: {
-  isChord: boolean;
-  pending: string[];
-  buildPrefix: (items: string[]) => string;
-}): string => {
-  const prefix = !options.isChord && options.pending.length > 0 ? options.buildPrefix(options.pending) : "";
-  clearAbcExportPendingIfConsumed(options.isChord, options.pending);
-  return prefix;
-};
-
-const clearAbcExportPendingIfConsumed = (isChord: boolean, pending: string[]): void => {
-  if (!isChord && pending.length > 0) {
-    pending.length = 0;
+  const harmonyPrefix = !isChord && pendingHarmonySymbols.length > 0 ? pendingHarmonySymbols.map((item) => `"${abcQuotedTextEscape(item)}"`).join("") : "";
+  const wordsPrefix = !isChord && pendingDirectionWords.length > 0 ? pendingDirectionWords.map((item) => `"${item}"`).join("") : "";
+  const decorationPrefix = !isChord && pendingDirectionDecorations.length > 0 ? pendingDirectionDecorations.join("") : "";
+  const gracePrefix = pendingGraceTokens.length > 0 ? `{${pendingGraceTokens.join("")}}` : "";
+  if (!isChord) {
+    pendingHarmonySymbols.length = 0;
+    pendingDirectionWords.length = 0;
+    pendingDirectionDecorations.length = 0;
+    pendingGraceTokens.length = 0;
   }
+  return `${harmonyPrefix}${wordsPrefix}${decorationPrefix}${gracePrefix}`;
 };
-
-const buildAbcExportTrillMetaLine = (
-  normalizedVoiceId: string,
-  measure: Element,
-  fallbackMeasureNumber: number,
-  eventNo: number,
-  trillAccidentalText: string
-): string => {
-  const measureNumber = measure.getAttribute("number") || fallbackMeasureNumber;
-  return `%@mks trill voice=${normalizedVoiceId} measure=${measureNumber} event=${eventNo} upper=${trillAccidentalText}`;
-};
-
-const buildAbcExportOrnamentPrefixInfo = (note: Element): AbcExportOrnamentPrefixInfo => {
-  const ornamentFeatures = extractMusicXmlOrnamentFeatures(note);
-  const ornamentKinds = new Set(ornamentFeatures.map((feature) => feature.kind));
-  const trillInfo = buildAbcExportOrnamentTrillPrefix(note, ornamentKinds);
-  return {
-    prefix: buildAbcExportOrnamentPrefixText(
-      trillInfo.prefix,
-      buildAbcExportOrnamentTurnPrefix(ornamentFeatures, ornamentKinds),
-      buildAbcExportOrnamentMordentPrefix(ornamentKinds),
-      buildAbcExportOrnamentTremoloPrefix(ornamentFeatures),
-      buildAbcExportOrnamentMotionPrefix(note, ornamentKinds)
-    ),
-    hasTrill: trillInfo.hasTrill,
-    trillAccidentalText: buildAbcExportOrnamentTrillAccidentalText(note),
-  };
-};
-
-const buildAbcExportOrnamentPrefixText = (
-  trillPrefix: string,
-  turnPrefix: string,
-  mordentPrefix: string,
-  tremoloPrefix: string,
-  motionPrefix: string
-): string => [trillPrefix, turnPrefix, mordentPrefix, tremoloPrefix, motionPrefix].join("");
-
-const buildAbcExportOrnamentTrillAccidentalText = (note: Element): string =>
-  note.querySelector(":scope > notations > ornaments > accidental-mark")?.textContent?.trim() ?? "";
-
-const buildAbcExportOrnamentTrillPrefix = (
-  note: Element,
-  ornamentKinds: Set<string>
-): { prefix: string; hasTrill: boolean } => {
-  const hasTrillMark = buildAbcExportOrnamentTrillMarkPresence(ornamentKinds);
-  const hasWavyLineStart = buildAbcExportOrnamentWavyLineStartPresence(note);
-  const hasWavyLineStop = buildAbcExportOrnamentWavyLineStopPresence(note);
-  return {
-    prefix: buildAbcExportOrnamentTrillPrefixFromPresence(hasTrillMark, hasWavyLineStart, hasWavyLineStop),
-    hasTrill: hasTrillMark || hasWavyLineStart,
-  };
-};
-
-const buildAbcExportOrnamentTrillPrefixFromPresence = (
-  hasTrillMark: boolean,
-  hasWavyLineStart: boolean,
-  hasWavyLineStop: boolean
-): string =>
-  hasWavyLineStop
-    ? "!trill)!"
-    : hasWavyLineStart && !hasTrillMark
-      ? "!trill!"
-      : hasWavyLineStart
-        ? "!trill(!"
-        : hasTrillMark
-          ? "!trill!"
-          : "";
-
-const buildAbcExportOrnamentTrillMarkPresence = (ornamentKinds: Set<string>): boolean =>
-  ornamentKinds.has("trill-mark");
-
-const buildAbcExportOrnamentWavyLineStartPresence = (note: Element): boolean =>
-  buildAbcExportOrnamentWavyLinePresence(note, (type) => type === "" || type === "start");
-
-const buildAbcExportOrnamentWavyLineStopPresence = (note: Element): boolean =>
-  buildAbcExportOrnamentWavyLinePresence(note, (type) => type === "stop");
-
-const buildAbcExportOrnamentWavyLinePresence = (
-  note: Element,
-  acceptsType: (type: string) => boolean
-): boolean =>
-  Array.from(note.querySelectorAll(":scope > notations > ornaments > wavy-line")).some((node) =>
-    acceptsType((node.getAttribute("type") ?? "").trim().toLowerCase())
-  );
-
-const buildAbcExportOrnamentTurnPrefix = (
-  ornamentFeatures: AbcExportOrnamentFeatures,
-  ornamentKinds: Set<string>
-): string =>
-  [
-    buildAbcExportOrnamentInvertedTurnPrefix(ornamentFeatures, ornamentKinds),
-    buildAbcExportOrnamentNormalTurnPrefix(ornamentFeatures, ornamentKinds),
-  ].join("");
-
-const buildAbcExportOrnamentInvertedTurnPrefix = (
-  ornamentFeatures: AbcExportOrnamentFeatures,
-  ornamentKinds: Set<string>
-): string =>
-  buildAbcExportOrnamentPresencePrefix(
-    ornamentKinds.has("inverted-turn"),
-    buildAbcExportOrnamentDelayedTurnPresence(ornamentKinds),
-    buildAbcExportOrnamentInvertedTurnSlashPresence(ornamentFeatures),
-    "!delayedinvertedturn!",
-    "!invertedturnx!",
-    "!invertedturn!"
-  );
-
-const buildAbcExportOrnamentNormalTurnPrefix = (
-  ornamentFeatures: AbcExportOrnamentFeatures,
-  ornamentKinds: Set<string>
-): string =>
-  buildAbcExportOrnamentPresencePrefix(
-    ornamentKinds.has("turn"),
-    buildAbcExportOrnamentDelayedTurnPresence(ornamentKinds),
-    buildAbcExportOrnamentNormalTurnSlashPresence(ornamentFeatures),
-    "!delayedturn!",
-    "!turnx!",
-    "!turn!"
-  );
-
-const buildAbcExportOrnamentInvertedTurnSlashPresence = (ornamentFeatures: AbcExportOrnamentFeatures): boolean =>
-  ornamentFeatures.some((feature) => feature.kind === "inverted-turn" && feature.slash);
-
-const buildAbcExportOrnamentNormalTurnSlashPresence = (ornamentFeatures: AbcExportOrnamentFeatures): boolean =>
-  ornamentFeatures.some((feature) => feature.kind === "turn" && feature.slash);
-
-const buildAbcExportOrnamentDelayedTurnPresence = (ornamentKinds: Set<string>): boolean =>
-  ornamentKinds.has("delayed-turn");
-
-const buildAbcExportOrnamentPresencePrefix = (
-  hasKind: boolean,
-  hasDelayed: boolean,
-  hasSlash: boolean,
-  delayedPrefix: string,
-  slashPrefix: string,
-  normalPrefix: string
-): string => (hasKind ? (hasDelayed ? delayedPrefix : hasSlash ? slashPrefix : normalPrefix) : "");
-
-const buildAbcExportOrnamentSimplePresencePrefix = (hasKind: boolean, prefix: string): string =>
-  hasKind ? prefix : "";
-
-const buildAbcExportOrnamentMordentPrefix = (ornamentKinds: Set<string>): string =>
-  [buildAbcExportOrnamentInvertedMordentPrefix(ornamentKinds), buildAbcExportOrnamentNormalMordentPrefix(ornamentKinds)].join("");
-
-const buildAbcExportOrnamentInvertedMordentPrefix = (ornamentKinds: Set<string>): string =>
-  buildAbcExportOrnamentSimplePresencePrefix(ornamentKinds.has("inverted-mordent"), "!pralltriller!");
-
-const buildAbcExportOrnamentNormalMordentPrefix = (ornamentKinds: Set<string>): string =>
-  buildAbcExportOrnamentSimplePresencePrefix(ornamentKinds.has("mordent"), "!mordent!");
-
-const buildAbcExportOrnamentTremoloPrefix = (ornamentFeatures: AbcExportOrnamentFeatures): string =>
-  (["single", "start", "stop"] as const)
-    .map((tremoloType) =>
-      buildAbcExportOrnamentTremoloPrefixFromFeature(
-        buildAbcExportOrnamentTremoloFeatureByType(ornamentFeatures, tremoloType),
-        tremoloType
-      )
-    )
-    .join("");
-
-const buildAbcExportOrnamentTremoloFeatureByType = (
-  ornamentFeatures: AbcExportOrnamentFeatures,
-  tremoloType: "single" | "start" | "stop"
-): AbcExportTremoloOrnamentFeature | undefined =>
-  ornamentFeatures.find((feature) => feature.kind === "tremolo" && feature.tremoloType === tremoloType);
-
-const buildAbcExportOrnamentTremoloPrefixFromFeature = (
-  tremoloFeature: AbcExportTremoloOrnamentFeature | undefined,
-  tremoloType: "single" | "start" | "stop"
-): string =>
-  tremoloFeature ? `!tremolo-${tremoloType}-${tremoloFeature.marks ? tremoloFeature.marks : 1}!` : "";
-
-const buildAbcExportOrnamentMotionPrefix = (note: Element, ornamentKinds: Set<string>): string =>
-  buildAbcExportOrnamentMotionPrefixParts(note, ornamentKinds).join("");
-
-const buildAbcExportOrnamentGlissandoSlidePrefix = (note: Element): string =>
-  buildAbcExportOrnamentGlissandoSlidePrefixParts(note).join("");
-
-const buildAbcExportOrnamentGlissandoPrefix = (note: Element): string =>
-  buildAbcExportOrnamentStartStopPrefixParts(
-    note.querySelector(':scope > notations > glissando[type="start"]'),
-    note.querySelector(':scope > notations > glissando[type="stop"]'),
-    "!gliss-start!",
-    "!gliss-stop!"
-  ).join("");
-
-const buildAbcExportOrnamentSlidePrefix = (note: Element): string =>
-  buildAbcExportOrnamentStartStopPrefixParts(
-    note.querySelector(':scope > notations > slide[type="start"]'),
-    note.querySelector(':scope > notations > slide[type="stop"]'),
-    "!slide!",
-    "!slide-stop!"
-  ).join("");
-
-const buildAbcExportOrnamentGlissandoSlidePrefixParts = (note: Element): string[] => [
-  buildAbcExportOrnamentGlissandoPrefix(note),
-  buildAbcExportOrnamentSlidePrefix(note),
-];
-
-const buildAbcExportOrnamentStartStopPrefixParts = (
-  hasStart: boolean | Element | null,
-  hasStop: boolean | Element | null,
-  startPrefix: string,
-  stopPrefix: string
-): string[] => [
-  ...(hasStart ? [startPrefix] : []),
-  ...(hasStop ? [stopPrefix] : []),
-];
-
-const buildAbcExportOrnamentMotionEffectPrefix = (note: Element, ornamentKinds: Set<string>): string =>
-  buildAbcExportOrnamentMotionEffectPrefixParts(note, ornamentKinds).join("");
-
-const buildAbcExportOrnamentSchleiferShakePrefix = (ornamentKinds: Set<string>): string =>
-  [buildAbcExportOrnamentSchleiferPrefix(ornamentKinds), buildAbcExportOrnamentShakePrefix(ornamentKinds)].join("");
-
-const buildAbcExportOrnamentSchleiferPrefix = (ornamentKinds: Set<string>): string =>
-  ornamentKinds.has("schleifer") ? "!schleifer!" : "";
-
-const buildAbcExportOrnamentShakePrefix = (ornamentKinds: Set<string>): string =>
-  ornamentKinds.has("shake") ? "!shake!" : "";
-
-const buildAbcExportOrnamentArpeggiatePrefix = (note: Element): string =>
-  note.querySelector(":scope > notations > arpeggiate") ? "!arpeggio!" : "";
-
-const buildAbcExportOrnamentMotionPrefixParts = (note: Element, ornamentKinds: Set<string>): string[] => [
-  buildAbcExportOrnamentGlissandoSlidePrefix(note),
-  buildAbcExportOrnamentMotionEffectPrefix(note, ornamentKinds),
-];
-
-const buildAbcExportOrnamentMotionEffectPrefixParts = (note: Element, ornamentKinds: Set<string>): string[] => [
-  buildAbcExportOrnamentSchleiferShakePrefix(ornamentKinds),
-  buildAbcExportOrnamentArpeggiatePrefix(note),
-];
-
-const buildAbcExportTechnicalPrefix = (note: Element): string =>
-  buildAbcExportTechnicalPrefixXmlParts(note).join("");
-
-const buildAbcExportTechnicalPrefixXmlParts = (note: Element): string[] => [
-  ...buildAbcExportTechnicalStrokeXmlParts(note),
-  ...buildAbcExportTechnicalCollectionXmlParts(note),
-  ...buildAbcExportTechnicalStateXmlParts(note),
-];
-
-const buildAbcExportTechnicalStrokeXmlParts = (note: Element): string[] => [
-  ...buildAbcExportTechnicalBowingXmlParts(note),
-  ...buildAbcExportTechnicalTongueAndFootXmlParts(note),
-];
-
-const buildAbcExportTechnicalBowingXmlParts = (note: Element): string[] => [
-  note.querySelector(":scope > notations > technical > up-bow") ? "!upbow!" : "",
-  note.querySelector(":scope > notations > technical > down-bow") ? "!downbow!" : "",
-];
-
-const buildAbcExportTechnicalTongueAndFootXmlParts = (note: Element): string[] =>
-  [
-    note.querySelector(":scope > notations > technical > double-tongue") ? "!doubletongue!" : "",
-    note.querySelector(":scope > notations > technical > triple-tongue") ? "!tripletongue!" : "",
-    note.querySelector(":scope > notations > technical > heel") ? "!heel!" : "",
-    note.querySelector(":scope > notations > technical > toe") ? "!toe!" : "",
-  ];
-
-const buildAbcExportTechnicalCollectionXmlParts = (note: Element): string[] =>
-  [
-    Array.from(note.querySelectorAll(":scope > notations > technical > fingering"))
-      .map((node) => (node.textContent ?? "").trim())
-      .filter((text) => text.length > 0)
-      .map((value) => (/^[0-5]$/.test(value) ? `!${value}!` : `!fingering:${value}!`))
-      .join(""),
-    Array.from(note.querySelectorAll(":scope > notations > technical > string"))
-      .map((node) => (node.textContent ?? "").trim())
-      .filter((text) => text.length > 0)
-      .map((value) => `!string:${value}!`)
-      .join(""),
-    Array.from(note.querySelectorAll(":scope > notations > technical > pluck"))
-      .map((node) => (node.textContent ?? "").trim())
-      .filter((text) => text.length > 0)
-      .map((value) => `!pluck:${value}!`)
-      .join(""),
-  ];
-
-const buildAbcExportTechnicalStateXmlParts = (note: Element): string[] =>
-  [
-    note.querySelector(":scope > notations > technical > open-string") ? "!open!" : "",
-    note.querySelector(":scope > notations > technical > snap-pizzicato") ? "!snap!" : "",
-    note.querySelector(":scope > notations > technical > harmonic") ? "!harmonic!" : "",
-    note.querySelector(":scope > notations > technical > stopped") ? "!stopped!" : "",
-    note.querySelector(":scope > notations > technical > thumb-position") ? "!thumb!" : "",
-  ];
-
-const buildAbcExportFermataPrefix = (note: Element): string => {
-  const fermata = note.querySelector(":scope > notations > fermata");
-  const type = fermata?.getAttribute("type")?.trim().toLowerCase() ?? "";
-  const shape = fermata?.textContent?.trim().toLowerCase() ?? "";
-  return fermata ? (type === "inverted" || shape === "inverted" ? "!invertedfermata!" : "!fermata!") : "";
-};
-
-const buildAbcExportArticulationPrefix = (note: Element): string =>
-  buildAbcExportArticulationPrefixXmlParts(note).join("");
-
-const buildAbcExportArticulationPrefixXmlParts = (note: Element): string[] => {
-  const articulationKinds = new Set(extractMusicXmlArticulationKinds(note));
-  return [
-    ...buildAbcExportArticulationCorePrefixXmlParts(articulationKinds),
-    ...buildAbcExportArticulationDecorativePrefixXmlParts(note, articulationKinds),
-    ...[
-      (
-        Array.from(note.querySelectorAll(":scope > notations > articulations > other-articulation"))
-          .map((node) => (node.textContent ?? "").trim().toLowerCase())
-          .find((text) => text === "shortphrase" || text === "mediumphrase" || text === "longphrase") ?? ""
-      )
-        ? `!${
-            Array.from(note.querySelectorAll(":scope > notations > articulations > other-articulation"))
-              .map((node) => (node.textContent ?? "").trim().toLowerCase())
-              .find((text) => text === "shortphrase" || text === "mediumphrase" || text === "longphrase") ?? ""
-          }!`
-        : "",
-    ].filter((part) => part.length > 0),
-  ];
-};
-
-const buildAbcExportArticulationCorePrefixXmlParts = (articulationKinds: Set<string>): string[] => [
-  buildAbcExportArticulationStaccatoXmlPart(articulationKinds),
-  buildAbcExportArticulationAccentXmlPart(articulationKinds),
-  buildAbcExportArticulationTenutoXmlPart(articulationKinds),
-];
-
-const buildAbcExportArticulationStaccatoXmlPart = (articulationKinds: Set<string>): string =>
-  articulationKinds.has("staccatissimo") ? "!wedge!" : (articulationKinds.has("staccato") ? "!staccato!" : "");
-
-const buildAbcExportArticulationAccentXmlPart = (articulationKinds: Set<string>): string =>
-  articulationKinds.has("accent") ? "!accent!" : "";
-
-const buildAbcExportArticulationTenutoXmlPart = (articulationKinds: Set<string>): string =>
-  articulationKinds.has("tenuto") ? "!tenuto!" : "";
-
-const buildAbcExportArticulationDecorativePrefixXmlParts = (note: Element, articulationKinds: Set<string>): string[] => [
-  ...buildAbcExportArticulationDirectDecorativeXmlParts(note),
-  ...buildAbcExportArticulationKindDecorativeXmlParts(articulationKinds),
-];
-
-const buildAbcExportArticulationDirectDecorativeXmlParts = (note: Element): string[] => [
-  buildAbcExportArticulationStressXmlPart(note),
-  buildAbcExportArticulationUnstressXmlPart(note),
-];
-
-const buildAbcExportArticulationKindDecorativeXmlParts = (articulationKinds: Set<string>): string[] => [
-  buildAbcExportArticulationStrongAccentXmlPart(articulationKinds),
-  buildAbcExportArticulationBreathXmlPart(articulationKinds),
-  buildAbcExportArticulationCaesuraXmlPart(articulationKinds),
-];
-
-const buildAbcExportArticulationStressXmlPart = (note: Element): string =>
-  buildAbcExportArticulationPresenceXmlPart(note, "stress", "!stress!");
-
-const buildAbcExportArticulationUnstressXmlPart = (note: Element): string =>
-  buildAbcExportArticulationPresenceXmlPart(note, "unstress", "!unstress!");
-
-const buildAbcExportArticulationStrongAccentXmlPart = (articulationKinds: Set<string>): string =>
-  buildAbcExportArticulationSimplePresenceXmlPart(articulationKinds.has("strong-accent"), "!marcato!");
-
-const buildAbcExportArticulationBreathXmlPart = (articulationKinds: Set<string>): string =>
-  buildAbcExportArticulationSimplePresenceXmlPart(articulationKinds.has("breath-mark"), "!breath!");
-
-const buildAbcExportArticulationCaesuraXmlPart = (articulationKinds: Set<string>): string =>
-  buildAbcExportArticulationSimplePresenceXmlPart(articulationKinds.has("caesura"), "!caesura!");
-
-const buildAbcExportArticulationSimplePresenceXmlPart = (hasKind: boolean, prefix: string): string =>
-  hasKind ? prefix : "";
-
-const buildAbcExportArticulationPresenceXmlPart = (
-  note: Element,
-  elementName: string,
-  prefix: string
-): string =>
-  buildAbcExportArticulationSimplePresenceXmlPart(note.querySelector(`:scope > notations > articulations > ${elementName}`) !== null, prefix);
 
 const appendAbcExportLyricToken = (
   note: Element,
@@ -5693,38 +4934,21 @@ const appendAbcExportLyricToken = (
   return false;
 };
 
-const buildAbcExportPendingEventToken = (pending: AbcExportPendingEvent): string => {
-  const tieSuffix = pending.tie ? "-" : "";
-  const slurStopSuffix = pending.slurStop ? ")" : "";
-  if (pending.pitches.length === 1) {
-    return `${pending.prefix}${pending.pitches[0]}${pending.len}${tieSuffix}${slurStopSuffix}`;
-  }
-  return `${pending.prefix}[${pending.pitches.join("")}]${pending.len}${tieSuffix}${slurStopSuffix}`;
-};
-
 const flushAbcExportPendingEvent = (
   pending: AbcExportPendingEvent | null,
   tokens: string[]
 ): null => {
   if (pending) {
-    tokens.push(buildAbcExportPendingEventToken(pending));
+    const tieSuffix = pending.tie ? "-" : "";
+    const slurStopSuffix = pending.slurStop ? ")" : "";
+    tokens.push(
+      pending.pitches.length === 1
+        ? `${pending.prefix}${pending.pitches[0]}${pending.len}${tieSuffix}${slurStopSuffix}`
+        : `${pending.prefix}[${pending.pitches.join("")}]${pending.len}${tieSuffix}${slurStopSuffix}`
+    );
   }
   return null;
 };
-
-const createAbcExportPendingEvent = (
-  pitchToken: string,
-  len: string,
-  hasTieStart: boolean,
-  hasSlurStop: boolean,
-  eventPrefix: string
-): AbcExportPendingEvent => ({
-  pitches: [pitchToken],
-  len,
-  tie: hasTieStart,
-  slurStop: hasSlurStop,
-  prefix: eventPrefix,
-});
 
 const appendAbcExportChordPitchToPendingEvent = (
   pending: AbcExportPendingEvent,
@@ -5756,48 +4980,19 @@ const startAbcExportPendingEventForNote = (
   const nextEventNo = eventNo + 1;
   const trillMetaLine =
     ornamentPrefixInfo.hasTrill && ornamentPrefixInfo.trillAccidentalText
-      ? buildAbcExportTrillMetaLine(
-          normalizedVoiceId,
-          measure,
-          fallbackMeasureNumber,
-          nextEventNo,
-          ornamentPrefixInfo.trillAccidentalText
-        )
+      ? `%@mks trill voice=${normalizedVoiceId} measure=${measure.getAttribute("number") || fallbackMeasureNumber} event=${nextEventNo} upper=${ornamentPrefixInfo.trillAccidentalText}`
       : "";
   if (trillMetaLine) metaLines.push(trillMetaLine);
   if (flushPending) flushAbcExportPendingEvent(pending, tokens);
   return {
-    pending: createAbcExportPendingEvent(pitchToken, len, hasTieStart, hasSlurStop, eventPrefix),
+    pending: {
+      pitches: [pitchToken],
+      len,
+      tie: hasTieStart,
+      slurStop: hasSlurStop,
+      prefix: eventPrefix,
+    },
     eventNo: nextEventNo,
-  };
-};
-
-const readAbcExportNoteEventInfo = (
-  note: Element,
-  currentDivisions: number,
-  unitLength: Fraction
-): AbcExportNoteEventInfo | null => {
-  const isChord = note.querySelector(":scope > chord") !== null;
-  const isGrace = note.querySelector(":scope > grace") !== null;
-  const duration = Number(note.querySelector(":scope > duration")?.textContent?.trim() ?? "0");
-  if (!isGrace && (!Number.isFinite(duration) || duration <= 0)) return null;
-  const noteDuration = isGrace
-    ? (Number.isFinite(duration) && duration > 0 ? duration : Math.round(currentDivisions / 2))
-    : duration;
-  const tieState = extractMusicXmlTieState(note);
-  const slurFeatures = extractMusicXmlSlurFeatures(note);
-  const timeModification = readAbcExportTimeModification(note);
-  return {
-    isChord,
-    isGrace,
-    hasTieStart: tieState.tieStart,
-    ornamentPrefixInfo: buildAbcExportOrnamentPrefixInfo(note),
-    hasSlurStart: slurFeatures.some((slur) => slur.type === "start"),
-    hasSlurStop: slurFeatures.some((slur) => slur.type === "stop"),
-    hasGraceSlash: (note.querySelector(":scope > grace")?.getAttribute("slash") ?? "").trim().toLowerCase() === "yes",
-    hasTupletStart: note.querySelector(':scope > notations > tuplet[type="start"]') !== null,
-    timeModification,
-    len: buildAbcExportLengthToken(noteDuration, currentDivisions, unitLength, timeModification),
   };
 };
 
@@ -5810,54 +5005,36 @@ const buildAbcExportEventPrefix = (
   pendingDirectionDecorations: string[],
   pendingGraceTokens: string[]
 ): string => {
-  const tupletPrefix = buildAbcExportTupletPrefix(activeTuplet, noteEventInfo.isChord);
-  const articulationPrefix = buildAbcExportArticulationPrefix(note);
-  const technicalPrefix = buildAbcExportTechnicalPrefix(note);
-  const fermataPrefix = buildAbcExportFermataPrefix(note);
+  const tupletPrefix =
+    noteEventInfo.isChord || !activeTuplet || activeTuplet.remaining !== activeTuplet.actual
+      ? ""
+      : `(${activeTuplet.actual}:${activeTuplet.normal}:${activeTuplet.actual}`;
+  const articulationKinds = new Set(extractMusicXmlArticulationKinds(note));
+  const otherPhrase = Array.from(note.querySelectorAll(":scope > notations > articulations > other-articulation"))
+    .map((node) => (node.textContent ?? "").trim().toLowerCase())
+    .find((text) => text === "shortphrase" || text === "mediumphrase" || text === "longphrase") ?? "";
+  const articulationPrefix = `${articulationKinds.has("staccatissimo") ? "!wedge!" : (articulationKinds.has("staccato") ? "!staccato!" : "")}${articulationKinds.has("accent") ? "!accent!" : ""}${articulationKinds.has("tenuto") ? "!tenuto!" : ""}${note.querySelector(":scope > notations > articulations > stress") !== null ? "!stress!" : ""}${note.querySelector(":scope > notations > articulations > unstress") !== null ? "!unstress!" : ""}${articulationKinds.has("strong-accent") ? "!marcato!" : ""}${articulationKinds.has("breath-mark") ? "!breath!" : ""}${articulationKinds.has("caesura") ? "!caesura!" : ""}${otherPhrase ? `!${otherPhrase}!` : ""}`;
+  const technicalPrefix = `${`${note.querySelector(":scope > notations > technical > up-bow") ? "!upbow!" : ""}${note.querySelector(":scope > notations > technical > down-bow") ? "!downbow!" : ""}`}${`${note.querySelector(":scope > notations > technical > double-tongue") ? "!doubletongue!" : ""}${note.querySelector(":scope > notations > technical > triple-tongue") ? "!tripletongue!" : ""}${note.querySelector(":scope > notations > technical > heel") ? "!heel!" : ""}${note.querySelector(":scope > notations > technical > toe") ? "!toe!" : ""}`}${Array.from(note.querySelectorAll(":scope > notations > technical > fingering")).map((node) => (node.textContent ?? "").trim()).filter((text) => text.length > 0).map((value) => (/^[0-5]$/.test(value) ? `!${value}!` : `!fingering:${value}!`)).join("")}${Array.from(note.querySelectorAll(":scope > notations > technical > string")).map((node) => (node.textContent ?? "").trim()).filter((text) => text.length > 0).map((value) => `!string:${value}!`).join("")}${Array.from(note.querySelectorAll(":scope > notations > technical > pluck")).map((node) => (node.textContent ?? "").trim()).filter((text) => text.length > 0).map((value) => `!pluck:${value}!`).join("")}${`${note.querySelector(":scope > notations > technical > open-string") ? "!open!" : ""}${note.querySelector(":scope > notations > technical > snap-pizzicato") ? "!snap!" : ""}${note.querySelector(":scope > notations > technical > harmonic") ? "!harmonic!" : ""}${note.querySelector(":scope > notations > technical > stopped") ? "!stopped!" : ""}${note.querySelector(":scope > notations > technical > thumb-position") ? "!thumb!" : ""}`}`;
+  const fermata = note.querySelector(":scope > notations > fermata");
+  const fermataPrefix = fermata ? (fermata.getAttribute("type")?.trim().toLowerCase() === "inverted" || fermata.textContent?.trim().toLowerCase() === "inverted" ? "!invertedfermata!" : "!fermata!") : "";
   const slurStartPrefix = noteEventInfo.hasSlurStart ? "(" : "";
-  const parts = buildAbcExportEventPrefixParts(
-    noteEventInfo.isChord,
-    pendingHarmonySymbols,
-    pendingDirectionWords,
-    pendingDirectionDecorations,
-    pendingGraceTokens,
+  const parts = [
+    takeAbcExportQueuedEventPrefix(
+      noteEventInfo.isChord,
+      pendingHarmonySymbols,
+      pendingDirectionWords,
+      pendingDirectionDecorations,
+      pendingGraceTokens
+    ),
     tupletPrefix,
     slurStartPrefix,
     noteEventInfo.ornamentPrefixInfo.prefix,
     articulationPrefix,
     technicalPrefix,
-    fermataPrefix
-  );
+    fermataPrefix,
+  ];
   return parts.join("");
 };
-
-const buildAbcExportEventPrefixParts = (
-  isChord: boolean,
-  pendingHarmonySymbols: string[],
-  pendingDirectionWords: string[],
-  pendingDirectionDecorations: string[],
-  pendingGraceTokens: string[],
-  tupletPrefix: string,
-  slurStartPrefix: string,
-  ornamentPrefix: string,
-  articulationPrefix: string,
-  technicalPrefix: string,
-  fermataPrefix: string
-): string[] => [
-  takeAbcExportQueuedEventPrefix(
-    isChord,
-    pendingHarmonySymbols,
-    pendingDirectionWords,
-    pendingDirectionDecorations,
-    pendingGraceTokens
-  ),
-  tupletPrefix,
-  slurStartPrefix,
-  ornamentPrefix,
-  articulationPrefix,
-  technicalPrefix,
-  fermataPrefix,
-];
 
 const flushAbcExportPendingGraceTokens = (
   pendingGraceTokens: string[],
@@ -5885,35 +5062,6 @@ const appendAbcExportEmptyMeasureRestTokenIfNeeded = (
   tokens.push(`z${AbcCommon.abcLengthTokenFromFraction(lenRatio)}`);
 };
 
-const buildAbcExportMeasureBoundaryPrefix = (boundaryInfo: AbcExportMeasureBoundaryInfo): string =>
-  `${boundaryInfo.hasLeftRepeat ? "|:" : ""}${boundaryInfo.leftEndingNumber ? `[${boundaryInfo.leftEndingNumber}` : ""}`;
-
-const buildAbcExportMeasureKeyPrefix = (needsInlineKeyChange: boolean, currentFifths: number): string =>
-  needsInlineKeyChange
-    ? `[K:${AbcCommon.keyFromFifthsMode(Math.max(-7, Math.min(7, Math.round(currentFifths))), "major")}]`
-    : "";
-
-const buildAbcExportMeasureBoundarySuffix = (boundaryInfo: AbcExportMeasureBoundaryInfo): string =>
-  boundaryInfo.hasRightRepeat
-    ? (boundaryInfo.rightEndingNumber ? ":|]" : ":|")
-    : (boundaryInfo.rightEndingNumber ? "]|" : "|");
-
-const readAbcExportMeasureBoundaryInfo = (measure: Element): AbcExportMeasureBoundaryInfo => {
-  const leftRepeatNode = measure.querySelector(':scope > barline[location="left"] > repeat');
-  const rightRepeatNode = measure.querySelector(':scope > barline[location="right"] > repeat');
-  const leftEndingNode = measure.querySelector(':scope > barline[location="left"] > ending');
-  const rightEndingNode = measure.querySelector(':scope > barline[location="right"] > ending');
-  const leftRepeatDir = (leftRepeatNode?.getAttribute("direction") ?? "").trim().toLowerCase();
-  const rightRepeatDir = (rightRepeatNode?.getAttribute("direction") ?? "").trim().toLowerCase();
-  return {
-    hasLeftRepeat: leftRepeatDir === "forward",
-    hasRightRepeat: rightRepeatDir === "backward",
-    leftEndingNumber: (leftEndingNode?.getAttribute("number") ?? "").trim(),
-    rightEndingNumber: (rightEndingNode?.getAttribute("number") ?? "").trim(),
-    rightEndingType: (rightEndingNode?.getAttribute("type") ?? "").trim().toLowerCase(),
-  };
-};
-
 const applyAbcExportMeasureAttributesToState = (
   measure: Element,
   state: AbcExportMeasureState
@@ -5937,16 +5085,51 @@ const appendAbcExportMeasureMetaLines = (
   safeMeasureNumber: number,
   boundaryInfo: AbcExportMeasureBoundaryInfo
 ): void => {
-  const measureMetaLine = buildAbcExportMeasureMetaLine(
-    normalizedVoiceId,
-    measure,
-    safeMeasureNumber,
-    boundaryInfo.hasRightRepeat,
-    boundaryInfo.rightEndingNumber,
-    boundaryInfo.rightEndingType
-  );
+  const rawMeasureNumber = (measure.getAttribute("number") ?? "").trim() || String(safeMeasureNumber);
+  const implicitAttr = (measure.getAttribute("implicit") ?? "").trim().toLowerCase();
+  const isImplicit = implicitAttr === "yes" || implicitAttr === "true" || implicitAttr === "1";
+  const rightRepeatNode = measure.querySelector(':scope > barline[location="right"] > repeat');
+  const repeatTimes = Number.parseInt(String(rightRepeatNode?.getAttribute("times") ?? ""), 10);
+  const measureMetaLine =
+    !isImplicit &&
+    rawMeasureNumber === String(safeMeasureNumber) &&
+    (!boundaryInfo.hasRightRepeat || !Number.isFinite(repeatTimes) || repeatTimes <= 2) &&
+    (!boundaryInfo.rightEndingNumber || boundaryInfo.rightEndingType !== "discontinue")
+      ? null
+      : [
+          `%@mks measure voice=${normalizedVoiceId} measure=${safeMeasureNumber}`,
+          `number=${rawMeasureNumber}`,
+          `implicit=${isImplicit ? 1 : 0}`,
+          ...(boundaryInfo.hasRightRepeat && Number.isFinite(repeatTimes) && repeatTimes > 2 ? [`times=${Math.round(repeatTimes)}`] : []),
+          ...(boundaryInfo.rightEndingNumber && boundaryInfo.rightEndingType === "discontinue"
+            ? [`ending-stop=${boundaryInfo.rightEndingNumber}`, `ending-type=${boundaryInfo.rightEndingType}`]
+            : []),
+        ].join(" ");
   if (measureMetaLine) metaLines.push(measureMetaLine);
-  metaLines.push(...buildAbcExportDiagMetaLines(normalizedVoiceId, measure, safeMeasureNumber));
+  const diagFields = Array.from(measure.querySelectorAll(':scope > attributes > miscellaneous > miscellaneous-field[name^="mks:diag:"]'));
+  if (diagFields.length > 0) {
+    const byName = new Map<string, string>();
+    for (const field of diagFields) {
+      const name = (field.getAttribute("name") ?? "").trim();
+      if (!name) continue;
+      byName.set(name, (field.textContent ?? "").trim());
+    }
+    const orderedNames = Array.from(byName.keys()).sort((a, b) => {
+      const isCountA = a === "mks:diag:count";
+      const isCountB = b === "mks:diag:count";
+      if (isCountA && !isCountB) return -1;
+      if (!isCountA && isCountB) return 1;
+      return a.localeCompare(b);
+    });
+    metaLines.push(
+      ...orderedNames.map(
+        (name) =>
+          `%@mks diag voice=${normalizedVoiceId} measure=${safeMeasureNumber} name=${name} enc=uri-v1 value=${encodeURIComponent(
+            byName.get(name) ?? ""
+          )}`
+      )
+    );
+  }
 };
 
 const applyAbcExportNonNoteChildToPending = (
@@ -6173,10 +5356,60 @@ const processAbcExportNoteChild = (
   if (!isMusicXmlNoteInAbcExportLane(child, lane)) {
     return { handled: true, pending, eventNo, activeTuplet, pendingLyricExtension };
   }
-  const noteEventInfo = readAbcExportNoteEventInfo(child, currentDivisions, unitLength);
-  if (!noteEventInfo) {
+  const isChord = child.querySelector(":scope > chord") !== null;
+  const isGrace = child.querySelector(":scope > grace") !== null;
+  const duration = Number(child.querySelector(":scope > duration")?.textContent?.trim() ?? "0");
+  if (!isGrace && (!Number.isFinite(duration) || duration <= 0)) {
     return { handled: true, pending, eventNo, activeTuplet, pendingLyricExtension };
   }
+  const noteDuration = isGrace
+    ? (Number.isFinite(duration) && duration > 0 ? duration : Math.round(currentDivisions / 2))
+    : duration;
+  const tieState = extractMusicXmlTieState(child);
+  const slurFeatures = extractMusicXmlSlurFeatures(child);
+  const actualNotes = Number(child.querySelector(":scope > time-modification > actual-notes")?.textContent?.trim() ?? "");
+  const normalNotes = Number(child.querySelector(":scope > time-modification > normal-notes")?.textContent?.trim() ?? "");
+  const timeModification =
+    Number.isFinite(actualNotes) && actualNotes > 0 && Number.isFinite(normalNotes) && normalNotes > 0
+      ? { actual: Math.round(actualNotes), normal: Math.round(normalNotes) }
+      : null;
+  const ornamentFeatures = extractMusicXmlOrnamentFeatures(child);
+  const ornamentKinds = new Set(ornamentFeatures.map((feature) => feature.kind));
+  const hasTrillMark = ornamentKinds.has("trill-mark");
+  const hasWavyLineStart = Array.from(child.querySelectorAll(":scope > notations > ornaments > wavy-line")).some((node) =>
+    (node.getAttribute("type") ?? "").trim().toLowerCase() === "" || (node.getAttribute("type") ?? "").trim().toLowerCase() === "start"
+  );
+  const hasWavyLineStop = Array.from(child.querySelectorAll(":scope > notations > ornaments > wavy-line")).some((node) =>
+    (node.getAttribute("type") ?? "").trim().toLowerCase() === "stop"
+  );
+  const ornamentTrillPrefix = hasWavyLineStop
+    ? "!trill)!"
+    : hasWavyLineStart && !hasTrillMark
+      ? "!trill!"
+      : hasWavyLineStart
+        ? "!trill(!"
+        : hasTrillMark
+          ? "!trill!"
+          : "";
+  const noteEventInfo: AbcExportNoteEventInfo = {
+    isChord,
+    isGrace,
+    hasTieStart: tieState.tieStart,
+    ornamentPrefixInfo: {
+      prefix: `${ornamentTrillPrefix}${`${ornamentKinds.has("inverted-turn") ? (ornamentKinds.has("delayed-turn") ? "!delayedinvertedturn!" : (ornamentFeatures.some((feature) => feature.kind === "inverted-turn" && feature.slash) ? "!invertedturnx!" : "!invertedturn!")) : ""}${ornamentKinds.has("turn") ? (ornamentKinds.has("delayed-turn") ? "!delayedturn!" : (ornamentFeatures.some((feature) => feature.kind === "turn" && feature.slash) ? "!turnx!" : "!turn!")) : ""}`}${`${ornamentKinds.has("inverted-mordent") ? "!pralltriller!" : ""}${ornamentKinds.has("mordent") ? "!mordent!" : ""}`}${(["single", "start", "stop"] as const).map((tremoloType) => {
+        const tremoloFeature = ornamentFeatures.find((feature) => feature.kind === "tremolo" && feature.tremoloType === tremoloType);
+        return tremoloFeature ? `!tremolo-${tremoloType}-${tremoloFeature.marks ? tremoloFeature.marks : 1}!` : "";
+      }).join("")}${`${child.querySelector(':scope > notations > glissando[type="start"]') ? "!gliss-start!" : ""}${child.querySelector(':scope > notations > glissando[type="stop"]') ? "!gliss-stop!" : ""}${child.querySelector(':scope > notations > slide[type="start"]') ? "!slide!" : ""}${child.querySelector(':scope > notations > slide[type="stop"]') ? "!slide-stop!" : ""}${ornamentKinds.has("schleifer") ? "!schleifer!" : ""}${ornamentKinds.has("shake") ? "!shake!" : ""}${child.querySelector(":scope > notations > arpeggiate") ? "!arpeggio!" : ""}`}`,
+      hasTrill: hasTrillMark || hasWavyLineStart,
+      trillAccidentalText: child.querySelector(":scope > notations > ornaments > accidental-mark")?.textContent?.trim() ?? "",
+    },
+    hasSlurStart: slurFeatures.some((slur) => slur.type === "start"),
+    hasSlurStop: slurFeatures.some((slur) => slur.type === "stop"),
+    hasGraceSlash: (child.querySelector(":scope > grace")?.getAttribute("slash") ?? "").trim().toLowerCase() === "yes",
+    hasTupletStart: child.querySelector(':scope > notations > tuplet[type="start"]') !== null,
+    timeModification,
+    len: buildAbcExportLengthToken(noteDuration, currentDivisions, unitLength, timeModification),
+  };
 
   return applyAbcExportNoteEvent(
     child,
@@ -6391,7 +5624,17 @@ const renderAbcExportMeasureText = (
   } = context;
   let { pendingLyricExtension } = context;
   const measureState = applyAbcExportMeasureAttributesToState(measure, context.measureState);
-  const boundaryInfo = readAbcExportMeasureBoundaryInfo(measure);
+  const leftRepeatNode = measure.querySelector(':scope > barline[location="left"] > repeat');
+  const rightRepeatNode = measure.querySelector(':scope > barline[location="right"] > repeat');
+  const leftEndingNode = measure.querySelector(':scope > barline[location="left"] > ending');
+  const rightEndingNode = measure.querySelector(':scope > barline[location="right"] > ending');
+  const boundaryInfo = {
+    hasLeftRepeat: (leftRepeatNode?.getAttribute("direction") ?? "").trim().toLowerCase() === "forward",
+    hasRightRepeat: (rightRepeatNode?.getAttribute("direction") ?? "").trim().toLowerCase() === "backward",
+    leftEndingNumber: (leftEndingNode?.getAttribute("number") ?? "").trim(),
+    rightEndingNumber: (rightEndingNode?.getAttribute("number") ?? "").trim(),
+    rightEndingType: (rightEndingNode?.getAttribute("type") ?? "").trim().toLowerCase(),
+  };
   appendAbcExportMeasureMetaLines(metaLines, normalizedVoiceId, measure, fallbackMeasureNumber, boundaryInfo);
   const { currentDivisions, currentFifths, currentBeats, currentBeatType } = measureState;
   const needsInlineKeyChange = lastEmittedKeyFifths === null || lastEmittedKeyFifths !== currentFifths;
@@ -6422,9 +5665,13 @@ const renderAbcExportMeasureText = (
     currentBeatType,
     unitLength
   );
-  const boundaryPrefix = buildAbcExportMeasureBoundaryPrefix(boundaryInfo);
-  const keyPrefix = buildAbcExportMeasureKeyPrefix(needsInlineKeyChange, currentFifths);
-  const boundarySuffix = buildAbcExportMeasureBoundarySuffix(boundaryInfo);
+  const boundaryPrefix = `${boundaryInfo.hasLeftRepeat ? "|:" : ""}${boundaryInfo.leftEndingNumber ? `[${boundaryInfo.leftEndingNumber}` : ""}`;
+  const keyPrefix = needsInlineKeyChange
+    ? `[K:${AbcCommon.keyFromFifthsMode(Math.max(-7, Math.min(7, Math.round(currentFifths))), "major")}]`
+    : "";
+  const boundarySuffix = boundaryInfo.hasRightRepeat
+    ? (boundaryInfo.rightEndingNumber ? ":|]" : ":|")
+    : (boundaryInfo.rightEndingNumber ? "]|" : "|");
   return {
     measureText: [
       ...(boundaryPrefix ? [boundaryPrefix] : []),
@@ -6535,8 +5782,20 @@ const appendAbcExportPartFromRenderContext = (context: AbcExportPartRenderContex
     const abcClef = resolveAbcExportLaneClef(laneContext.part, laneContext.measures, laneContext.lane.staff);
     const clefSuffix = abcClef ? ` clef=${abcClef}` : "";
     laneContext.headerLines.push(`V:${normalizedVoiceId} name="${laneName}"${clefSuffix}`);
-    const transposeMetaLine = buildAbcExportTransposeMetaLine(normalizedVoiceId, laneContext.measures[0]);
-    if (transposeMetaLine) laneContext.metaLines.push(transposeMetaLine);
+    const transposeNode = laneContext.measures[0]?.querySelector(":scope > attributes > transpose");
+    if (transposeNode) {
+      const chromatic = Number(transposeNode.querySelector(":scope > chromatic")?.textContent?.trim() ?? "");
+      const diatonic = Number(transposeNode.querySelector(":scope > diatonic")?.textContent?.trim() ?? "");
+      if (Number.isFinite(chromatic) || Number.isFinite(diatonic)) {
+        laneContext.metaLines.push(
+          [
+            `%@mks transpose voice=${normalizedVoiceId}`,
+            ...(Number.isFinite(chromatic) ? [`chromatic=${Math.round(chromatic)}`] : []),
+            ...(Number.isFinite(diatonic) ? [`diatonic=${Math.round(diatonic)}`] : []),
+          ].join(" ")
+        );
+      }
+    }
     const state = createAbcExportLaneBodyStateFromPart(
       laneContext.part,
       laneContext.fifths,
@@ -6560,66 +5819,6 @@ const appendAbcExportPartFromRenderContext = (context: AbcExportPartRenderContex
   }
 };
 
-const hasAbcExportUnitTempoHeader = (
-  initialTempo: AbcExportInitialTempo
-): initialTempo is AbcExportInitialTempo & { unit: Fraction } =>
-  !!initialTempo.unit && Number.isFinite(initialTempo.bpm) && initialTempo.bpm > 0;
-
-const buildAbcExportFallbackTempoHeader = (tempoBpm: number): string =>
-  Number.isFinite(tempoBpm) ? `Q:1/4=${Math.round(tempoBpm)}` : "";
-
-const buildAbcExportTempoHeader = (doc: Document): string =>
-  (() => {
-    const initialTempo = readInitialTempoFromMusicXml(doc);
-    return initialTempo
-      ? (hasAbcExportUnitTempoHeader(initialTempo)
-          ? `Q:${fractionToAbcTempoUnit(initialTempo.unit)}=${Math.round(initialTempo.bpm)}`
-          : buildAbcExportFallbackTempoHeader(initialTempo.bpm))
-      : buildAbcExportFallbackTempoHeader(NaN);
-  })();
-
-const readAbcExportTitle = (doc: Document): string =>
-  doc.querySelector("work > work-title")?.textContent?.trim() ??
-  doc.querySelector("movement-title")?.textContent?.trim() ??
-  "mikuscore";
-
-const readAbcExportComposer = (doc: Document): string =>
-  doc.querySelector('identification > creator[type="composer"]')?.textContent?.trim() ?? "";
-
-const readAbcExportDocumentCredits = (doc: Document): AbcExportDocumentCredits => ({
-  title: readAbcExportTitle(doc),
-  composer: readAbcExportComposer(doc),
-});
-
-const createAbcExportDocumentHeaderInfo = (doc: Document): AbcExportDocumentHeaderInfo => {
-  const credits = readAbcExportDocumentCredits(doc);
-  const firstMeasure = doc.querySelector("score-partwise > part > measure");
-  const meterBeats = firstMeasure?.querySelector("attributes > time > beats")?.textContent?.trim() ?? "4";
-  const meterBeatType = firstMeasure?.querySelector("attributes > time > beat-type")?.textContent?.trim() ?? "4";
-  const fifths = Number(firstMeasure?.querySelector("attributes > key > fifths")?.textContent?.trim() ?? "0");
-  const mode = firstMeasure?.querySelector("attributes > key > mode")?.textContent?.trim() ?? "major";
-  const abcTempoHeader = buildAbcExportTempoHeader(doc);
-  return {
-    title: credits.title,
-    composer: credits.composer,
-    meterBeats,
-    meterBeatType,
-    fifths,
-    key: AbcCommon.keyFromFifthsMode(Number.isFinite(fifths) ? fifths : 0, mode),
-    abcTempoHeader,
-  };
-};
-
-const buildAbcExportRawHeaderLines = (headerInfo: AbcExportDocumentHeaderInfo): string[] => [
-  "X:1",
-  `T:${headerInfo.title}`,
-  headerInfo.composer ? `C:${headerInfo.composer}` : "",
-  `M:${headerInfo.meterBeats}/${headerInfo.meterBeatType}`,
-  `L:${fractionToAbcTempoUnit(DEFAULT_UNIT)}`,
-  headerInfo.abcTempoHeader,
-  `K:${headerInfo.key}`,
-];
-
 const appendAbcExportParts = (
   parts: Element[],
   exportContext: AbcExportDocumentContext
@@ -6641,9 +5840,32 @@ const appendAbcExportParts = (
 };
 
 export const exportMusicXmlDomToAbc = (doc: Document): string => {
-  const headerInfo = createAbcExportDocumentHeaderInfo(doc);
+  const title =
+    doc.querySelector("work > work-title")?.textContent?.trim() ??
+    doc.querySelector("movement-title")?.textContent?.trim() ??
+    "mikuscore";
+  const composer = doc.querySelector('identification > creator[type="composer"]')?.textContent?.trim() ?? "";
+  const firstMeasure = doc.querySelector("score-partwise > part > measure");
+  const meterBeats = firstMeasure?.querySelector("attributes > time > beats")?.textContent?.trim() ?? "4";
+  const meterBeatType = firstMeasure?.querySelector("attributes > time > beat-type")?.textContent?.trim() ?? "4";
+  const fifths = Number(firstMeasure?.querySelector("attributes > key > fifths")?.textContent?.trim() ?? "0");
+  const mode = firstMeasure?.querySelector("attributes > key > mode")?.textContent?.trim() ?? "major";
+  const initialTempo = readInitialTempoFromMusicXml(doc);
+  const abcTempoHeader = initialTempo
+    ? (initialTempo.unit && Number.isFinite(initialTempo.bpm) && initialTempo.bpm > 0
+        ? `Q:${fractionToAbcTempoUnit(initialTempo.unit)}=${Math.round(initialTempo.bpm)}`
+        : (Number.isFinite(initialTempo.bpm) ? `Q:1/4=${Math.round(initialTempo.bpm)}` : ""))
+    : "";
   const exportContext: AbcExportDocumentContext = {
-    headerLines: buildAbcExportRawHeaderLines(headerInfo).filter((line) => line.length > 0),
+    headerLines: [
+      "X:1",
+      `T:${title}`,
+      composer ? `C:${composer}` : "",
+      `M:${meterBeats}/${meterBeatType}`,
+      `L:${fractionToAbcTempoUnit(DEFAULT_UNIT)}`,
+      abcTempoHeader,
+      `K:${AbcCommon.keyFromFifthsMode(Number.isFinite(fifths) ? fifths : 0, mode)}`,
+    ].filter((line) => line.length > 0),
     bodyLines: [],
     metaLines: [],
     partNameById: new Map(
@@ -6654,9 +5876,9 @@ export const exportMusicXmlDomToAbc = (doc: Document): string => {
         })
         .filter((entry): entry is [string, string] => entry !== null)
     ),
-    fifths: headerInfo.fifths,
-    meterBeats: headerInfo.meterBeats,
-    meterBeatType: headerInfo.meterBeatType,
+    fifths,
+    meterBeats,
+    meterBeatType,
     unitLength: DEFAULT_UNIT,
   };
   appendAbcExportParts(Array.from(doc.querySelectorAll("score-partwise > part")), exportContext);
@@ -7120,104 +6342,6 @@ const toHex = (value: number, width = 2): string => {
   const safe = Math.max(0, Math.round(Number(value ?? 0)));
   return `0x${safe.toString(16).toUpperCase().padStart(width, "0")}`;
 };
-
-const normalizeAbcDebugStep = (note: AbcParsedNote): string =>
-  note.isRest ? "R" : (/^[A-G]$/.test(String(note.step ?? "").toUpperCase()) ? String(note.step).toUpperCase() : "C");
-
-const normalizeAbcDebugOctave = (octave?: number): number =>
-  Number.isFinite(Number(octave)) ? Math.max(0, Math.min(9, Math.round(Number(octave)))) : 4;
-
-const normalizeAbcDebugAlter = (alter?: number): number =>
-  Number.isFinite(Number(alter)) ? Math.round(Number(alter)) : 0;
-
-const buildAbcMeasureDebugMiscXml = (notes: AbcParsedNote[], measureNo: number): string =>
-  notes.length
-    ? `<attributes><miscellaneous><miscellaneous-field name="mks:dbg:abc:meta:count">${toHex(notes.length, 4)}</miscellaneous-field>${notes
-        .map(
-          (note, index) =>
-            `<miscellaneous-field name="mks:dbg:abc:meta:${String(index + 1).padStart(4, "0")}">${[
-              [
-                `idx=${toHex(index, 4)}`,
-                `m=${toHex(measureNo, 4)}`,
-                `v=${xmlEscape(normalizeVoiceForMusicXml(note.voice))}`,
-              ].join(";"),
-              [
-                `r=${note.isRest ? "1" : "0"}`,
-                `g=${note.grace ? "1" : "0"}`,
-                `ch=${note.chord ? "1" : "0"}`,
-                `st=${normalizeAbcDebugStep(note)}`,
-                `al=${String(normalizeAbcDebugAlter(note.alter))}`,
-                `oc=${toHex(normalizeAbcDebugOctave(note.octave), 2)}`,
-                `dd=${toHex(note.grace ? 0 : buildAbcNoteCoreDurationValuePart(note), 4)}`,
-                `tp=${xmlEscape(normalizeTypeForMusicXml(note.type))}`,
-              ].join(";"),
-            ].join(";")}</miscellaneous-field>`,
-        )
-        .join("")}</miscellaneous></attributes>`
-    : "";
-
-const encodeAbcSourceForMiscXml = (abcSource: string): string =>
-  String(abcSource ?? "")
-    .replace(/\\/g, "\\\\")
-    .replace(/\r/g, "\\r")
-    .replace(/\n/g, "\\n");
-
-const buildAbcSourceMiscXml = (abcSource: string): string => {
-  const source = String(abcSource ?? "");
-  if (!source.length) return "";
-  const encoded = encodeAbcSourceForMiscXml(source);
-  const CHUNK_SIZE = 240;
-  const MAX_CHUNKS = 512;
-  const chunks: string[] = [];
-  for (let i = 0; i < encoded.length && chunks.length < MAX_CHUNKS; i += CHUNK_SIZE) {
-    chunks.push(encoded.slice(i, i + CHUNK_SIZE));
-  }
-  const truncated = chunks.join("").length < encoded.length;
-  return `<attributes><miscellaneous>${[
-    `<miscellaneous-field name="mks:src:abc:raw-encoding">escape-v1</miscellaneous-field>`,
-    `<miscellaneous-field name="mks:src:abc:raw-length">${xmlEscape(String(source.length))}</miscellaneous-field>`,
-    `<miscellaneous-field name="mks:src:abc:raw-encoded-length">${xmlEscape(String(encoded.length))}</miscellaneous-field>`,
-    `<miscellaneous-field name="mks:src:abc:raw-chunks">${xmlEscape(String(chunks.length))}</miscellaneous-field>`,
-    `<miscellaneous-field name="mks:src:abc:raw-truncated">${truncated ? "1" : "0"}</miscellaneous-field>`,
-    ...chunks.map(
-      (chunk, index) =>
-        `<miscellaneous-field name="mks:src:abc:raw-${String(index + 1).padStart(4, "0")}">${xmlEscape(chunk)}</miscellaneous-field>`,
-    ),
-  ].join("")}</miscellaneous></attributes>`;
-};
-
-const buildAbcDiagMiscXml = (
-  diagnostics: Array<{
-    level: "warn";
-    code: string;
-    fmt: "abc";
-    message?: string;
-    voiceId?: string;
-    measure?: number;
-    action?: string;
-    movedEvents?: number;
-  }>  
-): string =>
-  diagnostics.length
-    ? `<attributes><miscellaneous><miscellaneous-field name="mks:diag:count">${Math.min(256, diagnostics.length)}</miscellaneous-field>${Array.from(
-        { length: Math.min(256, diagnostics.length) },
-        (_, i) =>
-          `<miscellaneous-field name="mks:diag:${String(i + 1).padStart(4, "0")}">${[
-            `level=${diagnostics[i].level}`,
-            `code=${diagnostics[i].code}`,
-            `fmt=${diagnostics[i].fmt}`,
-            ...(diagnostics[i].measure !== undefined && Number.isFinite(diagnostics[i].measure)
-              ? [`measure=${Math.max(1, Math.round(Number(diagnostics[i].measure)))}`]
-              : []),
-            ...(diagnostics[i].movedEvents !== undefined && Number.isFinite(diagnostics[i].movedEvents)
-              ? [`movedEvents=${Math.max(0, Math.round(Number(diagnostics[i].movedEvents)))}`]
-              : []),
-            ...(diagnostics[i].voiceId ? [`voice=${xmlEscape(diagnostics[i].voiceId)}`] : []),
-            ...(diagnostics[i].action ? [`action=${xmlEscape(diagnostics[i].action)}`] : []),
-            ...(diagnostics[i].message ? [`message=${xmlEscape(diagnostics[i].message)}`] : []),
-          ].join(";")}</miscellaneous-field>`
-      ).join("")}</miscellaneous></attributes>`
-    : "";
 
 const prettyPrintXml = (xml: string): string => {
   const compact = xml.replace(/>\s+</g, "><").trim();


### PR DESCRIPTION
## 概要

ABC/MusicXML変換処理まわりの細かなヘルパーを `src/ts/abc-io.ts` 内の利用箇所へ展開し、対応する生成物を更新しました。

## 変更内容

- `src/ts/abc-io.ts` のABCからMusicXMLへのノート・記譜・メタ情報生成処理を利用箇所へ展開
- MusicXMLからABCへのエクスポート処理で、ノート情報、装飾、反復記号、調号、移調、診断メタ情報の読み取り処理を利用箇所へ展開
- ABCソースメタ情報、デバッグメタ情報、診断メタ情報の生成処理を `buildAbcRenderedPartMeasureXml` 内で構築する形に変更
- `src/js/main.js`、`bundle/mikuscore.mjs`、`mikuscore.html` を更新
- `index.html` の更新日表示を `2026-05-28` に変更

## 確認事項

- テスト実行の証跡は未確認です。