### PR TITLE
GitHub リポジトリ名変更の完了を記録

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -49,7 +49,7 @@
   - Applied: migrated the local product, package, CLI, Web App, Node.js runtime bundle, Release asset naming, generated files, and current documentation to `miku-score`.
   - Compatibility: the private package exposes only the canonical `miku-score` CLI; existing `mks:` metadata, the v1 analysis namespace, MIDI SysEx `app=mikuscore`, and the published utaformatix3 vendor API remain unchanged.
   - Verification: `npm run build`, CLI help/version, `npm run smoke:bundle`, and versioned Release-asset preparation all succeeded under the canonical name.
-  - Blocking external step: a human maintainer must rename `igapyon/mikuscore` to `igapyon/miku-score`, then update this checkout's remote URL.
+  - External repository step: a human maintainer renamed `igapyon/mikuscore` to `igapyon/miku-score`; this checkout's `origin` remote now uses the canonical URL.
   - Next action: create `miku-score-web` only after the repository rename, with the browser-compatible Main Application contract decided before moving Web files.
 
 ## Specification

--- a/docs/MIGRATION_MIKUSCORE_TO_MIKU_SCORE.md
+++ b/docs/MIGRATION_MIKUSCORE_TO_MIKU_SCORE.md
@@ -70,6 +70,6 @@ test its own read/write compatibility policy.
 ## External Repository Step
 
 The GitHub repository rename from `igapyon/mikuscore` to
-`igapyon/miku-score` is a human-maintainer action. After it is complete, update
-the local remote URL and verify that all managed links use the new canonical
-repository URL rather than relying on a redirect.
+`igapyon/miku-score` was completed by a human maintainer on 2026-08-05. The
+local `origin` remote uses the new canonical repository URL; managed links
+must use that URL rather than rely on GitHub redirects.


### PR DESCRIPTION
## 概要

`igapyon/miku-score` への GitHub リポジトリ名変更と、ローカル checkout の `origin` 更新が完了したことを記録します。

## 変更内容

- `TODO.md` の Main Application rename にある外部作業を完了として更新
- `docs/MIGRATION_MIKUSCORE_TO_MIKU_SCORE.md` にリポジトリ名変更日と canonical remote URL を記録

## 確認

- `git fetch origin --prune`
- `git rev-list --left-right --count HEAD...origin/devel` が `0 0`

## 関連 Issue

Refs #198