### PR TITLE
fix: stabilize 0.6.1 release build

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -52,6 +52,18 @@
   - External repository step: a human maintainer renamed `igapyon/mikuscore` to `igapyon/miku-score`; this checkout's `origin` remote now uses the canonical URL.
   - Next action: create `miku-score-web` only after the repository rename, with the browser-compatible Main Application contract decided before moving Web files.
 
+- 2026-08-06 | miku-score | Rename release recovery and family follow-up
+  - Applied: prepared version `0.6.1`, regenerated the tracked CLI runtime bundle, and aligned CLI version coverage.
+  - Applied: raised the stdin-to-stdout CLI test timeout to 10 seconds so the first heavy CLI runtime load does not fail under CI startup contention.
+  - Verification: `npm run build`, versioned Release-asset preparation, and bundle smoke succeeded for `0.6.1`.
+  - Release recovery order:
+    1. recommit, publish, and merge the `0.6.1` change;
+    2. a human creates the `v0.6.1` GitHub Release tag;
+    3. verify that the Release workflow uploads `miku-score-0.6.1.mjs` and `miku-score-sources-0.6.1.tgz`.
+  - Human GitHub setting: update the repository Homepage from `https://igapyon.github.io/mikuscore/` to `https://igapyon.github.io/miku-score/`.
+  - Family follow-up: keep Issue #198 open until the Java repository, Agent Skills repository, and downstream `igapyon-agent-skills` references adopt the `miku-score` naming system.
+  - Next phase: after the Release and Homepage work above, create `miku-score-web` with the browser-compatible Main Application contract decided before moving Web files.
+
 ## Specification
 
 - [x] Create the first cross-format mapping table from the MusicXML canonical-state policy.

--- a/bundle/miku-score.mjs
+++ b/bundle/miku-score.mjs
@@ -133970,7 +133970,7 @@ var __filename = fileURLToPath(import.meta.url);
 var __dirname = path.dirname(__filename);
 var repoRoot = path.resolve(__dirname, "..");
 var DIAGNOSTICS_VERSION = 1;
-var PACKAGE_VERSION = "0.6.0";
+var PACKAGE_VERSION = "0.6.1";
 var HELP_TEXT = {
   top: [
     "Usage:",

--- a/index.html
+++ b/index.html
@@ -125,7 +125,7 @@
 <body>
   <main class="card">
     <h1>miku-score</h1>
-    <p class="sub">Updated: 2026-08-05</p>
+    <p class="sub">Updated: 2026-08-06</p>
     <section class="lang-block" aria-label="English">
       <h2>English</h2>
       <p>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "miku-score",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "miku-score",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "bin": {
         "miku-score": "scripts/miku-score-cli.mjs"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "miku-score",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "type": "module",
   "bin": {

--- a/tests/unit/miku-score-cli.spec.ts
+++ b/tests/unit/miku-score-cli.spec.ts
@@ -77,7 +77,7 @@ describe("miku-score cli", () => {
     const result = runCli(["--version"]);
 
     expect(result.status).toBe(0);
-    expect(result.stdout.trim()).toBe("0.6.0");
+    expect(result.stdout.trim()).toBe("0.6.1");
     expect(result.stderr).toBe("");
   }, 10000);
 
@@ -88,7 +88,7 @@ describe("miku-score cli", () => {
 
     expect(result.status).toBe(0);
     expect(result.stdout).toContain("<work-title>STDIN</work-title>");
-  });
+  }, 10000);
 
   it("converts ABC directly to MIDI", () => {
     const result = runCli(["convert", "--from", "abc", "--to", "midi"], {


### PR DESCRIPTION
## 概要

0.6.1 リリース復旧に向けて、配布 runtime の version 表示と CLI 回帰テストを整合させ、CI 起動時の標準入力変換テストのタイムアウトを安定化します。

## 変更内容

- package metadata、lockfile、CLI version expectation、追跡対象の CLI runtime bundle を `0.6.1` に更新
- 初回の重い CLI runtime load で揺れる stdin-to-stdout 変換テストの timeout を 10 秒に設定
- 更新日を反映し、Release 作成、Homepage 更新、miku-score ファミリー移行、`miku-score-web` 作成の後続手順を TODO に記録

## 確認事項

- `npm run build`
- `TAG_NAME=v0.6.1 npm run prepare:release-assets`
- `npm run smoke:bundle`

## 関連Issue

Refs #198